### PR TITLE
chore: drop Sentry to logs-only, fix local test baseline (#101, #102)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 .PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test
 
+# Prefer the project venv interpreter when it exists, fall back to bare python.
+# Path is relative to backend/ since the targets cd there first. CI has no
+# venv, so this resolves to `python` and matches the global install (issue #101).
+BACKEND_PY := $(shell [ -x backend/.venv/bin/python ] && echo .venv/bin/python || echo python)
+
 smoke: backend-smoke frontend-smoke
 
 backend-smoke:
-	cd backend && python -m pytest tests/test_smoke.py
+	cd backend && $(BACKEND_PY) -m pytest tests/test_smoke.py
 
 frontend-smoke:
 	cd frontend && npm run smoke
@@ -11,7 +16,7 @@ frontend-smoke:
 test: backend-test frontend-test
 
 backend-test:
-	cd backend && python -m pytest -m "not integration"
+	cd backend && $(BACKEND_PY) -m pytest -m "not integration"
 
 frontend-test:
 	cd frontend && npm run test

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -1,9 +1,11 @@
-"""Sentry SDK init and structured JSON logging.
+"""Structured JSON logging, with optional Sentry error tracking.
 
 Called from the entrypoint of each process group (web, worker, scheduler) so
-unhandled exceptions and error-level logs from any of them reach Sentry, and
-so log output is uniformly structured for ingestion by the hosting platform's
-log collector or any future log aggregator.
+log output is uniformly structured for ingestion by the hosting platform's log
+collector. Error tracking via Sentry is optional and logs-only by default (see
+issue #102): `sentry_sdk` is not a runtime dependency and `init_sentry` is a
+no-op unless both the SDK is installed (`pip install -e ".[observability]"`)
+and `SENTRY_DSN` is set.
 """
 
 from __future__ import annotations
@@ -14,9 +16,14 @@ import sys
 from datetime import datetime, timezone
 from typing import Any
 
-import sentry_sdk
-from sentry_sdk.integrations.logging import LoggingIntegration
-from sentry_sdk.integrations.rq import RqIntegration
+try:
+    import sentry_sdk
+    from sentry_sdk.integrations.logging import LoggingIntegration
+    from sentry_sdk.integrations.rq import RqIntegration
+
+    _SENTRY_AVAILABLE = True
+except ImportError:
+    _SENTRY_AVAILABLE = False
 
 from app.core.config import settings
 
@@ -72,7 +79,12 @@ def init_logging() -> None:
 
 
 def init_sentry(component: str) -> None:
-    """Initialise the Sentry SDK. No-op when SENTRY_DSN is unset.
+    """Initialise the Sentry SDK. No-op unless the SDK is installed and
+    SENTRY_DSN is set.
+
+    Sentry is optional (logs-only by default; see issue #102). When the
+    `observability` extra is not installed, `sentry_sdk` is absent and this is
+    a no-op regardless of SENTRY_DSN.
 
     `component` is the process group ("web", "worker", "scheduler") and is
     attached to every event as a tag so the Sentry UI can filter by process.
@@ -82,7 +94,7 @@ def init_sentry(component: str) -> None:
     process from booting; the same image runs `alembic upgrade head` as the
     deploy's release command, so an import-time crash here can block deploys.
     """
-    if not settings.SENTRY_DSN:
+    if not _SENTRY_AVAILABLE or not settings.SENTRY_DSN:
         return
     try:
         sentry_sdk.init(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,14 +17,21 @@ dependencies = [
     "rq-scheduler>=0.13.1",
     "python-multipart>=0.0.9",
     "numpy>=1.24.0",
-    "anthropic>=0.40.0",
-    "sentry-sdk[fastapi]>=2.0.0"
+    "anthropic>=0.40.0"
 ]
 
 [project.optional-dependencies]
+# Optional error tracking. Logs-only by default (issue #102); install this
+# extra and set SENTRY_DSN to re-enable Sentry capture.
+observability = [
+    "sentry-sdk[fastapi]>=2.0.0"
+]
 test = [
     "pytest>=8.0.0",
-    "pytest-asyncio>=0.23.0"
+    "pytest-asyncio>=0.23.0",
+    # Pull in the optional SDK so the suite can exercise the Sentry-present
+    # path; production installs core deps only and relies on the import guard.
+    "running-coach-backend[observability]"
 ]
 
 [tool.pytest.ini_options]

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -111,6 +111,21 @@ class TestInitLogging:
         assert payload["level"] == "INFO"
 
 
+class TestInitSentryWithoutSDK:
+    """Sentry is optional (issue #102): with the SDK absent, init_sentry is a
+    no-op regardless of SENTRY_DSN, and importing the module never fails."""
+
+    def test_noop_when_sdk_unavailable_even_with_dsn_set(self, monkeypatch):
+        monkeypatch.setattr(observability, "_SENTRY_AVAILABLE", False)
+        monkeypatch.setattr(settings, "SENTRY_DSN", "https://x@example.ingest.sentry.io/1")
+        # Must not raise (no sentry_sdk reference is reached) and must do nothing.
+        observability.init_sentry("web")
+
+
+@pytest.mark.skipif(
+    not observability._SENTRY_AVAILABLE,
+    reason="sentry_sdk not installed (install the 'observability' extra)",
+)
 class TestInitSentry:
     def test_is_noop_when_dsn_is_unset(self, monkeypatch):
         monkeypatch.setattr(settings, "SENTRY_DSN", "")

--- a/docs/deployment/phase-1-plan.md
+++ b/docs/deployment/phase-1-plan.md
@@ -1,6 +1,8 @@
 # Phase 1 deployment plan: ship the single-user app to Fly.io
 
 > **Historical — superseded.** This plan targeted Fly.io (backend), Neon (Postgres), and Upstash (Redis). The backend was later migrated to Railway, which consolidates the backend (web, worker, scheduler), Postgres, and Redis under a single workspace hard usage limit; the frontend remains on Vercel. See issue #97. This document is retained for historical context and the code/middleware changes it describes (basic auth, structured logging, settings) remain accurate; the Fly/Neon/Upstash provisioning and CI sections do not reflect the current deployment.
+>
+> **Observability — Sentry dropped (issue #102).** Error tracking was formally dropped in favour of logs-only observability for the single-user MVP. Structured JSON logging (described below) remains active and is the observability surface; `sentry-sdk` is now an optional `observability` extra rather than a runtime dependency, and `SENTRY_DSN` is unset in production. The done-criterion below — "Sentry has captured at least one deliberately-induced exception" — is therefore superseded and intentionally unmet. Re-enabling Sentry is `pip install -e "backend[observability]"` plus setting `SENTRY_DSN`.
 
 This is the concrete checklist for Phase 1 of the deployment roadmap agreed in a grilling session on 2026-05-28. The goal is **getting the current single-user codebase running in production on the public internet, end-to-end, with observability**, as a deliberate exercise in learning deployment without bundling other concerns.
 


### PR DESCRIPTION
Resolves #102 (decision) and #101 (local baseline). They share one root cause — the unconditional `sentry_sdk` import in `observability.py` — so they ship together.

## #102 — decision: drop Sentry, logs-only
Formally drops Sentry error tracking in favour of logs-only observability for the single-user MVP. Implemented reversibly:
- `sentry-sdk[fastapi]` moves from a runtime dependency to an optional `observability` extra.
- The `sentry_sdk` import in `observability.py` is `try/except ImportError`-guarded (`_SENTRY_AVAILABLE`).
- `init_sentry` no-ops unless **both** the SDK is installed and `SENTRY_DSN` is set (DSN gate preserved, SDK-presence gate added).
- Structured JSON logging is unchanged and remains the observability surface.

Re-enabling later is `pip install -e "backend[observability]"` + set `SENTRY_DSN` — no code change.

## #101 — local backend baseline runnable
- `make backend-test` / `backend-smoke` now prefer `backend/.venv/bin/python` when it exists, falling back to bare `python`. CI has no `.venv`, so it resolves to `python` and is unchanged.
- The `test` extra self-references `observability`, so a documented `pip install -e ".[test]"` still installs the SDK and the suite covers the Sentry-present path.

## Docs
`docs/deployment/phase-1-plan.md` records the logs-only decision and marks the "Sentry captured an induced exception" done-criterion superseded.

## Verification
- `make backend-test` → **228 passed, 3 deselected** via the venv interpreter.
- SDK-absent path (simulated by blocking the import): module + `app.main`/`app.worker`/`app.jobs.scheduler` import cleanly; `init_sentry` no-ops even with a DSN set.
- New regression test pins the absent-SDK no-op contract; the SDK-present tests are `skipif`-guarded.
- Deterministic policy validation: 22/22.

## Not covered here (post-merge)
The dependency drop only becomes real on the **live Railway image** at the next deploy. The current container still has `sentry-sdk` installed with `SENTRY_DSN` unset (already inactive), so there is no current-runtime change — confirm on the post-merge Railway deploy.