### PR TITLE
Phase 1 step 3: Sentry SDK + structured JSON logging (#59)

### DIFF
--- a/backend/app/api/debug.py
+++ b/backend/app/api/debug.py
@@ -1,0 +1,32 @@
+"""Diagnostic endpoints used to verify the observability stack end-to-end.
+
+Behind the same basic-auth middleware as the rest of /api. Endpoints here
+are intentionally never wired into the frontend or user-facing flows.
+
+TODO(phase-2): consider gating these behind a feature flag or removing if
+they outlive their usefulness past the first production deploy.
+"""
+
+from fastapi import APIRouter, HTTPException
+
+from app.core.config import settings
+
+router = APIRouter()
+
+
+class SentrySmokeError(RuntimeError):
+    """Deliberate exception raised to verify the Sentry pipeline."""
+
+
+@router.get("/_debug/sentry-test")
+def trigger_sentry_test_exception() -> None:
+    """Raise an exception so we can confirm Sentry captures it.
+
+    Disabled when SENTRY_DSN is unset so calling this in a misconfigured
+    environment produces a clean 404 rather than a meaningless 500.
+    """
+    if not settings.SENTRY_DSN:
+        raise HTTPException(status_code=404, detail="sentry not configured")
+    raise SentrySmokeError(
+        "phase-1 step 3 smoke test — if you see this in Sentry, the pipeline works"
+    )

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -1,0 +1,91 @@
+"""Sentry SDK init and structured JSON logging.
+
+Called from the entrypoint of each process group (web, worker, scheduler) so
+unhandled exceptions and error-level logs from any of them reach Sentry, and
+so log output is uniformly structured for ingestion by `flyctl logs` or any
+future log aggregator.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.rq import RqIntegration
+
+from app.core.config import settings
+
+
+_STANDARD_LOG_RECORD_FIELDS = frozenset(
+    {
+        "args", "asctime", "created", "exc_info", "exc_text", "filename",
+        "funcName", "levelname", "levelno", "lineno", "message", "module",
+        "msecs", "msg", "name", "pathname", "process", "processName",
+        "relativeCreated", "stack_info", "thread", "threadName", "taskName",
+    }
+)
+
+
+class JSONFormatter(logging.Formatter):
+    """Render a LogRecord as a single JSON line."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "ts": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        for key, value in record.__dict__.items():
+            if key in _STANDARD_LOG_RECORD_FIELDS or key.startswith("_"):
+                continue
+            payload[key] = value
+        return json.dumps(payload, default=str)
+
+
+def init_logging() -> None:
+    """Replace root handlers with a single stdout handler.
+
+    Emits JSON when APP_ENV is "production"; pretty otherwise. Idempotent —
+    repeated calls only ever leave one handler attached.
+    """
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler(sys.stdout)
+    if settings.APP_ENV == "production":
+        handler.setFormatter(JSONFormatter())
+    else:
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s")
+        )
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)
+
+
+def init_sentry(component: str) -> None:
+    """Initialise the Sentry SDK. No-op when SENTRY_DSN is unset.
+
+    `component` is the Fly process group ("web", "worker", "scheduler") and is
+    attached to every event as a tag so the Sentry UI can filter by process.
+    """
+    if not settings.SENTRY_DSN:
+        return
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        environment=settings.APP_ENV,
+        traces_sample_rate=0.0,
+        integrations=[
+            LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
+            RqIntegration(),
+        ],
+    )
+    sentry_sdk.set_tag("component", component)

--- a/backend/app/jobs/scheduler.py
+++ b/backend/app/jobs/scheduler.py
@@ -13,6 +13,7 @@ from redis import Redis
 from rq_scheduler import Scheduler
 
 from app.core.config import settings
+from app.core.observability import init_logging, init_sentry
 from app.jobs.polling import poll_for_new_activities_job
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,8 @@ def register_polling_schedule(scheduler: Scheduler | None = None) -> None:
 
 def run() -> None:
     """Register the schedule, then enter the rq-scheduler poll loop."""
+    init_logging()
+    init_sentry("scheduler")
     scheduler = _build_scheduler()
     register_polling_schedule(scheduler)
     logger.info("Entering rq-scheduler run loop")
@@ -57,5 +60,4 @@ def run() -> None:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
     run()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,13 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api import health, auth, activities, webhooks, profile, trends, coach
+from app.api import health, auth, activities, webhooks, profile, trends, coach, debug
 from app.core.auth import BasicAuthMiddleware
 from app.core.config import settings
