### PR TITLE
fix(processing): reconcile flag taxonomy and populate confidence_reasons

### DIFF
--- a/backend/app/services/processing/engine.py
+++ b/backend/app/services/processing/engine.py
@@ -17,39 +17,45 @@ async def process_deep(db: Session, activity_id: str) -> Optional[DerivedMetric]
     """
     activity = db.query(Activity).filter(Activity.id == activity_id).first()
     if not activity: return None
-    
+
     # Fetch streams
     account = db.query(StravaAccount).filter(StravaAccount.user_id == activity.user_id).first()
     if account:
         await fetch_and_store_streams(db, account, activity)
-    
+
     # Run normal processing (which now picks up streams)
     return process_activity(db, activity_id)
 
-def generate_flags_with_drift(metrics_data, check_in):
-    flags = []
-    # Drift Check
-    drift = metrics_data.get("hr_drift")
-    if drift and drift > 5.0:
-        flags.append("cardiac_drift_high")
-    
-    # Pace Var Check
-    pace_var = metrics_data.get("pace_variability")
-    if pace_var and pace_var > 15.0 and metrics_data.get("activity_class") == "Tempo":
-        flags.append("pace_unstable")
 
-    # Add back existing user feedback flags
-    if check_in:
-        if check_in.pain_score and check_in.pain_score >= 4:
-            flags.append("pain_reported")
-            
-    # Merge with base flags if needed or replace entirely
-    # For now, simplistic
-    return flags
+def compute_confidence(activity, streams_dict, check_in):
+    """
+    Determine confidence level and reasons based on available data.
+    Returns (level, reasons) tuple.
+    """
+    reasons = []
+
+    if not activity.avg_hr:
+        reasons.append("no_heart_rate_data")
+    if not streams_dict:
+        reasons.append("no_stream_data")
+    elif not streams_dict.get("latlng"):
+        reasons.append("no_gps_data")
+    if not check_in:
+        reasons.append("no_user_checkin")
+
+    if "no_heart_rate_data" in reasons and "no_stream_data" in reasons:
+        level = "low"
+    elif "no_heart_rate_data" in reasons or "no_stream_data" in reasons:
+        level = "medium"
+    else:
+        level = "high"
+
+    return level, reasons
+
 
 def process_activity(db: Session, activity_id: str) -> Optional[DerivedMetric]:
     """
-    Main entry point. 
+    Main entry point.
     Loads activity, history, computes all metrics, saves DerivedMetric.
     """
     # 1. Load Activity
@@ -58,49 +64,55 @@ def process_activity(db: Session, activity_id: str) -> Optional[DerivedMetric]:
     if not activity:
         return None
 
-    # 2. Load History (Last 30 days)
-    # Simple query for now
+    # 2. Load History (last 20 activities before this one)
     history = db.query(Activity).filter(
         Activity.user_id == activity.user_id,
         Activity.start_date < activity.start_date
     ).order_by(Activity.start_date.desc()).limit(20).all()
 
-    # *NEW* 2.5: Load Streams if available
+    # 2.5: Load Streams if available
     streams = db.query(ActivityStream).filter(ActivityStream.activity_id == activity.id).all()
     streams_dict = {s.stream_type: s.data for s in streams}
 
     # 3. Load CheckIn (if exists)
     check_in = db.query(CheckIn).filter(CheckIn.activity_id == activity.id).first()
 
-    # *NEW* Fetch Profile for Max HR
+    # 4. Fetch Profile for Max HR
     profile = db.query(UserProfile).filter(UserProfile.user_id == activity.user_id).first()
     max_hr = 190
     if profile and profile.max_hr and profile.max_hr > 100:
         max_hr = profile.max_hr
 
-    # 4. Compute
+    # 5. Compute metrics
     metrics_data = compute_derived_metrics_data(activity, streams_dict, max_hr=max_hr)
-    
-    # 5. Classify
+
+    # 6. Classify
     classification = classify_activity(activity, history)
     metrics_data["activity_class"] = classification
 
-    # 6. Flags
-    base_flags = generate_flags(activity, metrics_data, history, check_in)
-    drift_flags = generate_flags_with_drift(metrics_data, check_in)
-    
-    # Dedup
-    all_flags = list(set(base_flags + drift_flags))
-    metrics_data["flags"] = all_flags
-    
-    # 7. Confidence
-    # MVP logic: High if HR exists, Med otherwise
-    metrics_data["confidence"] = "high" if activity.avg_hr else "medium"
-    metrics_data["confidence_reasons"] = [] 
+    # 7. Load history metrics for load spike detection
+    history_metrics = (
+        db.query(DerivedMetric)
+        .filter(DerivedMetric.activity_id.in_([h.id for h in history]))
+        .all()
+        if history else []
+    )
 
-    # 8. Upsert DerivedMetric
+    # 8. Flags (all flag logic consolidated in flags.py)
+    all_flags = generate_flags(
+        activity, metrics_data, history, check_in,
+        history_metrics=history_metrics,
+    )
+    metrics_data["flags"] = all_flags
+
+    # 9. Confidence
+    confidence, confidence_reasons = compute_confidence(activity, streams_dict, check_in)
+    metrics_data["confidence"] = confidence
+    metrics_data["confidence_reasons"] = confidence_reasons
+
+    # 10. Upsert DerivedMetric
     existing_dm = db.query(DerivedMetric).filter(DerivedMetric.activity_id == activity.id).first()
-    
+
     if existing_dm:
         for k, v in metrics_data.items():
             setattr(existing_dm, k, v)
@@ -108,7 +120,7 @@ def process_activity(db: Session, activity_id: str) -> Optional[DerivedMetric]:
     else:
         dm = DerivedMetric(activity_id=activity.id, **metrics_data)
         db.add(dm)
-    
+
     db.commit()
     db.refresh(dm)
     return dm

--- a/backend/app/services/processing/flags.py
+++ b/backend/app/services/processing/flags.py
@@ -1,35 +1,66 @@
 from typing import List, Dict, Any, Optional
-from app.models import Activity, CheckIn
+from app.models import Activity, CheckIn, DerivedMetric
+
 
 def generate_flags(
-    activity: Activity, 
-    metric_data: Dict[str, Any], 
-    history: List[Activity], 
-    check_in: Optional[CheckIn] = None
+    activity: Activity,
+    metric_data: Dict[str, Any],
+    history: List[Activity],
+    check_in: Optional[CheckIn] = None,
+    history_metrics: Optional[List[DerivedMetric]] = None,
 ) -> List[str]:
     """
