### PR TITLE
feat(notifications): email coach report after each new activity

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,37 @@
+# Project glossary
+
+Definitions resolved during design discussions. Implementation details belong in code; this file is the shared vocabulary only.
+
+## Notification
+
+A side-channel delivery of a `CoachReport` to the runner — distinct from the in-app artifact. The `CoachReport` is the structured analysis stored in the DB and rendered by the frontend; a notification is one transmission of that report (or a representation of it) to an external channel such as email.
+
+A notification is at-most-once per `Activity` per channel. The sentinel for "this activity has been notified" lives on the `Activity` row (see `Notified at`), not on the `CoachReport`, because re-generating a report (e.g., `force=true`) must not re-fire a notification.
+
+## Notifier
+
+The abstraction for sending a notification. Modelled as a port (`NotifierPort`) with adapters per channel, mirroring `StravaPort` (see [ADR 0002](docs/adr/0002-strava-adapter-is-pure-transport.md)). Today: `SMTPNotifier` for production, `InMemoryNotifier` for tests. Adding a new channel means adding a new adapter, not modifying the port.
+
+## Notified at
+
+The single sentinel for notification dedup: a timestamp column on `Activity` indicating that a notification has been successfully sent for that activity. Null means "not yet notified." Set after a successful send; left null on failure so retries can re-send.
+
+## Process new activity
+
+The convergence pipeline triggered when a previously-unseen activity appears, regardless of source (Strava webhook `create` event or polling discovery). One pipeline: ingest → analyze → generate coach report → notify. Both source paths enqueue the same job; the `Notified at` sentinel makes re-entry safe.
+
+## Polling job
+
+A scheduled catch-up that periodically asks Strava for recent activities, diffs against the local DB, and enqueues `Process new activity` for each unseen one. Exists alongside the webhook path, not instead of it. Rationale in [ADR 0004](docs/adr/0004-activity-notification-dual-source-pipeline.md).
+
+## Activity ingestion
+
+Persisting a Strava activity (and its streams) into the local DB. Does not include analysis or notification. Composed with those steps at the job/orchestrator layer per [ADR 0003](docs/adr/0003-ingestion-does-not-call-analyze.md).
+
+## Activity analysis
+
+The deterministic processing pipeline that takes a persisted `Activity` + its `ActivityStream` rows and produces a `DerivedMetric`. Does not include coach report generation or notification.
+
+## Coach report generation
+
+The LLM-driven step that builds a context pack from a `DerivedMetric`, calls Anthropic, validates the response against the schema and the policy validator, and persists a `CoachReport`. Distinct from notification: a report can exist without ever being notified (e.g., older runs, low-confidence runs delivered only on-demand via the UI).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ In a second terminal (from `backend/`, venv activated):
 rq worker --url $REDIS_URL
 ```
 
+### 4b) Run the polling scheduler (optional, enables ASAP coach-report emails)
+In a third terminal (from `backend/`, venv activated):
+```bash
+python -m app.jobs.scheduler   # registers the recurring polling schedule once
+rqscheduler --url $REDIS_URL   # long-running process that actually fires jobs
+```
+The polling fallback periodically asks Strava for new activities and runs the
+ingest → analyze → coach report → email pipeline for each new one, in case
+your local backend can't receive Strava webhooks directly. Email delivery is
+off until `SMTP_HOST` and `NOTIFY_TO` are set in `backend/.env`.
+
 ### 5) Run frontend
 ```bash
 cd frontend

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,4 +23,25 @@ STRAVA_REDIRECT_URI=http://localhost:8000/api/auth/strava/callback
 STRAVA_WEBHOOK_VERIFY_TOKEN=dev-verify-token
 STRAVA_WEBHOOK_CALLBACK_URL=http://localhost:8000/api/webhooks/strava
 
+# --- Coach AI ---
+ANTHROPIC_API_KEY=
+COACH_MODEL_ID=claude-sonnet-4-20250514
+COACH_PROMPT_ID=coach_report_v1
+
+# --- Email notifications (post-run coach report) ---
+# Leave SMTP_HOST empty to disable email delivery entirely.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_FROM=
+SMTP_USE_STARTTLS=true
+NOTIFY_TO=
+
+# --- Polling fallback for missed Strava webhooks ---
+# Interval (seconds) at which the scheduler asks Strava for recent activities
+# and enqueues the pipeline for any new ones. Lower = fresher reports, more
+# Strava API usage. Strava's limit is 1000 requests/day per account; the
+# default of 120s sits at ~720/day.
+POLLING_INTERVAL_SECONDS=120
 

--- a/backend/alembic/versions/e2f7a3b9d4c1_add_notification_sent_at_and_is_fallback.py
+++ b/backend/alembic/versions/e2f7a3b9d4c1_add_notification_sent_at_and_is_fallback.py
@@ -1,0 +1,38 @@
+"""add coach_notification_sent_at on activities and is_fallback on coach_reports
+
+Revision ID: e2f7a3b9d4c1
+Revises: d1a4c9f7b201
+Create Date: 2026-05-27 18:40:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e2f7a3b9d4c1'
+down_revision: Union[str, None] = 'd1a4c9f7b201'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'activities',
+        sa.Column('coach_notification_sent_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        'coach_reports',
+        sa.Column(
+            'is_fallback',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text('false'),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('coach_reports', 'is_fallback')
+    op.drop_column('activities', 'coach_notification_sent_at')

--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -7,6 +7,7 @@ from app.core.config import settings
 from app.db.session import get_db
 from app.models import Activity
 from app.core.queue import queue
+from app.jobs.process_new_activity import process_new_activity_job
 from app.jobs.strava_sync import sync_activity_job
 
 router = APIRouter()
@@ -57,19 +58,28 @@ async def receive_webhook(
         db.commit()
         return {"status": "processed", "action": "deleted"}
 
-    elif event.aspect_type in ["create", "update"]:
-        # Enqueue job
-        # We use explicit job ID to prevent dupes in queue
-        job_id = f"sync_{event.object_id}_{event.event_time}"
-        
+    elif event.aspect_type == "create":
+        # Fresh activity: run the full pipeline (ingest → analyze → coach → notify).
+        job_id = f"pipeline_{event.object_id}_{event.event_time}"
         queue.enqueue(
-            sync_activity_job, 
-            strava_athlete_id=event.owner_id, 
+            process_new_activity_job,
+            strava_athlete_id=event.owner_id,
             strava_activity_id=event.object_id,
             job_id=job_id,
-            result_ttl=3600 # Keep result for 1 hour
+            result_ttl=3600,
         )
-        
-        return {"status": "processed", "action": "enqueued"}
+        return {"status": "processed", "action": "enqueued_pipeline"}
+
+    elif event.aspect_type == "update":
+        # Existing activity edit (title, visibility): re-ingest only.
+        job_id = f"sync_{event.object_id}_{event.event_time}"
+        queue.enqueue(
+            sync_activity_job,
+            strava_athlete_id=event.owner_id,
+            strava_activity_id=event.object_id,
+            job_id=job_id,
+            result_ttl=3600,
+        )
+        return {"status": "processed", "action": "enqueued_sync"}
 
     return {"status": "ignored", "reason": "unknown_aspect"}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -27,6 +27,18 @@ class Settings(BaseSettings):
     COACH_MODEL_ID: str = "claude-sonnet-4-20250514"
     COACH_PROMPT_ID: str = "coach_report_v1"
 
+    # Email notifications (feature off when SMTP_HOST is empty)
+    SMTP_HOST: str = ""
+    SMTP_PORT: int = 587
+    SMTP_USER: str = ""
+    SMTP_PASSWORD: str = ""
+    SMTP_FROM: str = ""
+    SMTP_USE_STARTTLS: bool = True
+    NOTIFY_TO: str = ""
+
+    # Polling fallback for missed Strava webhooks
+    POLLING_INTERVAL_SECONDS: int = 120
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_ignore_empty=True,

--- a/backend/app/jobs/polling.py
+++ b/backend/app/jobs/polling.py
@@ -1,0 +1,94 @@
+"""Polling fallback for missed Strava webhooks.
+
+Calls Strava's recent-activities list per linked account, diffs against the
+local DB by `strava_activity_id`, and enqueues `process_new_activity_job`
+for each previously-unseen id. Both webhook and polling converge on the
+same pipeline; the dedup sentinel lives on `Activity.coach_notification_sent_at`.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+
+from sqlalchemy.orm import Session
+
+from app.core.queue import queue
+from app.db.session import SessionLocal
+from app.models import Activity, StravaAccount
+from app.services.strava_ingestion import (
+    StravaPort,
+    ensure_valid_access_token,
+    get_strava_port,
+)
+
+logger = logging.getLogger(__name__)
+
+_LOOKBACK = timedelta(hours=6)
+
+
+async def poll_for_new_activities(
+    *, db: Session, strava_port: StravaPort
+) -> list[int]:
+    """For each linked StravaAccount, find newly-discovered activities and
+    enqueue the pipeline. Returns the strava_activity_ids enqueued (for
+    tests/visibility)."""
+    accounts: Iterable[StravaAccount] = db.query(StravaAccount).all()
+    enqueued: list[int] = []
+
+    since = datetime.now(timezone.utc) - _LOOKBACK
+
+    for account in accounts:
+        try:
+            access_token = await ensure_valid_access_token(db, account, strava_port)
+            raw_activities = await strava_port.list_recent_activities(
+                access_token=access_token, since=since, per_page=50
+            )
+        except Exception as exc:
+            logger.warning(
+                "Polling failed for athlete %s: %s",
+                account.strava_athlete_id,
+                exc,
+            )
+            continue
+
+        strava_ids = [int(raw["id"]) for raw in raw_activities if "id" in raw]
+        if not strava_ids:
+            continue
+
+        known = {
+            row[0]
+            for row in db.query(Activity.strava_activity_id)
+            .filter(Activity.strava_activity_id.in_(strava_ids))
+            .all()
+        }
+        new_ids = [sid for sid in strava_ids if sid not in known]
+
+        for sid in new_ids:
+            _enqueue_pipeline(account.strava_athlete_id, sid)
+            enqueued.append(sid)
+
+    return enqueued
+
+
+def _enqueue_pipeline(athlete_id: int, activity_id: int) -> None:
+    from app.jobs.process_new_activity import process_new_activity_job
+
+    queue.enqueue(
+        process_new_activity_job,
+        strava_athlete_id=athlete_id,
+        strava_activity_id=activity_id,
+        job_id=f"pipeline_poll_{activity_id}",
+        result_ttl=3600,
+    )
+
+
+def poll_for_new_activities_job() -> None:
+    """RQ entrypoint. Opens its own DB session and uses the active Strava port."""
+    db = SessionLocal()
+    try:
+        asyncio.run(
+            poll_for_new_activities(db=db, strava_port=get_strava_port())
+        )
+    finally:
+        db.close()

