### PR TITLE
ci(deploy): add Fly deploy workflow on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: ci-and-deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  backend-test:
+    name: backend-test
+    runs-on: ubuntu-latest
+    env:
+      # Required by app.core.config.Settings at import time. Tests use SQLite
+      # in-memory via conftest, so this URL is never actually dialled.
+      DATABASE_URL: postgresql+psycopg://test:test@localhost/test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e "./backend[test]"
+
+      - name: Run backend tests
+        run: make backend-test
+
+  frontend-test:
+    name: frontend-test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Lint + build
+        run: npm run test
+
+  deploy:
+    name: deploy
+    needs: [backend-test, frontend-test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: fly-deploy
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy to Fly
+        working-directory: backend
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --remote-only --config fly.toml

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,8 @@ frontend/tsconfig.tsbuildinfo
 .codex/
 .gemini/
 .githooks/
-.github/
+.github/*
+!.github/workflows/
 .vscode/
 AGENTS.md
 ai-workflow.md


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml`: backend pytest + frontend lint/build on every PR; `flyctl deploy --remote-only` on push to `main` gated on both checks.
- Adjusts `.gitignore` so `.github/workflows/` is tracked while existing `.github/` AI-tooling stays excluded.

Closes Phase 1 Step 5 in `docs/deployment/phase-1-plan.md`. `FLY_API_TOKEN` is set as a repo secret (1-year TTL).

## Test plan
- [ ] PR shows two checks running: `backend-test`, `frontend-test`
- [ ] Both pass
- [ ] After merge, `deploy` job runs and `flyctl logs` shows the new image deployed
- [ ] Verify branch protection can be configured to require both checks