### PR TITLE
fix(coach): normalize cadence in context pack (#47)

### DIFF
--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -24,6 +24,7 @@ from app.schemas.coach_context import (
     TrainingPeriodSummary,
 )
 from app.services.trends import _query_activity_facts
+from app.services.units.cadence import normalize_cadence_spm
 
 
 def build_context_pack(db: Session, activity: Activity) -> CoachContextPack:
@@ -83,7 +84,9 @@ def build_context_pack(db: Session, activity: Activity) -> CoachContextPack:
             moving_time_s=activity.moving_time_s,
             avg_hr=activity.avg_hr,
             max_hr=activity.max_hr,
-            avg_cadence=activity.avg_cadence,
+            avg_cadence=normalize_cadence_spm(
+                activity.user_intent or activity.type, activity.avg_cadence
+            ),
             elev_gain_m=activity.elev_gain_m,
         ),
         metrics=MetricsContext(

--- a/backend/tests/test_coach_context.py
+++ b/backend/tests/test_coach_context.py
@@ -161,6 +161,27 @@ def test_context_pack_includes_enriched_activity_fields(db):
     assert pack.activity.max_hr == 182.0
 
 
+def test_context_pack_normalizes_raw_strava_cadence(db):
+    """Sub-130 raw Strava cadence (strides/min) must be doubled to spm before
+    landing in the coach context pack.
+
+    The DB column stores the raw Strava value; the read schema doubles it for
+    every user-facing surface. The context pack must apply the same conversion
+    so the LLM and the user see the same number for the same activity.
+    """
+    user_id = uuid.uuid4()
+    from app.models.user import User
+    db.add(User(id=user_id, email=f"test_{user_id}@example.com"))
+    db.flush()
+
+    activity = _create_activity(db, user_id, avg_cadence=80.4)
+    _add_metrics(db, activity)
+
+    pack = build_context_pack(db, activity)
+
+    assert pack.activity.avg_cadence == 160.8
+
+
 def test_context_pack_passes_training_context_through(db):
     """build_context_pack returns the value persisted on DerivedMetric.training_context."""
     user_id = uuid.uuid4()


### PR DESCRIPTION
Closes #47.

## Summary
- The coach context pack was passing raw `activity.avg_cadence` (Strava strides-per-minute, ~80) to the LLM, while every user-facing surface normalizes it to steps-per-minute (~160). The coach was reasoning on a number the user never sees and producing a confident "low cadence" finding from it.
- Fix: apply the same `normalize_cadence_spm` conversion when assembling the context pack, using the same `user_intent or type` effective-type rule the other normalizers use.

## Cache impact
Activities whose raw cadence was sub-130 now have a different context-pack fingerprint, so any cached `CoachReport` for those activities will regenerate against the corrected context on next on-demand re-run. This matches the cache-invalidation pattern established by M1 for the `training_context` move.

Existing chat messages on affected activities stay as historical artifacts; new chat turns use the corrected context (verified live — fresh chat answers "160.8 steps per minute" against the same activity that previously got "80.4").

## Test plan
- [x] New failing unit test asserts the typed context pack normalizes raw sub-130 cadence.
- [x] Full backend suite passes (143/143, +1 for the new test, no regressions).
- [x] Live re-run against the activity from #47 produces a fresh report with no cadence mention and no "low cadence" finding.
- [x] Fresh chat turn against the same activity now answers with the normalized value matching the UI.