### PR TITLE
fix(smoke): allocate dynamic ports to avoid Docker port squat (#51)

### DIFF
--- a/frontend/scripts/smoke.mjs
+++ b/frontend/scripts/smoke.mjs
@@ -1,8 +1,24 @@
 import http from "node:http";
+import net from "node:net";
 import { spawn } from "node:child_process";
 
-const MOCK_API_PORT = 3001;
-const FRONTEND_PORT = 3100;
+// Pick ports dynamically. Fixed 3001/3100 collided with this project's
+// aiw-grafana / aiw-loki containers and caused the smoke to lock onto the
+// wrong server via fetch keep-alive.
+async function pickFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      server.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
+
+const MOCK_API_PORT = await pickFreePort();
+const FRONTEND_PORT = await pickFreePort();
 const MOCK_API_BASE_URL = `http://127.0.0.1:${MOCK_API_PORT}`;
 const FRONTEND_BASE_URL = `http://127.0.0.1:${FRONTEND_PORT}`;
 


### PR DESCRIPTION
## Summary
- Replaces the smoke harness's fixed ports 3001/3100 with runtime-allocated free ports.
- 3001 and 3100 collide with this project's own `aiw-grafana` and `aiw-loki` containers. When Docker answered the first probe before `next start` finished binding, Node's fetch keep-alive locked onto the Docker socket and returned 30s of `404 page not found`, killing `npm run smoke` at the boot wait before any route check ran.

Closes #51.

## Test plan
- [x] Reproduce the failure on `main` with the `aiw-*` stack running: `npm run smoke` → boot-time 404 timeout.
- [x] Apply fix, rerun with the same stack still running: `npm run smoke` → `Frontend smoke checks passed.`
- [ ] Optional: rerun with the `aiw-*` stack stopped to confirm no regression in the no-contention case.