### PR TITLE
refactor(coach): type the context pack with a Pydantic schema

### DIFF
--- a/backend/app/schemas/coach_context.py
+++ b/backend/app/schemas/coach_context.py
@@ -1,0 +1,125 @@
+"""
+Typed schema for the coach context pack — the data structure handed to the LLM
+and to the deterministic policy validator.
+
+The pack mirrors the dict shape that build_context_pack has historically returned.
+Field types are kept Optional anywhere the source row is nullable. Opaque JSONB
+blobs from the analysis pipeline (efficiency_analysis, time_in_zones, etc.) are
+typed as Optional[Dict[str, Any]] rather than fully expanded, because they are
+not consumed by code paths within the coach module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ActivityContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    date: str
+    name: Optional[str]
+    type: Optional[str]
+    distance_m: Optional[int]
+    moving_time_s: Optional[int]
+    avg_hr: Optional[float]
+    max_hr: Optional[float]
+    avg_cadence: Optional[float]
+    elev_gain_m: Optional[float]
+
+
+class MetricsContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    activity_class: Optional[str]
+    effort_score: Optional[float]
+    hr_drift: Optional[float]
+    pace_variability: Optional[float]
+    flags: List[str]
+    confidence: str
+    confidence_reasons: List[str]
+    time_in_zones: Optional[Dict[str, Any]]
+    zones_calibrated: bool
+    zones_basis: str
+    efficiency_analysis: Optional[Dict[str, Any]]
+    stops_analysis: Optional[Dict[str, Any]]
+    interval_structure: Optional[Dict[str, Any]]
+    workout_match: Optional[Dict[str, Any]]
+    interval_kpis: Optional[Dict[str, Any]]
+    risk_level: Optional[str]
+    risk_score: Optional[int]
+    risk_reasons: Optional[List[str]]
+    training_context: Optional[Dict[str, Any]]
+
+
+class CheckInContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rpe: Optional[int]
+    pain_score: Optional[int]
+    pain_location: Optional[str]
+    sleep_quality: Optional[int]
+    notes: Optional[str]
+
+
+class ProfileContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    goal_type: Optional[str]
+    experience_level: Optional[str]
+    weekly_days_available: Optional[int]
+    injury_notes: Optional[str]
+    max_hr: Optional[int]
+    max_hr_source: Optional[str]
+    current_weekly_km: Optional[int]
+
+
+class TrainingPeriodSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    activity_count: int
+    total_distance_m: int
+    total_moving_time_s: int
+    # round(sum(...), 1) returns int when the sum is integer-typed (empty fixture),
+    # float otherwise — Union preserves the type so the cache hash stays stable.
+    total_effort: Union[int, float]
+
+
+class RecentTrainingSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    last_7d: TrainingPeriodSummary
+    last_28d: TrainingPeriodSummary
+    previous_28d: TrainingPeriodSummary
+
+
+class SafetyRules(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    never_diagnose: bool
+    pain_severe_threshold: int
+    no_invented_facts: bool
+
+
+class CoachContextPack(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    activity: ActivityContext
+    metrics: MetricsContext
+    check_in: CheckInContext
+    profile: ProfileContext
+    recent_training_summary: RecentTrainingSummary
+    safety_rules: SafetyRules
+
+    def to_serializable_dict(self) -> Dict[str, Any]:
+        """Serialise to the JSON-primitive dict shape the LLM input and DB column expect."""
+        return self.model_dump(mode="python")
+
+    def fingerprint(self) -> str:
+        """Deterministic SHA-256 cache key. Byte-identical to the legacy hash_context_pack output."""
+        serialised = json.dumps(self.to_serializable_dict(), sort_keys=True, default=str)
+        return hashlib.sha256(serialised.encode()).hexdigest()

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -1,5 +1,5 @@
 """
-Context pack builder — assembles all facts the LLM needs into a single JSON dict.
+Context pack builder — assembles all facts the LLM needs into a typed pack.
 
 No computation happens here. This module only gathers and shapes existing data
 from the database (activity, metrics, check-in, profile, trends).
@@ -8,15 +8,25 @@ from the database (activity, metrics, check-in, profile, trends).
 import hashlib
 import json
 from datetime import timedelta
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from sqlalchemy.orm import Session
 
 from app.models import Activity, UserProfile
+from app.schemas.coach_context import (
+    ActivityContext,
+    CheckInContext,
+    CoachContextPack,
+    MetricsContext,
+    ProfileContext,
+    RecentTrainingSummary,
+    SafetyRules,
+    TrainingPeriodSummary,
+)
 from app.services.trends import _query_activity_facts
 
 
-def build_context_pack(db: Session, activity: Activity) -> dict:
+def build_context_pack(db: Session, activity: Activity) -> CoachContextPack:
     """Assemble all facts the LLM needs. No computation, just data gathering."""
     metrics = activity.metrics
     check_in = getattr(activity, "check_in", None)
@@ -52,87 +62,90 @@ def build_context_pack(db: Session, activity: Activity) -> dict:
         db, activity_date - timedelta(days=56), activity_date - timedelta(days=28)
     )
 
