### PR TITLE
fix(deploy): emit JSON logs from web (#61)

### DIFF
--- a/backend/app/web.py
+++ b/backend/app/web.py
@@ -1,0 +1,33 @@
+"""FastAPI web entrypoint.
+
+Invoked as `python -m app.web` so we get a Python startup hook for the
+observability layer (Sentry, structured logging) before handing control to
+uvicorn. Passing `log_config=None` to uvicorn disables uvicorn's built-in
+logging config, so uvicorn's `uvicorn`, `uvicorn.access`, and `uvicorn.error`
+loggers fall through to the root logger we configured in init_logging() —
+which means access logs are emitted as JSON in production.
+"""
+
+import logging
+
+import uvicorn
+
+from app.core.observability import init_logging, init_sentry
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    init_logging()
+    init_sentry("web")
+    logger.info("Web booting; uvicorn binding 0.0.0.0:8000")
+    uvicorn.run(
+        "app.main:app",
+        host="0.0.0.0",
+        port=8000,
+        log_config=None,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -22,7 +22,7 @@ primary_region = "lhr"
   PYTHONUNBUFFERED = "1"
 
 [processes]
-  web = "uvicorn app.main:app --host 0.0.0.0 --port 8000"
+  web = "python -m app.web"
   worker = "python -m app.worker"
   scheduler = "python -m app.jobs.scheduler"
 


### PR DESCRIPTION
## Summary

Phase 1 step 3 follow-up. Uvicorn's CLI pre-configures \`uvicorn\`, \`uvicorn.access\`, and \`uvicorn.error\` loggers with their own handlers, bypassing the root logger \`init_logging()\` set up. So worker and scheduler emitted JSON, but web emitted plain-text access logs.

- New \`app/web.py\` — symmetric with \`app/worker.py\` and \`app/jobs/scheduler.py\`. Calls \`init_logging()\` and \`init_sentry("web")\`, then invokes \`uvicorn.run()\` with \`log_config=None\` so uvicorn's loggers fall through to the root logger.
- \`fly.toml\` web command: \`uvicorn app.main:app ...\` → \`python -m app.web\`.

## Test plan

- [x] \`make backend-test\` → 193 passed.
- [ ] After deploy: \`flyctl logs --app running-coach-ths\` shows JSON access log lines from web (verifiable after merge).

Closes #61