### PR TITLE
feat(deploy): Next.js proxy + Strava OAuth callback exemption

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,9 +16,16 @@ app = FastAPI(
 )
 
 # TODO(phase-2): remove BasicAuthMiddleware when session auth from ADR 0005 lands.
+# /api/auth/strava/callback is exempt because Strava redirects the user's browser
+# there directly with an OAuth code; the code itself is the auth, and Strava has
+# no way to send basic auth credentials.
 app.add_middleware(
     BasicAuthMiddleware,
-    exempt_prefixes=("/api/health", "/api/webhooks"),
+    exempt_prefixes=(
+        "/api/health",
+        "/api/webhooks",
+        "/api/auth/strava/callback",
+    ),
 )
 
 app.add_middleware(

--- a/backend/tests/test_basic_auth_middleware.py
+++ b/backend/tests/test_basic_auth_middleware.py
@@ -42,6 +42,10 @@ class TestExemptRoutes:
         response = client.get("/api/webhooks/strava")
         assert response.status_code != 401
 
+    def test_strava_oauth_callback_is_reachable_without_credentials(self, client, auth_enabled):
+        response = client.get("/api/auth/strava/callback")
+        assert response.status_code != 401
+
 
 class TestGatedRoutes:
     def test_gated_route_rejects_request_without_authorization_header(self, client, auth_enabled):

--- a/frontend/app/api/[...path]/route.ts
+++ b/frontend/app/api/[...path]/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL;
+const BASIC_USER = process.env.BACKEND_BASIC_AUTH_USER;
+const BASIC_PASS = process.env.BACKEND_BASIC_AUTH_PASSWORD;
+
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'te',
+  'trailer',
+  'upgrade',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'content-encoding',
+  'content-length',
+]);
+
+async function proxy(
+  req: NextRequest,
+  { params }: { params: { path: string[] } }
+) {
+  if (!BACKEND_URL) {
+    return new Response('BACKEND_URL not configured', { status: 500 });
+  }
+
+  const pathSegments = params.path ?? [];
+  const target = `${BACKEND_URL}/api/${pathSegments.join('/')}${req.nextUrl.search}`;
+
+  const upstreamHeaders = new Headers();
+  req.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase()) && key.toLowerCase() !== 'host') {
+      upstreamHeaders.set(key, value);
+    }
+  });
+  if (BASIC_USER && BASIC_PASS) {
+    const token = Buffer.from(`${BASIC_USER}:${BASIC_PASS}`).toString('base64');
+    upstreamHeaders.set('authorization', `Basic ${token}`);
+  }
+
+  const init: RequestInit = {
+    method: req.method,
+    headers: upstreamHeaders,
+    redirect: 'manual',
+  };
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    init.body = await req.arrayBuffer();
+  }
+
+  const upstream = await fetch(target, init);
+
+  const responseHeaders = new Headers();
+  upstream.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) {
+      responseHeaders.set(key, value);
+    }
+  });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+  });
+}
+
+export const GET = proxy;
+export const POST = proxy;
+export const PUT = proxy;
+export const PATCH = proxy;
+export const DELETE = proxy;
+export const HEAD = proxy;
+
+export const dynamic = 'force-dynamic';

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -24,7 +24,7 @@ export default function ProfilePage() {
   });
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'}/api/profile`)
+    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/profile`)
       .then(res => {
         if (!res.ok) throw new Error('Failed to load profile');
         return res.json();
@@ -51,7 +51,7 @@ export default function ProfilePage() {
     e.preventDefault();
     setSaving(true);
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'}/api/profile`, {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/profile`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(formData)

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -11,8 +11,7 @@ import SufferScoreChart from "@/components/trends/SufferScoreChart";
 import EfficiencyTrendChart from "@/components/trends/EfficiencyTrendChart";
 import ZoneLoadChart from "@/components/trends/ZoneLoadChart";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8000";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 
 const DiffStat = ({
   current,

--- a/frontend/components/CheckInForm.tsx
+++ b/frontend/components/CheckInForm.tsx
@@ -72,7 +72,7 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
         
         // Parallel requests: Save Check-In AND Save Intent
         const promises = [
-            fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'}/api/activities/${activityId}/checkin`, {
+            fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/activities/${activityId}/checkin`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(checkInPayload)
@@ -82,7 +82,7 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
         // Only update intent if logic dictates (or always to be safe/simple)
         // The endpoint is PUT /intent
         promises.push(
-            fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'}/api/activities/${activityId}/intent`, {
+            fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/activities/${activityId}/intent`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ user_intent: intent })

--- a/frontend/components/ConnectStravaButton.tsx
+++ b/frontend/components/ConnectStravaButton.tsx
@@ -10,7 +10,7 @@ type StravaStatus = {
 };
 
 export default function ConnectStravaButton() {
-  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '';
   const [status, setStatus] = useState<StravaStatus | null>(null);
   const [loading, setLoading] = useState(true);
 

--- a/frontend/components/IntentSelector.tsx
+++ b/frontend/components/IntentSelector.tsx
@@ -23,7 +23,7 @@ export default function IntentSelector({ activityId, currentType, assignedClass 
     setLoading(true);
 
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'}/api/activities/${activityId}/intent`, {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/activities/${activityId}/intent`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/components/SyncButton.tsx
+++ b/frontend/components/SyncButton.tsx
@@ -13,7 +13,7 @@ export default function SyncButton() {
     setLoading(true);
     setStats(null);
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'}/api/sync`, {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/sync`, {
         method: 'POST'
       });
       

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,14 +1,38 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8000';
+// Server components hit the backend directly with basic auth (env vars stay
+// server-side). Client components hit relative /api/* paths; the catch-all
+// route handler in frontend/app/api/[...path]/route.ts proxies those to the
+// backend with the same auth.
+
+const isServer = typeof window === 'undefined';
+
+const SERVER_BASE_URL =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  'http://127.0.0.1:8000';
+const CLIENT_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+
+function buildAuthHeader(): string | null {
+  const user = process.env.BACKEND_BASIC_AUTH_USER;
+  const pass = process.env.BACKEND_BASIC_AUTH_PASSWORD;
+  if (!user || !pass) return null;
+  const token = Buffer.from(`${user}:${pass}`).toString('base64');
+  return `Basic ${token}`;
+}
 
 export async function fetchFromAPI(endpoint: string, options: RequestInit = {}) {
-  const res = await fetch(`${API_BASE_URL}${endpoint}`, {
+  const baseUrl = isServer ? SERVER_BASE_URL : CLIENT_BASE_URL;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options.headers as Record<string, string> | undefined),
+  };
+  if (isServer) {
+    const auth = buildAuthHeader();
+    if (auth) headers.Authorization = auth;
+  }
+  const res = await fetch(`${baseUrl}${endpoint}`, {
     ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...options.headers,
-    },
-    // We add cache: 'no-store' by default for simple dynamic behavior in this MVP, 
-    // though specific calls can override options.
+    headers,
     cache: 'no-store',
   });
 


### PR DESCRIPTION
## Summary
Sets up cross-origin authentication for the Vercel frontend without leaking basic-auth credentials to the browser bundle. Required before the Vercel deploy can authenticate against Fly.

- `frontend/app/api/[...path]/route.ts`: catch-all proxy that injects Basic auth server-side
- `frontend/lib/api.ts`: server components hit Fly directly with Basic auth, client components hit relative `/api/*` through the proxy
- Scattered client-side `process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'` fallbacks switched to `|| ''` so prod falls through to same-origin paths
- Backend: `/api/auth/strava/callback` exempted from `BasicAuthMiddleware` because Strava can't supply Basic auth on the redirect (mirrors existing `/api/webhooks` exemption); new test covers the exemption

## Test plan
- [ ] `backend-test` passes (now 194 tests, +1 for callback exemption)
- [ ] `frontend-test` passes (lint + build, including the new route handler)
- [ ] After merge, Vercel project links and first deploy uses the proxy