### PR TITLE
chore(config): remove unused SECRET_KEY setting

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,5 @@
 # --- Core ---
 APP_ENV=local
-SECRET_KEY=dev-only-secret-change-me
 
 # --- Database ---
 # Matches docker-compose.yml defaults (host port 5433)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,8 +5,7 @@ class Settings(BaseSettings):
     APP_ENV: str = "local"
     APP_BASE_URL: str = "http://localhost:3000"
     API_BASE_URL: str = "http://localhost:8000"
-    SECRET_KEY: str = "dev-only-secret"
-    
+
     # Database
     # Defaulting to a sensible local docker default if not provided, 
     # but strictly it should come from .env


### PR DESCRIPTION
## Summary

- `git grep SECRET_KEY` showed the setting in `core/config.py` and `.env.example` but no consumer in the app. Removing the dead definition.
- The `dev-only-secret` default looked like a placeholder a fresh reader might assume was load-bearing security; deletion removes the misleading signal.

## Judgement calls

- The issue offered two paths (delete vs reserve as a Phase 2 stub with a TODO). Picked delete. Phase 2 session signing per ADR 0005 can re-introduce the setting cleanly with proper validation and a non-misleading default at the time of need; a placeholder now is just a TODO with code attached.
- Based this PR on `chore/phase-1-wrap-up` (PR #75) rather than `main`, because that branch carries the `test_workout_matching` flake fix. Branching from `main` runs into a non-deterministic backend-test failure unrelated to this change. When #75 merges, GitHub will retarget this PR to `main` automatically.

## Test plan

- [x] `make backend-test` — 194 passed, 3 deselected.

Fixes #83