--- a/backend/app/jobs/process_new_activity.py
+++ b/backend/app/jobs/process_new_activity.py
@@ -1,0 +1,142 @@
+"""Pipeline job that runs ingest → analyze → coach report → notify for a fresh activity.
+
+Both the Strava webhook (`aspect_type=create`) and the polling fallback enqueue
+this job. Dedup is enforced via `Activity.coach_notification_sent_at`.
+"""
+
+import asyncio
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.db.session import SessionLocal
+from app.models import Activity, StravaAccount
+from app.models.coach_report import CoachReport
+from app.services.analysis import analyze_with_streams
+from app.services.coach.service import get_or_generate_coach_report
+from app.services.notifications import Notification, get_notifier
+from app.services.notifications.email_template import render_coach_report_email
+from app.services.notifications.port import NotifierPort
+from app.services.strava_ingestion import (
+    StravaPort,
+    get_strava_port,
+    ingest_activity_by_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def process_new_activity(
+    *,
+    db: Session,
+    account: StravaAccount,
+    strava_activity_id: int,
+    strava_port: StravaPort,
+    notifier: NotifierPort,
+) -> Optional[Notification]:
+    """Run the full ingest → analyze → coach → notify pipeline.
+
+    Returns the Notification that was sent, or None if skipped (already
+    notified, fallback report, NOTIFY_TO unset, or missing inputs).
+    """
+    activity = await ingest_activity_by_id(
+        db, account, strava_port, strava_activity_id
+    )
+
+    await analyze_with_streams(db, str(activity.id))
+
+    report = await get_or_generate_coach_report(db, str(activity.id))
+    if report is None:
+        logger.info(
+            "Skipping notification for activity %s: no coach report",
+            strava_activity_id,
+        )
+        return None
+
+    db.refresh(activity)
+    coach_row = (
+        db.query(CoachReport)
+        .filter(CoachReport.activity_id == _coerce_uuid(activity.id))
+        .first()
+    )
+    if coach_row is None or coach_row.is_fallback:
+        logger.info(
+            "Skipping notification for activity %s: report is fallback or missing",
+            strava_activity_id,
+        )
+        return None
+
+    if activity.coach_notification_sent_at is not None:
+        logger.info(
+            "Skipping notification for activity %s: already notified at %s",
+            strava_activity_id,
+            activity.coach_notification_sent_at,
+        )
+        return None
+
+    if not settings.NOTIFY_TO:
+        logger.info(
+            "Skipping notification for activity %s: NOTIFY_TO unset",
+            strava_activity_id,
+        )
+        return None
+
+    activity_class = (
+        activity.metrics.activity_class if activity.metrics else (activity.type or "Activity")
+    )
+    subject, html, text = render_coach_report_email(
+        report=report,
+        activity_class=activity_class,
+        distance_m=activity.distance_m or 0,
+        app_base_url=settings.APP_BASE_URL,
+    )
+    notification = Notification(
+        to=settings.NOTIFY_TO, subject=subject, html=html, text=text
+    )
+    notifier.send(notification)
+
+    activity.coach_notification_sent_at = datetime.now(timezone.utc)
+    db.add(activity)
+    db.commit()
+
+    return notification
+
+
+def process_new_activity_job(
+    strava_athlete_id: int, strava_activity_id: int
+) -> None:
+    """RQ entrypoint. Opens its own DB session and uses the active ports."""
+    db = SessionLocal()
+    try:
+        account = (
+            db.query(StravaAccount)
+            .filter(StravaAccount.strava_athlete_id == strava_athlete_id)
+            .first()
+        )
+        if account is None:
+            logger.warning(
+                "process_new_activity_job: unknown athlete %s", strava_athlete_id
+            )
+            return
+
+        asyncio.run(
+            process_new_activity(
+                db=db,
+                account=account,
+                strava_activity_id=strava_activity_id,
+                strava_port=get_strava_port(),
+                notifier=get_notifier(),
+            )
+        )
+    finally:
+        db.close()
+
+
+def _coerce_uuid(value) -> uuid.UUID:
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))

--- a/backend/app/jobs/scheduler.py
+++ b/backend/app/jobs/scheduler.py
@@ -1,0 +1,49 @@
+"""rq-scheduler bootstrap: register the recurring polling job.
+
+Run this once at startup of the scheduler process to install the recurring
+schedule, then run `rqscheduler --url $REDIS_URL` as a long-lived process
+to actually fire scheduled jobs.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from redis import Redis
+from rq_scheduler import Scheduler
+
+from app.core.config import settings
+from app.jobs.polling import poll_for_new_activities_job
+
+logger = logging.getLogger(__name__)
+
+_SCHEDULED_JOB_ID = "poll_for_new_activities_recurring"
+
+
+def register_polling_schedule() -> None:
+    """Idempotently install the recurring polling schedule into Redis."""
+    redis = Redis.from_url(settings.REDIS_URL)
+    scheduler = Scheduler(connection=redis)
+
+    # Cancel any existing instances to avoid duplicates after restarts.
+    for job in list(scheduler.get_jobs()):
+        if job.id == _SCHEDULED_JOB_ID:
+            scheduler.cancel(job)
+
+    scheduler.schedule(
+        scheduled_time=datetime.now(timezone.utc),
+        func=poll_for_new_activities_job,
+        interval=settings.POLLING_INTERVAL_SECONDS,
+        repeat=None,
+        id=_SCHEDULED_JOB_ID,
+        result_ttl=3600,
+    )
+    logger.info(
+        "Registered polling schedule every %ss as job %s",
+        settings.POLLING_INTERVAL_SECONDS,
+        _SCHEDULED_JOB_ID,
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    register_polling_schedule()

--- a/backend/app/models/activity.py
+++ b/backend/app/models/activity.py
@@ -38,6 +38,10 @@ class Activity(Base):
     raw_summary: Mapped[dict] = mapped_column(JSON, default={})
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
 
+    coach_notification_sent_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), onupdate=func.now(), server_default=func.now()

--- a/backend/app/models/coach_report.py
+++ b/backend/app/models/coach_report.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import ForeignKey, DateTime, JSON, Uuid, Text
+from sqlalchemy import Boolean, ForeignKey, DateTime, JSON, Uuid, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
@@ -20,6 +20,10 @@ class CoachReport(Base):
     meta: Mapped[dict] = mapped_column(JSON)
     context_pack: Mapped[dict] = mapped_column(JSON)
     raw_llm_response: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    is_fallback: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false", default=False
+    )
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/app/services/analysis/_orchestrator.py
+++ b/backend/app/services/analysis/_orchestrator.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Optional
 from sqlalchemy.orm import Session
 from sqlalchemy import select
@@ -30,7 +31,8 @@ async def analyze_with_streams(db: Session, activity_id: str) -> Optional[Derive
     """
     Explicitly fetches streams and re-runs analysis.
     """
-    activity = db.query(Activity).filter(Activity.id == activity_id).first()
+    activity_uuid = _coerce_uuid(activity_id)
+    activity = db.query(Activity).filter(Activity.id == activity_uuid).first()
     if not activity: return None
 
     # Fetch streams
@@ -42,6 +44,12 @@ async def analyze_with_streams(db: Session, activity_id: str) -> Optional[Derive
 
     # Run normal processing (which now picks up streams)
     return analyze(db, activity_id)
+
+
+def _coerce_uuid(value) -> uuid.UUID:
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))
 
 
 def compute_confidence(activity, streams_dict, check_in, interval_structure=None, workout_match=None):
@@ -105,8 +113,10 @@ def analyze(db: Session, activity_id: str) -> Optional[DerivedMetric]:
     Main entry point.
     Loads activity, history, computes all metrics, saves DerivedMetric.
     """
+    activity_uuid = _coerce_uuid(activity_id)
+
     # 1. Load Activity
-    stmt = select(Activity).where(Activity.id == activity_id)
+    stmt = select(Activity).where(Activity.id == activity_uuid)
     activity = db.execute(stmt).scalars().first()
     if not activity:
         return None

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -5,6 +5,7 @@ Coach service — orchestrates context pack → LLM → validate → policy chec
 import json
 import logging
 import re
+import uuid
 from datetime import datetime, timezone
 from typing import List, Optional
 
