### PR TITLE
feat: add zone load trend chart (3-zone stacked bar)

### DIFF
--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -54,6 +54,22 @@ class EfficiencyPoint(BaseModel):
     type: str
 
 
+class ZoneLoadWeekPoint(BaseModel):
+    """One week of 3-zone load data (Easy / Moderate / Hard minutes)."""
+    week_start: date
+    easy_min: float
+    moderate_min: float
+    hard_min: float
+
+
+class DailyZoneLoadPoint(BaseModel):
+    """One day of 3-zone load data (Easy / Moderate / Hard minutes)."""
+    date: date
+    easy_min: float
+    moderate_min: float
+    hard_min: float
+
+
 class TrendsSummary(BaseModel):
     total_distance_m: int
     total_moving_time_s: int
@@ -73,3 +89,5 @@ class TrendsResponse(BaseModel):
     suffer_score: List[SufferScorePoint]
     daily_suffer_score: List[DailySufferScorePoint]
     efficiency_trend: List[EfficiencyPoint]
+    weekly_zone_load: List[ZoneLoadWeekPoint]
+    daily_zone_load: List[DailyZoneLoadPoint]

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -9,6 +9,7 @@ import ActivityTypeFilter from "@/components/trends/ActivityTypeFilter";
 import TrendBarChart from "@/components/trends/TrendBarChart";
 import SufferScoreChart from "@/components/trends/SufferScoreChart";
 import EfficiencyTrendChart from "@/components/trends/EfficiencyTrendChart";
+import ZoneLoadChart from "@/components/trends/ZoneLoadChart";
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8000";
@@ -191,6 +192,10 @@ export default function TrendsPage() {
               granularity={granularity}
             />
           )}
+          <ZoneLoadChart
+            data={isDaily ? data.daily_zone_load : data.weekly_zone_load}
+            granularity={granularity}
+          />
         </div>
       )}
     </div>

--- a/frontend/components/trends/EfficiencyTrendChart.tsx
+++ b/frontend/components/trends/EfficiencyTrendChart.tsx
@@ -57,11 +57,11 @@ export default function EfficiencyTrendChart({ data, granularity }: Props) {
     return filtered.map((p, idx) => ({
       ...p,
       label: formatDateLabel(p.date),
-      // Scatter points
-      value: p.efficiency_mps_per_bpm, // Generic value key
-      [p.type]: p.efficiency_mps_per_bpm, // Specific value key
+      // Convert m/s per bpm → meters per heartbeat (×60)
+      value: +(p.efficiency_mps_per_bpm * 60).toFixed(2),
+      [p.type]: +(p.efficiency_mps_per_bpm * 60).toFixed(2),
       // Trend line
-      trend: sma[idx],
+      trend: sma[idx] != null ? +(sma[idx]! * 60).toFixed(2) : null,
     }));
   }, [data, selectedTypes]);
 
