### PR TITLE
docs: deployment & runtime topology + .env.example drift fix

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,17 @@ REDIS_URL=redis://localhost:6379/0
 API_BASE_URL=http://localhost:8000
 APP_BASE_URL=http://localhost:3000
 
+# --- CORS ---
+# Comma-separated list of origins allowed to call the API.
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000
+
+# --- Auth (Phase 1 HTTP basic auth) ---
+# Gates every route except /api/health, /api/webhooks, /api/auth/strava/callback.
+# Leave both empty in local dev to disable the gate; in production a missing
+# credential fails closed (503). Replaced by ADR 0005 magic-link sessions in Phase 2.
+BASIC_AUTH_USER=
+BASIC_AUTH_PASSWORD=
+
 # --- Strava OAuth ---
 # Fill these in if you want to connect to Strava.
 STRAVA_CLIENT_ID=
@@ -47,4 +58,17 @@ NOTIFY_TO=
 # Strava API usage. Strava's limit is 1000 requests/day per account; the
 # default of 120s sits at ~720/day.
 POLLING_INTERVAL_SECONDS=120
+# Lookback window (seconds) each poll asks Strava for. An ingestion outage
+# shorter than this window self-heals; a longer gap needs a manual POST /api/sync.
+POLLING_LOOKBACK_SECONDS=604800
 
+# --- Historical stream backfill (manual, self-pacing) ---
+# Activities per batch and the pause (seconds) before the next batch. Defaults
+# keep the one-time backfill under Strava's 100-requests/15-min ceiling.
+BACKFILL_BATCH_SIZE=20
+BACKFILL_BATCH_PAUSE_SECONDS=300
+
+# --- Observability (optional) ---
+# Set to enable Sentry capture; requires the `observability` extra installed.
+# Empty = logs-only, no Sentry.
+SENTRY_DSN=

