### PR TITLE
feat: Suffer Score trend chart

### DIFF
--- a/backend/app/api/trends.py
+++ b/backend/app/api/trends.py
@@ -17,6 +17,7 @@ from app.schemas.trends import (
     DailyTimePoint,
     PaceTrendPoint,
     SufferScorePoint,
+    DailySufferScorePoint,
 )
 from app.services.trends import (
     build_activity_facts,
@@ -25,6 +26,7 @@ from app.services.trends import (
     build_weekly_buckets,
     build_pace_trend,
     build_suffer_score_trend,
+    build_continuous_suffer_scores,
     get_available_types,
 )
 
@@ -114,6 +116,12 @@ def get_trends(
         SufferScorePoint(**p) for p in build_suffer_score_trend(activity_facts)
     ]
 
+    # 6. Daily suffer score (continuous — every day filled)
+    daily_suffer_score = [
+        DailySufferScorePoint(**p)
+        for p in build_continuous_suffer_scores(activity_facts, range_key=range_upper)
+    ]
+
     return TrendsResponse(
         range=range_upper,
         summary=summary,
@@ -123,4 +131,5 @@ def get_trends(
         daily_time=daily_time,
         pace_trend=pace_trend,
         suffer_score=suffer_score,
+        daily_suffer_score=daily_suffer_score,
     )

--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -44,6 +44,11 @@ class SufferScorePoint(BaseModel):
     type: str
 
 
+class DailySufferScorePoint(BaseModel):
+    date: date
+    effort_score: float
+
+
 class TrendsSummary(BaseModel):
     total_distance_m: int
     total_moving_time_s: int
@@ -59,3 +64,4 @@ class TrendsResponse(BaseModel):
     daily_time: List[DailyTimePoint]
     pace_trend: List[PaceTrendPoint]
     suffer_score: List[SufferScorePoint]
+    daily_suffer_score: List[DailySufferScorePoint]

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -116,7 +116,10 @@ export default function TrendsPage() {
             />
           </div>
           <PaceTrendChart data={data.pace_trend} />
-          <SufferScoreChart data={data.suffer_score} />
+          <SufferScoreChart
+            data={range === "7D" || range === "30D" ? data.daily_suffer_score : data.suffer_score}
+            granularity={range === "7D" || range === "30D" ? "daily" : "per-activity"}
+          />
         </div>
       )}
     </div>

--- a/frontend/components/trends/SufferScoreChart.tsx
+++ b/frontend/components/trends/SufferScoreChart.tsx
@@ -9,15 +9,16 @@ import {
   ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
-import { SufferScorePoint } from "@/lib/types";
+import { SufferScorePoint, DailySufferScorePoint } from "@/lib/types";
 import { formatDateLabel } from "@/lib/format";
 
 interface Props {
-  data: SufferScorePoint[];
+  data: SufferScorePoint[] | DailySufferScorePoint[];
+  granularity: "daily" | "per-activity";
 }
 
-export default function SufferScoreChart({ data }: Props) {
-  const chartData = data.map((d) => ({
+export default function SufferScoreChart({ data, granularity }: Props) {
+  const chartData = data.map((d: any) => ({
     ...d,
     label: formatDateLabel(d.date),
   }));

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -14,6 +14,7 @@ export type {
   DailyTimePoint,
   PaceTrendPoint,
   SufferScorePoint,
+  DailySufferScorePoint,
   TrendsSummary,
   TrendsData,
   TrendsRange,

--- a/frontend/lib/types/trends.ts
+++ b/frontend/lib/types/trends.ts
@@ -34,6 +34,11 @@ export interface SufferScorePoint {
   type: string;
 }
 
+export interface DailySufferScorePoint {
+  date: string;
+  effort_score: number;
+}
+
 export interface TrendsSummary {
   total_distance_m: number;
   total_moving_time_s: number;
@@ -49,6 +54,7 @@ export interface TrendsData {
   daily_time: DailyTimePoint[];
   pace_trend: PaceTrendPoint[];
   suffer_score: SufferScorePoint[];
+  daily_suffer_score: DailySufferScorePoint[];
 }
 
 export type TrendsRange = "7D" | "30D" | "3M" | "6M" | "1Y" | "ALL";


### PR DESCRIPTION
Adds a Suffer Score Over Time bar chart to the Trends page.

### Changes
- **Backend**: Pull `effort_score` from `DerivedMetric` into `ActivityFact`. New `build_suffer_score_trend()` and `build_continuous_suffer_scores()` functions for per-activity and continuous daily data.
- **Schemas**: `SufferScorePoint`, `DailySufferScorePoint` added to `TrendsResponse`.
- **Frontend**: New `SufferScoreChart` component (red bar chart). Shows continuous daily bars for 7D/30D, per-activity bars for longer ranges.
- **30D daily granularity**: Distance and time charts now also show daily bars for the 30D range.