-    def _summarize(facts):
-        return {
-            "activity_count": len(facts),
-            "total_distance_m": sum(f.distance_m for f in facts),
-            "total_moving_time_s": sum(f.moving_time_s for f in facts),
-            "total_effort": round(sum(f.effort_score or 0 for f in facts), 1),
-        }
+    def _summarize(facts) -> TrainingPeriodSummary:
+        return TrainingPeriodSummary(
+            activity_count=len(facts),
+            total_distance_m=sum(f.distance_m for f in facts),
+            total_moving_time_s=sum(f.moving_time_s for f in facts),
+            total_effort=round(sum(f.effort_score or 0 for f in facts), 1),
+        )
 
     # Training context: intensity distribution and recency signals (persisted
     # by the analysis pipeline on DerivedMetric).
     training_context = metrics.training_context if metrics else None
 
-    pack = {
-        "activity": {
-            "date": activity.start_date.isoformat(),
-            "name": activity.name,
-            "type": activity.user_intent or activity.type,
-            "distance_m": activity.distance_m,
-            "moving_time_s": activity.moving_time_s,
-            "avg_hr": activity.avg_hr,
-            "max_hr": activity.max_hr,
-            "avg_cadence": activity.avg_cadence,
-            "elev_gain_m": activity.elev_gain_m,
-        },
-        "metrics": {
-            "activity_class": metrics.activity_class if metrics else None,
-            "effort_score": round(metrics.effort_score, 1) if metrics else None,
-            "hr_drift": round(metrics.hr_drift, 1) if metrics and metrics.hr_drift else None,
-            "pace_variability": (
+    return CoachContextPack(
+        activity=ActivityContext(
+            date=activity.start_date.isoformat(),
+            name=activity.name,
+            type=activity.user_intent or activity.type,
+            distance_m=activity.distance_m,
+            moving_time_s=activity.moving_time_s,
+            avg_hr=activity.avg_hr,
+            max_hr=activity.max_hr,
+            avg_cadence=activity.avg_cadence,
+            elev_gain_m=activity.elev_gain_m,
+        ),
+        metrics=MetricsContext(
+            activity_class=metrics.activity_class if metrics else None,
+            effort_score=round(metrics.effort_score, 1) if metrics else None,
+            hr_drift=round(metrics.hr_drift, 1) if metrics and metrics.hr_drift else None,
+            pace_variability=(
                 round(metrics.pace_variability, 1)
                 if metrics and metrics.pace_variability
                 else None
             ),
-            "flags": metrics.flags if metrics else [],
-            "confidence": metrics.confidence if metrics else "low",
-            "confidence_reasons": metrics.confidence_reasons if metrics else [],
-            "time_in_zones": metrics.time_in_zones if metrics else None,
-            "zones_calibrated": zones_calibrated,
-            "zones_basis": zones_basis,
-            "efficiency_analysis": metrics.efficiency_analysis if metrics else None,
-            "stops_analysis": metrics.stops_analysis if metrics else None,
-            "interval_structure": metrics.interval_structure if metrics else None,
-            "workout_match": metrics.workout_match if metrics else None,
-            "interval_kpis": metrics.interval_kpis if metrics else None,
-            "risk_level": metrics.risk_level if metrics else None,
-            "risk_score": metrics.risk_score if metrics else None,
-            "risk_reasons": metrics.risk_reasons if metrics else [],
-            "training_context": training_context,
-        },
-        "check_in": {
-            "rpe": check_in.rpe if check_in else None,
-            "pain_score": check_in.pain_score if check_in else None,
-            "pain_location": check_in.pain_location if check_in else None,
-            "sleep_quality": check_in.sleep_quality if check_in else None,
-            "notes": check_in.notes if check_in else None,
-        },
-        "profile": {
-            "goal_type": profile.goal_type if profile else None,
-            "experience_level": profile.experience_level if profile else None,
-            "weekly_days_available": profile.weekly_days_available if profile else None,
-            "injury_notes": profile.injury_notes if profile else None,
-            "max_hr": profile.max_hr if profile else None,
-            "max_hr_source": getattr(profile, "max_hr_source", None) if profile else None,
-            "current_weekly_km": profile.current_weekly_km if profile else None,
-        },
-        "recent_training_summary": {
-            "last_7d": _summarize(facts_7d),
-            "last_28d": _summarize(facts_28d),
-            "previous_28d": _summarize(facts_prev_28d),
-        },
-        "safety_rules": {
-            "never_diagnose": True,
-            "pain_severe_threshold": 7,
-            "no_invented_facts": True,
-        },
-    }
-    return pack
+            flags=metrics.flags if metrics else [],
+            confidence=metrics.confidence if metrics else "low",
+            confidence_reasons=metrics.confidence_reasons if metrics else [],
+            time_in_zones=metrics.time_in_zones if metrics else None,
+            zones_calibrated=zones_calibrated,
+            zones_basis=zones_basis,
+            efficiency_analysis=metrics.efficiency_analysis if metrics else None,
+            stops_analysis=metrics.stops_analysis if metrics else None,
+            interval_structure=metrics.interval_structure if metrics else None,
+            workout_match=metrics.workout_match if metrics else None,
+            interval_kpis=metrics.interval_kpis if metrics else None,
+            risk_level=metrics.risk_level if metrics else None,
+            risk_score=metrics.risk_score if metrics else None,
+            risk_reasons=metrics.risk_reasons if metrics else [],
+            training_context=training_context,
+        ),
+        check_in=CheckInContext(
+            rpe=check_in.rpe if check_in else None,
+            pain_score=check_in.pain_score if check_in else None,
+            pain_location=check_in.pain_location if check_in else None,
+            sleep_quality=check_in.sleep_quality if check_in else None,
+            notes=check_in.notes if check_in else None,
+        ),
+        profile=ProfileContext(
+            goal_type=profile.goal_type if profile else None,
+            experience_level=profile.experience_level if profile else None,
+            weekly_days_available=profile.weekly_days_available if profile else None,
+            injury_notes=profile.injury_notes if profile else None,
+            max_hr=profile.max_hr if profile else None,
+            max_hr_source=getattr(profile, "max_hr_source", None) if profile else None,
+            current_weekly_km=profile.current_weekly_km if profile else None,
+        ),
+        recent_training_summary=RecentTrainingSummary(
+            last_7d=_summarize(facts_7d),
+            last_28d=_summarize(facts_28d),
+            previous_28d=_summarize(facts_prev_28d),
+        ),
+        safety_rules=SafetyRules(
+            never_diagnose=True,
+            pain_severe_threshold=7,
+            no_invented_facts=True,
+        ),
+    )
 
 
-def hash_context_pack(pack: dict) -> str:
-    """Deterministic SHA-256 hash of the context pack for reproducibility."""
+def hash_context_pack(pack: Dict[str, Any]) -> str:
+    """Deterministic SHA-256 hash of a legacy dict-shaped pack.
+
+    Retained for migration safety (tests pin the typed model's fingerprint against this);
+    new code should call CoachContextPack.fingerprint() instead.
+    """
     return hashlib.sha256(
         json.dumps(pack, sort_keys=True, default=str).encode()
     ).hexdigest()

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -17,7 +17,8 @@ from app.core.config import settings
 from app.models import Activity
 from app.models.coach_report import CoachReport
 from app.schemas.coach import CoachReportContent, CoachReportDebug, CoachReportMeta, CoachReportRead
-from app.services.coach.context import build_context_pack, hash_context_pack
+from app.schemas.coach_context import CoachContextPack
+from app.services.coach.context import build_context_pack
 from app.services.coach.llm import AnthropicClient
 from app.services.coach.prompts import PROMPT_VERSIONS, build_system_prompt
 from app.services.coach.validator import PolicyViolation, validate_policy
@@ -47,13 +48,14 @@ async def get_or_generate_coach_report(
 
     # Build context pack
     pack = build_context_pack(db, activity)
-    input_hash = hash_context_pack(pack)
+    input_hash = pack.fingerprint()
+    pack_dict = pack.to_serializable_dict()
 
     # Build prompt with activity-type playbook
     prompt_id = settings.COACH_PROMPT_ID
-    activity_class = pack["metrics"].get("activity_class")
+    activity_class = pack.metrics.activity_class
     system_prompt = build_system_prompt(prompt_id, activity_class)
-    user_message = json.dumps(pack, default=str)
+    user_message = json.dumps(pack_dict, default=str)
 
     client = AnthropicClient(
         api_key=settings.ANTHROPIC_API_KEY,
@@ -82,7 +84,7 @@ async def get_or_generate_coach_report(
                 [v.rule for v in violations],
             )
             content, retry_violations = await _retry_with_fixes(
-                client, system_prompt, user_message, violations
+                client, system_prompt, user_message, pack, violations
             )
             if retry_violations:
                 logger.warning(
@@ -108,7 +110,7 @@ async def get_or_generate_coach_report(
         )
 
     meta = CoachReportMeta(
-        confidence=pack["metrics"]["confidence"],
+        confidence=pack.metrics.confidence,
         model_id=settings.COACH_MODEL_ID,
         prompt_id=prompt_id,
         schema_version=SCHEMA_VERSION,
@@ -122,7 +124,7 @@ async def get_or_generate_coach_report(
         activity_id=activity_id,
         report=content.model_dump(),
         meta=meta.model_dump(mode="json"),
-        context_pack=pack,
+        context_pack=pack_dict,
         raw_llm_response=raw_response,
     )
     db.add(db_report)
@@ -136,6 +138,7 @@ async def _retry_with_fixes(
     client: AnthropicClient,
     system_prompt: str,
     original_user_message: str,
+    pack: CoachContextPack,
     violations: List[PolicyViolation],
 ) -> tuple[CoachReportContent, List[PolicyViolation]]:
     """
@@ -162,15 +165,11 @@ async def _retry_with_fixes(
         content = CoachReportContent.model_validate(parsed)
 
         # Re-validate — but don't loop again
-        remaining = validate_policy(content, json.loads(original_user_message))
+        remaining = validate_policy(content, pack)
         return content, remaining
 
     except (json.JSONDecodeError, ValidationError) as e:
         logger.error("Coach report retry parse error: %s", e)
-        # Return the original violations — caller will use first attempt's content
-        # Re-parse original to return something valid
-        original_parsed = json.loads(_strip_code_fences(original_user_message))
-        # This shouldn't happen in practice — fall through
         raise
 
 

--- a/backend/app/services/coach/validator.py
+++ b/backend/app/services/coach/validator.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import List
 
 from app.schemas.coach import CoachReportContent
+from app.schemas.coach_context import CoachContextPack
 
 
 @dataclass
@@ -30,7 +31,7 @@ _INTERVAL_CLAIM_PATTERNS = [
 
 def validate_policy(
     content: CoachReportContent,
-    context_pack: dict,
+    context_pack: CoachContextPack,
 ) -> List[PolicyViolation]:
     """
     Run deterministic policy checks on LLM output.
@@ -39,8 +40,10 @@ def validate_policy(
     violations = []
 
     # Rule 1: If all check_in fields are null and questions is empty → must ask questions
-    check_in = context_pack.get("check_in", {})
-    all_null = all(v is None for v in check_in.values())
+    check_in = context_pack.check_in
+    all_null = all(
+        getattr(check_in, field) is None for field in type(check_in).model_fields
+    )
     if all_null and len(content.questions) == 0:
         violations.append(PolicyViolation(
             rule="missing_questions_for_null_checkin",
@@ -53,8 +56,7 @@ def validate_policy(
         ))
 
     # Rule 2: If zones_calibrated=false and output mentions Z1/Z2/Z3/Z4/Z5
-    zones_calibrated = context_pack.get("metrics", {}).get("zones_calibrated", False)
-    if not zones_calibrated:
+    if not context_pack.metrics.zones_calibrated:
         full_text = _extract_all_text(content)
         zone_pattern = re.compile(r"\bZ[1-5]\b")
         if zone_pattern.search(full_text):
@@ -70,7 +72,7 @@ def validate_policy(
             ))
 
     # Rule 3: If risk references a flag not in the flags array
-    valid_flags = set(context_pack.get("metrics", {}).get("flags", []))
+    valid_flags = set(context_pack.metrics.flags)
     for risk in content.risks:
         if risk.flag not in valid_flags:
             violations.append(PolicyViolation(
@@ -83,7 +85,7 @@ def validate_policy(
             ))
 
     # Rule 4: If detection_confidence < high and LLM claims specific interval execution
-    workout_match = context_pack.get("metrics", {}).get("workout_match", {})
+    workout_match = context_pack.metrics.workout_match
     if workout_match:
         det_conf = workout_match.get("detection_confidence", "low")
         match_score = workout_match.get("match_score")

--- a/backend/tests/test_coach_context.py
+++ b/backend/tests/test_coach_context.py
@@ -1,86 +1,15 @@
-"""Tests for the coach context pack builder."""
+"""Tests for the coach context pack builder.
 
-import json
+Hash determinism, shape, and the typed-pack round-trip invariants are covered
+in test_coach_context_pack.py. This file covers the build-time behaviour:
+zone calibration, training-context pass-through, and profile field exposure.
+"""
+
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from app.models import Activity, DerivedMetric, UserProfile
-from app.services.coach.context import build_context_pack, hash_context_pack
-
-
-# ---------------------------------------------------------------------------
-# Hash tests (no DB needed)
-# ---------------------------------------------------------------------------
-
-def test_hash_deterministic():
-    pack = {"activity": {"date": "2024-01-01", "type": "Run"}, "metrics": {"effort_score": 100}}
-    h1 = hash_context_pack(pack)
-    h2 = hash_context_pack(pack)
-    assert h1 == h2
-    assert len(h1) == 64  # SHA-256 hex
-
-
-def test_hash_changes_on_input_change():
-    pack1 = {"activity": {"date": "2024-01-01"}, "metrics": {"effort_score": 100}}
-    pack2 = {"activity": {"date": "2024-01-01"}, "metrics": {"effort_score": 101}}
-    assert hash_context_pack(pack1) != hash_context_pack(pack2)
-
-
-# ---------------------------------------------------------------------------
-# Context pack shape (no DB needed)
-# ---------------------------------------------------------------------------
-
-def test_context_pack_shape():
-    """Verify expected top-level keys match the v2 contract."""
-    expected_keys = {
-        "activity",
-        "metrics",
-        "check_in",
-        "profile",
-        "recent_training_summary",
-        "safety_rules",
-    }
-    # Simulate a minimal pack with all v2 keys
-    pack = {
-        "activity": {
-            "date": None, "name": "Morning Run", "type": "Run",
-            "distance_m": 0, "moving_time_s": 0,
-            "avg_hr": None, "max_hr": None, "avg_cadence": None,
-            "elev_gain_m": 0,
-        },
-        "metrics": {
-            "activity_class": None, "effort_score": None,
-            "hr_drift": None, "pace_variability": None,
-            "flags": [], "confidence": "low", "confidence_reasons": [],
-            "time_in_zones": None,
-            "zones_calibrated": False, "zones_basis": "default_190",
-            "efficiency_analysis": None, "stops_analysis": None,
-            "training_context": {
-                "intensity_distribution_7d": {"easy": 0, "moderate": 0, "hard": 0},
-                "days_since_last_hard": None,
-                "hard_sessions_this_week": 0,
-            },
-        },
-        "check_in": {
-            "rpe": None, "pain_score": None, "pain_location": None,
-            "sleep_quality": None, "notes": None,
-        },
-        "profile": {
-            "goal_type": None, "experience_level": None,
-            "weekly_days_available": None, "injury_notes": None,
-            "max_hr": None, "current_weekly_km": None,
-        },
-        "recent_training_summary": {"last_7d": {}, "last_28d": {}, "previous_28d": {}},
-        "safety_rules": {"never_diagnose": True, "pain_severe_threshold": 7, "no_invented_facts": True},
-    }
-    assert set(pack.keys()) == expected_keys
-    # Verify it's JSON-serializable
-    json.dumps(pack, default=str)
-
-
-# ---------------------------------------------------------------------------
-# Integration tests (require DB fixture)
-# ---------------------------------------------------------------------------
+from app.services.coach.context import build_context_pack
 
 def _create_activity(db, user_id, name="Morning Run", start_date=None, **overrides):
     """Helper to create a minimal Activity row."""
@@ -159,9 +88,9 @@ def test_zones_calibrated_true_when_profile_has_max_hr(db):
 
     pack = build_context_pack(db, activity)
 
-    assert pack["metrics"]["zones_calibrated"] is True
-    assert pack["metrics"]["zones_basis"] == "user_user_entered"
-    assert pack["profile"]["max_hr"] == 185
+    assert pack.metrics.zones_calibrated is True
+    assert pack.metrics.zones_basis == "user_user_entered"
+    assert pack.profile.max_hr == 185
 
 
 def test_zones_calibrated_false_when_no_profile(db):
@@ -176,9 +105,9 @@ def test_zones_calibrated_false_when_no_profile(db):
 
     pack = build_context_pack(db, activity)
 
-    assert pack["metrics"]["zones_calibrated"] is False
-    assert pack["metrics"]["zones_basis"] == "uncalibrated"
-    assert pack["profile"]["max_hr"] is None
+    assert pack.metrics.zones_calibrated is False
+    assert pack.metrics.zones_basis == "uncalibrated"
+    assert pack.profile.max_hr is None
 
 
 def test_zones_calibrated_false_when_default_hr(db):
@@ -194,8 +123,8 @@ def test_zones_calibrated_false_when_default_hr(db):
 
     pack = build_context_pack(db, activity)
 
-    assert pack["metrics"]["zones_calibrated"] is False
-    assert pack["metrics"]["zones_basis"] == "uncalibrated"
+    assert pack.metrics.zones_calibrated is False
+    assert pack.metrics.zones_basis == "uncalibrated"
 
 
 def test_zones_calibrated_false_when_no_source(db):
@@ -211,8 +140,8 @@ def test_zones_calibrated_false_when_no_source(db):
 
     pack = build_context_pack(db, activity)
 
-    assert pack["metrics"]["zones_calibrated"] is False
-    assert pack["metrics"]["zones_basis"] == "uncalibrated"
+    assert pack.metrics.zones_calibrated is False
+    assert pack.metrics.zones_basis == "uncalibrated"
 
 
 def test_context_pack_includes_enriched_activity_fields(db):
@@ -227,9 +156,9 @@ def test_context_pack_includes_enriched_activity_fields(db):
 
     pack = build_context_pack(db, activity)
 
-    assert pack["activity"]["name"] == "Tempo Thursday"
-    assert pack["activity"]["avg_cadence"] == 178.0
-    assert pack["activity"]["max_hr"] == 182.0
+    assert pack.activity.name == "Tempo Thursday"
+    assert pack.activity.avg_cadence == 178.0
+    assert pack.activity.max_hr == 182.0
 
 
 def test_context_pack_passes_training_context_through(db):
@@ -249,7 +178,7 @@ def test_context_pack_passes_training_context_through(db):
 
     pack = build_context_pack(db, activity)
 
-    assert pack["metrics"]["training_context"] == persisted
+    assert pack.metrics.training_context == persisted
 
 
 def test_context_pack_training_context_none_when_unset(db):
@@ -264,7 +193,7 @@ def test_context_pack_training_context_none_when_unset(db):
 
     pack = build_context_pack(db, activity)
 
-    assert pack["metrics"]["training_context"] is None
+    assert pack.metrics.training_context is None
 
 
 def test_context_pack_profile_includes_new_fields(db):
@@ -280,6 +209,6 @@ def test_context_pack_profile_includes_new_fields(db):
 
     pack = build_context_pack(db, activity)
 
-    assert pack["profile"]["max_hr"] == 190
-    assert pack["profile"]["max_hr_source"] == "user_entered"
-    assert pack["profile"]["current_weekly_km"] == 35
+    assert pack.profile.max_hr == 190
+    assert pack.profile.max_hr_source == "user_entered"
+    assert pack.profile.current_weekly_km == 35

--- a/backend/tests/test_coach_context_pack.py
+++ b/backend/tests/test_coach_context_pack.py
@@ -1,0 +1,263 @@
+"""Characterisation tests for the typed CoachContextPack schema.
+
+These tests pin the migration's load-bearing invariant: a typed pack must produce
+the byte-identical cache hash the legacy dict-based pack produced, and round-trip
+through model_validate / model_dump without losing or reordering fields.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+from app.models import Activity, DerivedMetric, UserProfile
+from app.models.user import User
+from app.schemas.coach_context import CoachContextPack
+from app.services.coach.context import build_context_pack, hash_context_pack
+
+
+def _legacy_full_pack() -> dict:
+    """A pack dict in the same shape build_context_pack produces, with every field populated."""
+    return {
+        "activity": {
+            "date": "2026-02-15T10:00:00+00:00",
+            "name": "Tempo Thursday",
+            "type": "Run",
+            "distance_m": 10000,
+            "moving_time_s": 3600,
+            "avg_hr": 150.0,
+            "max_hr": 175.0,
+            "avg_cadence": 170.0,
+            "elev_gain_m": 50.0,
+        },
+        "metrics": {
+            "activity_class": "Easy Run",
+            "effort_score": 3.0,
+            "hr_drift": 4.2,
+            "pace_variability": 6.5,
+            "flags": ["high_drift"],
+            "confidence": "high",
+            "confidence_reasons": ["full_stream_coverage"],
+            "time_in_zones": {"Z1": 600, "Z2": 1200, "Z3": 600, "Z4": 300, "Z5": 60},
+            "zones_calibrated": True,
+            "zones_basis": "user_user_entered",
+            "efficiency_analysis": {"power_per_hr": 1.42},
+            "stops_analysis": {"count": 0},
+            "interval_structure": None,
+            "workout_match": {"detection_confidence": "low", "match_score": 0.4},
+            "interval_kpis": None,
+            "risk_level": "low",
+            "risk_score": 2,
+            "risk_reasons": [],
+            "training_context": {
+                "intensity_distribution_7d": {"easy": 3, "moderate": 1, "hard": 0},
+                "days_since_last_hard": 4,
+                "hard_sessions_this_week": 0,
+            },
+        },
+        "check_in": {
+            "rpe": 6,
+            "pain_score": 0,
+            "pain_location": None,
+            "sleep_quality": 7,
+            "notes": "Felt strong.",
+        },
+        "profile": {
+            "goal_type": "half",
+            "experience_level": "intermediate",
+            "weekly_days_available": 4,
+            "injury_notes": None,
+            "max_hr": 185,
+            "max_hr_source": "user_entered",
+            "current_weekly_km": 35,
+        },
+        "recent_training_summary": {
+            "last_7d": {
+                "activity_count": 3,
+                "total_distance_m": 28000,
+                "total_moving_time_s": 9800,
+                "total_effort": 12.4,
+            },
+            "last_28d": {
+                "activity_count": 12,
+                "total_distance_m": 110000,
+                "total_moving_time_s": 38000,
+                "total_effort": 48.1,
+            },
+            "previous_28d": {
+                "activity_count": 10,
+                "total_distance_m": 95000,
+                "total_moving_time_s": 33000,
+                "total_effort": 41.0,
+            },
+        },
+        "safety_rules": {
+            "never_diagnose": True,
+            "pain_severe_threshold": 7,
+            "no_invented_facts": True,
+        },
+    }
+
+
+def _legacy_sparse_pack() -> dict:
+    """A pack with every Optional field set to None and every defaultable collection empty."""
+    return {
+        "activity": {
+            "date": "2026-02-15T10:00:00+00:00",
+            "name": None,
+            "type": None,
+            "distance_m": 0,
+            "moving_time_s": 0,
+            "avg_hr": None,
+            "max_hr": None,
+            "avg_cadence": None,
+            "elev_gain_m": 0.0,
+        },
+        "metrics": {
+            "activity_class": None,
+            "effort_score": None,
+            "hr_drift": None,
+            "pace_variability": None,
+            "flags": [],
+            "confidence": "low",
+            "confidence_reasons": [],
+            "time_in_zones": None,
+            "zones_calibrated": False,
+            "zones_basis": "uncalibrated",
+            "efficiency_analysis": None,
+            "stops_analysis": None,
+            "interval_structure": None,
+            "workout_match": None,
+            "interval_kpis": None,
+            "risk_level": None,
+            "risk_score": None,
+            "risk_reasons": [],
+            "training_context": None,
+        },
+        "check_in": {
+            "rpe": None,
+            "pain_score": None,
+            "pain_location": None,
+            "sleep_quality": None,
+            "notes": None,
+        },
+        "profile": {
+            "goal_type": None,
+            "experience_level": None,
+            "weekly_days_available": None,
+            "injury_notes": None,
+            "max_hr": None,
+            "max_hr_source": None,
+            "current_weekly_km": None,
+        },
+        "recent_training_summary": {
+            "last_7d": {
+                "activity_count": 0,
+                "total_distance_m": 0,
+                "total_moving_time_s": 0,
+                "total_effort": 0.0,
+            },
+            "last_28d": {
+                "activity_count": 0,
+                "total_distance_m": 0,
+                "total_moving_time_s": 0,
+                "total_effort": 0.0,
+            },
+            "previous_28d": {
+                "activity_count": 0,
+                "total_distance_m": 0,
+                "total_moving_time_s": 0,
+                "total_effort": 0.0,
+            },
+        },
+        "safety_rules": {
+            "never_diagnose": True,
+            "pain_severe_threshold": 7,
+            "no_invented_facts": True,
+        },
+    }
+
+
+def test_roundtrip_preserves_full_dict_shape():
+    pack_dict = _legacy_full_pack()
+    pack = CoachContextPack.model_validate(pack_dict)
+    assert pack.to_serializable_dict() == pack_dict
+
+
+def test_roundtrip_preserves_sparse_dict_shape():
+    pack_dict = _legacy_sparse_pack()
+    pack = CoachContextPack.model_validate(pack_dict)
+    assert pack.to_serializable_dict() == pack_dict
+
+
+def test_fingerprint_matches_legacy_hash_full():
+    pack_dict = _legacy_full_pack()
+    expected = hash_context_pack(pack_dict)
+    pack = CoachContextPack.model_validate(pack_dict)
+    assert pack.fingerprint() == expected
+
+
+def test_fingerprint_matches_legacy_hash_sparse():
+    pack_dict = _legacy_sparse_pack()
+    expected = hash_context_pack(pack_dict)
+    pack = CoachContextPack.model_validate(pack_dict)
+    assert pack.fingerprint() == expected
+
+
+def test_real_fixture_pack_roundtrips_through_typed_schema(db):
+    """Build a pack from a real fixture activity and confirm the typed schema preserves it."""
+    user_id = uuid.uuid4()
+    db.add(User(id=user_id, email=f"test_{user_id}@example.com"))
+    db.flush()
+
+    activity = Activity(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        strava_activity_id=12345,
+        name="Tempo Thursday",
+        type="Run",
+        user_intent="tempo",
+        start_date=datetime(2026, 2, 15, 10, 0, tzinfo=timezone.utc),
+        distance_m=10000,
+        moving_time_s=3600,
+        elapsed_time_s=3700,
+        avg_hr=150.0,
+        max_hr=175.0,
+        avg_cadence=170.0,
+        elev_gain_m=50.0,
+        average_speed_mps=2.78,
+    )
+    db.add(activity)
+    db.flush()
+
+    db.add(DerivedMetric(
+        id=uuid.uuid4(),
+        activity_id=activity.id,
+        activity_class="Tempo",
+        effort_score=5.5,
+        pace_variability=4.2,
+        hr_drift=3.1,
+        time_in_zones={"Z2": 600, "Z3": 1800, "Z4": 1200},
+        flags=["high_intensity"],
+        confidence="high",
+        confidence_reasons=["full_coverage"],
+        training_context={"intensity_distribution_7d": {"easy": 3, "moderate": 1, "hard": 0}},
+    ))
+    db.add(UserProfile(
+        user_id=user_id,
+        goal_type="half",
+        experience_level="intermediate",
+        weekly_days_available=4,
+        current_weekly_km=35,
+        max_hr=185,
+        max_hr_source="user_entered",
+    ))
+    db.flush()
+    # Refresh so .metrics / .check_in relationships populate.
+    db.refresh(activity)
+
+    pack = build_context_pack(db, activity)
+    pack_dict = pack.to_serializable_dict()
+
+    # Round-trip through model_validate preserves the dict shape.
+    assert CoachContextPack.model_validate(pack_dict).to_serializable_dict() == pack_dict
+    # The typed fingerprint matches the legacy dict-based hash byte-for-byte.
+    assert pack.fingerprint() == hash_context_pack(pack_dict)

--- a/backend/tests/test_policy_validator.py
+++ b/backend/tests/test_policy_validator.py
@@ -1,6 +1,7 @@
 """Tests for the coach policy validator."""
 
 from app.schemas.coach import CoachReportContent, CoachTakeaway, CoachNextStep, CoachRisk, CoachQuestion
+from app.schemas.coach_context import CoachContextPack
 from app.services.coach.validator import validate_policy
 
 
@@ -21,28 +22,44 @@ def _make_content(**overrides):
     return CoachReportContent(**defaults)
 
 
-def _make_pack(**overrides):
-    """Build a minimal context pack with sensible defaults."""
-    pack = {
-        "metrics": {
-            "zones_calibrated": True,
-            "flags": [],
-            "confidence": "high",
-        },
-        "check_in": {
-            "rpe": 6,
-            "pain_score": 0,
-            "pain_location": None,
-            "sleep_quality": 4,
-            "notes": None,
-        },
-    }
-    for key, val in overrides.items():
-        if key in pack:
-            pack[key].update(val)
-        else:
-            pack[key] = val
-    return pack
+_DEFAULT_PACK_DICT = {
+    "activity": {
+        "date": "2026-02-15T10:00:00+00:00", "name": "Run", "type": "Run",
+        "distance_m": 10000, "moving_time_s": 3600,
+        "avg_hr": 150.0, "max_hr": 175.0, "avg_cadence": 170.0, "elev_gain_m": 50.0,
+    },
+    "metrics": {
+        "activity_class": "Easy Run", "effort_score": 3.0,
+        "hr_drift": None, "pace_variability": None,
+        "flags": [], "confidence": "high", "confidence_reasons": [],
+        "time_in_zones": None, "zones_calibrated": True, "zones_basis": "user_user_entered",
+        "efficiency_analysis": None, "stops_analysis": None, "interval_structure": None,
+        "workout_match": None, "interval_kpis": None,
+        "risk_level": None, "risk_score": None, "risk_reasons": [],
+        "training_context": None,
+    },
+    "check_in": {
+        "rpe": 6, "pain_score": 0, "pain_location": None, "sleep_quality": 4, "notes": None,
+    },
+    "profile": {
+        "goal_type": None, "experience_level": None, "weekly_days_available": None,
+        "injury_notes": None, "max_hr": None, "max_hr_source": None, "current_weekly_km": None,
+    },
+    "recent_training_summary": {
+        "last_7d": {"activity_count": 0, "total_distance_m": 0, "total_moving_time_s": 0, "total_effort": 0.0},
+        "last_28d": {"activity_count": 0, "total_distance_m": 0, "total_moving_time_s": 0, "total_effort": 0.0},
+        "previous_28d": {"activity_count": 0, "total_distance_m": 0, "total_moving_time_s": 0, "total_effort": 0.0},
+    },
+    "safety_rules": {"never_diagnose": True, "pain_severe_threshold": 7, "no_invented_facts": True},
+}
+
+
+def _make_pack(**section_overrides) -> CoachContextPack:
+    """Build a CoachContextPack from a default pack, with shallow per-section overrides."""
+    pack = {key: dict(value) if isinstance(value, dict) else value for key, value in _DEFAULT_PACK_DICT.items()}
+    for section, override in section_overrides.items():
+        pack[section].update(override)
+    return CoachContextPack.model_validate(pack)
 
 
 class TestPolicyValidator:


### PR DESCRIPTION
Closes #43.

## What changed

The coach context pack is now a `CoachContextPack` Pydantic schema instead of an untyped dict. Downstream consumers (`validate_policy`, `service.py`) work against attribute access; the policy validator's signature now enforces the type.

The legacy `hash_context_pack(dict)` function is retained as the migration reference — the typed pack's `fingerprint()` routes through the same JSON serialisation so the cache key stays byte-identical for any pack the legacy code could produce.

`chat.py` reads the stored dict from `CoachReport.context_pack` and stringifies it into the prompt; no attribute access happens there, so it stays as a dict consumer.

## Why

`context.py` describes itself as having no logic, only data gathering — yet its return type was implicit and four downstream call sites had to re-derive the shape via string-key lookups. Typing the pack makes the contract explicit and makes shape drift a type error rather than a runtime surprise.

## Cache stability

The load-bearing invariant: `CoachContextPack.model_validate(d).fingerprint() == hash_context_pack(d)` for any pack `d` the legacy builder produced. Pinned by four round-trip tests in `tests/test_coach_context_pack.py` against a fully-populated synthetic pack, a fully-sparse pack, and a pack built from `build_context_pack` against a seeded DB.

Two type choices were load-bearing for byte-identity:
- `TrainingPeriodSummary.total_distance_m` / `total_moving_time_s` are `int` (sum of `Activity.distance_m: Integer`) — `float` would serialise empty fixtures as `0.0` vs the legacy `0`.
- `total_effort` is `Union[int, float]` because `round(0, 1)` returns `int` for empty fixtures but `float` for populated ones.

## Test plan

- [x] `make backend-test` runs 136 passed, 2 pre-existing failures unrelated to this change (`test_models.py::test_create_user_and_activity`, `test_sync_integration.py::test_integration_sync_upserts_and_runs_analysis` — both SQLite UUID issues on `main`).
- [x] New tests: `tests/test_coach_context_pack.py` (5 tests) covering hash byte-stability and round-trip dict equality.
- [x] Existing tests migrated: `tests/test_coach_context.py` and `tests/test_policy_validator.py` updated to use the typed pack.
- [x] Grep check: `grep -rn 'context_pack\.get\|context_pack\[' app/services/coach/` returns zero matches.
- [x] **Manual smoke (requires live setup):** generate a coach report end-to-end against a real activity, confirm a `CoachReport` row writes with `meta.input_hash` populated and the report renders in the UI; second access returns the cached row without re-generating.