--- a/docs/deployment/topology.md
+++ b/docs/deployment/topology.md
@@ -1,0 +1,124 @@
+# Deployment & runtime topology
+
+How the system is wired in production and in local development, and how the pieces connect.
+This is the operational reference; `project-context.md` carries the one-line summary and points here.
+
+For the historical Fly/Neon/Upstash plan (now decommissioned) see `phase-1-plan.md`. Fly is gone: the
+`running-coach-ths` app and the whole Fly account were deleted on 2026-06-02.
+
+## Production
+
+Two platforms. Vercel serves the frontend and proxies API traffic to the backend on Railway.
+
+```
+                 browser
+                    │
+         ┌──────────┴───────────┐
+         │  Vercel               │   project: ai-running-coach
+         │  (Next.js frontend)   │   https://ai-running-coach-eta.vercel.app
+         └──────────┬───────────┘
+                    │  server-side fetch with HTTP Basic auth
+                    │  (BACKEND_URL + BACKEND_BASIC_AUTH_*)
+                    ▼
+         ┌──────────────────────┐
+         │  Railway              │   project: running-coach / production
+         │                       │
+         │  web (FastAPI)  ◄─────┼──── Strava webhooks (no Basic auth; exempt)
+         │   ├─ worker (RQ)      │
+         │   └─ scheduler (rqsch)│
+         │  Postgres   Redis     │
+         └──────────────────────┘
+                    │
+                    ▼
+              Strava API, Anthropic API, SMTP
+```
+
+### Vercel (frontend)
+
+- Project `ai-running-coach`, production URL `https://ai-running-coach-eta.vercel.app`.
+- Hosts the Next.js App Router app from `frontend/`.
+- Does not talk to Postgres/Redis directly; all data comes from the backend over HTTP.
+
+### Railway (backend + data)
+
+- Project `running-coach`, environment `production`. Web service public URL `https://web-production-b64d8.up.railway.app`.
+- Three app services run off the same image (`backend/Dockerfile`):
+  - `web` — the FastAPI app (`uvicorn app.main:app`), serves `/api/*`.
+  - `worker` — `rq worker`, runs background jobs (ingest, analyze, coach, email).
+  - `scheduler` — `rqscheduler`, fires the recurring polling job. (ADR 0006 deletes this service under multi-user.)
+- Two managed databases: `Postgres` and `Redis`.
+- Env vars are per-service (see "Configuration" below). The `worker` runs the RQ jobs and sends email, so SMTP/notify vars must be present on `worker`, not only `web`.
+
+### The Vercel → Railway connection seam
+
+There are two paths, both adding HTTP Basic credentials server-side so the browser never sees them:
+
+1. **Server components** call `fetchFromAPI` (`frontend/lib/api.ts`), which on the server uses
+   `BACKEND_URL` directly and attaches a Basic auth header from `BACKEND_BASIC_AUTH_USER` /
+   `BACKEND_BASIC_AUTH_PASSWORD`.
+2. **Client components** call relative `/api/*`. The Next catch-all route handler
+   `frontend/app/api/[...path]/route.ts` proxies each request to `${BACKEND_URL}/api/...`, attaching the
+   same Basic auth header. It returns 500 if `BACKEND_URL` is unset, so a live prod (health returns 200)
+   proves `BACKEND_URL` is configured.
+
+`frontend/vercel.json` has a `/api/:path* → /api/:path*` rewrite that keeps `/api` paths handled by the
+app (the route handler) rather than treated as static; the route handler, not the rewrite, is the proxy.
+
+### Auth model (Phase 1)
+
+- The backend gates every route with `BasicAuthMiddleware` (`backend/app/core/auth.py`).
+- Exempt prefixes (`backend/app/main.py`): `/api/health`, `/api/webhooks`, `/api/auth/strava/callback`.
+  Strava cannot send Basic credentials, so its webhook and OAuth-callback hits must be exempt; webhook
+  authenticity is instead checked by `_event_is_authentic` in `app/api/webhooks.py`.
+- In production a missing `BASIC_AUTH_USER`/`BASIC_AUTH_PASSWORD` fails closed with 503. Outside
+  production the middleware is a no-op when either is unset, so local dev needs no credentials.
+- This whole layer is throwaway: ADR 0005 replaces it with magic-link sessions in Phase 2.
+
+### Configuration (where each secret lives)
+
+| Variable | Vercel (frontend) | Railway `web` | Railway `worker` |
+| --- | --- | --- | --- |
+| `BACKEND_URL` | ✓ (points at Railway web) | — | — |
+| `BACKEND_BASIC_AUTH_USER` / `_PASSWORD` | ✓ | — | — |
+| `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD` | — | ✓ | (gate is web-only) |
+| `DATABASE_URL`, `REDIS_URL` | — | ✓ | ✓ |
+| `ANTHROPIC_API_KEY`, `COACH_MODEL_ID`, `COACH_PROMPT_ID` | — | ✓ | ✓ |
+| `STRAVA_CLIENT_ID/SECRET`, `STRAVA_REDIRECT_URI`, `STRAVA_WEBHOOK_*` | — | ✓ (all) | ✓ (client id/secret + webhook verify token only) |
+| `SMTP_*`, `NOTIFY_TO` | — | ✓ | ✓ (worker sends the email) |
+| `CORS_ALLOWED_ORIGINS` | — | ✓ | — |
+
+The Vercel-side names are `BACKEND_*`; the Railway-side gate names are `BASIC_AUTH_*`. They are different
+variables that must agree in value for the proxy to authenticate against the backend.
+
+### Spend controls
+
+The no-runaway-spend rule requires hard caps. These are platform dashboard settings, not in the repo and
+not readable via the project-scoped Railway token. Verify in the Railway workspace usage limits and in
+Vercel before relying on them.
+
+## Local development
+
+`docker compose` provides only the datastores; the app processes run on the host.
+
+| Process | Command | Port |
+| --- | --- | --- |
+| Postgres | `docker compose up -d postgres redis` | host `5433` → container `5432` |
+| Redis | (same compose) | `6379` |
+| Backend web | `uvicorn app.main:app --reload --port 8000` | `8000` |
+| Backend worker | `rq worker --url $REDIS_URL` | — |
+| Backend scheduler (optional) | `python -m app.jobs.scheduler` then `rqscheduler --url $REDIS_URL` | — |
+| Frontend | `npm run dev` | `3000` |
+
+- Config: `backend/.env` (from `backend/.env.example`) and `frontend/.env.local`. `DATABASE_URL` is
+  required or the backend will not boot.
+- Locally the frontend talks to the backend directly via `NEXT_PUBLIC_API_BASE_URL`
+  (`http://localhost:8000`); the Vercel route-handler proxy and Basic auth are production-only.
+- The scheduler is optional locally; run it only to exercise the polling-driven ASAP coach-report path.
+- Health check: `curl http://localhost:8000/api/health`.
+
+## Migration / drift notes
+
+- Backend moved Fly → Railway (issue #97); Fly is fully decommissioned.
+- `backend/.env.example` is missing several live settings: `BASIC_AUTH_USER`, `BASIC_AUTH_PASSWORD`,
+  `CORS_ALLOWED_ORIGINS`, `POLLING_LOOKBACK_SECONDS`, `BACKFILL_BATCH_SIZE`,
+  `BACKFILL_BATCH_PAUSE_SECONDS`, `SENTRY_DSN`.

--- a/project-context.md
+++ b/project-context.md
@@ -31,7 +31,12 @@ Coach-report email delivery is gated by `SMTP_HOST` and `NOTIFY_TO`; with both u
 The frontend renders an activity list on the home page, a per-activity detail page with charts and panels, a profile page, and a trends page with filters and chart views.
 Planned-workout capture is not yet implemented; `_extract_planned_workout` in `services/analysis/_orchestrator.py` returns `None` as a placeholder.
 There is no multi-user auth layer; the backend assumes a single local user and auto-creates one on first profile read.
-Railway hosts the backend, Postgres, and Redis, and Vercel hosts the frontend; their build and deploy config lives on the platforms rather than in an in-repo deploy manifest. The repo's only committed automation is the CI workflow under `.github/workflows/`. Locally the runtime is `docker compose` plus uvicorn and `next dev`.
+Railway runs the backend as three services off one image (`web` FastAPI, `worker` RQ jobs, `scheduler` rqscheduler) plus managed Postgres and Redis; Vercel hosts the Next.js frontend.
+The Vercel frontend reaches the backend over HTTP: server components call `BACKEND_URL` directly and the catch-all route handler `frontend/app/api/[...path]/route.ts` proxies client-side `/api/*` calls, both injecting HTTP Basic credentials server-side so the browser never sees them.
+The backend gates all routes with `BasicAuthMiddleware`, exempting `/api/health`, `/api/webhooks`, and `/api/auth/strava/callback`; this Phase 1 layer is replaced by ADR 0005 magic-link sessions in Phase 2.
+Build and deploy config lives on the platforms rather than in an in-repo deploy manifest; the repo's only committed automation is the CI workflow under `.github/workflows/`.
+Locally `docker compose` provides only Postgres and Redis, while the host runs `uvicorn`, `rq worker`, an optional `rqscheduler`, and `next dev`.
+The full production and local-dev topology, the connection seam, and per-service env var ownership are documented in `docs/deployment/topology.md`.
 
 ## Important Constraints
 
@@ -85,7 +90,7 @@ Data flow: Strava API → strava_ingestion → Activity/ActivityStream rows → 
 ## Project Structure
 
 `backend/app/main.py` boots the FastAPI app and registers routers.
-`backend/app/api/` contains one router per resource: `health.py`, `auth.py`, `profile.py`, `activities.py`, `webhooks.py`, `trends.py`, `coach.py`.
+`backend/app/api/` contains one router per resource: `health.py`, `auth.py`, `profile.py`, `activities.py`, `webhooks.py`, `trends.py`, `coach.py`, `debug.py`.
 `backend/app/core/config.py` defines the typed settings object; `backend/app/core/queue.py` holds RQ queue setup; `backend/app/core/observability.py` provides `init_logging` and `init_sentry` (import-guarded, no-op without the optional SDK).
 `backend/app/db/base.py` defines the SQLAlchemy `Base`; `backend/app/db/session.py` provides `SessionLocal` and the `get_db` dependency.
 `backend/app/models/` holds one ORM model per file (`activity`, `activity_stream`, `checkin`, `coach_chat_message`, `coach_report`, `derived_metric`, `runner_baseline`, `strava_account`, `user`, `user_profile`) with a barrel `__init__.py`.


### PR DESCRIPTION
Closes #116.

Documents how the system is actually wired so each session starts with an accurate picture instead of re-discovering it. No runtime code changes.

## What
- **New `docs/deployment/topology.md`** — authoritative operational reference:
  - Production diagram and the Vercel↔Railway connection seam (server components fetch `BACKEND_URL` directly; the catch-all route handler `frontend/app/api/[...path]/route.ts` proxies client `/api/*`), both injecting HTTP Basic credentials server-side.
  - Phase 1 auth model and exempt list (`/api/health`, `/api/webhooks`, `/api/auth/strava/callback`), production fail-closed behaviour.
  - Per-service env-var ownership table (Vercel / Railway `web` / Railway `worker`), verified against live service vars.
  - Local-dev process and port table.
  - Drift/migration notes (Fly decommissioned 2026-06-02).
- **`project-context.md`** — topology lines rewritten to match reality (three Railway services, the proxy seam, the basic-auth gate), pointer to the new doc, and `debug.py` added to the router list. Still 136/300 lines.
- **`backend/.env.example`** — added settings present in `config.py` but missing from the template: `BASIC_AUTH_USER`, `BASIC_AUTH_PASSWORD`, `CORS_ALLOWED_ORIGINS`, `POLLING_LOOKBACK_SECONDS`, `BACKFILL_BATCH_SIZE`, `BACKFILL_BATCH_PAUSE_SECONDS`, `SENTRY_DSN`.

## Verification
Every topology claim cross-checked against source (`auth.py`, `main.py`, `route.ts`, `api.ts`) and live infrastructure (Railway `web`/`worker` vars, curl of both prod surfaces). Every `.env.example` name/default confirmed against `config.py`. Policy-layer validation passed. No executable code changed.