+from app.core.observability import init_logging, init_sentry
+
+init_logging()
+init_sentry("web")
 
 app = FastAPI(
     title="Running Coach",
@@ -33,6 +37,7 @@ app.include_router(activities.router, prefix="/api", tags=["Activities"])
 app.include_router(webhooks.router, prefix="/api", tags=["Webhooks"])
 app.include_router(trends.router, prefix="/api", tags=["Trends"])
 app.include_router(coach.router, prefix="/api", tags=["Coach"])
+app.include_router(debug.router, prefix="/api", tags=["Debug"])
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,13 +1,30 @@
+"""RQ worker entrypoint.
+
+Invoked as `python -m app.worker` so we get a Python startup hook for the
+observability layer (Sentry, structured logging) before handing control to
+RQ's worker loop.
+"""
+
 import logging
-import sys
-from rq import Worker, Queue
+
+from rq import Queue, Worker
+
+from app.core.observability import init_logging, init_sentry
 from app.core.queue import redis_conn
 
-listen = ['default']
+LISTEN = ("default",)
+
 logger = logging.getLogger(__name__)
 
-if __name__ == '__main__':
-    logger.info("Worker initiating...")
-    queues = [Queue(name, connection=redis_conn) for name in listen]
+
+def main() -> None:
+    init_logging()
+    init_sentry("worker")
+    logger.info("Worker booting; listening on %s", ",".join(LISTEN))
+    queues = [Queue(name, connection=redis_conn) for name in LISTEN]
     worker = Worker(queues, connection=redis_conn)
     worker.work()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -23,7 +23,7 @@ primary_region = "lhr"
 
 [processes]
   web = "uvicorn app.main:app --host 0.0.0.0 --port 8000"
-  worker = "sh -c 'rq worker --url $REDIS_URL'"
+  worker = "python -m app.worker"
   scheduler = "python -m app.jobs.scheduler"
 
 [deploy]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "rq-scheduler>=0.13.1",
     "python-multipart>=0.0.9",
     "numpy>=1.24.0",
-    "anthropic>=0.40.0"
+    "anthropic>=0.40.0",
+    "sentry-sdk[fastapi]>=2.0.0"
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_debug_endpoint.py
+++ b/backend/tests/test_debug_endpoint.py
@@ -1,0 +1,18 @@
+"""Tests for the diagnostic /api/_debug/sentry-test endpoint."""
+
+import pytest
+
+from app.api.debug import SentrySmokeError
+from app.core.config import settings
+
+
+def test_returns_404_when_sentry_dsn_unset(client, monkeypatch):
+    monkeypatch.setattr(settings, "SENTRY_DSN", "")
+    response = client.get("/api/_debug/sentry-test")
+    assert response.status_code == 404
+
+
+def test_raises_smoke_error_when_sentry_dsn_set(client, monkeypatch):
+    monkeypatch.setattr(settings, "SENTRY_DSN", "https://x@example.ingest.sentry.io/1")
+    with pytest.raises(SentrySmokeError, match="phase-1 step 3 smoke test"):
+        client.get("/api/_debug/sentry-test")

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,142 @@
+"""Tests for the observability layer (Sentry init + structured JSON logging)."""
+
+import io
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from app.core import observability
+from app.core.config import settings
+
+
+class TestJSONFormatter:
+    def test_renders_a_single_json_object_with_required_keys(self):
+        formatter = observability.JSONFormatter()
+        record = logging.LogRecord(
+            name="app.test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=10,
+            msg="hello %s",
+            args=("world",),
+            exc_info=None,
+        )
+
+        payload = json.loads(formatter.format(record))
+
+        assert payload["level"] == "INFO"
+        assert payload["logger"] == "app.test"
+        assert payload["message"] == "hello world"
+        assert "ts" in payload
+
+    def test_includes_exception_info_when_present(self):
+        formatter = observability.JSONFormatter()
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+            exc_info = sys.exc_info()
+
+        record = logging.LogRecord(
+            name="app.test",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=20,
+            msg="caught",
+            args=None,
+            exc_info=exc_info,
+        )
+        payload = json.loads(formatter.format(record))
+
+        assert "exc_info" in payload
+        assert "ValueError: boom" in payload["exc_info"]
+
+    def test_includes_extra_fields_attached_to_the_record(self):
+        formatter = observability.JSONFormatter()
+        record = logging.LogRecord(
+            name="app.test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=30,
+            msg="m",
+            args=None,
+            exc_info=None,
+        )
+        record.activity_id = 42
+        record.user = "philippe"
+
+        payload = json.loads(formatter.format(record))
+
+        assert payload["activity_id"] == 42
+        assert payload["user"] == "philippe"
+
+
+class TestInitLogging:
+    def test_replaces_existing_handlers_idempotently(self, monkeypatch):
+        monkeypatch.setattr(settings, "APP_ENV", "local")
+        root = logging.getLogger()
+        observability.init_logging()
+        first_handlers = list(root.handlers)
+        observability.init_logging()
+        second_handlers = list(root.handlers)
+
+        assert len(first_handlers) == 1
+        assert len(second_handlers) == 1
+        assert first_handlers[0] is not second_handlers[0]
+
+    def test_uses_json_formatter_in_production(self, monkeypatch):
+        monkeypatch.setattr(settings, "APP_ENV", "production")
+        observability.init_logging()
+        handler = logging.getLogger().handlers[0]
+        assert isinstance(handler.formatter, observability.JSONFormatter)
+
+    def test_uses_human_formatter_outside_production(self, monkeypatch):
+        monkeypatch.setattr(settings, "APP_ENV", "local")
+        observability.init_logging()
+        handler = logging.getLogger().handlers[0]
+        assert not isinstance(handler.formatter, observability.JSONFormatter)
+
+    def test_json_handler_actually_emits_json(self, monkeypatch):
+        monkeypatch.setattr(settings, "APP_ENV", "production")
+        observability.init_logging()
+        buffer = io.StringIO()
+        logging.getLogger().handlers[0].stream = buffer
+
+        logging.getLogger("app.test").info("hello")
+
+        payload = json.loads(buffer.getvalue().strip())
+        assert payload["message"] == "hello"
+        assert payload["level"] == "INFO"
+
+
+class TestInitSentry:
+    def test_is_noop_when_dsn_is_unset(self, monkeypatch):
+        monkeypatch.setattr(settings, "SENTRY_DSN", "")
+        with patch.object(observability.sentry_sdk, "init") as mock_init:
+            observability.init_sentry("web")
+        mock_init.assert_not_called()
+
+    def test_initialises_sdk_when_dsn_is_set(self, monkeypatch):
+        monkeypatch.setattr(settings, "SENTRY_DSN", "https://x@example.ingest.sentry.io/1")
+        monkeypatch.setattr(settings, "APP_ENV", "production")
+        with patch.object(observability.sentry_sdk, "init") as mock_init, \
+                patch.object(observability.sentry_sdk, "set_tag") as mock_tag:
+            observability.init_sentry("worker")
+
+        mock_init.assert_called_once()
+        kwargs = mock_init.call_args.kwargs
+        assert kwargs["dsn"] == "https://x@example.ingest.sentry.io/1"
+        assert kwargs["environment"] == "production"
+        assert kwargs["traces_sample_rate"] == 0.0
+        mock_tag.assert_called_once_with("component", "worker")
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging_after_each_test():
+    """Tests mutate the root logger; restore baseline afterwards."""
+    yield
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)


