### PR TITLE
[codex] Establish global test suite baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: test backend-test frontend-test
+
+test: backend-test frontend-test
+
+backend-test:
+	cd backend && python -m pytest -m "not integration"
+
+frontend-test:
+	cd frontend && npm run test

--- a/README.md
+++ b/README.md
@@ -63,6 +63,32 @@ npm run dev
 
 Open: http://localhost:3000
 
+## Automated validation
+
+The repository-level automated regression suite is:
+
+```bash
+make test
+```
+
+This currently runs:
+- backend stable automated tests via `python -m pytest -m "not integration"`
+- frontend automated regression checks via `npm run test`, which runs lint and production build validation
+
+### Install backend test dependencies
+If you want to run the backend suite in a fresh environment, install the test extras:
+
+```bash
+cd backend
+pip install -e ".[test]"
+```
+
+### Current boundary
+- `make test` is the main repo-wide regression routine.
+- The backend global baseline excludes tests marked `integration`, which currently rely on local services or deeper cross-layer behavior that is not yet dependable as a routine regression check.
+- Smoke checks are a separate test layer and are not yet standardized in this repository-level command.
+- Frontend unit and route-level automated coverage are also tracked separately from this baseline.
+
 ## Strava setup
 1. Create a Strava API application and copy Client ID + Client Secret.
 2. Set backend env vars in `backend/.env`: STRAVA_CLIENT_ID, STRAVA_CLIENT_SECRET, STRAVA_REDIRECT_URI.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,17 @@ dependencies = [
     "anthropic>=0.40.0"
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0"
+]
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: requires local services or deeper cross-layer setup that is outside the stable global test baseline"
+]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["app*"]

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,7 +1,10 @@
+import pytest
 from datetime import datetime
 from sqlalchemy import text
 from app.db.session import SessionLocal
 from app.models import User, Activity
+
+pytestmark = pytest.mark.integration
 
 def test_create_user_and_activity():
     db = SessionLocal()

--- a/backend/tests/test_sync_integration.py
+++ b/backend/tests/test_sync_integration.py
@@ -5,6 +5,7 @@ from app.api.activities import sync_activities
 from app.models import Activity, StravaAccount, User
 from app.schemas import SyncResponse
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_integration_sync_upserts_and_runs_analysis(db: Session):
     """

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -30,6 +30,7 @@ def test_webhook_verification_fail_token(client, test_webhook_token):
     )
     assert response.status_code == 403
 
+@pytest.mark.integration
 def test_webhook_receive_event(client, override_get_db):
     """
     Test receiving a new activity event.

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "next/core-web-vitals"
+  ]
+}

--- a/frontend/components/CheckInForm.tsx
+++ b/frontend/components/CheckInForm.tsx
@@ -54,11 +54,10 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
       setPain(existingCheckIn.pain_score);
       setEffort(existingCheckIn.rpe);
       setNotes(existingCheckIn.notes || '');
-      if (!isEditing) setIsEditing(false);
     }
     // Also sync intent if it changes externally or on load
     setIntent(currentType || assignedClass || typeOptions[0]);
-  }, [existingCheckIn, currentType, assignedClass]); 
+  }, [existingCheckIn, currentType, assignedClass, typeOptions]); 
   
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -141,7 +140,7 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
                   <div className="col-span-2 pt-1">
                        <dt className="text-xs font-bold uppercase tracking-wider text-green-800 opacity-60 mb-1">Notes</dt>
                        <dd className="italic bg-white/50 p-2 rounded border border-green-100/50 text-green-900 break-words">
-                        "{existingCheckIn.notes}"
+                        &ldquo;{existingCheckIn.notes}&rdquo;
                       </dd>
                   </div>
               )}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "npm run lint && npm run build"
   },
   "dependencies": {
     "date-fns": "^3.3.1",


### PR DESCRIPTION
## Summary

Establishes a repo-level global test suite baseline for the project.

This PR:
- adds `make test` as the root automated regression entry point
- defines the current backend baseline as the stable pytest subset excluding `integration` tests
- adds a frontend `test` script that runs lint and production build validation
- documents the boundary between the global suite, smoke checks, and broader future coverage
- adds explicit frontend ESLint config so lint runs non-interactively
- fixes the small existing lint issues in `CheckInForm`

## Why

Issue #29 asks for a shared, repeatable answer to "run the tests" at the repository level. The repo already had meaningful backend tests and frontend automated checks, but no single root command or clear boundary between the stable routine and deeper environment-coupled coverage.

## Impact

Developers can now run `make test` from the repo root as the main automated regression check.

The PR also makes the current limits explicit:
- smoke checks remain a separate layer
- backend tests that still depend on local services or deeper cross-layer setup are marked `integration` and excluded from the stable baseline
- frontend unit and route-level coverage remain follow-up work

## Validation

Passed:
- `make test`
- `cd frontend && npm run lint`

Notes:
- backend stable suite passed with 129 tests
- 3 backend tests were deselected as `integration`
- the backend passing suite still emits 3 async-mock warnings in existing Strava auth tests
