### PR TITLE
Phase 1 wrap-up: docs cleanup + bump to v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Running Coach (Strava) — Local-first MVP
+# Running Coach (Strava): Single-user MVP
 
-Local-first app that connects to Strava, ingests running activities, computes training signals, and displays actionable analysis.
+App that connects to Strava, ingests running activities, computes training signals, and displays actionable analysis. Runs locally via `docker compose` or as a deployed single-user instance on Fly and Vercel (see [Production deployment](#production-deployment)).
 
 Most Strava-based tools surface raw stats but offer little actionable insight — they tell you what happened, not what to do next. This project is an experiment in using computed training signals and an LLM coaching layer to bridge that gap, producing short and opinionated post-run analysis from the data you already have.
 
@@ -8,6 +8,10 @@ Most Strava-based tools surface raw stats but offer little actionable insight �
 - Backend: FastAPI + SQLAlchemy + Alembic + Postgres
 - Jobs: Redis + RQ
 - Frontend: Next.js (App Router)
+
+## Production deployment
+
+The app also runs in production on Fly.io (backend) and Vercel (frontend), with Neon Postgres, Upstash Redis, and Sentry. The setup is documented in [`docs/deployment/phase-1-plan.md`](docs/deployment/phase-1-plan.md). It is single-user and gated by HTTP basic auth; multi-user readiness is tracked under Phase 2 (see [ADR 0005](docs/adr/0005-magic-link-is-identity-strava-is-an-integration.md) and [ADR 0006](docs/adr/0006-multi-user-drops-polling-for-user-triggered-self-healing.md)).
 
 ## Repo structure
 ```

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "running-coach-backend"
-version = "0.1.0"
+version = "0.2.0"
 description = "Running Coach Backend"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_workout_matching.py
+++ b/backend/tests/test_workout_matching.py
@@ -17,8 +17,15 @@ def _make_interval_structure(
     rest_speed: float = 2.0,
     distance_per_rep: float = 400.0,
     include_hr: bool = True,
+    seed: int = 42,
 ):
-    """Build a synthetic interval_structure dict matching detect_intervals output."""
+    """Build a synthetic interval_structure dict matching detect_intervals output.
+
+    The per-rep jitter on distance and speed is drawn from a locally-seeded
+    generator so the fixture is deterministic regardless of test order. Pass
+    a different seed when a test wants different jitter.
+    """
+    rng = np.random.default_rng(seed)
     work_segments = []
     rest_segments = []
     for i in range(reps):
@@ -26,8 +33,8 @@ def _make_interval_structure(
             "segment_number": i + 1,
             "start_time_s": 300 + i * (work_duration + rest_duration),
             "duration_s": work_duration,
-            "distance_m": round(distance_per_rep + np.random.uniform(-20, 20), 1),
-            "avg_speed_mps": round(work_speed + np.random.uniform(-0.2, 0.2), 2),
+            "distance_m": round(distance_per_rep + rng.uniform(-20, 20), 1),
+            "avg_speed_mps": round(work_speed + rng.uniform(-0.2, 0.2), 2),
             "avg_hr": 170.0 if include_hr else None,
             "peak_hr": 178.0 if include_hr else None,
         }

--- a/project-context.md
+++ b/project-context.md
@@ -1,7 +1,9 @@
+> Domain vocabulary lives in `CONTEXT.md`. This file describes the current implementation; the glossary describes the language.
+
 ## Product Summary
 
-Running Coach is a local-first MVP that connects to Strava, ingests running activities, computes training signals, and produces opinionated post-run analysis.
-The intended user is an individual runner running the app on their own machine against their own Strava account.
+Running Coach is a single-user MVP that connects to Strava, ingests running activities, computes training signals, and produces opinionated post-run analysis.
+The intended user is an individual runner connected to their own Strava account; the app runs either locally via docker compose or as a deployed single-user instance on Fly and Vercel (see `docs/deployment/phase-1-plan.md`). Phase 2 introduces multi-user signup per ADR 0005.
 The core flow is: connect Strava → sync activities → deep-process a run → view derived metrics and an LLM-generated coach report on the activity page.
 
 ## Domain Concepts


### PR DESCRIPTION
## Summary

Small docs hygiene + version alignment so the upcoming v0.2.0 GitHub release lands on a clean main.

- **Version alignment.** Bump `backend/pyproject.toml` from 0.1.0 to 0.2.0 so it matches `app/main.py` and the v0.2.0 release tag.
- **Drop "Local-first" framing.** The app now runs deployed on Fly + Vercel, not only on the developer's machine. README title and project-context Product Summary updated to "Single-user MVP", with explicit acknowledgement of the deployed path.
- **Add Production section to README.** Points at `docs/deployment/phase-1-plan.md` plus ADR 0005 and ADR 0006 so a fresh reader can follow the breadcrumb from the README.
- **Cross-link CONTEXT.md from project-context.md.** Surfaces the glossary so the implementation file and the vocabulary file are visibly linked.

## Not in this PR

- Edits to `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md` to register `CONTEXT.md` as a read-on-start file. Those files are gitignored (see commit 51b2cdb `chore: untrack AI tooling config files`) so the changes live locally only. If you want all contributors / fresh clones to pick up the glossary read, those three need to be tracked again. Out of scope for this PR; flagging.
- The actual v0.2.0 GitHub release. Already drafted at https://github.com/philippe-ths/ai-running-coach/releases (untagged draft). Publish that after this PR merges so the tag lands on the version-aligned commit.

## Test plan

- [ ] CI passes (backend tests + frontend lint+build).
- [ ] README renders correctly on GitHub (the new `(#production-deployment)` anchor link resolves).
- [ ] After merge, publish the v0.2.0 draft release on GitHub.