### PR DESCRIPTION
## Summary

- New module \`app/core/observability.py\` with \`init_logging()\` (stdlib logging + custom JSONFormatter, emits JSON when \`APP_ENV=production\` and pretty lines otherwise; idempotent) and \`init_sentry(component)\` (no-op when \`SENTRY_DSN\` is unset; tags every event with the Fly process group so the Sentry UI can filter web vs worker vs scheduler).
- Wired in all three entrypoints: \`app/main.py\` (web), \`app/worker.py\` (now a real \`main()\` function), \`app/jobs/scheduler.py\`.
- Switched \`fly.toml\` worker command from \`sh -c 'rq worker --url \$REDIS_URL'\` to \`python -m app.worker\`. Eliminates the shell-expansion hack and gives us a clean Python startup hook.
- New endpoint \`/api/_debug/sentry-test\`: basic-auth gated, only enabled when \`SENTRY_DSN\` is set, raises a \`SentrySmokeError\` so we can verify the pipeline end-to-end after deploy. Returns 404 when Sentry is not configured.
- New dependency: \`sentry-sdk[fastapi]>=2.0.0\`. The FastAPI extra brings the ASGI middleware Sentry uses for request context capture.

## Test plan
- [x] \`make backend-test\` → 193 passed (+11), 0 regressions.
- [x] JSON formatter unit tests (renders required keys, includes exc_info, includes extra fields).
- [x] \`init_logging\` is idempotent and switches formatter based on APP_ENV.
- [x] \`init_sentry\` is a no-op when DSN is unset; correctly initialises SDK with environment, traces_sample_rate=0.0, and component tag when DSN is set.
- [x] Debug endpoint returns 404 when DSN unset; raises SentrySmokeError when set.
- [ ] \`flyctl logs\` shows JSON-formatted lines from web, worker, scheduler (deferred to deploy after merge).
- [ ] \`curl -u philippe:<pw> /api/_debug/sentry-test\` produces an event in the Sentry dashboard tagged \`component=web\` (deferred to deploy after merge).

## Notes

- \`traces_sample_rate=0.0\` per phase-1-plan.md item 5 — free tier; no performance traces in Phase 1.
- LoggingIntegration set to capture INFO-level logs as breadcrumbs and ERROR-level as events. The standard Sentry default.
- RqIntegration is included so worker jobs that raise are auto-captured with job context.
- The \`/api/_debug/sentry-test\` endpoint stays in the codebase past Phase 1; it's cheap and useful for verifying Sentry config in future redeploys. Phase 2 may gate behind a feature flag if we add user-facing routes near it.

Closes #59