### PR TITLE
refactor(frontend): route six fetch sites through fetchFromAPI

### DIFF
--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import ConnectStravaButton from '@/components/ConnectStravaButton';
+import { fetchFromAPI } from '@/lib/api';
 
 export default function ProfilePage() {
   const router = useRouter();
@@ -24,12 +25,12 @@ export default function ProfilePage() {
   });
 
   useEffect(() => {
-    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/profile`)
-      .then(res => {
-        if (!res.ok) throw new Error('Failed to load profile');
-        return res.json();
-      })
+    fetchFromAPI('/api/profile')
       .then(data => {
+        if (!data) {
+          setLoading(false);
+          return;
+        }
         setFormData({
             goal_type: data.goal_type || 'general',
             experience_level: data.experience_level || 'intermediate',
@@ -51,12 +52,10 @@ export default function ProfilePage() {
     e.preventDefault();
     setSaving(true);
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/profile`, {
+      await fetchFromAPI('/api/profile', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(formData)
+        body: JSON.stringify(formData),
       });
-      if (!res.ok) throw new Error('Failed to update');
       router.push('/');
     } catch (err) {
       console.error(err);

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -4,14 +4,13 @@ import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import { TrendsData, TrendsRange } from "@/lib/types";
 import { formatDistanceKm, formatDuration } from "@/lib/format";
+import { fetchFromAPI } from "@/lib/api";
 import RangeSelector from "@/components/trends/RangeSelector";
 import ActivityTypeFilter from "@/components/trends/ActivityTypeFilter";
 import TrendBarChart from "@/components/trends/TrendBarChart";
 import SufferScoreChart from "@/components/trends/SufferScoreChart";
 import EfficiencyTrendChart from "@/components/trends/EfficiencyTrendChart";
 import ZoneLoadChart from "@/components/trends/ZoneLoadChart";
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 
 const DiffStat = ({
   current,
@@ -56,9 +55,8 @@ export default function TrendsPage() {
 
   // Fetch available activity types once on mount
   useEffect(() => {
-    fetch(`${API_BASE_URL}/api/trends/types`)
-      .then((res) => (res.ok ? res.json() : []))
-      .then((types: string[]) => setAvailableTypes(types))
+    fetchFromAPI("/api/trends/types")
+      .then((types: string[] | null) => setAvailableTypes(types ?? []))
       .catch(() => {});
   }, []);
 
@@ -71,9 +69,7 @@ export default function TrendsPage() {
       if (types.length > 0) {
         types.forEach((t) => params.append("types", t));
       }
-      const res = await fetch(`${API_BASE_URL}/api/trends?${params}`);
-      if (!res.ok) throw new Error(`API error: ${res.statusText}`);
-      const json: TrendsData = await res.json();
+      const json: TrendsData = await fetchFromAPI(`/api/trends?${params}`);
       setData(json);
     } catch (e: any) {
       setError(e.message || "Failed to load trends");

--- a/frontend/components/CheckInForm.tsx
+++ b/frontend/components/CheckInForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
+import { fetchFromAPI } from '@/lib/api';
 
 const OPTIONS_BY_TYPE: Record<string, string[]> = {
   Run: ["Easy Run", "Recovery", "Long Run", "Tempo", "Intervals", "Hills", "Race", "Treadmill"],
@@ -70,30 +71,19 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
             notes: notes || null
         };
         
-        // Parallel requests: Save Check-In AND Save Intent
-        const promises = [
-            fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/activities/${activityId}/checkin`, {
+        // Parallel requests: Save Check-In AND Save Intent. fetchFromAPI
+        // throws on non-OK, so Promise.all rejects if either call fails.
+        await Promise.all([
+            fetchFromAPI(`/api/activities/${activityId}/checkin`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(checkInPayload)
-            })
-        ];
-
-        // Only update intent if logic dictates (or always to be safe/simple)
-        // The endpoint is PUT /intent
-        promises.push(
-            fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/activities/${activityId}/intent`, {
+                body: JSON.stringify(checkInPayload),
+            }),
+            fetchFromAPI(`/api/activities/${activityId}/intent`, {
                 method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ user_intent: intent })
-            })
-        );
-        
-        const results = await Promise.all(promises);
-        results.forEach(res => {
-            if (!res.ok) throw new Error("Failed to save data");
-        });
-        
+                body: JSON.stringify({ user_intent: intent }),
+            }),
+        ]);
+
         // Optimistic update / switch to view
         setIsEditing(false);
         router.refresh(); 

