### PR TITLE
feat: Add Heart Rate Efficiency chart

### DIFF
--- a/backend/app/api/trends.py
+++ b/backend/app/api/trends.py
@@ -18,6 +18,7 @@ from app.schemas.trends import (
     PaceTrendPoint,
     SufferScorePoint,
     DailySufferScorePoint,
+    EfficiencyPoint,
 )
 from app.services.trends import (
     build_activity_facts,
@@ -27,6 +28,7 @@ from app.services.trends import (
     build_pace_trend,
     build_suffer_score_trend,
     build_continuous_suffer_scores,
+    build_efficiency_trend,
     get_available_types,
 )
 
@@ -122,6 +124,12 @@ def get_trends(
         for p in build_continuous_suffer_scores(activity_facts, range_key=range_upper)
     ]
 
+    # 7. Efficiency trend
+    efficiency_trend = [
+        EfficiencyPoint(**p)
+        for p in build_efficiency_trend(activity_facts)
+    ]
+
     return TrendsResponse(
         range=range_upper,
         summary=summary,
@@ -132,4 +140,5 @@ def get_trends(
         pace_trend=pace_trend,
         suffer_score=suffer_score,
         daily_suffer_score=daily_suffer_score,
+        efficiency_trend=efficiency_trend,
     )

--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -49,6 +49,12 @@ class DailySufferScorePoint(BaseModel):
     effort_score: float
 
 
+class EfficiencyPoint(BaseModel):
+    date: date
+    efficiency_mps_per_bpm: float
+    type: str
+
+
 class TrendsSummary(BaseModel):
     total_distance_m: int
     total_moving_time_s: int
@@ -65,3 +71,4 @@ class TrendsResponse(BaseModel):
     pace_trend: List[PaceTrendPoint]
     suffer_score: List[SufferScorePoint]
     daily_suffer_score: List[DailySufferScorePoint]
+    efficiency_trend: List[EfficiencyPoint]

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -348,3 +348,28 @@ def build_continuous_suffer_scores(
         cursor += timedelta(days=1)
 
     return result
+
+def build_efficiency_trend(facts: List[ActivityFact]) -> List[dict]:
+    """
+    Build data points for Efficiency = Speed (m/s) / HR (bpm).
+    Only includes activities with distance > 1km and valid HR.
+    """
+    points = []
+    for f in facts:
+        # Filter for meaningful runs/walks
+        if f.distance_m < 1000:
+            continue
+        if not f.avg_hr or f.avg_hr < 1:
+            continue
+        if not f.average_speed_mps or f.average_speed_mps <= 0:
+            continue
+
+        efficiency = f.average_speed_mps / f.avg_hr
+        
+        points.append({
+            "date": f.local_date.isoformat(),
+            "efficiency_mps_per_bpm": round(efficiency, 4),
+            "type": f.activity_type,
+        })
+    
+    return sorted(points, key=lambda p: p["date"])

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -10,6 +10,7 @@ import WeeklyDistanceChart from "@/components/trends/WeeklyDistanceChart";
 import WeeklyTimeChart from "@/components/trends/WeeklyTimeChart";
 import PaceTrendChart from "@/components/trends/PaceTrendChart";
 import SufferScoreChart from "@/components/trends/SufferScoreChart";
+import EfficiencyTrendChart from "@/components/trends/EfficiencyTrendChart";
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8000";
@@ -118,6 +119,7 @@ export default function TrendsPage() {
             data={range === "7D" || range === "30D" ? data.daily_suffer_score : data.suffer_score}
             granularity={range === "7D" || range === "30D" ? "daily" : "per-activity"}
           />
+          {data.efficiency_trend && <EfficiencyTrendChart data={data.efficiency_trend} />}
         </div>
       )}
     </div>

--- a/frontend/components/trends/EfficiencyTrendChart.tsx
+++ b/frontend/components/trends/EfficiencyTrendChart.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import {
+  ComposedChart,
+  Line,
+  Scatter,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+} from "recharts";
+import { EfficiencyPoint } from "@/lib/types";
+import { formatDateLabel } from "@/lib/format";
+import { useMemo } from "react";
+
+interface Props {
+  data: EfficiencyPoint[];
+}
+
+function calculateSMA(data: EfficiencyPoint[], window: number = 5): (number | null)[] {
+  const result: (number | null)[] = [];
+  for (let i = 0; i < data.length; i++) {
+    const start = Math.max(0, i - window + 1);
+    const subset = data.slice(start, i + 1);
+    const sum = subset.reduce((acc, curr) => acc + curr.efficiency_mps_per_bpm, 0);
+    result.push(sum / subset.length);
+  }
+  return result;
+}
+
+export default function EfficiencyTrendChart({ data }: Props) {
+  const chartData = useMemo(() => {
+    const sma = calculateSMA(data, 5); // 5-activity moving average
+    return data.map((p, idx) => ({
+      ...p,
+      label: formatDateLabel(p.date),
+      // Scatter points
+      run: p.type.toLowerCase() === "run" ? p.efficiency_mps_per_bpm : undefined,
+      walk: p.type.toLowerCase() === "walk" ? p.efficiency_mps_per_bpm : undefined,
+      // Trend line
+      trend: sma[idx],
+    }));
+  }, [data]);
+
+  const hasRun = data.some((p) => p.type.toLowerCase() === "run");
+  const hasWalk = data.some((p) => p.type.toLowerCase() === "walk");
+
+  return (
+    <div className="bg-white rounded-lg border shadow-sm p-5">
+      <div className="mb-4">
+        <h3 className="text-sm font-semibold text-gray-700">
+          Heart Rate Efficiency
+        </h3>
+        <p className="text-xs text-gray-500 mt-1">
+          Speed (m/s) per Heart beat. Higher is better.
+        </p>
+      </div>
+
+      {chartData.length === 0 ? (
+        <p className="text-gray-400 text-sm py-8 text-center">
+          No sufficient heart rate data for this range.
+        </p>
+      ) : (
+        <div className="h-[300px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                tick={{ fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+                width={40}
+                domain={["auto", "auto"]}
+                tickFormatter={(val) => val.toFixed(3)}
+              />
+              <Tooltip
+                formatter={(value: number, name: string) => [
+                  value.toFixed(4),
+                  name === "trend" ? "Trend (5-act avg)" : name,
+                ]}
+                labelFormatter={(label) => label}
+              />
+              <Legend />
+              
+              {/* Trend Line */}
+              <Line
+                type="monotone"
+                dataKey="trend"
+                stroke="#64748b" // slate-500
+                strokeWidth={2}
+                dot={false}
+                name="Trend"
+              />
+
+              {/* Individual Activities as Scatter points (using Line with only dots and no line connection if we want specific coloring) 
+                 Actually ComposedChart allows Scatter. But combining Line and Scatter is tricky with categorical axis sometimes. 
+                 Alternative: Use Line with strokeWidth={0} for dots.
+              */}
+              
+               {hasRun && (
+                <Line
+                  type="monotone"
+                  dataKey="run"
+                  stroke="#3b82f6"
+                  strokeWidth={0}
+                  dot={{ r: 3, fill: "#3b82f6" }}
+                  connectNulls={false}
+                  name="Run"
+                  isAnimationActive={false}
+                />
+              )}
+              {hasWalk && (
+                <Line
+                  type="monotone"
+                  dataKey="walk"
+                  stroke="#f59e0b"
+                  strokeWidth={0}
+                  dot={{ r: 3, fill: "#f59e0b" }}
+                  connectNulls={false}
+                  name="Walk"
+                  isAnimationActive={false}
+                />
+              )}
+
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+      
+      <div className="mt-3 text-xs text-gray-500 bg-gray-50 p-2 rounded">
+        Efficiency is affected by heat, hills, wind, terrain, and stops. Compare similar routes/efforts for best signal.
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/types/trends.ts
+++ b/frontend/lib/types/trends.ts
@@ -39,6 +39,12 @@ export interface DailySufferScorePoint {
   effort_score: number;
 }
 
+export interface EfficiencyPoint {
+  date: string;
+  efficiency_mps_per_bpm: number;
+  type: string;
+}
+
 export interface TrendsSummary {
   total_distance_m: number;
   total_moving_time_s: number;
@@ -55,6 +61,7 @@ export interface TrendsData {
   pace_trend: PaceTrendPoint[];
   suffer_score: SufferScorePoint[];
   daily_suffer_score: DailySufferScorePoint[];
+  efficiency_trend: EfficiencyPoint[];
 }
 
 export type TrendsRange = "7D" | "30D" | "3M" | "6M" | "1Y" | "ALL";


### PR DESCRIPTION
Adds a new Heart Rate Efficiency chart to the trends page. Calculates efficiency as Speed (m/s) / Heart Rate (bpm) for runs and walks. Includes a backend service update, schema changes, and a new frontend chart component.