### PR TITLE
feat(webhooks): authenticate incoming Strava webhook events (#100)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,6 +21,10 @@ STRAVA_REDIRECT_URI=http://localhost:8000/api/auth/strava/callback
 # --- Strava Webhooks (optional for local MVP) ---
 STRAVA_WEBHOOK_VERIFY_TOKEN=dev-verify-token
 STRAVA_WEBHOOK_CALLBACK_URL=http://localhost:8000/api/webhooks/strava
+# Active push-subscription id from Strava. Incoming events whose subscription_id
+# does not match are rejected (#100). Leave 0 in local dev to skip this check;
+# set it to the live subscription id in production.
+STRAVA_WEBHOOK_SUBSCRIPTION_ID=0
 
 # --- Coach AI ---
 ANTHROPIC_API_KEY=

--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from app.core.config import settings
 from app.db.session import get_db
-from app.models import Activity
+from app.models import Activity, StravaAccount
 from app.core.queue import queue
 from app.jobs.process_new_activity import process_new_activity_job
 from app.jobs.strava_sync import sync_activity_job
@@ -54,14 +54,63 @@ def verify_webhook(
 
     raise HTTPException(status_code=403, detail="Invalid verification token")
 
+def _event_is_authentic(event: "StravaEvent", db: Session) -> bool:
+    """Authenticate an incoming webhook event.
+
+    Strava does not sign webhook payloads, and the endpoint is exempt from
+    basic auth so the verification handshake can reach it. Anyone who learns
+    the callback URL could otherwise POST a forged but well-formed event to
+    enqueue jobs or soft-delete activities (see #100). Guard with two cheap
+    equality checks against values we already hold:
+
+    1. The event must reference our active push subscription. Strava only
+       returns the subscription id to us at registration, so it is the
+       stronger (secret-ish) check. Skipped when unconfigured (id 0) so local
+       dev is not blocked.
+    2. The event owner must be a connected athlete. Athlete ids are public, so
+       this check is weaker on its own, but it is always available from the DB
+       and never drifts, so it stays on even when (1) is unconfigured.
+    """
+    expected_subscription_id = settings.STRAVA_WEBHOOK_SUBSCRIPTION_ID
+    if expected_subscription_id and event.subscription_id != expected_subscription_id:
+        logger.warning(
+            "strava_webhook_rejected_subscription_mismatch",
+            extra={
+                "event_subscription_id": event.subscription_id,
+                "object_id": event.object_id,
+            },
+        )
+        return False
+
+    account = db.execute(
+        select(StravaAccount).where(
+            StravaAccount.strava_athlete_id == event.owner_id
+        )
+    ).scalars().first()
+    if account is None:
+        logger.warning(
+            "strava_webhook_rejected_unknown_owner",
+            extra={"owner_id": event.owner_id, "object_id": event.object_id},
+        )
+        return False
+
+    return True
+
+
 @router.post("/webhooks/strava")
 async def receive_webhook(
-    event: StravaEvent, 
+    event: StravaEvent,
     db: Session = Depends(get_db)
 ):
     """
     Handle incoming events from Strava.
     """
+    if not _event_is_authentic(event, db):
+        # Reject before any side effect (enqueue or soft-delete). A forged
+        # sender is not Strava, so a 403 here does not affect the real
+        # subscription's health.
+        raise HTTPException(status_code=403, detail="Unauthenticated webhook event")
+
     if event.object_type != "activity":
         # We assume we only care about activities for now
         return {"status": "ignored", "reason": "not_activity"}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -21,6 +21,11 @@ class Settings(BaseSettings):
     STRAVA_REDIRECT_URI: str = "http://localhost:8000/api/auth/strava/callback"
     STRAVA_WEBHOOK_VERIFY_TOKEN: str = ""
     STRAVA_WEBHOOK_CALLBACK_URL: str = "http://localhost:8000/api/webhooks/strava"
+    # Active push-subscription id returned by Strava at registration. Strava
+    # does not sign webhook payloads, so incoming events are authenticated by
+    # matching this id (when set) and the connected athlete. 0 = unenforced
+    # (local dev); set this to the live subscription id in production. See #100.
+    STRAVA_WEBHOOK_SUBSCRIPTION_ID: int = 0
 
     # Coach AI
     ANTHROPIC_API_KEY: str = ""

--- a/backend/tests/test_webhook_dispatch.py
+++ b/backend/tests/test_webhook_dispatch.py
@@ -1,8 +1,22 @@
-"""Verify that the webhook handler dispatches the right job per aspect_type."""
+"""Verify webhook event authentication and per-aspect_type job dispatch.
+
+Strava does not sign webhook payloads (#100), so the handler authenticates
+each event against the connected athlete and (when configured) the active
+subscription id before doing any work. These tests cover both the dispatch
+behaviour for authentic events and the rejection of forged ones.
+"""
 
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
+
+from app.core.config import settings
+from app.models import Activity, StravaAccount, User
+
+# The athlete id that the seeded connected account owns. Authentic events in
+# these tests carry this owner_id; forged events carry a different one.
+CONNECTED_ATHLETE_ID = 999
 
 
 @pytest.fixture
@@ -12,45 +26,140 @@ def fake_queue():
         yield fake
 
 
-def _post(client, *, aspect_type: str, object_id: int = 7777):
+@pytest.fixture
+def connected_account(db):
+    """Seed the single connected athlete so authentic events pass the owner
+    check. Without this, every event is rejected as an unknown owner."""
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    account = StravaAccount(
+        user_id=user.id,
+        strava_athlete_id=CONNECTED_ATHLETE_ID,
+        access_token="test-token-do-not-use-in-prod",
+        refresh_token="test-refresh-do-not-use-in-prod",
+        expires_at=9999999999,
+        scope="read",
+    )
+    db.add(account)
+    db.commit()
+    return account
+
+
+def _post(
+    client,
+    *,
+    aspect_type: str,
+    object_id: int = 7777,
+    owner_id: int = CONNECTED_ATHLETE_ID,
+    subscription_id: int = 1,
+):
     payload = {
         "object_type": "activity",
         "object_id": object_id,
         "aspect_type": aspect_type,
-        "owner_id": 999,
-        "subscription_id": 1,
+        "owner_id": owner_id,
+        "subscription_id": subscription_id,
         "event_time": 1700000000,
         "updates": {},
     }
     return client.post("/api/webhooks/strava", json=payload)
 
 
-def test_create_enqueues_process_new_activity_job(client, fake_queue):
-    from app.jobs.process_new_activity import process_new_activity_job
+class TestDispatchForAuthenticEvents:
+    def test_create_enqueues_process_new_activity_job(
+        self, client, fake_queue, connected_account
+    ):
+        from app.jobs.process_new_activity import process_new_activity_job
 
-    response = _post(client, aspect_type="create")
-    assert response.status_code == 200
-    assert response.json()["status"] == "processed"
+        response = _post(client, aspect_type="create")
+        assert response.status_code == 200
+        assert response.json()["status"] == "processed"
 
-    fake_queue.enqueue.assert_called_once()
-    args, kwargs = fake_queue.enqueue.call_args
-    assert args[0] is process_new_activity_job
-    assert kwargs["strava_athlete_id"] == 999
-    assert kwargs["strava_activity_id"] == 7777
+        fake_queue.enqueue.assert_called_once()
+        args, kwargs = fake_queue.enqueue.call_args
+        assert args[0] is process_new_activity_job
+        assert kwargs["strava_athlete_id"] == CONNECTED_ATHLETE_ID
+        assert kwargs["strava_activity_id"] == 7777
+
+    def test_update_enqueues_existing_sync_activity_job(
+        self, client, fake_queue, connected_account
+    ):
+        from app.jobs.strava_sync import sync_activity_job
+
+        response = _post(client, aspect_type="update")
+        assert response.status_code == 200
+
+        fake_queue.enqueue.assert_called_once()
+        args, kwargs = fake_queue.enqueue.call_args
+        assert args[0] is sync_activity_job
+
+    def test_delete_does_not_enqueue(self, client, fake_queue, connected_account):
+        response = _post(client, aspect_type="delete")
+        assert response.status_code == 200
+        fake_queue.enqueue.assert_not_called()
 
 
-def test_update_enqueues_existing_sync_activity_job(client, fake_queue):
-    from app.jobs.strava_sync import sync_activity_job
+class TestRejectsForgedEvents:
+    """Threat model: an attacker who learns the callback URL POSTs a forged
+    but well-formed event. The attacker must not be able to enqueue a job or
+    mutate any activity."""
 
-    response = _post(client, aspect_type="update")
-    assert response.status_code == 200
+    def test_unknown_owner_is_rejected_without_enqueue(
+        self, client, fake_queue, connected_account
+    ):
+        # No connected account owns athlete 12345.
+        response = _post(client, aspect_type="create", owner_id=12345)
+        assert response.status_code == 403
+        fake_queue.enqueue.assert_not_called()
 
-    fake_queue.enqueue.assert_called_once()
-    args, kwargs = fake_queue.enqueue.call_args
-    assert args[0] is sync_activity_job
+    def test_no_connected_account_rejects_everything(self, client, fake_queue):
+        # Nothing seeded: there is no connected athlete, so no event is authentic.
+        response = _post(client, aspect_type="create")
+        assert response.status_code == 403
+        fake_queue.enqueue.assert_not_called()
 
+    def test_subscription_mismatch_is_rejected_without_enqueue(
+        self, client, fake_queue, connected_account, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "STRAVA_WEBHOOK_SUBSCRIPTION_ID", 350809)
+        # Authentic owner, but the event references a different subscription.
+        response = _post(client, aspect_type="create", subscription_id=1)
+        assert response.status_code == 403
+        fake_queue.enqueue.assert_not_called()
 
-def test_delete_does_not_enqueue(client, fake_queue):
-    response = _post(client, aspect_type="delete")
-    assert response.status_code == 200
-    fake_queue.enqueue.assert_not_called()
+    def test_matching_subscription_and_owner_is_accepted(
+        self, client, fake_queue, connected_account, monkeypatch
+    ):
+        monkeypatch.setattr(settings, "STRAVA_WEBHOOK_SUBSCRIPTION_ID", 350809)
+        response = _post(client, aspect_type="create", subscription_id=350809)
+        assert response.status_code == 200
+        fake_queue.enqueue.assert_called_once()
+
+    def test_forged_delete_does_not_soft_delete_activity(self, client, db, fake_queue):
+        """The delete branch soft-deletes by object_id. A forged delete event
+        must not be able to remove an activity it does not own."""
+        from datetime import datetime
+
+        user = User(email=f"u-{uuid4()}@example.com")
+        db.add(user)
+        db.commit()
+        activity = Activity(
+            user_id=user.id,
+            strava_activity_id=5555,
+            start_date=datetime(2026, 5, 27, 10, 0, 0),
+            type="Run",
+            name="Victim run",
+            distance_m=5000,
+            moving_time_s=1500,
+            elapsed_time_s=1500,
+        )
+        db.add(activity)
+        db.commit()
+
+        # Forged delete from an owner with no connected account.
+        response = _post(client, aspect_type="delete", object_id=5555, owner_id=12345)
+        assert response.status_code == 403
+
+        db.refresh(activity)
+        assert activity.is_deleted is False

--- a/backend/tests/test_webhooks.py
+++ b/backend/tests/test_webhooks.py
@@ -97,11 +97,30 @@ class TestWebhookVerifyFailsClosedInProduction:
         assert response.status_code != 503
 
 @pytest.mark.integration
-def test_webhook_receive_event(client, override_get_db):
+def test_webhook_receive_event(client, db):
     """
     Test receiving a new activity event.
     Since handling is mocked/placeholder for now, just check 200 OK
     """
+    from uuid import uuid4
+    from app.models import StravaAccount, User
+
+    # The event must come from a connected athlete to be authentic (#100).
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    db.add(
+        StravaAccount(
+            user_id=user.id,
+            strava_athlete_id=999,
+            access_token="test-token-do-not-use-in-prod",
+            refresh_token="test-refresh-do-not-use-in-prod",
+            expires_at=9999999999,
+            scope="read",
+        )
+    )
+    db.commit()
+
     payload = {
         "object_type": "activity",
         "object_id": 12345,


### PR DESCRIPTION
Closes #100.

## Problem
Strava does not sign webhook payloads, and `POST /api/webhooks/strava` is exempt from basic auth so the verification handshake can reach it. The handler trusted any well-formed event: it dispatched `process_new_activity_job` / `sync_activity_job` by `owner_id`/`object_id` (queue DoS / spurious re-processing) and — beyond the issue text — soft-deleted an `Activity` by `object_id` in the `delete` branch with **no athlete check at all** (data tampering).

## Fix
Authenticate every event before any side effect, with two cheap checks against values we already hold:
- **`subscription_id`** must equal `STRAVA_WEBHOOK_SUBSCRIPTION_ID` when configured — Strava only returns this id to us at registration, so it is the stronger (secret-ish) check. Skipped at the default `0` so local dev is unblocked.
- **`owner_id`** must match a connected `StravaAccount` — always on, DB-backed, never drifts.

A failed check logs a warning and returns `403` without enqueuing or mutating anything. The gate sits ahead of the aspect dispatch, so it also closes the forged-delete vector.

## Changes
- `config.py`: new `STRAVA_WEBHOOK_SUBSCRIPTION_ID: int = 0`; documented in `.env.example`.
- `webhooks.py`: `_event_is_authentic()` gate in `receive_webhook`.
- Tests: existing dispatch tests now seed a connected account (so they represent authentic events); new negative-path tests cover unknown owner, no connected account, subscription mismatch, and a forged delete that must not soft-delete its target.

## Verification
- `make backend-test` → **233 passed, 3 deselected**.
- Negative-path assertions anchored to attacker outcomes (no enqueue; `is_deleted` stays `False`), not query shape.
- Policy validation 22/22.

## Production config (required for full protection)
The strong `subscription_id` check is inert until `STRAVA_WEBHOOK_SUBSCRIPTION_ID` is set on Railway to the active subscription (`350809`). Until then production runs the owner-only check, and Strava athlete ids are public. Setting this Railway var is part of landing this change.