--- a/frontend/components/ConnectStravaButton.tsx
+++ b/frontend/components/ConnectStravaButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { CheckCircle2, ExternalLink, RefreshCw } from 'lucide-react';
+import { fetchFromAPI } from '@/lib/api';
 
 type StravaStatus = {
   connected: boolean;
@@ -9,20 +10,20 @@ type StravaStatus = {
   expires_at: number | null;
 };
 
+// OAuth login link is a browser navigation (not a fetch), and the callback
+// path is exempted from basic auth in the Next.js proxy, so leaving these
+// as relative URLs keeps the flow working in both local and deployed envs.
+const STRAVA_LOGIN_HREF = '/api/auth/strava/login';
+
 export default function ConnectStravaButton() {
-  const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '';
   const [status, setStatus] = useState<StravaStatus | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`${API_BASE_URL}/api/auth/strava/status`)
-      .then((res) => {
-        if (!res.ok) throw new Error(`status ${res.status}`);
-        return res.json();
-      })
-      .then((data: StravaStatus) => {
-        if (!cancelled) setStatus(data);
+    fetchFromAPI('/api/auth/strava/status')
+      .then((data: StravaStatus | null) => {
+        if (!cancelled && data) setStatus(data);
       })
       .catch(() => {
         if (!cancelled) setStatus({ connected: false, athlete_id: null, scope: null, expires_at: null });
@@ -33,7 +34,7 @@ export default function ConnectStravaButton() {
     return () => {
       cancelled = true;
     };
-  }, [API_BASE_URL]);
+  }, []);
 
   if (loading) {
     return <span className="text-sm text-gray-500">Checking Strava…</span>;
@@ -52,7 +53,7 @@ export default function ConnectStravaButton() {
           </span>
         </span>
         <a
-          href={`${API_BASE_URL}/api/auth/strava/login`}
+          href={STRAVA_LOGIN_HREF}
           className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
           title="Re-run the Strava OAuth flow to refresh tokens or switch athletes"
         >
@@ -65,7 +66,7 @@ export default function ConnectStravaButton() {
 
   return (
     <a
-      href={`${API_BASE_URL}/api/auth/strava/login`}
+      href={STRAVA_LOGIN_HREF}
       className="inline-flex items-center gap-2 bg-[#FC4C02] text-white px-4 py-2 rounded font-semibold hover:bg-[#E34402] transition-colors"
     >
       <ExternalLink size={18} />

--- a/frontend/components/IntentSelector.tsx
+++ b/frontend/components/IntentSelector.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { fetchFromAPI } from '@/lib/api';
 
 const ACTIVITY_TYPES = [
   "Easy Run", "Recovery", "Long Run", 
@@ -23,15 +24,10 @@ export default function IntentSelector({ activityId, currentType, assignedClass 
     setLoading(true);
 
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/activities/${activityId}/intent`, {
+      await fetchFromAPI(`/api/activities/${activityId}/intent`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({ user_intent: newIntent }),
       });
-
-      if (!res.ok) throw new Error("Failed to update intent");
       router.refresh(); // Refresh page to see new metrics
     } catch (err) {
       console.error(err);

--- a/frontend/components/SyncButton.tsx
+++ b/frontend/components/SyncButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { RefreshCw } from 'lucide-react';
+import { fetchFromAPI } from '@/lib/api';
 
 export default function SyncButton() {
   const router = useRouter();
@@ -13,13 +14,7 @@ export default function SyncButton() {
     setLoading(true);
     setStats(null);
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/sync`, {
-        method: 'POST'
-      });
-      
-      if (!res.ok) throw new Error("Sync failed");
-      
-      const data = await res.json();
+      const data = await fetchFromAPI('/api/sync', { method: 'POST' });
       setStats(data);
       router.refresh(); // Reload server components to show new activities
       


### PR DESCRIPTION
## Summary

Six client components called `fetch()` with `process.env.NEXT_PUBLIC_API_BASE_URL || ''` inline instead of going through `fetchFromAPI`. Today this works because the env var is unset on Vercel prod, so requests fall back to relative `/api/...` paths and the Next.js proxy adds basic auth. The bypass would silently break those flows the moment the env var is set to a non-empty backend URL: the browser cannot hold creds and the requests would hit the backend without auth.

Sites consolidated:
- `app/profile/page.tsx` GET + PUT
- `app/trends/page.tsx` GET trends + GET trends/types
- `components/ConnectStravaButton.tsx` status GET
- `components/SyncButton.tsx` POST
- `components/IntentSelector.tsx` PUT
- `components/CheckInForm.tsx` POST + PUT (in parallel)

## Judgement calls

- `ConnectStravaButton`'s OAuth link (`/api/auth/strava/login`) is a browser navigation, not a `fetch`. Left it as a relative URL stored in a `STRAVA_LOGIN_HREF` constant. Putting it through `fetchFromAPI` would have broken the OAuth flow; the callback path is already exempted from basic auth in the Next.js proxy, so a relative URL works in both local and deployed envs.
- Accepted `fetchFromAPI`'s implicit `Content-Type: application/json` on GET requests. It's a no-op for GETs and removes a row of boilerplate at every mutating call site.
- For 404s, `fetchFromAPI` returns `null` rather than throwing. Profile GET and Strava status GET now handle the `null` case explicitly (graceful empty state).

## Test plan

- [x] `npm run lint` clean.
- [x] `npm run test` (lint + build) clean.
- [x] `npm run smoke` passes.
- [ ] Visual: profile load + save, trends load + filter, sync, intent change, check-in submit on Vercel preview.

Fixes #81