### PR TITLE
Email magic-link auth infrastructure (#118, PR-A)

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_login_tokens_and_sessions.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_login_tokens_and_sessions.py
@@ -1,0 +1,59 @@
+"""add login_tokens and sessions tables
+
+Backs the email magic-link identity layer (ADR 0005, #118): single-use login
+tokens and server-side sessions. Additive only. `users.email` already carries a
+unique constraint and stays nullable here; the non-null + placeholder backfill
+lands with the basic-auth cutover (PR-B).
+
+Revision ID: a1b2c3d4e5f6
+Revises: f3a91c2d7e10
+Create Date: 2026-06-02 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = 'f3a91c2d7e10'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'login_tokens',
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('token_hash', sa.String(), nullable=False),
+        sa.Column('email', sa.String(), nullable=False),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('used_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_login_tokens_token_hash', 'login_tokens', ['token_hash'], unique=True)
+    op.create_index('ix_login_tokens_email', 'login_tokens', ['email'], unique=False)
+
+    op.create_table(
+        'sessions',
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('user_id', sa.Uuid(), nullable=False),
+        sa.Column('token_hash', sa.String(), nullable=False),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_sessions_token_hash', 'sessions', ['token_hash'], unique=True)
+    op.create_index('ix_sessions_user_id', 'sessions', ['user_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_sessions_user_id', table_name='sessions')
+    op.drop_index('ix_sessions_token_hash', table_name='sessions')
+    op.drop_table('sessions')
+    op.drop_index('ix_login_tokens_email', table_name='login_tokens')
+    op.drop_index('ix_login_tokens_token_hash', table_name='login_tokens')
+    op.drop_table('login_tokens')

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,4 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+import logging
+import time
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -8,9 +11,96 @@ from typing import Optional
 from app.core.config import settings
 from app.db.session import get_db
 from app.models import User, StravaAccount
+from app.services.auth import (
+    consume_login_token,
+    create_login_token,
+    create_session,
+    delete_session,
+    get_rate_limiter,
+    normalize_email,
+)
+from app.services.notifications import Notification, get_notifier
+from app.services.notifications.email_template import render_login_email
 from app.services.strava_ingestion import get_strava_port
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+
+class LoginLinkRequest(BaseModel):
+    email: str
+
+
+def _client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _set_session_cookie(response: Response, raw_token: str) -> None:
+    response.set_cookie(
+        key=settings.SESSION_COOKIE_NAME,
+        value=raw_token,
+        max_age=settings.SESSION_TTL_SECONDS,
+        httponly=True,
+        samesite="lax",
+        secure=settings.SESSION_COOKIE_SECURE,
+        path="/",
+    )
+
+
+@router.post("/auth/request-link", status_code=202)
+def request_login_link(payload: LoginLinkRequest, request: Request, db: Session = Depends(get_db)):
+    """Email a single-use magic-link to ``email``.
+
+    Always returns 202 for a well-formed email so the response does not reveal
+    whether an account exists. Rate-limited per email and per IP.
+    """
+    email = normalize_email(payload.email)
+    if "@" not in email or "." not in email.split("@")[-1]:
+        raise HTTPException(status_code=422, detail="Invalid email address")
+
+    limiter = get_rate_limiter()
+    if not limiter.allow_login_request(email=email, ip=_client_ip(request), now_epoch=time.time()):
+        raise HTTPException(status_code=429, detail="Too many sign-in requests. Try again later.")
+
+    raw = create_login_token(db, email)
+    verify_url = f"{settings.APP_BASE_URL.rstrip('/')}/api/auth/verify?token={raw}"
+    subject, html, text = render_login_email(
+        verify_url=verify_url, ttl_minutes=settings.LOGIN_TOKEN_TTL_SECONDS // 60
+    )
+    try:
+        get_notifier().send(Notification(to=email, subject=subject, html=html, text=text))
+    except Exception:  # noqa: BLE001 - transport failures must not 500 the caller
+        logger.exception("Failed to send login link to %s", email)
+    return {"status": "sent"}
+
+
+@router.get("/auth/verify")
+def verify_login_link(token: str = Query(...), db: Session = Depends(get_db)):
+    """Exchange a magic-link token for a session cookie, then redirect to the app."""
+    user = consume_login_token(db, token)
+    if user is None:
+        return RedirectResponse(
+            url=f"{settings.APP_BASE_URL.rstrip('/')}/login?error=invalid_link",
+            status_code=303,
+        )
+    raw_session = create_session(db, user)
+    response = RedirectResponse(url=settings.APP_BASE_URL, status_code=303)
+    _set_session_cookie(response, raw_session)
+    return response
+
+
+@router.post("/auth/logout", status_code=204)
+def logout(request: Request, response: Response, db: Session = Depends(get_db)):
+    """Revoke the current session and clear the cookie."""
+    raw = request.cookies.get(settings.SESSION_COOKIE_NAME)
+    if raw:
+        delete_session(db, raw)
+    response.delete_cookie(key=settings.SESSION_COOKIE_NAME, path="/")
+    return Response(status_code=204)
 
 
 class StravaConnectionStatus(BaseModel):

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -46,27 +46,9 @@ class BasicAuthMiddleware(BaseHTTPMiddleware):
         if self._is_exempt(path):
             return await call_next(request)
 
-        expected_user = settings.BASIC_AUTH_USER
-        expected_password = settings.BASIC_AUTH_PASSWORD
-        if not expected_user or not expected_password:
-            if settings.APP_ENV == "production":
-                logger.critical(
-                    "basic_auth_credentials_missing_in_production",
-                    extra={"path": path},
-                )
-                return _service_unavailable()
-            return await call_next(request)
-
-        credentials = _parse_basic_auth(request.headers.get("authorization"))
-        if credentials is None:
-            return _unauthorized()
-
-        user, password = credentials
-        user_ok = secrets.compare_digest(user.encode("utf-8"), expected_user.encode("utf-8"))
-        pass_ok = secrets.compare_digest(password.encode("utf-8"), expected_password.encode("utf-8"))
-        if not (user_ok and pass_ok):
-            return _unauthorized()
-
+        rejection = evaluate_basic_auth(request)
+        if rejection is not None:
+            return rejection
         return await call_next(request)
 
     def _is_exempt(self, path: str) -> bool:
@@ -74,6 +56,38 @@ class BasicAuthMiddleware(BaseHTTPMiddleware):
             path == prefix or path.startswith(prefix + "/")
             for prefix in self._exempt_prefixes
         )
+
+
+def evaluate_basic_auth(request: Request) -> Response | None:
+    """Evaluate HTTP basic auth for a request.
+
+    Returns a ``Response`` to reject the request, or ``None`` to allow it. No-op
+    (allow) when credentials are unset outside production so local dev works;
+    fails closed (503) when unset in production. Shared by the transitional
+    session middleware so a request without a valid session can still fall back
+    to basic auth during the PR-A → PR-B cutover.
+    """
+    expected_user = settings.BASIC_AUTH_USER
+    expected_password = settings.BASIC_AUTH_PASSWORD
+    if not expected_user or not expected_password:
+        if settings.APP_ENV == "production":
+            logger.critical(
+                "basic_auth_credentials_missing_in_production",
+                extra={"path": request.url.path},
+            )
+            return _service_unavailable()
+        return None
+
+    credentials = _parse_basic_auth(request.headers.get("authorization"))
+    if credentials is None:
+        return _unauthorized()
+
+    user, password = credentials
+    user_ok = secrets.compare_digest(user.encode("utf-8"), expected_user.encode("utf-8"))
+    pass_ok = secrets.compare_digest(password.encode("utf-8"), expected_password.encode("utf-8"))
+    if not (user_ok and pass_ok):
+        return _unauthorized()
+    return None
 
 
 def _parse_basic_auth(header_value: str | None) -> tuple[str, str] | None:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -62,9 +62,20 @@ class Settings(BaseSettings):
 
     # Phase 1 deployment: throwaway basic auth in front of /api/*.
     # Both must be set for the middleware to enforce; either empty disables it.
-    # TODO(phase-2): remove when session auth lands.
+    # TODO(phase-2): remove at the basic-auth cutover (PR-B of #118).
     BASIC_AUTH_USER: str = ""
     BASIC_AUTH_PASSWORD: str = ""
+
+    # Email magic-link auth (ADR 0005, #118).
+    # Cookie carrying the opaque session token. Secure should be true wherever
+    # the app is served over HTTPS; left false so plain-HTTP local dev works.
+    SESSION_COOKIE_NAME: str = "rc_session"
+    SESSION_COOKIE_SECURE: bool = False
+    SESSION_TTL_SECONDS: int = 60 * 60 * 24 * 30  # 30 days
+    LOGIN_TOKEN_TTL_SECONDS: int = 900  # 15 minutes
+    # request-link rate limits, enforced via Redis. Caps the email-spam vector.
+    LOGIN_RATE_PER_EMAIL_HOUR: int = 5
+    LOGIN_RATE_PER_IP_MINUTE: int = 10
 
     # Sentry DSN; empty disables Sentry init (Phase 1 step 3 wires the SDK).
     SENTRY_DSN: str = ""

--- a/backend/app/core/session_auth.py
+++ b/backend/app/core/session_auth.py
@@ -1,0 +1,49 @@
+"""Session gate for /api/* (ADR 0005, #118).
+
+A valid session cookie authenticates the request and pins the user id onto
+``request.state`` for downstream handlers (the tenant-scoping sweep, #119,
+consumes it). During the PR-A → PR-B cutover this middleware also falls back to
+HTTP basic auth, so the still-basic-auth frontend keeps working while the new
+session flow is exercisable. PR-B drops the basic-auth fallback and deletes the
+legacy module.
+"""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.types import ASGIApp
+
+from app.core.auth import evaluate_basic_auth
+from app.core.config import settings
+from app.services.auth import resolve_session_user_id_from_token
+
+
+class SessionAuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp, exempt_prefixes: tuple[str, ...]) -> None:
+        super().__init__(app)
+        self._exempt_prefixes = tuple(exempt_prefixes)
+
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+        if self._is_exempt(path):
+            return await call_next(request)
+
+        raw = request.cookies.get(settings.SESSION_COOKIE_NAME)
+        if raw:
+            user_id = resolve_session_user_id_from_token(raw)
+            if user_id is not None:
+                request.state.user_id = user_id
+                return await call_next(request)
+
+        # Transitional fallback; removed at the cutover (PR-B).
+        rejection = evaluate_basic_auth(request)
+        if rejection is not None:
+            return rejection
+        return await call_next(request)
+
+    def _is_exempt(self, path: str) -> bool:
+        return any(
+            path == prefix or path.startswith(prefix + "/")
+            for prefix in self._exempt_prefixes
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,9 +2,9 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api import health, auth, activities, webhooks, profile, trends, coach, debug
-from app.core.auth import BasicAuthMiddleware
 from app.core.config import settings
 from app.core.observability import init_logging, init_sentry
+from app.core.session_auth import SessionAuthMiddleware
 
 init_logging()
 init_sentry("web")
@@ -15,16 +15,19 @@ app = FastAPI(
     version="0.2.0",
 )
 
-# TODO(phase-2): remove BasicAuthMiddleware when session auth from ADR 0005 lands.
-# /api/auth/strava/callback is exempt because Strava redirects the user's browser
-# there directly with an OAuth code; the code itself is the auth, and Strava has
-# no way to send basic auth credentials.
+# Session gate (ADR 0005). The whole /api/auth/* surface is exempt: the
+# magic-link request/verify/logout endpoints serve unauthenticated callers, and
+# the Strava OAuth callback is hit by a browser redirect carrying the OAuth code
+# as its own auth. /api/webhooks/* is server-to-server (authenticated in-handler)
+# and /api/health must stay open for probes.
+# PR-A: this middleware still falls back to basic auth so the not-yet-cutover
+# frontend keeps working. PR-B removes that fallback and deletes app/core/auth.py.
 app.add_middleware(
-    BasicAuthMiddleware,
+    SessionAuthMiddleware,
     exempt_prefixes=(
         "/api/health",
         "/api/webhooks",
-        "/api/auth/strava/callback",
+        "/api/auth",
     ),
 )
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,6 +8,8 @@ from the submodule when you only need one model.
 
 from app.models.base import generate_uuid  # noqa: F401
 from app.models.user import User  # noqa: F401
+from app.models.login_token import LoginToken  # noqa: F401
+from app.models.session import Session  # noqa: F401
 from app.models.strava_account import StravaAccount  # noqa: F401
 from app.models.activity import Activity  # noqa: F401
 from app.models.activity_stream import ActivityStream  # noqa: F401
@@ -21,6 +23,8 @@ from app.models.runner_baseline import RunnerBaseline  # noqa: F401
 __all__ = [
     "generate_uuid",
     "User",
+    "LoginToken",
+    "Session",
     "StravaAccount",
     "Activity",
     "ActivityStream",

--- a/backend/app/models/login_token.py
+++ b/backend/app/models/login_token.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import String, DateTime, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+from app.models.base import generate_uuid
+
+
+class LoginToken(Base):
+    """A single-use magic-link token (ADR 0005).
+
+    The raw token is emailed to the user and never stored; only its SHA-256
+    hash lives here, so a database leak does not yield usable links. A token is
+    spent the moment it is verified (`used_at` set) and is only valid before
+    `expires_at`.
+    """
+
+    __tablename__ = "login_tokens"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=generate_uuid)
+    token_hash: Mapped[str] = mapped_column(String, unique=True, index=True)
+    email: Mapped[str] = mapped_column(String, index=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    used_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import String, DateTime, Uuid, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+from app.models.base import generate_uuid
+
+
+class Session(Base):
+    """A server-side session backing a signed-out-able login (ADR 0005).
+
+    The browser cookie carries a random opaque token; only its SHA-256 hash is
+    stored, so the row is the source of truth and a session can be revoked by
+    deleting it (used by logout and account deletion). A session is valid only
+    while a matching, unexpired row exists.
+    """
+
+    __tablename__ = "sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=generate_uuid)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    token_hash: Mapped[str] = mapped_column(String, unique=True, index=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User")

--- a/backend/app/services/auth/__init__.py
+++ b/backend/app/services/auth/__init__.py
@@ -1,0 +1,22 @@
+from app.services.auth.service import (
+    consume_login_token,
+    create_login_token,
+    create_session,
+    delete_session,
+    normalize_email,
+    resolve_session_user_id,
+    resolve_session_user_id_from_token,
+)
+from app.services.auth.rate_limit import RateLimiter, get_rate_limiter
+
+__all__ = [
+    "consume_login_token",
+    "create_login_token",
+    "create_session",
+    "delete_session",
+    "normalize_email",
+    "resolve_session_user_id",
+    "resolve_session_user_id_from_token",
+    "RateLimiter",
+    "get_rate_limiter",
+]

--- a/backend/app/services/auth/rate_limit.py
+++ b/backend/app/services/auth/rate_limit.py
@@ -1,0 +1,53 @@
+"""Redis-backed rate limiting for the magic-link request endpoint (ADR 0005).
+
+Two independent fixed windows cap the email-spam vector: per-email-per-hour and
+per-IP-per-minute. The limiter fails open if Redis is unavailable: login
+availability outweighs the rate cap, and the residual abuse window is still
+bounded by SMTP throughput. Outages are logged.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class _RedisLike(Protocol):
+    def incr(self, name: str) -> int: ...
+    def expire(self, name: str, seconds: int) -> bool: ...
+
+
+class RateLimiter:
+    def __init__(self, redis_client: _RedisLike) -> None:
+        self._redis = redis_client
+
+    def _under_limit(self, key: str, limit: int, window_seconds: int) -> bool:
+        try:
+            count = self._redis.incr(key)
+            if count == 1:
+                self._redis.expire(key, window_seconds)
+            return count <= limit
+        except Exception:  # noqa: BLE001 - any Redis failure fails open
+            logger.warning("rate_limit_backend_unavailable key=%s; failing open", key)
+            return True
+
+    def allow_login_request(self, *, email: str, ip: str, now_epoch: float) -> bool:
+        """Count this request against both windows; allow only if both are under
+        their limit. Both counters are always incremented so each dimension
+        independently reflects attempt volume."""
+        email_key = f"loginrate:email:{email}:{int(now_epoch // 3600)}"
+        ip_key = f"loginrate:ip:{ip}:{int(now_epoch // 60)}"
+        email_ok = self._under_limit(email_key, settings.LOGIN_RATE_PER_EMAIL_HOUR, 3600)
+        ip_ok = self._under_limit(ip_key, settings.LOGIN_RATE_PER_IP_MINUTE, 60)
+        return email_ok and ip_ok
+
+
+def get_rate_limiter() -> RateLimiter:
+    """Default limiter wrapping the shared Redis connection."""
+    from app.core.queue import redis_conn
+
+    return RateLimiter(redis_conn)

--- a/backend/app/services/auth/service.py
+++ b/backend/app/services/auth/service.py
@@ -1,0 +1,148 @@
+"""Magic-link token and server-side session logic (ADR 0005, #118).
+
+Raw tokens (the link token and the session cookie value) are high-entropy
+secrets that are never stored; only their SHA-256 hash is persisted, so a
+database leak yields no usable credential. The db-injectable functions carry
+the real logic and are unit-tested directly; `resolve_session_user_id_from_token`
+is the thin wrapper the request middleware uses, opening its own session because
+it runs outside the per-request `get_db` dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session as DBSession
+
+from app.core.config import settings
+from app.models import LoginToken, Session, User
+
+
+def _hash(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _is_expired(when: datetime) -> bool:
+    # Stored timezone-aware, but SQLite (tests) round-trips naive datetimes;
+    # treat a naive value as UTC so the comparison never raises.
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    return _now() >= when
+
+
+def normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+def create_login_token(db: DBSession, email: str) -> str:
+    """Create a single-use login token for ``email``; return the raw token.
+
+    The raw token is what gets emailed; only its hash is stored.
+    """
+    raw = secrets.token_urlsafe(32)
+    db.add(
+        LoginToken(
+            token_hash=_hash(raw),
+            email=normalize_email(email),
+            expires_at=_now() + timedelta(seconds=settings.LOGIN_TOKEN_TTL_SECONDS),
+        )
+    )
+    db.commit()
+    return raw
+
+
+def consume_login_token(db: DBSession, raw: str) -> Optional[User]:
+    """Validate and spend a login token, returning the resolved ``User``.
+
+    Returns ``None`` when the token is unknown, already used, or expired. The
+    first valid use for an email creates the ``User``; later uses match by
+    email, so an expired cookie just means signing in again restores the same
+    account.
+    """
+    if not raw:
+        return None
+    record = (
+        db.execute(select(LoginToken).where(LoginToken.token_hash == _hash(raw)))
+        .scalars()
+        .first()
+    )
+    if record is None or record.used_at is not None or _is_expired(record.expires_at):
+        return None
+
+    record.used_at = _now()
+    user = (
+        db.execute(select(User).where(User.email == record.email)).scalars().first()
+    )
+    if user is None:
+        user = User(email=record.email)
+        db.add(user)
+        db.flush()
+    db.commit()
+    return user
+
+
+def create_session(db: DBSession, user: User) -> str:
+    """Create a session for ``user``; return the raw cookie token."""
+    raw = secrets.token_urlsafe(32)
+    db.add(
+        Session(
+            user_id=user.id,
+            token_hash=_hash(raw),
+            expires_at=_now() + timedelta(seconds=settings.SESSION_TTL_SECONDS),
+        )
+    )
+    db.commit()
+    return raw
+
+
+def resolve_session_user_id(db: DBSession, raw: str) -> Optional[uuid.UUID]:
+    """Return the user id for a valid session token, else ``None``."""
+    if not raw:
+        return None
+    session = (
+        db.execute(select(Session).where(Session.token_hash == _hash(raw)))
+        .scalars()
+        .first()
+    )
+    if session is None or _is_expired(session.expires_at):
+        return None
+    return session.user_id
+
+
+def delete_session(db: DBSession, raw: str) -> None:
+    """Revoke a session by deleting its row (logout)."""
+    if not raw:
+        return
+    session = (
+        db.execute(select(Session).where(Session.token_hash == _hash(raw)))
+        .scalars()
+        .first()
+    )
+    if session is not None:
+        db.delete(session)
+        db.commit()
+
+
+def resolve_session_user_id_from_token(raw: str) -> Optional[uuid.UUID]:
+    """Middleware entry point: resolve a session token using a fresh DB session.
+
+    Runs outside the per-request ``get_db`` dependency, so it owns its session.
+    """
+    if not raw:
+        return None
+    from app.db.session import SessionLocal
+
+    db = SessionLocal()
+    try:
+        return resolve_session_user_id(db, raw)
+    finally:
+        db.close()

--- a/backend/app/services/notifications/email_template.py
+++ b/backend/app/services/notifications/email_template.py
@@ -3,6 +3,30 @@ from html import escape
 from app.schemas.coach import CoachReportRead
 
 
+def render_login_email(*, verify_url: str, ttl_minutes: int) -> tuple[str, str, str]:
+    """Render subject + HTML body + plain-text body for a magic-link email."""
+    subject = "Your Running Coach sign-in link"
+    safe_url = escape(verify_url)
+    html = (
+        "<!doctype html><html><body style=\"font-family:-apple-system,sans-serif;max-width:600px;margin:0 auto;padding:16px;\">"
+        "<h2>Sign in to Running Coach</h2>"
+        "<p>Click the button below to sign in. This link works once and expires "
+        f"in {ttl_minutes} minutes.</p>"
+        f"<p><a href=\"{safe_url}\" style=\"display:inline-block;padding:10px 16px;"
+        "background:#111;color:#fff;border-radius:6px;text-decoration:none;\">Sign in</a></p>"
+        f"<p style=\"color:#666;font-size:13px;\">Or paste this link into your browser:<br/>{safe_url}</p>"
+        "<p style=\"color:#666;font-size:13px;\">If you did not request this, you can ignore this email.</p>"
+        "</body></html>"
+    )
+    text = (
+        "Sign in to Running Coach\n\n"
+        f"Open this link to sign in (works once, expires in {ttl_minutes} minutes):\n"
+        f"{verify_url}\n\n"
+        "If you did not request this, you can ignore this email.\n"
+    )
+    return subject, html, text
+
+
 def render_coach_report_email(
     *,
     report: CoachReportRead,

--- a/backend/tests/test_auth_endpoints.py
+++ b/backend/tests/test_auth_endpoints.py
@@ -1,0 +1,88 @@
+"""request-link / verify / logout endpoints (ADR 0005)."""
+
+import pytest
+from sqlalchemy import select
+
+import app.api.auth as auth_api
+from app.core.config import settings
+from app.models import LoginToken, Session, User
+from app.services.auth import create_login_token, create_session
+from app.services.notifications import InMemoryNotifier, set_notifier
+
+
+class _AllowLimiter:
+    def allow_login_request(self, **kwargs):
+        return True
+
+
+class _DenyLimiter:
+    def allow_login_request(self, **kwargs):
+        return False
+
+
+@pytest.fixture
+def notifier():
+    inbox = InMemoryNotifier()
+    set_notifier(inbox)
+    yield inbox
+    set_notifier(None)
+
+
+def test_request_link_sends_email_with_token(client, db, notifier, monkeypatch):
+    monkeypatch.setattr(auth_api, "get_rate_limiter", lambda: _AllowLimiter())
+
+    res = client.post("/api/auth/request-link", json={"email": "Runner@Example.com"})
+
+    assert res.status_code == 202
+    assert len(notifier.sent) == 1
+    sent = notifier.sent[0]
+    assert sent.to == "runner@example.com"
+    assert "/api/auth/verify?token=" in sent.text
+    # A token row was persisted (hashed).
+    assert db.execute(select(LoginToken)).scalars().first() is not None
+
+
+def test_request_link_rejects_malformed_email(client, monkeypatch):
+    monkeypatch.setattr(auth_api, "get_rate_limiter", lambda: _AllowLimiter())
+    res = client.post("/api/auth/request-link", json={"email": "not-an-email"})
+    assert res.status_code == 422
+
+
+def test_request_link_is_rate_limited(client, notifier, monkeypatch):
+    monkeypatch.setattr(auth_api, "get_rate_limiter", lambda: _DenyLimiter())
+    res = client.post("/api/auth/request-link", json={"email": "spam@example.com"})
+    assert res.status_code == 429
+    assert notifier.sent == []
+
+
+def test_verify_valid_token_sets_session_cookie(client, db):
+    raw = create_login_token(db, "verify@example.com")
+
+    res = client.get(f"/api/auth/verify?token={raw}", follow_redirects=False)
+
+    assert res.status_code == 303
+    assert res.headers["location"] == settings.APP_BASE_URL
+    assert settings.SESSION_COOKIE_NAME in res.headers.get("set-cookie", "")
+    # User + session now exist.
+    user = db.execute(select(User).where(User.email == "verify@example.com")).scalars().first()
+    assert user is not None
+    assert db.execute(select(Session).where(Session.user_id == user.id)).scalars().first() is not None
+
+
+def test_verify_invalid_token_redirects_to_login_error(client, db):
+    res = client.get("/api/auth/verify?token=bogus", follow_redirects=False)
+    assert res.status_code == 303
+    assert "error=invalid_link" in res.headers["location"]
+    assert settings.SESSION_COOKIE_NAME not in res.headers.get("set-cookie", "")
+
+
+def test_logout_revokes_session(client, db):
+    user = User(email="bye@example.com")
+    db.add(user)
+    db.commit()
+    raw = create_session(db, user)
+
+    res = client.post("/api/auth/logout", cookies={settings.SESSION_COOKIE_NAME: raw})
+
+    assert res.status_code == 204
+    assert db.execute(select(Session)).scalars().first() is None

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -1,0 +1,75 @@
+"""Magic-link request rate limiter (ADR 0005)."""
+
+import pytest
+
+from app.core.config import settings
+from app.services.auth import RateLimiter
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def incr(self, name):
+        self.store[name] = self.store.get(name, 0) + 1
+        return self.store[name]
+
+    def expire(self, name, seconds):
+        return True
+
+
+class BrokenRedis:
+    def incr(self, name):
+        raise RuntimeError("redis down")
+
+    def expire(self, name, seconds):
+        raise RuntimeError("redis down")
+
+
+def test_allows_requests_under_the_limit(monkeypatch):
+    monkeypatch.setattr(settings, "LOGIN_RATE_PER_EMAIL_HOUR", 3)
+    monkeypatch.setattr(settings, "LOGIN_RATE_PER_IP_MINUTE", 10)
+    limiter = RateLimiter(FakeRedis())
+
+    for _ in range(3):
+        assert limiter.allow_login_request(email="a@b.com", ip="1.1.1.1", now_epoch=1000.0)
+
+
+def test_blocks_when_per_email_limit_exceeded(monkeypatch):
+    monkeypatch.setattr(settings, "LOGIN_RATE_PER_EMAIL_HOUR", 2)
+    monkeypatch.setattr(settings, "LOGIN_RATE_PER_IP_MINUTE", 100)
+    limiter = RateLimiter(FakeRedis())
+
+    assert limiter.allow_login_request(email="a@b.com", ip="1.1.1.1", now_epoch=1000.0)
+    assert limiter.allow_login_request(email="a@b.com", ip="1.1.1.1", now_epoch=1000.0)
+    assert not limiter.allow_login_request(email="a@b.com", ip="1.1.1.1", now_epoch=1000.0)
+
+
+def test_blocks_when_per_ip_limit_exceeded(monkeypatch):
+    monkeypatch.setattr(settings, "LOGIN_RATE_PER_EMAIL_HOUR", 100)
+    monkeypatch.setattr(settings, "LOGIN_RATE_PER_IP_MINUTE", 1)
+    limiter = RateLimiter(FakeRedis())
+
+    # Different emails, same IP: the IP window still trips.
+    assert limiter.allow_login_request(email="a@b.com", ip="9.9.9.9", now_epoch=1000.0)
+    assert not limiter.allow_login_request(email="c@d.com", ip="9.9.9.9", now_epoch=1000.0)
+
+
+def test_separate_windows_are_independent(monkeypatch):
+    monkeypatch.setattr(settings, "LOGIN_RATE_PER_EMAIL_HOUR", 1)
+    monkeypatch.setattr(settings, "LOGIN_RATE_PER_IP_MINUTE", 100)
+    limiter = RateLimiter(FakeRedis())
+
+    assert limiter.allow_login_request(email="a@b.com", ip="1.1.1.1", now_epoch=1000.0)
+    # Same email, next hour bucket -> allowed again.
+    assert limiter.allow_login_request(email="a@b.com", ip="1.1.1.1", now_epoch=1000.0 + 3600)
+
+
+def test_fails_open_when_redis_unavailable(monkeypatch):
+    monkeypatch.setattr(settings, "LOGIN_RATE_PER_EMAIL_HOUR", 1)
+    monkeypatch.setattr(settings, "LOGIN_RATE_PER_IP_MINUTE", 1)
+    limiter = RateLimiter(BrokenRedis())
+
+    # Login must remain available even when the rate-limit backend is down.
+    for _ in range(5):
+        assert limiter.allow_login_request(email="a@b.com", ip="1.1.1.1", now_epoch=1000.0)

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,0 +1,98 @@
+"""Token and session logic (ADR 0005). Oracle: ADR 0005's specified semantics."""
+
+import uuid
+
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.models import LoginToken, Session, User
+from app.services.auth import (
+    consume_login_token,
+    create_login_token,
+    create_session,
+    delete_session,
+    resolve_session_user_id,
+)
+
+
+def test_first_valid_token_use_creates_user(db):
+    raw = create_login_token(db, "Runner@Example.com")
+
+    user = consume_login_token(db, raw)
+
+    assert user is not None
+    assert user.email == "runner@example.com"  # normalized
+    assert db.execute(select(User).where(User.email == "runner@example.com")).scalars().first() is not None
+
+
+def test_returning_email_matches_same_user(db):
+    existing = User(email="repeat@example.com")
+    db.add(existing)
+    db.commit()
+
+    raw = create_login_token(db, "repeat@example.com")
+    user = consume_login_token(db, raw)
+
+    assert user is not None
+    assert user.id == existing.id
+
+
+def test_token_is_single_use(db):
+    raw = create_login_token(db, "once@example.com")
+
+    assert consume_login_token(db, raw) is not None
+    assert consume_login_token(db, raw) is None
+
+
+def test_expired_token_is_rejected(db, monkeypatch):
+    monkeypatch.setattr(settings, "LOGIN_TOKEN_TTL_SECONDS", -1)
+    raw = create_login_token(db, "expired@example.com")
+
+    assert consume_login_token(db, raw) is None
+
+
+def test_unknown_token_returns_none(db):
+    assert consume_login_token(db, "not-a-real-token") is None
+
+
+def test_raw_token_is_not_stored(db):
+    raw = create_login_token(db, "secret@example.com")
+    record = db.execute(select(LoginToken)).scalars().first()
+    assert record.token_hash != raw
+    assert raw not in record.token_hash
+
+
+def test_session_round_trip(db):
+    user = User(email="sess@example.com")
+    db.add(user)
+    db.commit()
+
+    raw = create_session(db, user)
+    assert resolve_session_user_id(db, raw) == user.id
+
+
+def test_expired_session_returns_none(db, monkeypatch):
+    user = User(email="oldsess@example.com")
+    db.add(user)
+    db.commit()
+    monkeypatch.setattr(settings, "SESSION_TTL_SECONDS", -1)
+    raw = create_session(db, user)
+
+    assert resolve_session_user_id(db, raw) is None
+
+
+def test_unknown_session_token_returns_none(db):
+    assert resolve_session_user_id(db, "nope") is None
+
+
+def test_delete_session_revokes_it(db):
+    user = User(email="logout@example.com")
+    db.add(user)
+    db.commit()
+    raw = create_session(db, user)
+    assert resolve_session_user_id(db, raw) == user.id
+
+    delete_session(db, raw)
+
+    assert resolve_session_user_id(db, raw) is None
+    assert db.execute(select(Session)).scalars().first() is None

--- a/backend/tests/test_login_email.py
+++ b/backend/tests/test_login_email.py
@@ -1,0 +1,21 @@
+"""render_login_email (ADR 0005)."""
+
+from app.services.notifications.email_template import render_login_email
+
+
+def test_login_email_contains_link_and_ttl():
+    url = "http://localhost:3000/api/auth/verify?token=abc123"
+    subject, html, text = render_login_email(verify_url=url, ttl_minutes=15)
+
+    assert "sign-in" in subject.lower()
+    assert url in text
+    assert url in html
+    assert "15 minutes" in text
+    assert "15 minutes" in html
+
+
+def test_login_email_escapes_url_in_html():
+    url = "http://localhost:3000/api/auth/verify?token=a&b=<script>"
+    _subject, html, _text = render_login_email(verify_url=url, ttl_minutes=15)
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html

--- a/backend/tests/test_session_gating.py
+++ b/backend/tests/test_session_gating.py
@@ -1,0 +1,73 @@
+"""SessionAuthMiddleware gating (ADR 0005, #118 PR-A).
+
+Migrate-aspect oracle: the exempt set stays {/api/health, /api/webhooks,
+/api/auth}; gated routes require a valid session OR (transitionally) basic auth.
+The session DB lookup is monkeypatched here so gating is tested without a DB;
+the lookup logic itself is covered by test_auth_service.
+"""
+
+import uuid
+
+import pytest
+
+import app.core.session_auth as session_auth
+from app.core.config import settings
+
+GATED = "/api/profile"
+
+
+@pytest.fixture
+def valid_session(monkeypatch):
+    """Make exactly cookie value 'good-token' resolve to a user."""
+    uid = uuid.uuid4()
+
+    def fake_resolve(raw):
+        return uid if raw == "good-token" else None
+
+    monkeypatch.setattr(session_auth, "resolve_session_user_id_from_token", fake_resolve)
+    return uid
+
+
+def test_valid_session_grants_access(client, valid_session):
+    res = client.get(GATED, cookies={settings.SESSION_COOKIE_NAME: "good-token"})
+    assert res.status_code == 200
+
+
+def test_no_credentials_allowed_when_basic_auth_unset(client, valid_session, monkeypatch):
+    # Test env leaves basic-auth creds empty -> middleware is a no-op gate.
+    monkeypatch.setattr(settings, "BASIC_AUTH_USER", "")
+    monkeypatch.setattr(settings, "BASIC_AUTH_PASSWORD", "")
+    res = client.get(GATED)
+    assert res.status_code == 200
+
+
+def test_invalid_session_falls_back_to_basic_auth(client, valid_session, monkeypatch):
+    monkeypatch.setattr(settings, "BASIC_AUTH_USER", "u")
+    monkeypatch.setattr(settings, "BASIC_AUTH_PASSWORD", "p")
+
+    # Bad cookie, no Authorization header -> basic-auth fallback rejects.
+    res = client.get(GATED, cookies={settings.SESSION_COOKIE_NAME: "wrong"})
+    assert res.status_code == 401
+
+    # Valid session bypasses basic auth entirely.
+    res2 = client.get(GATED, cookies={settings.SESSION_COOKIE_NAME: "good-token"})
+    assert res2.status_code == 200
+
+    # Correct basic-auth header also passes when no session is present.
+    res3 = client.get(GATED, auth=("u", "p"))
+    assert res3.status_code == 200
+
+
+def test_health_is_exempt(client, monkeypatch):
+    monkeypatch.setattr(settings, "BASIC_AUTH_USER", "u")
+    monkeypatch.setattr(settings, "BASIC_AUTH_PASSWORD", "p")
+    res = client.get("/api/health")
+    assert res.status_code == 200
+
+
+def test_auth_endpoints_are_exempt(client, monkeypatch):
+    monkeypatch.setattr(settings, "BASIC_AUTH_USER", "u")
+    monkeypatch.setattr(settings, "BASIC_AUTH_PASSWORD", "p")
+    # No session, no basic-auth header, but /api/auth/* is exempt -> not a 401.
+    res = client.get("/api/auth/verify?token=bogus", follow_redirects=False)
+    assert res.status_code != 401


### PR DESCRIPTION
Part of #118 (PR-A of 2). Establishes email magic-link identity + server-side sessions per [ADR 0005](docs/adr/0005-magic-link-is-identity-strava-is-an-integration.md), backward compatible. The basic-auth removal and frontend login flow land in PR-B.

## What this adds
- `login_tokens` + `sessions` tables (additive alembic migration revising `f3a91c2d7e10`).
- Token + session service: raw secrets are hashed at rest, single-use tokens (~15 min TTL), revocable server-side sessions (30-day TTL).
- Redis-backed `request-link` rate limiter (per-email-hour + per-ip-minute), fails open on Redis outage.
- `POST /api/auth/request-link`, `GET /api/auth/verify`, `POST /api/auth/logout`.
- `SessionAuthMiddleware`: a valid session cookie authenticates and pins `request.state.user_id`; transitionally falls back to HTTP basic auth so the not-yet-cutover frontend keeps working. Pins the user id for the #119 tenant sweep.
- `render_login_email` peer to the coach-report email.

## Why backward compatible
PR-A is backend-only. The middleware accepts **either** a valid session **or** existing basic auth, so the frontend (still basic-auth) is unaffected. PR-B removes the basic-auth fallback, deletes `app/core/auth.py`, and adds the frontend login page + cookie forwarding.

## Verification
- 28 new tests; full backend suite **283 passed**, 0 regressions.
- Migration applied + `downgrade`/re-`upgrade` round-trip clean on real Postgres; schema, indexes, and `ON DELETE CASCADE` FK verified.
- Live end-to-end against the running backend with basic-auth enabled: `401` without creds → mint token → `verify` sets `HttpOnly; SameSite=lax` cookie → gated route `200` with session / `401` with a bad cookie. Confirms the real Postgres session lookup through the live middleware (the one path unit tests monkeypatch).

## Known scope boundaries (follow-ups, not bugs)
- **Not multi-user-safe on its own:** endpoints still serve "the one user" until the tenant-isolation sweep (#119), which is a hard prerequisite before any second real user.
- `/api/auth/*` is now fully exempt per ADR 0005, so `/api/auth/strava/status` and `/api/auth/strava/login` are reachable unauthenticated; #119 must session-scope them.
- `SESSION_COOKIE_SECURE` defaults `False` (local HTTP); set `True` in production.
- Cross-origin cookie relay through the Vercel proxy and real SMTP send are verified at PR-B (the cutover), where they become load-bearing.
- `project-context.md` update deferred to PR-B, when the auth model becomes user-facing truth.