@@ -32,17 +33,19 @@ async def get_or_generate_coach_report(
     """
     Returns cached report if one exists, otherwise generates a new one via LLM.
     """
+    activity_uuid = _coerce_uuid(activity_id)
+
     # Check cache
     existing = (
         db.query(CoachReport)
-        .filter(CoachReport.activity_id == activity_id)
+        .filter(CoachReport.activity_id == activity_uuid)
         .first()
     )
     if existing:
         return _to_read(existing)
 
     # Load activity
-    activity = db.query(Activity).filter(Activity.id == activity_id).first()
+    activity = db.query(Activity).filter(Activity.id == activity_uuid).first()
     if not activity or not activity.metrics:
         return None
 
@@ -64,6 +67,7 @@ async def get_or_generate_coach_report(
 
     raw_response = ""
     policy_violations: List[str] = []
+    is_fallback = False
 
     try:
         raw_response = await client.generate_json(
@@ -95,6 +99,7 @@ async def get_or_generate_coach_report(
 
     except (json.JSONDecodeError, ValidationError) as e:
         logger.error("Coach report parse/validation error: %s", e)
+        is_fallback = True
         content = CoachReportContent(
             key_takeaways=[
                 {"text": "Analysis is temporarily unavailable for this activity."},
@@ -121,11 +126,12 @@ async def get_or_generate_coach_report(
 
     # Store
     db_report = CoachReport(
-        activity_id=activity_id,
+        activity_id=activity_uuid,
         report=content.model_dump(),
         meta=meta.model_dump(mode="json"),
         context_pack=pack_dict,
         raw_llm_response=raw_response,
+        is_fallback=is_fallback,
     )
     db.add(db_report)
     db.commit()
@@ -171,6 +177,14 @@ async def _retry_with_fixes(
     except (json.JSONDecodeError, ValidationError) as e:
         logger.error("Coach report retry parse error: %s", e)
         raise
+
+
+def _coerce_uuid(value) -> uuid.UUID:
+    """Accept either a UUID or its string form. Postgres tolerates the latter
+    via implicit cast; SQLite (used in tests) does not, so coerce up front."""
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))
 
 
 def _strip_code_fences(text: str) -> str:

--- a/backend/app/services/notifications/__init__.py
+++ b/backend/app/services/notifications/__init__.py
@@ -1,0 +1,50 @@
+from app.services.notifications.in_memory_adapter import InMemoryNotifier
+from app.services.notifications.noop_adapter import NoOpNotifier
+from app.services.notifications.port import Notification, NotifierPort
+
+_active: NotifierPort | None = None
+
+
+def get_notifier() -> NotifierPort:
+    """Return the active notifier.
+
+    If overridden via `set_notifier`, returns the override.
+    Otherwise constructs the default: SMTPNotifier when `SMTP_HOST` is set,
+    NoOpNotifier when not.
+    """
+    global _active
+    if _active is not None:
+        return _active
+
+    from app.core.config import settings
+
+    if settings.SMTP_HOST:
+        from app.services.notifications.smtp_adapter import SMTPNotifier
+
+        _active = SMTPNotifier(
+            host=settings.SMTP_HOST,
+            port=settings.SMTP_PORT,
+            username=settings.SMTP_USER,
+            password=settings.SMTP_PASSWORD,
+            from_addr=settings.SMTP_FROM,
+            use_starttls=settings.SMTP_USE_STARTTLS,
+        )
+    else:
+        _active = NoOpNotifier()
+    return _active
+
+
+def set_notifier(notifier: NotifierPort | None) -> None:
+    """Override the active notifier. Pass None to reset to the default."""
+    global _active
+    _active = notifier
+
+
+__all__ = [
+    "InMemoryNotifier",
+    "Notification",
+    "NoOpNotifier",
+    "NotifierPort",
+    "get_notifier",
+    "set_notifier",
+]

--- a/backend/app/services/notifications/email_template.py
+++ b/backend/app/services/notifications/email_template.py
@@ -1,0 +1,119 @@
+from html import escape
+
+from app.schemas.coach import CoachReportRead
+
+
+def render_coach_report_email(
+    *,
+    report: CoachReportRead,
+    activity_class: str,
+    distance_m: int,
+    app_base_url: str,
+) -> tuple[str, str, str]:
+    """Render subject + HTML body + plain-text body for a coach report email."""
+    distance_km = round((distance_m or 0) / 1000.0, 1)
+    confidence = report.meta.confidence
+    activity_label = activity_class or "Activity"
+    # Subject shape: "{label} — {dist}km · {conf} confidence" for activities
+    # with distance, "{label} — {conf} confidence" for those without (indoor
+    # rides record 0m). The label already includes the noun (e.g. "Easy Run",
+    # "Indoor Ride"), so we don't append it.
+    if distance_km > 0:
+        subject = f"{activity_label} — {distance_km}km · {confidence} confidence"
+    else:
+        subject = f"{activity_label} — {confidence} confidence"
+
+    activity_url = f"{app_base_url.rstrip('/')}/activity/{report.activity_id}"
+
+    html = _render_html(report, activity_label, distance_km, confidence, activity_url)
+    text = _render_text(report, activity_label, distance_km, confidence, activity_url)
+    return subject, html, text
+
+
+def _render_html(report, activity_label, distance_km, confidence, activity_url) -> str:
+    content = report.report
+
+    takeaways_items = "".join(
+        f"<li>{escape(t.text)}</li>" for t in content.key_takeaways
+    )
+    next_steps_items = "".join(
+        (
+            "<li>"
+            f"<strong>{escape(s.action)}</strong>"
+            f"<div>{escape(s.details)}</div>"
+            f"<div style=\"color:#666;\"><em>Why:</em> {escape(s.why)}</div>"
+            "</li>"
+        )
+        for s in content.next_steps
+    )
+    risks_block = ""
+    if content.risks:
+        risks_items = "".join(
+            (
+                "<li>"
+                f"<strong>{escape(r.flag)}</strong>: {escape(r.explanation)}<br/>"
+                f"<em>Mitigation:</em> {escape(r.mitigation)}"
+                "</li>"
+            )
+            for r in content.risks
+        )
+        risks_block = f"<h3>Risks</h3><ul>{risks_items}</ul>"
+
+    questions_block = ""
+    if content.questions:
+        questions_items = "".join(
+            (
+                "<li>"
+                f"<strong>{escape(q.question)}</strong><br/>"
+                f"<em>{escape(q.reason)}</em>"
+                "</li>"
+            )
+            for q in content.questions
+        )
+        questions_block = f"<h3>Follow-up questions</h3><ul>{questions_items}</ul>"
+
+    heading_distance = f" · {distance_km}km" if distance_km > 0 else ""
+    return (
+        "<!doctype html><html><body style=\"font-family:-apple-system,sans-serif;max-width:600px;margin:0 auto;padding:16px;\">"
+        f"<h2>{escape(activity_label)}{heading_distance}</h2>"
+        f"<p style=\"color:#666;\">Confidence: <strong>{escape(confidence)}</strong></p>"
+        "<h3>Key takeaways</h3>"
+        f"<ul>{takeaways_items}</ul>"
+        "<h3>Next steps</h3>"
+        f"<ol>{next_steps_items}</ol>"
+        f"{risks_block}"
+        f"{questions_block}"
+        f"<p><a href=\"{escape(activity_url)}\">View in app</a></p>"
+        "</body></html>"
+    )
+
+
+def _render_text(report, activity_label, distance_km, confidence, activity_url) -> str:
+    content = report.report
+
+    if distance_km > 0:
+        header = f"{activity_label} — {distance_km}km · {confidence} confidence"
+    else:
+        header = f"{activity_label} — {confidence} confidence"
+    lines = [
+        header,
+        "",
+        "Key takeaways:",
+    ]
+    for t in content.key_takeaways:
+        lines.append(f"  - {t.text}")
+    lines += ["", "Next steps:"]
+    for s in content.next_steps:
+        lines.append(f"  - {s.action}: {s.details}")
+        lines.append(f"      Why: {s.why}")
+    if content.risks:
+        lines += ["", "Risks:"]
+        for r in content.risks:
+            lines.append(f"  - {r.flag}: {r.explanation}")
+            lines.append(f"      Mitigation: {r.mitigation}")
+    if content.questions:
+        lines += ["", "Follow-up questions:"]
+        for q in content.questions:
+            lines.append(f"  - {q.question} ({q.reason})")
+    lines += ["", f"View in app: {activity_url}"]
+    return "\n".join(lines) + "\n"

--- a/backend/app/services/notifications/in_memory_adapter.py
+++ b/backend/app/services/notifications/in_memory_adapter.py
@@ -1,0 +1,11 @@
+from app.services.notifications.port import Notification
+
+
+class InMemoryNotifier:
+    """In-memory notifier for tests. Captures sends in a list."""
+
+    def __init__(self) -> None:
+        self.sent: list[Notification] = []
+
+    def send(self, notification: Notification) -> None:
+        self.sent.append(notification)

--- a/backend/app/services/notifications/noop_adapter.py
+++ b/backend/app/services/notifications/noop_adapter.py
@@ -1,0 +1,16 @@
+import logging
+
+from app.services.notifications.port import Notification
+
+logger = logging.getLogger(__name__)
+
+
+class NoOpNotifier:
+    """Notifier that drops sends. Used when SMTP is not configured."""
+
+    def send(self, notification: Notification) -> None:
+        logger.info(
+            "Notifier no-op (SMTP not configured); would have sent to %s subject=%r",
+            notification.to,
+            notification.subject,
+        )

--- a/backend/app/services/notifications/port.py
+++ b/backend/app/services/notifications/port.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class Notification:
+    to: str
+    subject: str
+    html: str
+    text: str
+
+
+@runtime_checkable
+class NotifierPort(Protocol):
+    """Transport interface for outbound notifications. Pure side effects."""
+
+    def send(self, notification: Notification) -> None: ...

--- a/backend/app/services/notifications/smtp_adapter.py
+++ b/backend/app/services/notifications/smtp_adapter.py
@@ -1,0 +1,53 @@
+import logging
+import smtplib
+from email.message import EmailMessage
+
+from app.services.notifications.port import Notification
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT_SECONDS = 20
+
+
+class SMTPNotifier:
+    """SMTP transport. STARTTLS by default; SSL when use_starttls=False."""
+
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int,
+        username: str,
+        password: str,
+        from_addr: str,
+        use_starttls: bool = True,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.from_addr = from_addr
+        self.use_starttls = use_starttls
+
+    def send(self, notification: Notification) -> None:
+        message = EmailMessage()
+        message["From"] = self.from_addr
+        message["To"] = notification.to
+        message["Subject"] = notification.subject
+        message.set_content(notification.text)
+        message.add_alternative(notification.html, subtype="html")
+
+        if self.use_starttls:
+            server = smtplib.SMTP(self.host, self.port, timeout=_TIMEOUT_SECONDS)
+        else:
+            server = smtplib.SMTP_SSL(self.host, self.port, timeout=_TIMEOUT_SECONDS)
+        try:
+            server.ehlo()
+            if self.use_starttls:
+                server.starttls()
+                server.ehlo()
+            if self.username and self.password:
+                server.login(self.username, self.password)
+            server.send_message(message)
+        finally:
+            server.quit()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "httpx>=0.26.0",
     "redis>=5.0.0",
     "rq>=1.16.0",
+    "rq-scheduler>=0.13.1",
     "python-multipart>=0.0.9",
     "numpy>=1.24.0",
     "anthropic>=0.40.0"

--- a/backend/tests/test_coach_report_fallback_flag.py
+++ b/backend/tests/test_coach_report_fallback_flag.py
@@ -1,0 +1,116 @@
+"""Tests that CoachReport.is_fallback is set correctly when the LLM fails."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.models import (
+    Activity,
+    DerivedMetric,
+    StravaAccount,
+    User,
+    UserProfile,
+)
+from app.models.coach_report import CoachReport
+from app.services.coach.service import get_or_generate_coach_report
+
+
+def _seed_activity_with_metrics(db) -> Activity:
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+
+    profile = UserProfile(
+        user_id=user.id,
+        goal_type="general",
+        experience_level="intermediate",
+        weekly_days_available=4,
+        max_hr=190,
+    )
+    db.add(profile)
+
+    account = StravaAccount(
+        user_id=user.id,
+        strava_athlete_id=1,
+        access_token="t",
+        refresh_token="r",
+        expires_at=9999999999,
+        scope="read",
+    )
+    db.add(account)
+
+    activity = Activity(
+        user_id=user.id,
+        strava_activity_id=42,
+        start_date=datetime(2026, 5, 27, 10, 0, 0),
+        type="Run",
+        name="Test run",
+        distance_m=5000,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=10.0,
+        avg_hr=140,
+        raw_summary={},
+    )
+    db.add(activity)
+    db.commit()
+
+    # Minimal DerivedMetric so get_or_generate_coach_report has metrics to read
+    metric = DerivedMetric(
+        activity_id=activity.id,
+        activity_class="Easy",
+        effort_score=50.0,
+        flags=[],
+        confidence="medium",
+        confidence_reasons=[],
+    )
+    db.add(metric)
+    db.commit()
+    db.refresh(activity)
+    return activity
+
+
+@pytest.mark.asyncio
+async def test_is_fallback_true_when_llm_returns_invalid_json(db, monkeypatch):
+    activity = _seed_activity_with_metrics(db)
+
+    fake_client = AsyncMock()
+    fake_client.generate_json = AsyncMock(return_value="not valid json at all")
+
+    with patch(
+        "app.services.coach.service.AnthropicClient", return_value=fake_client
+    ):
+        report = await get_or_generate_coach_report(db, str(activity.id))
+
+    assert report is not None
+    stored = db.query(CoachReport).filter(CoachReport.activity_id == activity.id).first()
+    assert stored is not None
+    assert stored.is_fallback is True
+
+
+@pytest.mark.asyncio
+async def test_is_fallback_false_on_happy_path(db):
+    activity = _seed_activity_with_metrics(db)
+
+    valid_json = (
+        '{"key_takeaways":['
+        '{"text":"You ran well."},'
+        '{"text":"Heart rate was steady."}'
+        '],'
+        '"next_steps":[{"action":"Keep going","details":"Stay easy","why":"Build base"}]'
+        '}'
+    )
+    fake_client = AsyncMock()
+    fake_client.generate_json = AsyncMock(return_value=valid_json)
+
+    with patch(
+        "app.services.coach.service.AnthropicClient", return_value=fake_client
+    ):
+        report = await get_or_generate_coach_report(db, str(activity.id))
+
+    assert report is not None
+    stored = db.query(CoachReport).filter(CoachReport.activity_id == activity.id).first()
+    assert stored is not None
+    assert stored.is_fallback is False

--- a/backend/tests/test_email_template.py
+++ b/backend/tests/test_email_template.py
@@ -1,0 +1,139 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from app.schemas.coach import (
+    CoachNextStep,
+    CoachQuestion,
+    CoachReportContent,
+    CoachReportDebug,
+    CoachReportMeta,
+    CoachReportRead,
+    CoachRisk,
+    CoachTakeaway,
+)
+from app.services.notifications.email_template import render_coach_report_email
+
+
+def _build_report(*, activity_class: str = "Easy", confidence: str = "medium") -> CoachReportRead:
+    return CoachReportRead(
+        id=uuid4(),
+        activity_id=uuid4(),
+        report=CoachReportContent(
+            key_takeaways=[
+                CoachTakeaway(text="Effort stayed in zone 2 throughout."),
+                CoachTakeaway(text="HR drift was minimal at 2.1%."),
+            ],
+            next_steps=[
+                CoachNextStep(
+                    action="Add a tempo run mid-week",
+                    details="Target 4km at threshold pace.",
+                    why="To extend lactate clearance.",
+                )
+            ],
+            risks=[
+                CoachRisk(
+                    flag="cadence_low",
+                    explanation="Cadence averaged 162 spm.",
+                    mitigation="Consider strides 1-2x/week.",
+                )
+            ],
+            questions=[
+                CoachQuestion(
+                    question="How did sleep feel last night?",
+                    reason="Helps calibrate effort guidance.",
+                )
+            ],
+        ),
+        meta=CoachReportMeta(
+            confidence=confidence,
+            model_id="claude-sonnet-4-20250514",
+            prompt_id="coach_report_v1",
+            schema_version="1.1",
+            input_hash="abc123",
+            generated_at=datetime.now(timezone.utc),
+        ),
+        debug=CoachReportDebug(context_pack={}, system_prompt=""),
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_subject_includes_class_distance_confidence():
+    report = _build_report(activity_class="Easy Run", confidence="medium")
+    subject, _html, _text = render_coach_report_email(
+        report=report,
+        activity_class="Easy Run",
+        distance_m=8200,
+        app_base_url="http://localhost:3000",
+    )
+    assert subject == "Easy Run — 8.2km · medium confidence"
+
+
+def test_subject_does_not_append_literal_run_word():
+    """The classifier returns labels that already include the activity noun
+    (e.g. 'Easy Run', 'Indoor Ride'). The template must not append ' run'."""
+    report = _build_report()
+    subject, html, text = render_coach_report_email(
+        report=report,
+        activity_class="Indoor Ride",
+        distance_m=0,
+        app_base_url="http://localhost:3000",
+    )
+    assert "Ride run" not in subject
+    assert "Ride run" not in html
+    assert "Ride run" not in text
+
+
+def test_subject_drops_distance_when_zero():
+    report = _build_report()
+    subject, html, text = render_coach_report_email(
+        report=report,
+        activity_class="Indoor Ride",
+        distance_m=0,
+        app_base_url="http://localhost:3000",
+    )
+    assert subject == "Indoor Ride — medium confidence"
+    assert "0.0km" not in subject
+    assert "0.0km" not in html
+    assert "0.0km" not in text
+
+
+def test_html_contains_all_sections_and_app_link():
+    report = _build_report()
+    _subject, html, _text = render_coach_report_email(
+        report=report,
+        activity_class="Easy",
+        distance_m=8200,
+        app_base_url="http://localhost:3000",
+    )
+    assert "Effort stayed in zone 2 throughout." in html
+    assert "Add a tempo run mid-week" in html
+    assert "Target 4km at threshold pace." in html
+    assert "cadence_low" in html
+    assert "How did sleep feel last night?" in html
+    assert (
+        f'href="http://localhost:3000/activity/{report.activity_id}"' in html
+    )
+
+
+def test_text_body_contains_takeaways_and_link():
+    report = _build_report()
+    _subject, _html, text = render_coach_report_email(
+        report=report,
+        activity_class="Easy",
+        distance_m=8200,
+        app_base_url="http://localhost:3000",
+    )
+    assert "Effort stayed in zone 2 throughout." in text
+    assert "Add a tempo run mid-week" in text
+    assert f"http://localhost:3000/activity/{report.activity_id}" in text
+
+
+def test_distance_rounded_to_one_decimal():
+    report = _build_report()
+    subject, _html, _text = render_coach_report_email(
+        report=report,
+        activity_class="Tempo Run",
+        distance_m=5347,
+        app_base_url="http://localhost:3000",
+    )
+    assert subject == "Tempo Run — 5.3km · medium confidence"

--- a/backend/tests/test_notifier_port.py
+++ b/backend/tests/test_notifier_port.py
@@ -1,0 +1,61 @@
+from app.services.notifications import (
+    InMemoryNotifier,
+    Notification,
+    NotifierPort,
+    get_notifier,
+    set_notifier,
+)
+
+
+def test_in_memory_notifier_captures_sends():
+    notifier = InMemoryNotifier()
+    notifier.send(
+        Notification(
+            to="me@example.com",
+            subject="Run analysis: easy 8km",
+            html="<p>Body</p>",
+            text="Body",
+        )
+    )
+    notifier.send(
+        Notification(
+            to="other@example.com",
+            subject="Another",
+            html="<p>X</p>",
+            text="X",
+        )
+    )
+    assert len(notifier.sent) == 2
+    assert notifier.sent[0].to == "me@example.com"
+    assert notifier.sent[0].subject == "Run analysis: easy 8km"
+    assert notifier.sent[1].to == "other@example.com"
+
+
+def test_in_memory_notifier_satisfies_port_protocol():
+    notifier = InMemoryNotifier()
+    assert isinstance(notifier, NotifierPort)
+
+
+def test_set_and_get_notifier_override():
+    custom = InMemoryNotifier()
+    set_notifier(custom)
+    try:
+        assert get_notifier() is custom
+    finally:
+        set_notifier(None)
+
+
+def test_default_notifier_is_no_op_when_smtp_unset(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "SMTP_HOST", "")
+    set_notifier(None)
+    notifier = get_notifier()
+    notifier.send(
+        Notification(
+            to="x@example.com",
+            subject="s",
+            html="<p>h</p>",
+            text="t",
+        )
+    )

--- a/backend/tests/test_pipeline_end_to_end.py
+++ b/backend/tests/test_pipeline_end_to_end.py
@@ -1,0 +1,204 @@
+"""End-to-end: HTTP webhook → enqueued job → email captured.
+
+Replaces RQ with an inline enqueuer that runs the captured job synchronously
+inside the test session, using in-memory Strava and notifier adapters and a
+patched AnthropicClient. This is the test the user pointed at in the design:
+'simulate a webhook create event end-to-end and assert one email captured;
+a second webhook for the same activity captures no further sends.'
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.config import settings
+from app.models import Activity, StravaAccount, User, UserProfile
+from app.services.notifications import InMemoryNotifier, set_notifier
+from app.services.strava_ingestion import (
+    InMemoryStravaAdapter,
+    set_strava_port,
+)
+
+
+@pytest.fixture
+def strava_adapter():
+    adapter = InMemoryStravaAdapter()
+    set_strava_port(adapter)
+    yield adapter
+    set_strava_port(None)
+
+
+@pytest.fixture
+def notifier():
+    n = InMemoryNotifier()
+    set_notifier(n)
+    yield n
+    set_notifier(None)
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setattr(settings, "NOTIFY_TO", "runner@example.com")
+    monkeypatch.setattr(settings, "APP_BASE_URL", "http://localhost:3000")
+    monkeypatch.setattr(settings, "SMTP_HOST", "smtp.example.com")
+    monkeypatch.setattr(settings, "STRAVA_WEBHOOK_VERIFY_TOKEN", "x")
+
+
+def _seed(db, athlete_id: int = 70707):
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    db.add(
+        UserProfile(
+            user_id=user.id,
+            goal_type="general",
+            experience_level="intermediate",
+            weekly_days_available=4,
+            max_hr=190,
+        )
+    )
+    account = StravaAccount(
+        user_id=user.id,
+        strava_athlete_id=athlete_id,
+        access_token="t",
+        refresh_token="r",
+        expires_at=9999999999,
+        scope="read,activity:read_all",
+    )
+    db.add(account)
+    db.commit()
+
+
+def _seed_strava(adapter, strava_activity_id: int = 1234567):
+    adapter.seed_activities(
+        [
+            {
+                "id": strava_activity_id,
+                "name": "Easy",
+                "type": "Run",
+                "start_date": "2026-05-27T07:00:00Z",
+                "distance": 8200,
+                "moving_time": 2400,
+                "elapsed_time": 2400,
+                "total_elevation_gain": 40,
+                "average_heartrate": 142,
+                "average_speed": 3.4,
+            }
+        ]
+    )
+    adapter.seed_streams(
+        strava_activity_id,
+        {
+            "time": {"data": [0, 60, 120, 180]},
+            "heartrate": {"data": [130, 140, 145, 148]},
+        },
+    )
+
+
+def _valid_llm_json() -> str:
+    return (
+        '{'
+        '"key_takeaways":['
+        '{"text":"Stayed in zone 2."},'
+        '{"text":"HR drift minimal."}'
+        '],'
+        '"next_steps":[{"action":"Strides","details":"4x20s","why":"Turnover"}]'
+        '}'
+    )
+
+
+def _webhook_payload(*, aspect_type: str, activity_id: int, athlete_id: int):
+    return {
+        "object_type": "activity",
+        "object_id": activity_id,
+        "aspect_type": aspect_type,
+        "owner_id": athlete_id,
+        "subscription_id": 1,
+        "event_time": 1700000000,
+        "updates": {},
+    }
+
+
+def test_webhook_create_triggers_one_email_and_dedupes_on_replay(
+    client, db, strava_adapter, notifier, configured
+):
+    _seed(db)
+    _seed_strava(strava_adapter)
+
+    captured: list[tuple] = []
+
+    def inline_enqueue(func, **kwargs):
+        captured.append((func, kwargs))
+
+    fake_queue = AsyncMock()
+    fake_queue.enqueue = inline_enqueue
+
+    fake_client = AsyncMock()
+    fake_client.generate_json = AsyncMock(return_value=_valid_llm_json())
+
+    # Replace the queue.enqueue at the webhook handler import site and patch
+    # the AnthropicClient inside the coach service.
+    with patch("app.api.webhooks.queue", fake_queue), patch(
+        "app.services.coach.service.AnthropicClient", return_value=fake_client
+    ):
+        # First webhook: should enqueue the pipeline job
+        r1 = client.post(
+            "/api/webhooks/strava",
+            json=_webhook_payload(
+                aspect_type="create", activity_id=1234567, athlete_id=70707
+            ),
+        )
+        assert r1.status_code == 200
+        assert r1.json()["action"] == "enqueued_pipeline"
+        assert len(captured) == 1
+
+        # Run the captured job inline against the test DB by calling the inner
+        # async function directly with our shared session + ports.
+        from app.jobs.process_new_activity import process_new_activity
+        import asyncio
+
+        account = (
+            db.query(StravaAccount).filter_by(strava_athlete_id=70707).first()
+        )
+        sent_notif = asyncio.new_event_loop().run_until_complete(
+            process_new_activity(
+                db=db,
+                account=account,
+                strava_activity_id=1234567,
+                strava_port=strava_adapter,
+                notifier=notifier,
+            )
+        )
+
+        assert sent_notif is not None
+        assert len(notifier.sent) == 1
+        assert notifier.sent[0].to == "runner@example.com"
+        assert "8.2km" in notifier.sent[0].subject
+
+        # Second webhook for same activity — handler still enqueues (RQ would
+        # dedup via job_id; here we just simulate the pipeline running again
+        # and assert dedup-via-notified_at kicks in).
+        r2 = client.post(
+            "/api/webhooks/strava",
+            json=_webhook_payload(
+                aspect_type="create", activity_id=1234567, athlete_id=70707
+            ),
+        )
+        assert r2.status_code == 200
+        sent_notif_2 = asyncio.new_event_loop().run_until_complete(
+            process_new_activity(
+                db=db,
+                account=account,
+                strava_activity_id=1234567,
+                strava_port=strava_adapter,
+                notifier=notifier,
+            )
+        )
+
+    assert sent_notif_2 is None
+    assert len(notifier.sent) == 1  # still one email total
+
+    activity = db.query(Activity).filter_by(strava_activity_id=1234567).first()
+    assert activity.coach_notification_sent_at is not None

--- a/backend/tests/test_polling_job.py
+++ b/backend/tests/test_polling_job.py
@@ -1,0 +1,136 @@
+"""Polling job: discovers new activities via Strava and enqueues the pipeline."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.jobs.polling import poll_for_new_activities
+from app.models import Activity, StravaAccount, User
+from app.services.strava_ingestion import InMemoryStravaAdapter
+
+
+@pytest.fixture
+def fake_queue():
+    fake = MagicMock()
+    with patch("app.jobs.polling.queue", fake):
+        yield fake
+
+
+def _seed_user_and_account(db, athlete_id: int = 555):
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    account = StravaAccount(
+        user_id=user.id,
+        strava_athlete_id=athlete_id,
+        access_token="t",
+        refresh_token="r",
+        expires_at=9999999999,
+        scope="read,activity:read_all",
+    )
+    db.add(account)
+    db.commit()
+    return user, account
+
+
+@pytest.mark.asyncio
+async def test_polling_enqueues_pipeline_for_each_new_activity(db, fake_queue):
+    user, account = _seed_user_and_account(db)
+
+    # Activity 1000 is already in DB (known); 1001 is new.
+    existing = Activity(
+        user_id=user.id,
+        strava_activity_id=1000,
+        start_date=datetime(2026, 5, 26, 10, 0, 0),
+        type="Run",
+        name="Yesterday",
+        distance_m=5000,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=10,
+    )
+    db.add(existing)
+    db.commit()
+
+    adapter = InMemoryStravaAdapter()
+    adapter.seed_activities(
+        [
+            {
+                "id": 1000,
+                "name": "Yesterday",
+                "type": "Run",
+                "start_date": "2026-05-26T10:00:00Z",
+                "distance": 5000,
+                "moving_time": 1500,
+                "elapsed_time": 1500,
+                "total_elevation_gain": 10,
+            },
+            {
+                "id": 1001,
+                "name": "Fresh run",
+                "type": "Run",
+                "start_date": "2026-05-27T10:00:00Z",
+                "distance": 6000,
+                "moving_time": 1800,
+                "elapsed_time": 1800,
+                "total_elevation_gain": 12,
+            },
+        ]
+    )
+
+    enqueued = await poll_for_new_activities(db=db, strava_port=adapter)
+
+    assert enqueued == [1001]
+    fake_queue.enqueue.assert_called_once()
+    args, kwargs = fake_queue.enqueue.call_args
+    from app.jobs.process_new_activity import process_new_activity_job
+
+    assert args[0] is process_new_activity_job
+    assert kwargs["strava_athlete_id"] == 555
+    assert kwargs["strava_activity_id"] == 1001
+
+
+@pytest.mark.asyncio
+async def test_polling_with_no_new_activities_enqueues_nothing(db, fake_queue):
+    user, _account = _seed_user_and_account(db)
+    existing = Activity(
+        user_id=user.id,
+        strava_activity_id=1000,
+        start_date=datetime(2026, 5, 26, 10, 0, 0),
+        type="Run",
+        name="Yesterday",
+        distance_m=5000,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=10,
+    )
+    db.add(existing)
+    db.commit()
+
+    adapter = InMemoryStravaAdapter()
+    adapter.seed_activities([
+        {
+            "id": 1000,
+            "name": "Yesterday",
+            "type": "Run",
+            "start_date": "2026-05-26T10:00:00Z",
+            "distance": 5000,
+            "moving_time": 1500,
+            "elapsed_time": 1500,
+            "total_elevation_gain": 10,
+        }
+    ])
+
+    enqueued = await poll_for_new_activities(db=db, strava_port=adapter)
+    assert enqueued == []
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_polling_with_no_accounts_is_a_noop(db, fake_queue):
+    adapter = InMemoryStravaAdapter()
+    enqueued = await poll_for_new_activities(db=db, strava_port=adapter)
+    assert enqueued == []
+    fake_queue.enqueue.assert_not_called()

--- a/backend/tests/test_process_new_activity_job.py
+++ b/backend/tests/test_process_new_activity_job.py
@@ -1,0 +1,207 @@
+"""End-to-end test for the activity-notification pipeline job."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.config import settings
+from app.jobs.process_new_activity import process_new_activity
+from app.models import Activity, StravaAccount, User, UserProfile
+from app.services.notifications import InMemoryNotifier, set_notifier
+from app.services.strava_ingestion import (
+    InMemoryStravaAdapter,
+    set_strava_port,
+)
+
+
+@pytest.fixture
+def strava_adapter():
+    adapter = InMemoryStravaAdapter()
+    set_strava_port(adapter)
+    yield adapter
+    set_strava_port(None)
+
+
+@pytest.fixture
+def notifier():
+    n = InMemoryNotifier()
+    set_notifier(n)
+    yield n
+    set_notifier(None)
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setattr(settings, "NOTIFY_TO", "runner@example.com")
+    monkeypatch.setattr(settings, "APP_BASE_URL", "http://localhost:3000")
+    monkeypatch.setattr(settings, "SMTP_HOST", "smtp.example.com")
+
+
+def _seed(db, *, strava_activity_id: int = 9001):
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    db.add(
+        UserProfile(
+            user_id=user.id,
+            goal_type="general",
+            experience_level="intermediate",
+            weekly_days_available=4,
+            max_hr=190,
+        )
+    )
+    account = StravaAccount(
+        user_id=user.id,
+        strava_athlete_id=12345,
+        access_token="t",
+        refresh_token="r",
+        expires_at=9999999999,
+        scope="read,activity:read_all",
+    )
+    db.add(account)
+    db.commit()
+    return user, account
+
+
+def _seed_strava(adapter, strava_activity_id: int = 9001):
+    adapter.seed_activities(
+        [
+            {
+                "id": strava_activity_id,
+                "name": "Morning easy run",
+                "type": "Run",
+                "start_date": "2026-05-27T08:00:00Z",
+                "distance": 8200,
+                "moving_time": 2400,
+                "elapsed_time": 2400,
+                "total_elevation_gain": 40,
+                "average_heartrate": 142,
+                "average_speed": 3.4,
+            }
+        ]
+    )
+    adapter.seed_streams(
+        strava_activity_id,
+        {
+            "time": {"data": [0, 60, 120, 180]},
+            "heartrate": {"data": [130, 140, 145, 148]},
+            "distance": {"data": [0, 200, 400, 600]},
+        },
+    )
+
+
+def _valid_llm_json() -> str:
+    return (
+        '{'
+        '"key_takeaways":['
+        '{"text":"Stayed in zone 2 throughout."},'
+        '{"text":"HR drift was minimal."}'
+        '],'
+        '"next_steps":[{"action":"Add strides","details":"4x20s","why":"Improve turnover"}],'
+        '"risks":[],'
+        '"questions":[]'
+        '}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_sends_email_on_happy_path(
+    db, strava_adapter, notifier, configured
+):
+    _user, account = _seed(db)
+    _seed_strava(strava_adapter)
+
+    fake_client = AsyncMock()
+    fake_client.generate_json = AsyncMock(return_value=_valid_llm_json())
+
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake_client):
+        result = await process_new_activity(
+            db=db,
+            account=account,
+            strava_activity_id=9001,
+            strava_port=strava_adapter,
+            notifier=notifier,
+        )
+
+    assert result is not None
+    assert len(notifier.sent) == 1
+    sent = notifier.sent[0]
+    assert sent.to == "runner@example.com"
+    assert "8.2km" in sent.subject
+    assert "Stayed in zone 2 throughout." in sent.text
+    assert "Stayed in zone 2 throughout." in sent.html
+
+    activity = db.query(Activity).filter_by(strava_activity_id=9001).first()
+    assert activity.coach_notification_sent_at is not None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_dedupes_second_run(
+    db, strava_adapter, notifier, configured
+):
+    _user, account = _seed(db)
+    _seed_strava(strava_adapter)
+
+    fake_client = AsyncMock()
+    fake_client.generate_json = AsyncMock(return_value=_valid_llm_json())
+
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake_client):
+        await process_new_activity(
+            db=db, account=account, strava_activity_id=9001,
+            strava_port=strava_adapter, notifier=notifier,
+        )
+        # Second invocation must not send a second email
+        result_2 = await process_new_activity(
+            db=db, account=account, strava_activity_id=9001,
+            strava_port=strava_adapter, notifier=notifier,
+        )
+
+    assert result_2 is None
+    assert len(notifier.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_pipeline_skips_email_when_llm_fallback(
+    db, strava_adapter, notifier, configured
+):
+    _user, account = _seed(db)
+    _seed_strava(strava_adapter)
+
+    fake_client = AsyncMock()
+    fake_client.generate_json = AsyncMock(return_value="invalid json")
+
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake_client):
+        result = await process_new_activity(
+            db=db, account=account, strava_activity_id=9001,
+            strava_port=strava_adapter, notifier=notifier,
+        )
+
+    assert result is None
+    assert notifier.sent == []
+    activity = db.query(Activity).filter_by(strava_activity_id=9001).first()
+    assert activity.coach_notification_sent_at is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_skips_when_notify_to_unset(
+    db, strava_adapter, notifier, monkeypatch
+):
+    monkeypatch.setattr(settings, "NOTIFY_TO", "")
+    monkeypatch.setattr(settings, "APP_BASE_URL", "http://localhost:3000")
+    monkeypatch.setattr(settings, "SMTP_HOST", "")
+    _user, account = _seed(db)
+    _seed_strava(strava_adapter)
+
+    fake_client = AsyncMock()
+    fake_client.generate_json = AsyncMock(return_value=_valid_llm_json())
+
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake_client):
+        result = await process_new_activity(
+            db=db, account=account, strava_activity_id=9001,
+            strava_port=strava_adapter, notifier=notifier,
+        )
+
+    assert result is None
+    assert notifier.sent == []

--- a/backend/tests/test_smtp_notifier.py
+++ b/backend/tests/test_smtp_notifier.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock, patch
+
+from app.services.notifications import Notification
+from app.services.notifications.smtp_adapter import SMTPNotifier
+
+
+def _build_notification() -> Notification:
+    return Notification(
+        to="runner@example.com",
+        subject="Easy run — 8.2km · medium confidence",
+        html="<html><body><h1>Coach report</h1></body></html>",
+        text="Coach report\n",
+    )
+
+
+def test_smtp_notifier_sends_via_starttls():
+    notifier = SMTPNotifier(
+        host="smtp.example.com",
+        port=587,
+        username="user",
+        password="pw",
+        from_addr="coach@example.com",
+        use_starttls=True,
+    )
+    fake_server = MagicMock()
+    with patch("smtplib.SMTP", return_value=fake_server) as smtp_cls:
+        notifier.send(_build_notification())
+
+    smtp_cls.assert_called_once_with("smtp.example.com", 587, timeout=20)
+    enter_calls = [c[0] for c in fake_server.method_calls]
+    # Order matters: starttls before login, login before send_message
+    assert enter_calls.index("starttls") < enter_calls.index("login")
+    assert enter_calls.index("login") < enter_calls.index("send_message")
+    fake_server.login.assert_called_once_with("user", "pw")
+    fake_server.send_message.assert_called_once()
+    sent_message = fake_server.send_message.call_args.args[0]
+    assert sent_message["From"] == "coach@example.com"
+    assert sent_message["To"] == "runner@example.com"
+    assert sent_message["Subject"] == "Easy run — 8.2km · medium confidence"
+    # Multipart/alternative with both text and html parts
+    parts = list(sent_message.iter_parts())
+    content_types = {p.get_content_type() for p in parts}
+    assert content_types == {"text/plain", "text/html"}
+    fake_server.quit.assert_called_once()
+
+
+def test_smtp_notifier_uses_ssl_when_starttls_false():
+    notifier = SMTPNotifier(
+        host="smtp.example.com",
+        port=465,
+        username="user",
+        password="pw",
+        from_addr="coach@example.com",
+        use_starttls=False,
+    )
+    fake_server = MagicMock()
+    with patch("smtplib.SMTP_SSL", return_value=fake_server) as ssl_cls:
+        notifier.send(_build_notification())
+
+    ssl_cls.assert_called_once_with("smtp.example.com", 465, timeout=20)
+    fake_server.starttls.assert_not_called()
+    fake_server.login.assert_called_once_with("user", "pw")
+    fake_server.send_message.assert_called_once()
+
+
+def test_smtp_notifier_skips_login_when_no_credentials():
+    notifier = SMTPNotifier(
+        host="smtp.example.com",
+        port=587,
+        username="",
+        password="",
+        from_addr="coach@example.com",
+        use_starttls=True,
+    )
+    fake_server = MagicMock()
+    with patch("smtplib.SMTP", return_value=fake_server):
+        notifier.send(_build_notification())
+    fake_server.login.assert_not_called()
+    fake_server.send_message.assert_called_once()

--- a/backend/tests/test_webhook_dispatch.py
+++ b/backend/tests/test_webhook_dispatch.py
@@ -1,0 +1,56 @@
+"""Verify that the webhook handler dispatches the right job per aspect_type."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def fake_queue():
+    fake = MagicMock()
+    with patch("app.api.webhooks.queue", fake):
+        yield fake
+
+
+def _post(client, *, aspect_type: str, object_id: int = 7777):
+    payload = {
+        "object_type": "activity",
+        "object_id": object_id,
+        "aspect_type": aspect_type,
+        "owner_id": 999,
+        "subscription_id": 1,
+        "event_time": 1700000000,
+        "updates": {},
+    }
+    return client.post("/api/webhooks/strava", json=payload)
+
+
+def test_create_enqueues_process_new_activity_job(client, fake_queue):
+    from app.jobs.process_new_activity import process_new_activity_job
+
+    response = _post(client, aspect_type="create")
+    assert response.status_code == 200
+    assert response.json()["status"] == "processed"
+
+    fake_queue.enqueue.assert_called_once()
+    args, kwargs = fake_queue.enqueue.call_args
+    assert args[0] is process_new_activity_job
+    assert kwargs["strava_athlete_id"] == 999
+    assert kwargs["strava_activity_id"] == 7777
+
+
+def test_update_enqueues_existing_sync_activity_job(client, fake_queue):
+    from app.jobs.strava_sync import sync_activity_job
+
+    response = _post(client, aspect_type="update")
+    assert response.status_code == 200
+
+    fake_queue.enqueue.assert_called_once()
+    args, kwargs = fake_queue.enqueue.call_args
+    assert args[0] is sync_activity_job
+
+
+def test_delete_does_not_enqueue(client, fake_queue):
+    response = _post(client, aspect_type="delete")
+    assert response.status_code == 200
+    fake_queue.enqueue.assert_not_called()

--- a/docs/adr/0004-activity-notification-dual-source-pipeline.md
+++ b/docs/adr/0004-activity-notification-dual-source-pipeline.md
@@ -1,0 +1,23 @@
+# Activity notification uses a dual-source pipeline with one convergence job
+
+The runner wants the coach report delivered out-of-band (email) as soon as possible after completing a run, without depending on opening the laptop frontend. The Strava webhook is the fastest signal, but it requires a public HTTPS endpoint, which is not part of the local-first runtime. A polling fallback is needed for the case where no tunnel is configured.
+
+Both paths converge on a single job: `process_new_activity_job(athlete_id, activity_id)`, which runs ingest → analyze → generate coach report → notify. The webhook handler dispatches `aspect_type=create` events to this job (and keeps the existing `sync_activity_job` for `update` events). A scheduled polling job (`rq-scheduler`, ~2 minute interval) calls `ingest_recent_activities`, diffs against the local DB, and enqueues `process_new_activity_job` for each previously-unseen activity.
+
+Dedup is enforced by a single `coach_notification_sent_at` column on `Activity`. Webhook and polling can both fire for the same activity (e.g., webhook is briefly delayed and polling catches it first) without producing duplicate emails: whichever path finishes first sets the timestamp; the other observes it and skips the send.
+
+The notifier is a port (`NotifierPort.send(subject, html, text, to)`) with two adapters: `SMTPNotifier` for production and `InMemoryNotifier` for tests. This mirrors the Strava port pattern established in [ADR 0002](0002-strava-adapter-is-pure-transport.md) and keeps the pipeline job free of transport concerns.
+
+Failure semantics:
+- SMTP failure raises out of the job; `coach_notification_sent_at` stays null; RQ retries per its bounded policy. Permanent failures surface in `rq info`.
+- LLM failure produces the existing canned fallback `CoachReport`, marked with a new `is_fallback` flag. The notifier checks this flag and skips the send so the inbox does not fill with "analysis unavailable" emails on transient LLM hiccups.
+- The notifier is a no-op when `SMTP_HOST` is unset, so the feature is implicitly off in dev environments without credentials.
+
+## Consequences
+
+- New dependency: `rq-scheduler`. A second worker process (`rqscheduler`) is added to docker-compose alongside the existing `rq worker`.
+- Schema change: a new `coach_notification_sent_at` column on `activity` and an `is_fallback` boolean on `coach_report`, both via alembic migration.
+- New env vars: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM`, `NOTIFY_TO`, `APP_BASE_URL`.
+- The webhook handler now branches by `aspect_type`. `create` enqueues the new pipeline job; `update` keeps the existing thin re-ingest job; `delete` is unchanged.
+- The polling job hits Strava ~720 times/day, well under the documented 1000/day account limit. Per-15-minute spikes are bounded (~7 calls).
+- Future architecture reviews should not re-suggest collapsing the two source paths into "webhook-only" — the polling path is the local-first runtime's only reliable trigger when no tunnel is set up. Likewise, do not re-suggest promoting `coach_notification_sent_at` to a separate `ActivityNotification` table until there is a second channel that needs distinct dedup state.

--- a/project-context.md
+++ b/project-context.md
@@ -17,11 +17,13 @@ A `RunnerBaseline` stores rolling baselines used for comparison and drift detect
 ## Scope
 
 The backend exposes JSON endpoints under `/api` for health, Strava OAuth, profile CRUD, activity listing/detail, sync, deep processing, intent labelling, check-ins, trends, coach report, and coach chat.
-Strava ingestion supports both manual sync (`POST /api/sync`) and incoming webhooks (`/api/webhooks/strava`); webhook events enqueue RQ jobs that fetch and persist activities.
+Strava ingestion supports both manual sync (`POST /api/sync`) and incoming webhooks (`/api/webhooks/strava`); webhook `aspect_type=create` events enqueue `process_new_activity_job` (ingest → analyze → coach → email), `update` events enqueue `sync_activity_job` (re-ingest only), and `delete` events soft-delete the activity row.
+A polling fallback (`poll_for_new_activities_job`) discovers activities Strava webhook missed and converges on the same pipeline; it runs every `POLLING_INTERVAL_SECONDS` via an `rq-scheduler` process.
 Deep processing classifies the activity, computes metrics from streams (smoothing, splits, intervals, stops, efficiency, risk), and runs workout matching against any planned workout.
-The coach pipeline builds a context pack, calls Anthropic, validates the response against a Pydantic schema, then runs a deterministic policy validator before storing the report.
+The coach pipeline builds a context pack, calls Anthropic, validates the response against a Pydantic schema, then runs a deterministic policy validator before storing the report; LLM/parse failures persist a fallback `CoachReport` with `is_fallback=True`.
+Coach-report email delivery is gated by `SMTP_HOST` and `NOTIFY_TO`; with both unset the notifier is a no-op. Successful delivery sets `Activity.coach_notification_sent_at`, which is the dedup sentinel for at-most-once-per-activity email semantics.
 The frontend renders an activity list on the home page, a per-activity detail page with charts and panels, a profile page, and a trends page with filters and chart views.
-Planned-workout capture is not yet implemented; `_extract_planned_workout` in `services/processing/engine.py` returns `None` as a placeholder.
+Planned-workout capture is not yet implemented; `_extract_planned_workout` in `services/analysis/_orchestrator.py` returns `None` as a placeholder.
 There is no multi-user auth layer; the backend assumes a single local user and auto-creates one on first profile read.
 There is no production deployment target in-repo; the only runtime is local via `docker compose` plus uvicorn and `next dev`.
 
@@ -29,6 +31,8 @@ There is no production deployment target in-repo; the only runtime is local via 
 
 Settings come from `backend/.env` via `pydantic-settings`; `DATABASE_URL` is required and the app will not boot without it.
 Anthropic access requires `ANTHROPIC_API_KEY`; the coach model id and prompt id are configured via `COACH_MODEL_ID` and `COACH_PROMPT_ID`.
+Email notifications are gated by `SMTP_HOST` (empty = notifier is no-op) and `NOTIFY_TO`; transport is configured via `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM`, `SMTP_USE_STARTTLS`.
+The polling fallback interval is `POLLING_INTERVAL_SECONDS` (default 120s, ~720 Strava calls/day per account, well under Strava's 1000/day limit).
 CORS is restricted to `http://localhost:3000` and `http://localhost:8000` in `app/main.py`.
 The deterministic policy validator in `services/coach/validator.py` rejects LLM output that claims specific interval execution counts (e.g. "8x400m", "executed 8") and other policy violations; per `ai-workflow.md` this gate must not be bypassed.
 When data confidence is low, downstream analysis is expected to default to conservative output (documented intent in `README.md`).
@@ -39,12 +43,14 @@ Backend test baseline excludes tests marked `integration` (pytest marker registe
 
 The backend is a FastAPI app (`app/main.py`) wiring routers from `app/api/*` under the `/api` prefix.
 Persistence uses SQLAlchemy 2.x ORM with a Postgres database; schema migrations live under `backend/alembic/versions/`.
-Background work runs via Redis-backed RQ; jobs are defined in `app/jobs/` and a worker is started with `rq worker`.
-The Strava integration lives in `app/services/strava/client.py` and is orchestrated by `app/services/activity_service.py`.
-Processing is a pipeline of pure-ish functions in `app/services/processing/` (smoothing, metrics, classifier, splits, intervals, stops, flags, risk, workout matching) composed by `engine.py`.
-The coach layer is `context.py` (builds the pack) → `llm.py` (Anthropic client) → Pydantic schemas in `app/schemas/coach.py` → `validator.py` (policy gate) → `service.py` (caches result in `CoachReport`).
+Background work runs via Redis-backed RQ; jobs are defined in `app/jobs/` and a worker is started with `rq worker`. A separate `rqscheduler` process registers and fires the recurring polling job; bootstrap it once via `python -m app.jobs.scheduler`.
+The Strava integration is a port (`StravaPort` in `app/services/strava_ingestion/port.py`) with `HTTPStravaAdapter` and `InMemoryStravaAdapter`; the ingestion module (`app/services/strava_ingestion/ingestion.py`) owns persistence and orchestration on top of that port (ADR 0002, ADR 0003).
+Analysis is a pipeline of pure-ish functions in `app/services/analysis/` (smoothing, metrics, classifier, splits, intervals, stops, flags, risk, workout matching) composed by `_orchestrator.py`; the public surface is `analyze` and `analyze_with_streams`.
+The coach layer is `context.py` (builds the pack) → `llm.py` (Anthropic client) → Pydantic schemas in `app/schemas/coach.py` → `validator.py` (policy gate) → `service.py` (caches result in `CoachReport`, with `is_fallback=True` on LLM/parse failure).
+The notifications layer is a port (`NotifierPort` in `app/services/notifications/port.py`) with `SMTPNotifier` (stdlib `smtplib`), `InMemoryNotifier`, and `NoOpNotifier`. `app/services/notifications/email_template.py` renders the coach-report email (subject + HTML + plaintext).
+The webhook/polling convergence is `app/jobs/process_new_activity.py`: ingest → analyze → coach generate → notify, gated by `Activity.coach_notification_sent_at` (ADR 0004).
 The frontend is a Next.js 14 App Router project; pages live under `frontend/app/`, reusable UI under `frontend/components/`, and the typed API client and shared types under `frontend/lib/`.
-Data flow: Strava API → activity_service → Activity/ActivityStream rows → processing engine → DerivedMetric → coach service → CoachReport → frontend via `/api/activities/{id}` and `/api/activities/{id}/coach-report`.
+Data flow: Strava API → strava_ingestion → Activity/ActivityStream rows → analysis pipeline → DerivedMetric → coach service → CoachReport → either (a) frontend via `/api/activities/{id}/coach-report`, or (b) notifications via the pipeline job's email send.
 
 ## Key Dependencies
 
@@ -53,6 +59,7 @@ Data flow: Strava API → activity_service → Activity/ActivityStream rows → 
 `pydantic`, `pydantic-settings`: request/response schemas and environment configuration.
 `httpx`: outbound HTTP client used for Strava and Anthropic calls.
 `redis`, `rq`: job queue for sync and processing background work.
+`rq-scheduler`: schedules the recurring polling job that catches activities Strava webhook missed.
 `numpy`: numerical computation in the processing pipeline (smoothing, metrics, intervals).
 `anthropic`: Claude API client used by the coach service.
 `python-multipart`: form parsing required by FastAPI for non-JSON request bodies.
@@ -73,12 +80,12 @@ Data flow: Strava API → activity_service → Activity/ActivityStream rows → 
 `backend/app/db/base.py` defines the SQLAlchemy `Base`; `backend/app/db/session.py` provides `SessionLocal` and the `get_db` dependency.
 `backend/app/models/` holds one ORM model per file (`activity`, `activity_stream`, `checkin`, `coach_chat_message`, `coach_report`, `derived_metric`, `runner_baseline`, `strava_account`, `user`, `user_profile`) with a barrel `__init__.py`.
 `backend/app/schemas/` holds Pydantic request/response schemas, one file per domain (`activity`, `chat`, `checkin`, `coach`, `detail`, `profile`, `sync`, `trends`, `user`).
-`backend/app/services/activity_service.py` owns Strava-to-DB ingestion and stream fetching.
-`backend/app/services/strava/client.py` is the Strava HTTP client.
-`backend/app/services/processing/` is the metrics pipeline (`engine.py` orchestrates `smoothing.py`, `metrics.py`, `classifier.py`, `splits.py`, `intervals.py`, `stops.py`, `flags.py`, `risk.py`, `workout_matching.py`).
+`backend/app/services/strava_ingestion/` holds the Strava port + adapters (`port.py`, `http_adapter.py`, `in_memory_adapter.py`) and the ingestion module (`ingestion.py`) that persists activities and streams.
+`backend/app/services/analysis/` is the metrics pipeline (`_orchestrator.py` composes `smoothing.py`, `metrics.py`, `classifier.py`, `splits.py`, `intervals.py`, `stops.py`, `flags.py`, `risk.py`, `workout_matching.py`, `_training_context.py`); the public surface is `analyze` and `analyze_with_streams`.
 `backend/app/services/coach/` owns the LLM coach (`context.py`, `prompts.py`, `llm.py`, `validator.py`, `service.py`, `chat.py`).
-`backend/app/services/trends.py` produces aggregated trend data; `backend/app/services/units/cadence.py` normalises cadence units.
-`backend/app/jobs/strava_sync.py` defines RQ job entry points; `backend/app/worker.py` is the worker bootstrap.
+`backend/app/services/notifications/` owns the notifier port + adapters (`port.py`, `smtp_adapter.py`, `in_memory_adapter.py`, `noop_adapter.py`) and the email template (`email_template.py`).
+`backend/app/services/trends.py` produces aggregated trend data; `backend/app/services/units/cadence.py` normalises cadence units; `backend/app/services/activity_queries.py` holds shared activity-query helpers.
+`backend/app/jobs/strava_sync.py` defines the legacy sync RQ job entries; `backend/app/jobs/process_new_activity.py` is the convergence pipeline job; `backend/app/jobs/polling.py` is the Strava polling fallback; `backend/app/jobs/scheduler.py` bootstraps `rq-scheduler`. `backend/app/worker.py` is the worker bootstrap.
 `backend/alembic/versions/` holds migrations, one per schema change.
 `backend/tests/` holds pytest suites covering analysis, intervals, policy validator, sync integration, webhooks, stream metrics, workout matching, smoke, and others.
 `frontend/app/page.tsx` is the home view; `frontend/app/activity/[id]/page.tsx` is the activity detail view.
@@ -95,7 +102,7 @@ Data flow: Strava API → activity_service → Activity/ActivityStream rows → 
 
 Backend tests run via `python -m pytest`; the global baseline command is `make backend-test`, which excludes tests marked `integration`.
 Backend smoke is a single file (`backend/tests/test_smoke.py`) covering a FastAPI health-check readiness path.
-Backend unit and policy coverage exists for analysis, coach context, coach schema, intervals, models, playbooks, policy validator, profile, risk, strava auth, stream metrics, sync integration, units/cadence, webhooks, and workout matching.
+Backend unit and policy coverage exists for analysis, coach context, coach schema, coach fallback flag, email template, notifier port, SMTP notifier, pipeline job (`process_new_activity`), polling job, webhook dispatch, end-to-end pipeline, intervals, models, playbooks, policy validator, profile, risk, strava auth, stream metrics, sync integration, units/cadence, webhooks, and workout matching.
 Integration-tagged tests are excluded from the default regression run because they depend on local services or deeper cross-layer setup.
 Frontend regression runs via `npm run test`, which invokes `next lint` then `next build`; there is no Jest or component test runner configured.
 Frontend smoke runs via `npm run smoke` (`scripts/smoke.mjs`), which boots a mock API on `3001` and a Next dev server on `3100` and verifies core routes load.


### PR DESCRIPTION
## Summary
- New convergence pipeline (`process_new_activity_job`) runs ingest → analyze → coach → email for each newly discovered activity. Both Strava webhook `aspect_type=create` and a 2-minute polling fallback enqueue this same job; dedup via `Activity.coach_notification_sent_at`.
- New `NotifierPort` (SMTP / in-memory / no-op adapters) mirroring `StravaPort`. Email is off until `SMTP_HOST` and `NOTIFY_TO` are set.
- `CoachReport.is_fallback` flag so transient LLM failures don't generate "analysis unavailable" emails.
- Polling job + `rq-scheduler` bootstrap; runs every `POLLING_INTERVAL_SECONDS` (default 120s).
- Webhook handler now dispatches `create` to the pipeline job and `update` to the existing re-ingest job (`delete` unchanged).
- Latent bug fix in `services/analysis/_orchestrator.py`: `analyze` / `analyze_with_streams` now coerce `activity_id` to UUID before querying. Postgres auto-cast hid this; SQLite tests masked it because the API handler swallowed analyze exceptions. My pipeline doesn't swallow, so the fix was forced.
- Design rationale: [docs/adr/0004](docs/adr/0004-activity-notification-dual-source-pipeline.md). Glossary added at [CONTEXT.md](CONTEXT.md). `project-context.md` refreshed (was referencing the old `services/processing/` and `services/strava/client.py` paths that no longer exist).

## What this PR does NOT change
- No frontend changes. The lazy on-demand coach report endpoint still works the same way.
- No Strava-side subscription setup; the webhook path is wired but the user still has to expose the backend publicly (tunnel) if they want it.
- No multi-user surface. Single recipient via `NOTIFY_TO` env.

## Test plan
- [x] 171 backend tests pass (`make backend-test`), +26 new
- [x] Backend smoke green (`make backend-smoke`)
- [x] Frontend smoke green (untouched)
- [x] Alembic migration applied against local Postgres; both columns visible in `\d activities` / `\d coach_reports`
- [x] Real-world end-to-end: pipeline ran against my two real Strava activities from today; both emails landed in Gmail with the expected subjects (`Easy Run — 3.5km · medium confidence` and `Indoor Ride — medium confidence`)
- [ ] SMTP STARTTLS path also verified manually against Gmail; SSL path covered only by unit test with mocked `smtplib.SMTP_SSL`

## Operational notes
- `alembic upgrade head` adds two columns: `activities.coach_notification_sent_at` and `coach_reports.is_fallback`. Safe / additive.
- New env vars in `backend/.env.example`: `SMTP_*`, `NOTIFY_TO`, `POLLING_INTERVAL_SECONDS`.
- Two new long-running processes needed for the feature to be live: `rq worker --url \$REDIS_URL` and `rqscheduler --url \$REDIS_URL`. Both must be running for the polling path to fire.
- New dep: `rq-scheduler>=0.13.1`.

## Known follow-ups (not in this PR)
- No automatic filtering by activity type. Walks, rides, etc. all get emails.
- Webhook POST handler doesn't HMAC-verify Strava payloads; the `STRAVA_WEBHOOK_VERIFY_TOKEN` only covers the GET subscription handshake.
- Transient LLM failures persist a fallback `CoachReport`; polling won't re-discover the activity (it's now in the DB), so a permanent miss is silent. Manual re-trigger required.
- No launchd/systemd auto-start for the worker + scheduler.