@@ -88,7 +88,7 @@ export default function EfficiencyTrendChart({ data, granularity }: Props) {
         <div>
           <h3 className="text-sm font-semibold text-gray-700">{title}</h3>
           <p className="text-xs text-gray-500 mt-1">
-            Speed (m/s) per Heart beat. Higher is better.
+            Meters per heartbeat. Higher is better.
           </p>
         </div>
         <div>
@@ -119,13 +119,14 @@ export default function EfficiencyTrendChart({ data, granularity }: Props) {
                 tick={{ fontSize: 12 }}
                 tickLine={false}
                 axisLine={false}
-                width={40}
+                width={50}
                 domain={["auto", "auto"]}
-                tickFormatter={(val) => val.toFixed(3)}
+                tickFormatter={(val) => `${val.toFixed(1)} m`}
+                unit=""
               />
               <Tooltip
                 formatter={(value: any, name: any) => [
-                  typeof value === "number" ? value.toFixed(4) : value,
+                  typeof value === "number" ? `${value.toFixed(2)} m/beat` : value,
                   name === "trend" ? "Trend (5-act avg)" : name,
                 ]}
                 labelFormatter={(label) => label}

--- a/frontend/components/trends/ZoneLoadChart.tsx
+++ b/frontend/components/trends/ZoneLoadChart.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { ZoneLoadWeekPoint, DailyZoneLoadPoint } from "@/lib/types";
+import { formatDateLabel } from "@/lib/format";
+
+interface ZoneLoadChartProps {
+  data: ZoneLoadWeekPoint[] | DailyZoneLoadPoint[];
+  granularity: "daily" | "weekly";
+}
+
+const ZONE_COLORS = {
+  easy: "#34d399", // emerald-400
+  moderate: "#fbbf24", // amber-400
+  hard: "#f87171", // red-400
+};
+
+interface PayloadItem {
+  name: string;
+  value: number;
+  color: string;
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: PayloadItem[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+
+  const total = payload.reduce((s, p) => s + p.value, 0);
+  if (total === 0) return null;
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-3 text-sm">
+      <p className="font-semibold text-gray-700 mb-1">{label}</p>
+      {payload.map((p) => (
+        <div key={p.name} className="flex justify-between gap-6">
+          <span style={{ color: p.color }}>{p.name}</span>
+          <span className="font-mono">{Math.round(p.value)} min</span>
+        </div>
+      ))}
+      <div className="border-t mt-1 pt-1 flex justify-between gap-6 font-semibold text-gray-800">
+        <span>Total</span>
+        <span className="font-mono">{Math.round(total)} min</span>
+      </div>
+    </div>
+  );
+}
+
+export default function ZoneLoadChart({ data, granularity }: ZoneLoadChartProps) {
+  const title =
+    granularity === "daily"
+      ? "Training Load by Zone per Day"
+      : "Training Load by Zone per Week";
+
+  // Check if all entries have zero zone data
+  const hasAnyData = data.some(
+    (d) => d.easy_min > 0 || d.moderate_min > 0 || d.hard_min > 0
+  );
+
+  if (!data.length || !hasAnyData) {
+    return (
+      <div className="bg-white rounded-lg border shadow-sm p-5">
+        <h3 className="text-sm font-semibold text-gray-700 mb-4">{title}</h3>
+        <p className="text-gray-400 text-sm py-8 text-center">
+          No HR zone data available yet. Sync activities with heart rate data.
+        </p>
+      </div>
+    );
+  }
+
+  const chartData = data.map((d) => ({
+    ...d,
+    label: formatDateLabel(
+      "week_start" in d ? d.week_start : d.date
+    ),
+  }));
+
+  const tooltipPrefix = granularity === "daily" ? "" : "Week of ";
+
+  return (
+    <div className="bg-white rounded-lg border shadow-sm p-5">
+      <div className="mb-4">
+        <h3 className="text-sm font-semibold text-gray-700">{title}</h3>
+        <p className="text-xs text-gray-400 mt-0.5">
+          Easy (&lt;70% HR) · Moderate (70-80%) · Hard (&gt;80%)
+        </p>
+      </div>
+      <ResponsiveContainer width="100%" height={260}>
+        <BarChart data={chartData} barCategoryGap="20%">
+          <CartesianGrid strokeDasharray="3 3" vertical={false} />
+          <XAxis
+            dataKey="label"
+            tick={{ fontSize: 12 }}
+            tickLine={false}
+            axisLine={false}
+          />
+          <YAxis
+            tick={{ fontSize: 12 }}
+            tickLine={false}
+            axisLine={false}
+            unit=" min"
+            width={60}
+          />
+          <Tooltip
+            content={<CustomTooltip />}
+            cursor={{ fill: "rgba(0,0,0,0.05)" }}
+          />
+          <Legend wrapperStyle={{ fontSize: 13, paddingTop: 4 }} />
+          <Bar
+            dataKey="easy_min"
+            name="Easy"
+            stackId="zone"
+            fill={ZONE_COLORS.easy}
+            radius={[0, 0, 0, 0]}
+            maxBarSize={40}
+          />
+          <Bar
+            dataKey="moderate_min"
+            name="Moderate"
+            stackId="zone"
+            fill={ZONE_COLORS.moderate}
+            radius={[0, 0, 0, 0]}
+            maxBarSize={40}
+          />
+          <Bar
+            dataKey="hard_min"
+            name="Hard"
+            stackId="zone"
+            fill={ZONE_COLORS.hard}
+            radius={[4, 4, 0, 0]}
+            maxBarSize={40}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -16,6 +16,8 @@ export type {
   DailySufferScorePoint,
   WeeklySufferScorePoint,
   EfficiencyPoint,
+  ZoneLoadWeekPoint,
+  DailyZoneLoadPoint,
   TrendsSummary,
   TrendsData,
   TrendsRange,

--- a/frontend/lib/types/trends.ts
+++ b/frontend/lib/types/trends.ts
@@ -44,6 +44,20 @@ export interface EfficiencyPoint {
   type: string;
 }
 
+export interface ZoneLoadWeekPoint {
+  week_start: string;
+  easy_min: number;
+  moderate_min: number;
+  hard_min: number;
+}
+
+export interface DailyZoneLoadPoint {
+  date: string;
+  easy_min: number;
+  moderate_min: number;
+  hard_min: number;
+}
+
 export interface TrendsSummary {
   total_distance_m: number;
   total_moving_time_s: number;
@@ -63,6 +77,8 @@ export interface TrendsData {
   suffer_score: SufferScorePoint[];
   daily_suffer_score: DailySufferScorePoint[];
   efficiency_trend: EfficiencyPoint[];
+  weekly_zone_load: ZoneLoadWeekPoint[];
+  daily_zone_load: DailyZoneLoadPoint[];
 }
 
 export type TrendsRange = "7D" | "30D" | "3M" | "6M" | "1Y" | "ALL";


### PR DESCRIPTION
## Summary

Adds a **Training Load by Zone** stacked bar chart to the Trends page, showing Easy / Moderate / Hard minutes per day or week.

### Changes

**Backend**
- New schemas: `ZoneLoadWeekPoint`, `DailyZoneLoadPoint`
- New pipeline functions: `_collapse_to_3_zones`, `build_zone_load_weekly`, `build_zone_load_daily`
- `TrendsResponse` now includes `weekly_zone_load` and `daily_zone_load`
- `ActivityFact` now carries `time_in_zones`; `WeekBucket` tracks zone seconds

**Frontend**
- New `ZoneLoadChart` component (Recharts stacked bar)
- Updated TypeScript types (`ZoneLoadWeekPoint`, `DailyZoneLoadPoint`, `TrendsData`)
- Improved `EfficiencyTrendChart` units → meters per heartbeat (×60 conversion)