### PR TITLE
fix(profile): show Strava connection state on profile page

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from sqlalchemy import select
+from typing import Optional
 
 from app.core.config import settings
 from app.db.session import get_db
@@ -11,10 +13,31 @@ from app.services.strava_ingestion import get_strava_port
 router = APIRouter()
 
 
+class StravaConnectionStatus(BaseModel):
+    connected: bool
+    athlete_id: Optional[int] = None
+    scope: Optional[str] = None
+    expires_at: Optional[int] = None
+
+
 @router.get("/auth/strava/login")
 def strava_login():
     """Redirects user to Strava OAuth page."""
     return RedirectResponse(get_strava_port().get_auth_url())
+
+
+@router.get("/auth/strava/status", response_model=StravaConnectionStatus)
+def strava_status(db: Session = Depends(get_db)) -> StravaConnectionStatus:
+    """Reports whether a Strava account is linked, and surfaces the athlete id and token scope."""
+    account = db.execute(select(StravaAccount)).scalars().first()
+    if account is None:
+        return StravaConnectionStatus(connected=False)
+    return StravaConnectionStatus(
+        connected=True,
+        athlete_id=account.strava_athlete_id,
+        scope=account.scope,
+        expires_at=account.expires_at,
+    )
 
 
 @router.get("/auth/strava/callback")

--- a/backend/tests/test_strava_auth.py
+++ b/backend/tests/test_strava_auth.py
@@ -1,6 +1,7 @@
 import time
 
 import pytest
+from fastapi.testclient import TestClient
 
 from app.models import StravaAccount, User
 from app.services.strava_ingestion import (
@@ -56,3 +57,30 @@ async def test_ensure_valid_access_token_returns_existing_when_valid(db):
 
     assert token == "old_access"
     assert adapter.refresh_calls == []
+
+
+def test_strava_status_returns_disconnected_when_no_account(client: TestClient):
+    response = client.get("/api/auth/strava/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "connected": False,
+        "athlete_id": None,
+        "scope": None,
+        "expires_at": None,
+    }
+
+
+def test_strava_status_returns_connected_when_account_linked(client: TestClient, db):
+    expires_at = int(time.time()) + 3600
+    _make_account(db, expires_at=expires_at)
+
+    response = client.get("/api/auth/strava/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "connected": True,
+        "athlete_id": 42,
+        "scope": "read,activity:read_all",
+        "expires_at": expires_at,
+    }

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -77,9 +77,9 @@ export default function ProfilePage() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 md:p-8">
-      <header className="mb-6 flex justify-between items-center">
-        <h1 className="text-2xl font-bold">Athlete Profile</h1>
-        <div className="flex items-center gap-4">
+      <header className="mb-6 flex flex-wrap justify-between items-center gap-4">
+        <h1 className="text-2xl font-bold whitespace-nowrap">Athlete Profile</h1>
+        <div className="flex items-center gap-4 flex-wrap">
             <ConnectStravaButton />
             <Link href="/" className="text-blue-600 hover:underline">Cancel</Link>
         </div>

--- a/frontend/components/ConnectStravaButton.tsx
+++ b/frontend/components/ConnectStravaButton.tsx
@@ -1,11 +1,70 @@
 'use client';
-import { ExternalLink } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { CheckCircle2, ExternalLink, RefreshCw } from 'lucide-react';
+
+type StravaStatus = {
+  connected: boolean;
+  athlete_id: number | null;
+  scope: string | null;
+  expires_at: number | null;
+};
 
 export default function ConnectStravaButton() {
   const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
-  
+  const [status, setStatus] = useState<StravaStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${API_BASE_URL}/api/auth/strava/status`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        return res.json();
+      })
+      .then((data: StravaStatus) => {
+        if (!cancelled) setStatus(data);
+      })
+      .catch(() => {
+        if (!cancelled) setStatus({ connected: false, athlete_id: null, scope: null, expires_at: null });
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [API_BASE_URL]);
+
+  if (loading) {
+    return <span className="text-sm text-gray-500">Checking Strava…</span>;
+  }
+
+  if (status?.connected) {
+    return (
+      <div className="flex items-center gap-3 whitespace-nowrap">
+        <span className="inline-flex items-center gap-2 text-sm text-green-700">
+          <CheckCircle2 size={16} />
+          <span>
+            Connected to Strava
+            {status.athlete_id != null && (
+              <span className="text-gray-500"> (#{status.athlete_id})</span>
+            )}
+          </span>
+        </span>
+        <a
+          href={`${API_BASE_URL}/api/auth/strava/login`}
+          className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+          title="Re-run the Strava OAuth flow to refresh tokens or switch athletes"
+        >
+          <RefreshCw size={14} />
+          Reconnect
+        </a>
+      </div>
+    );
+  }
+
   return (
-    <a 
+    <a
       href={`${API_BASE_URL}/api/auth/strava/login`}
       className="inline-flex items-center gap-2 bg-[#FC4C02] text-white px-4 py-2 rounded font-semibold hover:bg-[#E34402] transition-colors"
     >

--- a/frontend/scripts/smoke.mjs
+++ b/frontend/scripts/smoke.mjs
@@ -113,6 +113,15 @@ function createMockApiServer() {
       return;
     }
 
+    if (pathname === "/api/auth/strava/status") {
+      return sendJson(res, 200, {
+        connected: true,
+        athlete_id: 12345,
+        scope: "read,activity:read_all,profile:read_all",
+        expires_at: 9999999999,
+      });
+    }
+
     res.writeHead(404, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ detail: `Unhandled smoke route: ${pathname}` }));
   });


### PR DESCRIPTION
Closes #48.

## Summary
- New `GET /api/auth/strava/status` returns `{ connected, athlete_id, scope, expires_at }` from the existing `StravaAccount` row.
- `ConnectStravaButton` is now state-aware: shows a green "Connected to Strava (#athlete_id)" indicator plus a "Reconnect" link when a Strava account is linked, falls back to the original orange CTA otherwise.
- Profile page header wraps gracefully so the connected chip doesn't push the title onto a second line.

## Verification
- `make backend-test` — 145/145 pass, with two new cases covering connected and disconnected status.
- `cd frontend && npm run test` — lint and build clean.
- Manual: ran dev backend + `npm run dev`, loaded `/profile`. Live backend returned the user's real athlete id; UI showed the connected indicator + Reconnect. Re-loaded with the status endpoint stubbed to `connected:false` and confirmed the original "Connect with Strava" CTA renders.

## Out of scope (worth follow-ups)
- A disconnect / unlink action. The issue mentioned it as an example only; it's a destructive change that cascades into `Activity`/`ActivityStream` and deserves its own decision.
- Showing the athlete's name/avatar instead of the bare athlete id. The Strava `athlete` payload comes through on OAuth callback but we don't persist `firstname`/`lastname`/`profile`; that's a small schema + ingest change.
- `frontend/scripts/smoke.mjs` times out at `/` with HTTP 404 on `main` as well, unrelated to this change. Worth a separate issue.

## Test plan
- [ ] On a fresh DB with no `StravaAccount`, load `/profile` and confirm the orange "Connect with Strava" CTA renders.
- [ ] After completing OAuth, reload `/profile` and confirm the green "Connected to Strava (#athlete_id)" chip and "Reconnect" link render.
- [ ] Click "Reconnect" and confirm it re-enters the OAuth flow.