### PR TITLE
[codex] Add smoke coverage for app readiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-.PHONY: test backend-test frontend-test
+.PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test
+
+smoke: backend-smoke frontend-smoke
+
+backend-smoke:
+	cd backend && python -m pytest tests/test_smoke.py
+
+frontend-smoke:
+	cd frontend && npm run smoke
 
 test: backend-test frontend-test
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ Open: http://localhost:3000
 
 ## Automated validation
 
+The repository-level smoke suite is:
+
+```bash
+make smoke
+```
+
+This currently runs:
+- backend readiness coverage via a lightweight FastAPI health check smoke test
+- frontend route readiness coverage via a mocked API server plus a running Next.js app that verifies the core routes load successfully
+
 The repository-level automated regression suite is:
 
 ```bash
@@ -84,9 +94,10 @@ pip install -e ".[test]"
 ```
 
 ### Current boundary
+- `make smoke` is the fast readiness layer for basic startup and core route availability.
 - `make test` is the main repo-wide regression routine.
 - The backend global baseline excludes tests marked `integration`, which currently rely on local services or deeper cross-layer behavior that is not yet dependable as a routine regression check.
-- Smoke checks are a separate test layer and are not yet standardized in this repository-level command.
+- Smoke checks are now standardized as a separate repository-level command.
 - Frontend unit and route-level automated coverage are also tracked separately from this baseline.
 
 ## Strava setup

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -1,0 +1,8 @@
+def test_health_check_reports_app_and_database_ready(client):
+    response = client.get("/api/health")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "database": "ok",
+    }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "npm run lint && npm run build"
+    "test": "npm run lint && npm run build",
+    "smoke": "node scripts/smoke.mjs"
   },
   "dependencies": {
     "date-fns": "^3.3.1",

--- a/frontend/scripts/smoke.mjs
+++ b/frontend/scripts/smoke.mjs
@@ -1,0 +1,255 @@
+import http from "node:http";
+import { spawn } from "node:child_process";
+
+const MOCK_API_PORT = 3001;
+const FRONTEND_PORT = 3100;
+const MOCK_API_BASE_URL = `http://127.0.0.1:${MOCK_API_PORT}`;
+const FRONTEND_BASE_URL = `http://127.0.0.1:${FRONTEND_PORT}`;
+
+const mockActivity = {
+  id: "42",
+  name: "Morning Tempo",
+  type: "Run",
+  start_date: "2026-03-28T07:00:00Z",
+  distance_m: 10250,
+  moving_time_s: 2820,
+  elapsed_time_s: 2880,
+  elev_gain_m: 85,
+  avg_hr: 158,
+  avg_cadence: 176,
+  raw_summary: {
+    sport_type: "Run",
+    type: "Run",
+    elapsed_time: 2880,
+    max_heartrate: 172,
+    suffer_score: 48,
+    average_watts: 255,
+    weighted_average_watts: 268,
+    kilojoules: 719,
+    device_name: "Forerunner",
+  },
+  check_in: null,
+  user_intent: null,
+  metrics: null,
+  streams: [],
+  splits: [],
+};
+
+const mockProfile = {
+  goal_type: "general",
+  experience_level: "intermediate",
+  weekly_days_available: 4,
+  current_weekly_km: 40,
+  injury_notes: "",
+  upcoming_races: [],
+  max_hr: 190,
+};
+
+const mockTrends = {
+  summary: {
+    total_distance_m: 25000,
+    total_moving_time_s: 7200,
+    activity_count: 3,
+    total_suffer_score: 120,
+  },
+  previous_summary: {
+    total_distance_m: 22000,
+    total_moving_time_s: 6900,
+    activity_count: 3,
+    total_suffer_score: 105,
+  },
+  daily_distance: [],
+  weekly_distance: [],
+  daily_time: [],
+  weekly_time: [],
+  daily_suffer_score: [],
+  weekly_suffer_score: [],
+  efficiency_trend: [],
+  daily_zone_load: [],
+  weekly_zone_load: [],
+};
+
+const routesToCheck = [
+  { path: "/", expectedText: "Weekly Summary" },
+  { path: "/trends", expectedText: "Track your progress over time." },
+  { path: "/profile", expectedText: "Loading profile..." },
+  { path: "/activity/42", expectedText: "Morning Tempo" },
+];
+
+function createMockApiServer() {
+  return http.createServer((req, res) => {
+    if (!req.url) {
+      res.writeHead(400);
+      res.end("Missing request URL");
+      return;
+    }
+
+    const url = new URL(req.url, MOCK_API_BASE_URL);
+    const { pathname, searchParams } = url;
+
+    if (pathname === "/api/activities" && searchParams.get("limit") === "10") {
+      return sendJson(res, 200, [mockActivity]);
+    }
+
+    if (pathname === "/api/activities/42") {
+      return sendJson(res, 200, mockActivity);
+    }
+
+    if (pathname === "/api/profile") {
+      return sendJson(res, 200, mockProfile);
+    }
+
+    if (pathname === "/api/trends") {
+      return sendJson(res, 200, mockTrends);
+    }
+
+    if (pathname === "/api/trends/types") {
+      return sendJson(res, 200, ["Run"]);
+    }
+
+    if (pathname === "/api/auth/strava/login") {
+      res.writeHead(302, { Location: "https://www.strava.com/oauth/mock" });
+      res.end();
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ detail: `Unhandled smoke route: ${pathname}` }));
+  });
+}
+
+function sendJson(res, statusCode, body) {
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function spawnProcess(command, args, options = {}) {
+  return spawn(command, args, {
+    stdio: "inherit",
+    ...options,
+  });
+}
+
+async function runCommand(command, args, options = {}) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      ...options,
+    });
+
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} ${args.join(" ")} exited with code ${code}`));
+    });
+  });
+}
+
+async function waitForHttp(url, timeoutMs) {
+  const startedAt = Date.now();
+  let lastError;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`HTTP ${response.status} from ${url}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await sleep(500);
+  }
+
+  throw new Error(`Timed out waiting for ${url}: ${lastError}`);
+}
+
+async function fetchHtml(pathname) {
+  const response = await fetch(`${FRONTEND_BASE_URL}${pathname}`);
+  const html = await response.text();
+  if (!response.ok) {
+    throw new Error(`Expected 200 for ${pathname}, received ${response.status}`);
+  }
+  return html;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const mockApiServer = createMockApiServer();
+const runningChildren = [];
+
+function cleanup() {
+  for (const child of runningChildren) {
+    if (!child.killed) {
+      child.kill("SIGTERM");
+    }
+  }
+  mockApiServer.close();
+}
+
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(1);
+});
+
+process.on("SIGTERM", () => {
+  cleanup();
+  process.exit(1);
+});
+
+process.on("exit", cleanup);
+
+async function main() {
+  await new Promise((resolve, reject) => {
+    mockApiServer.once("error", reject);
+    mockApiServer.listen(MOCK_API_PORT, "127.0.0.1", resolve);
+  });
+
+  await runCommand("npm", ["run", "build"], {
+    env: {
+      ...process.env,
+      NEXT_PUBLIC_API_BASE_URL: MOCK_API_BASE_URL,
+    },
+  });
+
+  const nextServer = spawnProcess(
+    "npm",
+    ["run", "start", "--", "--hostname", "127.0.0.1", "--port", `${FRONTEND_PORT}`],
+    {
+      env: {
+        ...process.env,
+        NEXT_PUBLIC_API_BASE_URL: MOCK_API_BASE_URL,
+      },
+    },
+  );
+  runningChildren.push(nextServer);
+
+  await waitForHttp(FRONTEND_BASE_URL, 30000);
+
+  for (const route of routesToCheck) {
+    const html = await fetchHtml(route.path);
+    if (!html.includes(route.expectedText)) {
+      throw new Error(
+        `Route ${route.path} did not include expected text: ${route.expectedText}`,
+      );
+    }
+  }
+
+  console.log("Frontend smoke checks passed.");
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    cleanup();
+    await sleep(250);
+  });


### PR DESCRIPTION
## What changed
- added a dedicated `make smoke` repo-level readiness suite
- added a backend smoke test for `/api/health`
- added a frontend smoke harness that boots a mock API plus the built Next app and verifies the main routes load
- documented the smoke-vs-global testing boundary in the README

## Why
Issue #28 calls for a lightweight readiness layer that answers whether the app starts and whether the key product surfaces basically work without turning the smoke suite into deep integration coverage.

## Impact
- contributors now have a fast smoke command for core application readiness
- the existing `make test` regression baseline remains separate
- failures in the smoke layer should point to fundamental startup or route-loading problems

## Validation
- `make smoke`
- `make test`

## Notes
- the working tree still has an unrelated local `.gitignore` modification that is not included in this PR
- closes #28