### PR TITLE
Railway migration stage 1: $PORT bind, DATABASE_URL driver normalization, CI swap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: ci-and-deploy
+name: ci
 
 on:
   push:
@@ -62,20 +62,3 @@ jobs:
 
       - name: Lint + build
         run: npm run test
-
-  deploy:
-    name: deploy
-    needs: [backend-test, frontend-test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    concurrency:
-      group: fly-deploy
-      cancel-in-progress: false
-    steps:
-      - uses: actions/checkout@v4
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-      - name: Deploy to Fly
-        working-directory: backend
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        run: flyctl deploy --remote-only --config fly.toml

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,3 +1,4 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
@@ -49,6 +50,27 @@ class Settings(BaseSettings):
 
     # CORS allowlist (comma-separated). Drives app.add_middleware(CORSMiddleware).
     CORS_ALLOWED_ORIGINS: str = "http://localhost:3000,http://localhost:8000"
+
+    @field_validator("DATABASE_URL")
+    @classmethod
+    def _ensure_psycopg_driver(cls, v: str) -> str:
+        """Normalise the DATABASE_URL to the psycopg driver SQLAlchemy needs.
+
+        Railway's managed Postgres (and most providers) hand out a bare
+        ``postgresql://`` URL, and some emit the legacy ``postgres://`` scheme.
+        SQLAlchemy requires the explicit ``postgresql+psycopg://`` driver
+        prefix. Normalising here means every consumer (the engine in
+        ``db/session.py`` and Alembic in ``alembic/env.py``) inherits a
+        driver-qualified URL. A URL that already names a driver
+        (e.g. ``postgresql+psycopg://``) or a non-postgres URL is left as-is.
+        """
+        if v.startswith("postgresql+"):
+            return v
+        if v.startswith("postgresql://"):
+            return "postgresql+psycopg://" + v[len("postgresql://"):]
+        if v.startswith("postgres://"):
+            return "postgresql+psycopg://" + v[len("postgres://"):]
+        return v
 
     @property
     def cors_allowed_origins_list(self) -> list[str]:

--- a/backend/app/web.py
+++ b/backend/app/web.py
@@ -9,6 +9,7 @@ which means access logs are emitted as JSON in production.
 """
 
 import logging
+import os
 
 import uvicorn
 
@@ -20,11 +21,14 @@ logger = logging.getLogger(__name__)
 def main() -> None:
     init_logging()
     init_sentry("web")
-    logger.info("Web booting; uvicorn binding 0.0.0.0:8000")
+    # Railway (and most PaaS) route to an injected $PORT; default to 8000 for
+    # local/docker parity where no PORT is set.
+    port = int(os.environ.get("PORT", "8000"))
+    logger.info("Web booting; uvicorn binding 0.0.0.0:%d", port)
     uvicorn.run(
         "app.main:app",
         host="0.0.0.0",
-        port=8000,
+        port=port,
         log_config=None,
     )
 

--- a/backend/tests/test_config_database_url.py
+++ b/backend/tests/test_config_database_url.py
@@ -1,0 +1,34 @@
+"""DATABASE_URL driver-prefix normalisation.
+
+Oracle: SQLAlchemy + psycopg (v3) require the ``postgresql+psycopg://`` driver
+prefix. Railway's managed Postgres hands out a bare ``postgresql://`` URL, and
+some providers emit the legacy ``postgres://`` scheme that SQLAlchemy rejects
+outright. ``Settings`` normalises these so the engine and Alembic always get a
+driver-qualified URL.
+"""
+
+from app.core.config import Settings
+
+
+def _settings(url: str) -> Settings:
+    return Settings(DATABASE_URL=url)
+
+
+def test_bare_postgresql_url_gets_psycopg_driver():
+    s = _settings("postgresql://user:pass@host:5432/db")
+    assert s.DATABASE_URL == "postgresql+psycopg://user:pass@host:5432/db"
+
+
+def test_legacy_postgres_scheme_normalised():
+    s = _settings("postgres://user:pass@host:5432/db")
+    assert s.DATABASE_URL == "postgresql+psycopg://user:pass@host:5432/db"
+
+
+def test_already_psycopg_url_left_unchanged():
+    url = "postgresql+psycopg://user:pass@host:5432/db"
+    assert _settings(url).DATABASE_URL == url
+
+
+def test_other_named_driver_left_unchanged():
+    url = "postgresql+asyncpg://user:pass@host:5432/db"
+    assert _settings(url).DATABASE_URL == url


### PR DESCRIPTION
Stage 1 of the Fly→Railway migration (#97): the account-independent, locally-verifiable changes that make the backend deployable on Railway. Railway account setup (project, Postgres, Redis, env/secrets) and the live cutover are separate stages.

## Changes
- **`app/web.py`** — bind `0.0.0.0:$PORT` (default `8000`) so the web service honours Railway's injected port; preserves local/docker parity.
- **`app/core/config.py`** — normalize `DATABASE_URL` to the `postgresql+psycopg://` driver prefix SQLAlchemy requires, covering Railway's bare `postgresql://` and the legacy `postgres://` scheme. Done once in the settings singleton, so the engine (`db/session.py`) and Alembic (`alembic/env.py`) both inherit it.
- **`tests/test_config_database_url.py`** — covers the four normalization cases (bare, legacy, already-`+psycopg`, other named driver).
- **`.github/workflows/deploy.yml`** — drop the `flyctl` deploy job; Railway deploys natively on push via the GitHub integration, gated by each service's "Wait for CI" toggle. Renamed `ci-and-deploy` → `ci`. This also clears the red `main` CI caused by the failing Fly step.

## Verification (Migrate + Configure)
- Unit: 4 new tests; full backend suite **227 passed, 3 deselected** (no regression on the 223 baseline).
- End-to-end (real artifact): booted `app.web` with `PORT=9123` and a **bare** `postgresql://` URL against local Postgres → `200` on 9123 with `"database":"ok"`, nothing on 8000. One run proves the injected-port bind, the untouched default, and the driver normalization against a real DB.
- **Not verified (deferred to cutover):** the real Railway deploy (Dockerfile build, `alembic upgrade head` pre-deploy, Railway's `$PORT` injection, reference-variable resolution). That is the Migrate modality's old→new end-to-end and is gated on the account.

## Follow-ups (not in this PR)
- README / `project-context.md` Fly references → cutover/Delete stage (#96).
- `FLY_API_TOKEN` secret now unused; `fly.toml` removed at cutover.