### PR TITLE
feat(frontend): gate Debug LLM panel behind NEXT_PUBLIC_SHOW_DEBUG_PANEL

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,8 @@
 # Frontend talks to FastAPI here
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+
+# Set to "true" (or "1") to render the "Debug: LLM Input & Output" panel on
+# the activity page. Useful when iterating on the coach prompt or context
+# pack; off by default because the panel exposes the full prompt and the
+# entire metric payload sent to the LLM.
+NEXT_PUBLIC_SHOW_DEBUG_PANEL=

--- a/frontend/components/CoachReportPanel.tsx
+++ b/frontend/components/CoachReportPanel.tsx
@@ -4,6 +4,12 @@ import { useState, useEffect, useCallback } from 'react';
 import { CoachReport } from '@/lib/types';
 import { Sparkles, ChevronRight, AlertTriangle, HelpCircle, Loader2, RefreshCw } from 'lucide-react';
 
+// Public env var inlined at build time. Set NEXT_PUBLIC_SHOW_DEBUG_PANEL=true
+// (or "1") on the build environment to expose the LLM-input/output panel.
+const SHOW_DEBUG_PANEL =
+  process.env.NEXT_PUBLIC_SHOW_DEBUG_PANEL === 'true' ||
+  process.env.NEXT_PUBLIC_SHOW_DEBUG_PANEL === '1';
+
 interface Props {
   activityId: string;
   hasMetrics: boolean;
@@ -206,38 +212,41 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
         </span>
       </div>
 
-      {/* Debug */}
-      <details className="text-xs text-slate-400">
-        <summary className="cursor-pointer hover:text-slate-600">
-          Debug: LLM Input & Output
-        </summary>
-        <div className="mt-2 space-y-3">
-          <div>
-            <h4 className="font-semibold text-slate-500 mb-1">System Prompt</h4>
-            <pre className="p-3 bg-slate-50 rounded border border-slate-100 overflow-x-auto whitespace-pre-wrap max-h-64 overflow-y-auto">
-              {report.debug.system_prompt}
-            </pre>
+      {/* Debug: opt-in via NEXT_PUBLIC_SHOW_DEBUG_PANEL=true (or "1"). Off in
+          prod by default; the panel exposes the full context pack and prompt. */}
+      {SHOW_DEBUG_PANEL && (
+        <details className="text-xs text-slate-400">
+          <summary className="cursor-pointer hover:text-slate-600">
+            Debug: LLM Input & Output
+          </summary>
+          <div className="mt-2 space-y-3">
+            <div>
+              <h4 className="font-semibold text-slate-500 mb-1">System Prompt</h4>
+              <pre className="p-3 bg-slate-50 rounded border border-slate-100 overflow-x-auto whitespace-pre-wrap max-h-64 overflow-y-auto">
+                {report.debug.system_prompt}
+              </pre>
+            </div>
+            <div>
+              <h4 className="font-semibold text-slate-500 mb-1">Context Pack (LLM Input)</h4>
+              <pre className="p-3 bg-slate-50 rounded border border-slate-100 overflow-x-auto max-h-96 overflow-y-auto">
+                {JSON.stringify(report.debug.context_pack, null, 2)}
+              </pre>
+            </div>
+            <div>
+              <h4 className="font-semibold text-slate-500 mb-1">Raw LLM Response</h4>
+              <pre className="p-3 bg-slate-50 rounded border border-slate-100 overflow-x-auto whitespace-pre-wrap max-h-64 overflow-y-auto">
+                {report.debug.raw_llm_response || '(empty)'}
+              </pre>
+            </div>
+            <div>
+              <h4 className="font-semibold text-slate-500 mb-1">Meta</h4>
+              <pre className="p-3 bg-slate-50 rounded border border-slate-100 overflow-x-auto">
+                {JSON.stringify(report.meta, null, 2)}
+              </pre>
+            </div>
           </div>
-          <div>
-            <h4 className="font-semibold text-slate-500 mb-1">Context Pack (LLM Input)</h4>
-            <pre className="p-3 bg-slate-50 rounded border border-slate-100 overflow-x-auto max-h-96 overflow-y-auto">
-              {JSON.stringify(report.debug.context_pack, null, 2)}
-            </pre>
-          </div>
-          <div>
-            <h4 className="font-semibold text-slate-500 mb-1">Raw LLM Response</h4>
-            <pre className="p-3 bg-slate-50 rounded border border-slate-100 overflow-x-auto whitespace-pre-wrap max-h-64 overflow-y-auto">
-              {report.debug.raw_llm_response || '(empty)'}
-            </pre>
-          </div>
-          <div>
-            <h4 className="font-semibold text-slate-500 mb-1">Meta</h4>
-            <pre className="p-3 bg-slate-50 rounded border border-slate-100 overflow-x-auto">
-              {JSON.stringify(report.meta, null, 2)}
-            </pre>
-          </div>
-        </div>
-      </details>
+        </details>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- The Debug: LLM Input & Output panel on the activity page exposed the system prompt, full JSON context pack, and raw LLM response in every environment.
- Gate it behind a public env flag: set `NEXT_PUBLIC_SHOW_DEBUG_PANEL=true` (or `1`) at build time to render the panel; off by default.
- Document the flag in `frontend/.env.example`.

## Why a build-time public flag (and not NODE_ENV gating)

- The `NEXT_PUBLIC_` prefix means Next inlines the value at build time. With the flag unset, the panel's markup and the embedded prompt strings are not in the production bundle at all, not just hidden behind an unrenderable `<details>`.
- Build-time also means Philippe can flip the panel on for a single Vercel preview deploy when he wants to inspect a prompt without changing production behaviour.

## Judgement calls

- Picked `NEXT_PUBLIC_SHOW_DEBUG_PANEL` over `NODE_ENV === 'development'`. The latter would force a re-deploy or local-only debugging; the env flag is more flexible and matches the existing `NEXT_PUBLIC_API_BASE_URL` pattern in this project.
- Accept both `"true"` and `"1"` because Vercel UI users sometimes set `1` out of habit.

## Test plan

- [x] `npm run lint` clean.
- [x] `npm run smoke` passes against the mock API.
- [ ] On Vercel preview without the env var: panel does not render.
- [ ] On a local build with `NEXT_PUBLIC_SHOW_DEBUG_PANEL=true npm run build && npm start`: panel renders.

Fixes #66