### PR TITLE
chore(ui): remove MVP Mode label from nav header

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -28,7 +28,6 @@ export default function RootLayout({
                 Trends
               </Link>
             </div>
-            <div className="text-sm text-gray-500">MVP Mode</div>
           </div>
         </nav>
         <main className="flex-1 max-w-4xl w-full mx-auto px-4 py-8">


### PR DESCRIPTION
## Summary

- Removes the hardcoded `<div>MVP Mode</div>` from `frontend/app/layout.tsx` so users no longer see a dev label on every page.

## Judgement calls

- The issue offered three options (delete, replace with something useful, gate on `NODE_ENV`). Picked the delete option. Replacement content (athlete name, sync badge) is a separate small UX project and shouldn't be inlined into a cosmetic-cleanup PR. Gating on `NODE_ENV` keeps the leftover label rather than removing it.

## Test plan

- [x] `npm run lint` clean.
- [x] Visual check on Vercel preview that the nav still renders with brand + Trends link, no right-side label.

Fixes #74