### PR TITLE
ci: force Node 24 for JS actions to clear deprecation warnings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Opt JavaScript-based actions into Node 24 ahead of the June 2026
+# deprecation of Node 20. The pinned major tags (checkout@v4, setup-python@v5,
+# setup-node@v4) still ship Node 20 internally; this env forces them onto the
+# runner's Node 24. See issue #71.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   backend-test:
     name: backend-test


### PR DESCRIPTION
## Summary

- Adds workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` so the existing actions (`checkout@v4`, `setup-python@v5`, `setup-node@v4`) run on the runner's Node 24 instead of the Node 20 bundled inside the action.
- Pre-empts the June 2026 forced migration and silences the per-run deprecation annotation.

## Judgement calls

- Took the env-var route instead of bumping major tags. The issue lists both as acceptable; bumping majors carries breaking-change risk and would still need re-verification, while the env flag is one line, fully reversible, and exactly what the deprecation note suggests for the transition window. We can bump to checkout@v5 / setup-node@v5 / setup-python@v6 in a follow-up once Node 24 is the runner default.

## Test plan

- [x] `yamllint` mental parse: env block sits at workflow root, valid YAML.
- [ ] CI run on this PR shows the deprecation annotation gone (verified by Philippe on first CI run).

Fixes #71