-    Generates warning/info flags based on data quality, intensity, and user feedback.
+    Generates warning/info flags based on data quality, intensity,
+    fatigue signals, load spikes, and user feedback.
+
+    All flag names align with SPEC.md taxonomy.
     """
     flags = []
 
     # --- Data Quality ---
     if not activity.avg_hr:
-        flags.append("missing_heart_rate")
-    
-    # --- Intensity Check ---
-    # "intensity_too_high_for_easy"
-    # Logic: if labeled "Easy Run" but HR > 80% max (if max exists)
+        flags.append("data_low_confidence_hr")
+
+    # --- Intensity Mismatch ---
     is_easy = metric_data.get("activity_class") == "Easy Run"
     if is_easy and activity.avg_hr and activity.max_hr:
-         if (activity.avg_hr / activity.max_hr) > 0.8:
-             flags.append("intensity_too_high_for_easy")
+        if (activity.avg_hr / activity.max_hr) > 0.8:
+            flags.append("intensity_mismatch")
+
+    # --- Fatigue Possible (was cardiac_drift_high) ---
+    drift = metric_data.get("hr_drift")
+    if drift is not None and drift > 5.0:
+        flags.append("fatigue_possible")
+
+    # --- Pace Unstable ---
+    pace_var = metric_data.get("pace_variability")
+    if (
+        pace_var is not None
+        and pace_var > 15.0
+        and metric_data.get("activity_class") == "Tempo"
+    ):
+        flags.append("pace_unstable")
 
     # --- Load Spike ---
-    # Simple check: Is this run's effort > 2x average of last 7 runs?
-    if history:
-        # In a real impl, we'd query previously computed DerivedMetrics for history.
-        # For MVP, we'll skip complex load calculation triggers here.
-        pass
+    if history_metrics:
+        recent_efforts = [
+            m.effort_score
+            for m in history_metrics[:7]
+            if m.effort_score is not None
+        ]
+        if recent_efforts:
+            mean_effort = sum(recent_efforts) / len(recent_efforts)
+            current_effort = metric_data.get("effort_score")
+            if current_effort and mean_effort > 0 and current_effort > 1.8 * mean_effort:
+                flags.append("load_spike")
+
+    # --- Illness or Extreme Fatigue ---
+    if check_in:
+        rpe = check_in.rpe or 0
+        sleep = check_in.sleep_quality or 10  # default high to avoid false positives
+        pain = check_in.pain_score or 0
+        if rpe >= 8 and sleep <= 2 and pain >= 5:
+            flags.append("illness_or_extreme_fatigue")
 
     # --- User Feedback ---
     if check_in:
@@ -37,5 +68,5 @@ def generate_flags(
             flags.append("pain_reported")
         if check_in.pain_score and check_in.pain_score >= 7:
             flags.append("pain_severe")
-    
+
     return flags

--- a/backend/tests/test_analysis.py
+++ b/backend/tests/test_analysis.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 from app.models import Activity, CheckIn
-from app.services.analysis.classifier import classify_activity
-from app.services.analysis.metrics import calculate_effort_score
-from app.services.analysis.flags import generate_flags
+from app.services.processing.classifier import classify_activity
+from app.services.processing.metrics import calculate_effort_score
+from app.services.processing.flags import generate_flags
 
 def test_classifier_long_run():
     # Long run > 75 mins
@@ -27,13 +27,7 @@ def test_effort_score_calculation():
     assert score == 60.0 # 60 mins
 
     # With HR
-    act_hr = Activity(moving_time_s=3600, avg_hr=150, max_hr=200) 
-    # Ratio = 0.75. Score = 60 * 0.75^3 * 10 = 60 * 0.4218 * 10 = ~253
-    # Wait, my math was: 60 * (0.75^3) * 10 = 60 * 0.421875 * 10 = 253.1
-    # Actually 150/200 = 0.75
-    # 0.75^3 = 0.421875
-    # 60 * 0.421875 = 25.3125
-    # * 10 = 253.1
+    act_hr = Activity(moving_time_s=3600, avg_hr=150, max_hr=200)
     score_hr = calculate_effort_score(act_hr)
     assert score_hr > 200
 
@@ -48,20 +42,49 @@ def test_flags_intensity_mismatch():
     # Easy run but HR is high (90% max)
     act = Activity(avg_hr=180, max_hr=200)
     flags = generate_flags(act, {"activity_class": "Easy Run"}, [], None)
-    assert "intensity_too_high_for_easy" in flags
+    assert "intensity_mismatch" in flags
+
+def test_flags_data_low_confidence_hr():
+    # No HR data
+    act = Activity(avg_hr=None)
+    flags = generate_flags(act, {"activity_class": "Easy Run"}, [], None)
+    assert "data_low_confidence_hr" in flags
+
+def test_flags_fatigue_possible():
+    act = Activity(avg_hr=150)
+    flags = generate_flags(act, {"activity_class": "Tempo", "hr_drift": 7.0}, [], None)
+    assert "fatigue_possible" in flags
+
+def test_flags_pace_unstable():
+    act = Activity(avg_hr=150)
+    flags = generate_flags(act, {"activity_class": "Tempo", "pace_variability": 18.0}, [], None)
+    assert "pace_unstable" in flags
+
+def test_flags_pain_severe():
+    act = Activity(avg_hr=140)
+    checkin = CheckIn(pain_score=8)
+    flags = generate_flags(act, {"activity_class": "Easy Run"}, [], checkin)
+    assert "pain_reported" in flags
+    assert "pain_severe" in flags
+
+def test_flags_illness_or_extreme_fatigue():
+    act = Activity(avg_hr=140)
+    checkin = CheckIn(rpe=9, sleep_quality=1, pain_score=6)
+    flags = generate_flags(act, {"activity_class": "Easy Run"}, [], checkin)
+    assert "illness_or_extreme_fatigue" in flags
 
 def test_classifier_hills():
     # 5km run with 150m gain = 30m/km -> Hills
     act = Activity(name="Lunch Run", distance_m=5000, elev_gain_m=150, moving_time_s=1800)
     classification = classify_activity(act, [])
     assert classification == "Hills"
-    
+
 def test_classifier_hills_with_hr():
     # 5km run with 80m gain = 16m/km (borderline) + High HR
     act = Activity(
-        name="Lunch Run", 
-        distance_m=5000, 
-        elev_gain_m=80, 
+        name="Lunch Run",
+        distance_m=5000,
+        elev_gain_m=80,
         moving_time_s=1800,
         avg_hr=165 # High effort
     )
@@ -71,9 +94,9 @@ def test_classifier_hills_with_hr():
 def test_classifier_intent_override():
     # Data looks like Easy Run, but User says 'Tempo'
     act = Activity(
-        name="Slow Jog", 
-        distance_m=5000, 
-        elev_gain_m=10, 
+        name="Slow Jog",
+        distance_m=5000,
+        elev_gain_m=10,
         moving_time_s=2500,
         user_intent="Tempo"
     )

--- a/backend/tests/test_stream_metrics.py
+++ b/backend/tests/test_stream_metrics.py
@@ -1,4 +1,4 @@
-from app.services.analysis.metrics import calculate_hr_drift, calculate_pace_variability
+from app.services.processing.metrics import calculate_hr_drift, calculate_pace_variability
 
 def test_hr_drift_calculation():
     # 10 data points, first half efficient, second half inefficient (HR spikes for same speed)
@@ -33,7 +33,7 @@ def test_pace_variability():
     assert cv_bad > 20.0
 
 def test_calculate_time_in_zones():
-    from app.services.analysis.metrics import calculate_time_in_zones
+    from app.services.processing.metrics import calculate_time_in_zones
     
     # Max HR = 200
     # Zones:


### PR DESCRIPTION
## Summary
- Reconcile flag names with SPEC.md taxonomy (`missing_heart_rate` → `data_low_confidence_hr`, `intensity_too_high_for_easy` → `intensity_mismatch`, `cardiac_drift_high` → `fatigue_possible`)
- Implement `load_spike` and `illness_or_extreme_fatigue` flags
- Consolidate all flag logic into `flags.py` (remove `generate_flags_with_drift` from engine)
- Add `compute_confidence()` with meaningful `confidence_reasons` list
- Fix stale test imports (`app.services.analysis` → `app.services.processing`)

## Test plan
- [x] All 14 analysis tests pass (including 5 new flag tests)
- [x] All 28 non-integration tests pass
- [ ] Note: `test_sync_integration` has a pre-existing SQLite UUID issue unrelated to these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)