### PR TITLE
refactor(analysis): collapse unreachable confidence-level branch

### DIFF
--- a/backend/app/services/analysis/_orchestrator.py
+++ b/backend/app/services/analysis/_orchestrator.py
@@ -103,7 +103,8 @@ def compute_confidence(activity, streams_dict, check_in, interval_structure=None
     elif len(reasons) == 0:
         level = "high"
     else:
-        level = "medium" if reasons else "high"
+        # 0 < len(reasons) < 3 and no critical hits.
+        level = "medium"
 
     return level, reasons
 


### PR DESCRIPTION
## Summary

- The final `else` of `compute_confidence` in `services/analysis/_orchestrator.py` was reached only when `critical_hits` was empty and `0 < len(reasons) < 3`. Under that invariant, `\"medium\" if reasons else \"high\"` always picks `\"medium\"`.
- Replace the ternary with a direct assignment and a single-line comment that restates the surviving invariant for future readers.

## Judgement calls

- Did not add a new characterisation test. `tests/test_analysis.py` and `tests/test_analysis_interface.py` already exercise this code path indirectly through the public `analyze` entry point. The issue's acceptance note explicitly allows this (\"Characterisation test optional\").

## Test plan

- [x] `make backend-test` — 194 passed, 3 deselected.

Fixes #82