### PR TITLE
Polish repo for portfolio presentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,14 @@ frontend/tsconfig.tsbuildinfo
 
 # Claude Code local settings
 .claude/
+
+# Codex
+.codex/
+
+# AI workflow and skills (tooling config, not product code)
+.github/copilot-instructions.md
+.github/skills/
+.ai-policy/
+.githooks/
+ai-workflow.md
+project-spec.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,0 @@
-# Instructions
-
-Read the following files before responding to any request in this repository:
-
-- `ai-workflow.md` — defines the required workflow for all implementation tasks. Follow it for every task.
-- `project-spec.md` — reflects the current implementation. Use it as the reference for architecture, patterns, and conventions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,0 @@
-# Instructions
-
-Read the following files before responding to any request in this repository:
-
-- `ai-workflow.md` — defines the required workflow for all implementation tasks. Follow it for every task.
-- `project-spec.md` — reflects the current implementation. Use it as the reference for architecture, patterns, and conventions.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 philippe-ths
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Local-first app that connects to Strava, ingests running activities, computes training signals, and displays actionable analysis.
 
+Most Strava-based tools surface raw stats but offer little actionable insight — they tell you what happened, not what to do next. This project is an experiment in using computed training signals and an LLM coaching layer to bridge that gap, producing short and opinionated post-run analysis from the data you already have.
+
 ## Stack
 - Backend: FastAPI + SQLAlchemy + Alembic + Postgres
 - Jobs: Redis + RQ

--- a/backend/app/jobs/strava_sync.py
+++ b/backend/app/jobs/strava_sync.py
@@ -1,8 +1,11 @@
 import asyncio
+import logging
 from sqlalchemy import select
 from app.db.session import SessionLocal
 from app.models import User, StravaAccount, Activity
 from app.services import activity_service
+
+logger = logging.getLogger(__name__)
 
 def sync_recent_activities_job(user_id: str):
     """
@@ -15,11 +18,11 @@ def sync_recent_activities_job(user_id: str):
         account = db.execute(stmt).scalars().first()
         
         if not account:
-            print(f"Job failed: No Strava account for user_id {user_id}")
+            logger.error("Job failed: No Strava account for user_id %s", user_id)
             return
 
         asyncio.run(activity_service.sync_recent_activities(db, account))
-        print(f"Sync complete for user {user_id}")
+        logger.info("Sync complete for user %s", user_id)
     finally:
         db.close()
 
@@ -33,12 +36,12 @@ def sync_activity_job(strava_athlete_id: int, strava_activity_id: int):
         account = db.execute(stmt).scalars().first()
         
         if not account:
-            print(f"Skipping sync: Unknown athlete {strava_athlete_id}")
+            logger.warning("Skipping sync: Unknown athlete %s", strava_athlete_id)
             return
 
         asyncio.run(
             activity_service.sync_activity_by_id(db, account, strava_activity_id)
         )
-        print(f"Synced activity {strava_activity_id}")
+        logger.info("Synced activity %s", strava_activity_id)
     finally:
         db.close()

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,11 +1,13 @@
+import logging
 import sys
 from rq import Worker, Queue
 from app.core.queue import redis_conn
 
 listen = ['default']
+logger = logging.getLogger(__name__)
 
 if __name__ == '__main__':
-    print("Worker initiating...")
+    logger.info("Worker initiating...")
     queues = [Queue(name, connection=redis_conn) for name in listen]
     worker = Worker(queues, connection=redis_conn)
     worker.work()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "AI-running-coach",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Closes #36

## Changes

- **LICENSE** — MIT licence added
- **README** — motivation statement added after the title
- **Logging** — replaced 5 bare `print()` calls with `logging.getLogger(__name__)` in `strava_sync.py` and `worker.py`
- **Cleanup** — removed root `package-lock.json` stub, `AGENTS.md`, and `CLAUDE.md`
- **.gitignore** — added entries for AI tooling paths (`.codex/`, `.github/skills/`, `ai-workflow.md`, etc.)
- **GitHub** — repo description set; triage comments posted on issues #27, #30, #31, #32, #33
- **Branches** — 23 stale merged branches deleted from remote

## Validation

- Backend smoke: 1/1 passed
- Frontend smoke: all route checks passed (after `npm install`)
- Backend test suite: 130 passed, 3 pre-existing infrastructure failures (unchanged from baseline)