### PR TITLE
Local DB seeding from production snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test
+.PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test seed-local
 
 # Prefer the project venv interpreter when it exists, fall back to bare python.
 # Path is relative to backend/ since the targets cd there first. CI has no
@@ -20,3 +20,15 @@ backend-test:
 
 frontend-test:
 	cd frontend && npm run test
+
+# Seed the local DB from the production snapshot so local testing uses real data
+# without a Strava OAuth link. Resets the local schema, then copies a snapshot
+# with Strava tokens REDACTED by default. Requires a Railway project token at
+# ~/.railway_token. Pass extra flags via SEED_ARGS, e.g.:
+#   make seed-local SEED_ARGS="--activities 20"
+#   make seed-local SEED_ARGS="--with-live-tokens"   # only to test real sync
+seed-local:
+	cd backend && \
+	TOK="$$(tr -d '[:space:]' < $$HOME/.railway_token)" && \
+	SRC="$$(RAILWAY_TOKEN="$$TOK" railway variables --service Postgres --kv | grep '^DATABASE_PUBLIC_URL=' | cut -d= -f2-)" && \
+	SEED_SOURCE_URL="$$SRC" $(BACKEND_PY) scripts/seed_from_prod.py $(SEED_ARGS)

--- a/backend/scripts/seed_from_prod.py
+++ b/backend/scripts/seed_from_prod.py
@@ -1,0 +1,210 @@
+"""Seed the local database from a production snapshot.
+
+Why this exists
+---------------
+There is no Strava OAuth link for local/dev, so the usual "connect Strava ->
+sync" path cannot bootstrap data outside production. But Strava is only a port:
+once ``Activity`` / ``ActivityStream`` rows exist locally, the whole
+analyze -> coach -> frontend chain runs with zero Strava dependency. This script
+copies a bounded, real snapshot from a source (production) database into the
+local one so that local testing exercises real data.
+
+Safety
+------
+- Strava OAuth tokens are REDACTED by default (``--with-live-tokens`` opts in).
+  This keeps live secrets out of the local working tree and, crucially, stops a
+  local environment from refreshing -- and thereby rotating/invalidating -- the
+  production refresh token.
+- The script only ever READS from the source and only WRITES to the target. The
+  target schema is reset to this branch's migration head before loading so the
+  copy is deterministic regardless of the local DB's prior state.
+
+Usage
+-----
+    SEED_SOURCE_URL=postgresql://... python scripts/seed_from_prod.py
+    python scripts/seed_from_prod.py --source-url postgresql://... --activities 20
+    python scripts/seed_from_prod.py --with-live-tokens   # only when testing real sync
+
+The target defaults to ``settings.DATABASE_URL`` (the local app DB). Prefer the
+``make seed-local`` wrapper, which injects the source URL from Railway.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from sqlalchemy import create_engine, insert, select, text
+from sqlalchemy.engine import Engine
+
+# Make the backend package importable when run as a bare script.
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from app.core.config import settings  # noqa: E402
+from app.models import (  # noqa: E402
+    Activity,
+    ActivityStream,
+    CheckIn,
+    CoachChatMessage,
+    CoachReport,
+    DerivedMetric,
+    RunnerBaseline,
+    StravaAccount,
+    User,
+    UserProfile,
+)
+
+# Models in foreign-key dependency order. Load top-to-bottom; wipe bottom-to-top.
+USER_MODELS = [User, UserProfile, StravaAccount, RunnerBaseline]
+ACTIVITY_MODELS = [Activity, ActivityStream, DerivedMetric, CoachReport, CoachChatMessage, CheckIn]
+ORDERED_MODELS = USER_MODELS + ACTIVITY_MODELS
+
+# Tables keyed off activity_id, filtered when --activities limits the snapshot.
+ACTIVITY_CHILD_MODELS = [ActivityStream, DerivedMetric, CoachReport, CoachChatMessage, CheckIn]
+
+REDACTED_TOKEN = "dev-redacted-not-a-real-token"
+INSERT_CHUNK = 500
+
+
+def _normalise_driver(url: str) -> str:
+    """Mirror Settings._ensure_psycopg_driver so raw provider URLs work here."""
+    if url.startswith("postgresql+"):
+        return url
+    if url.startswith("postgresql://"):
+        return "postgresql+psycopg://" + url[len("postgresql://") :]
+    if url.startswith("postgres://"):
+        return "postgresql+psycopg://" + url[len("postgres://") :]
+    return url
+
+
+def _read_rows(engine: Engine, model) -> list[dict]:
+    with engine.connect() as conn:
+        return [dict(r) for r in conn.execute(select(model.__table__)).mappings()]
+
+
+def _reset_target_schema(target_url: str) -> None:
+    """Drop and rebuild the local schema at this branch's migration head.
+
+    A plain ``alembic upgrade head`` can fail when the local DB is stamped at a
+    revision that does not exist on the current branch (e.g. after switching off
+    a feature branch). Dropping the schema removes the stale alembic_version, so
+    the subsequent upgrade builds everything cleanly.
+    """
+    print("Resetting target schema (DROP SCHEMA public CASCADE; CREATE SCHEMA public)...")
+    engine = create_engine(target_url)
+    with engine.begin() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+    engine.dispose()
+
+    print("Running 'alembic upgrade head' against the target...")
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=BACKEND_DIR,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stdout + result.stderr)
+        raise SystemExit("alembic upgrade head failed; aborting before any data load.")
+
+
+def _select_activity_ids(rows: list[dict], limit: int) -> set:
+    """Most-recent ``limit`` activity ids by start_date (0 = keep all)."""
+    if limit <= 0:
+        return {r["id"] for r in rows}
+    ordered = sorted(rows, key=lambda r: r["start_date"], reverse=True)
+    return {r["id"] for r in ordered[:limit]}
+
+
+def _insert_rows(engine: Engine, model, rows: list[dict]) -> int:
+    if not rows:
+        return 0
+    with engine.begin() as conn:
+        for start in range(0, len(rows), INSERT_CHUNK):
+            conn.execute(insert(model.__table__), rows[start : start + INSERT_CHUNK])
+    return len(rows)
+
+
+def seed(source_url: str, target_url: str, activities_limit: int, with_live_tokens: bool) -> None:
+    source = create_engine(_normalise_driver(source_url))
+    target = create_engine(_normalise_driver(target_url))
+
+    # Pull everything up front so we can compute the activity-id filter before
+    # touching the target.
+    snapshot: dict = {model: _read_rows(source, model) for model in ORDERED_MODELS}
+
+    keep_activity_ids = _select_activity_ids(snapshot[Activity], activities_limit)
+    snapshot[Activity] = [r for r in snapshot[Activity] if r["id"] in keep_activity_ids]
+    for model in ACTIVITY_CHILD_MODELS:
+        snapshot[model] = [r for r in snapshot[model] if r["activity_id"] in keep_activity_ids]
+
+    if not with_live_tokens:
+        for row in snapshot[StravaAccount]:
+            row["access_token"] = REDACTED_TOKEN
+            row["refresh_token"] = REDACTED_TOKEN
+
+    print(f"\nLoading into target (tokens {'LIVE' if with_live_tokens else 'redacted'}):")
+    for model in ORDERED_MODELS:
+        count = _insert_rows(target, model, snapshot[model])
+        print(f"  {model.__tablename__:<22} {count}")
+
+    source.dispose()
+    target.dispose()
+    print("\nDone. Local DB seeded from snapshot.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-url",
+        default=os.environ.get("SEED_SOURCE_URL"),
+        help="Source (production) DB URL. Defaults to $SEED_SOURCE_URL.",
+    )
+    parser.add_argument(
+        "--target-url",
+        default=settings.DATABASE_URL,
+        help="Target (local) DB URL. Defaults to settings.DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--activities",
+        type=int,
+        default=0,
+        help="Keep only the N most recent activities (0 = all).",
+    )
+    parser.add_argument(
+        "--with-live-tokens",
+        action="store_true",
+        help="Copy real Strava tokens instead of redacting them. Use only to test real sync; "
+        "this can rotate and invalidate the production refresh token.",
+    )
+    parser.add_argument(
+        "--no-reset-schema",
+        action="store_true",
+        help="Skip the schema drop/rebuild and load into the existing target schema.",
+    )
+    args = parser.parse_args()
+
+    if not args.source_url:
+        raise SystemExit("No source URL. Set $SEED_SOURCE_URL or pass --source-url.")
+
+    target_url = _normalise_driver(args.target_url)
+    if "localhost" not in target_url and "127.0.0.1" not in target_url:
+        raise SystemExit(
+            f"Refusing to seed a non-local target ({target_url!r}). "
+            "This script wipes the target schema and is for local dev only."
+        )
+
+    if not args.no_reset_schema:
+        _reset_target_schema(target_url)
+
+    seed(args.source_url, target_url, args.activities, args.with_live_tokens)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/testing/local-seed.md
+++ b/docs/testing/local-seed.md
@@ -1,0 +1,60 @@
+# Testing without a Strava link
+
+There is no Strava OAuth app for dev/local, so the usual "connect Strava -> sync"
+path cannot bootstrap data outside production. This is less limiting than it
+looks, because Strava is only a port: once `Activity` / `ActivityStream` rows
+exist locally, the whole analyze -> coach -> frontend chain runs with zero
+Strava dependency. There are two real testing paths.
+
+## Path 1: drive the deployed app (no setup)
+
+The production Vercel app and per-branch preview deployments are publicly
+reachable and render real synced data (the frontend injects the backend's HTTP
+Basic credentials server-side). For UI, render, and read-path changes, verify
+against the actual deployment — navigate, interact, screenshot, inspect console
+and network. This is the highest-fidelity oracle and needs no local setup.
+
+- Production: https://ai-running-coach-eta.vercel.app/
+- Previews: one per active branch (Vercel dashboard -> Active Branches).
+
+Caveat: previews point at the same single backend/DB as production, so they show
+the same data and write to the same place. Treat them as read-mostly.
+
+## Path 2: seed the local DB from a production snapshot
+
+For backend pipeline work (analysis, coach generation, the API itself) and for
+offline iteration, copy a real snapshot from production into the local DB:
+
+```sh
+make seed-local                          # full snapshot, Strava tokens redacted
+make seed-local SEED_ARGS="--activities 20"   # only the 20 most recent activities
+```
+
+What it does (`backend/scripts/seed_from_prod.py`):
+
+1. Pulls the source URL from Railway (`DATABASE_PUBLIC_URL`) using the project
+   token at `~/.railway_token`.
+2. Resets the local schema (`DROP SCHEMA public CASCADE` then
+   `alembic upgrade head`), so the load is deterministic even if the local DB
+   was stamped at a revision from another branch.
+3. Copies `users`, profiles, the Strava account, activities and their streams,
+   derived metrics, coach reports, chat messages, and check-ins, in FK order.
+
+### Safety
+
+- **Strava tokens are redacted by default.** The copied `StravaAccount` gets
+  dummy tokens, so local cannot call real Strava and cannot rotate (and thereby
+  invalidate) production's live refresh token. Pass
+  `SEED_ARGS="--with-live-tokens"` only when you specifically need to exercise a
+  real sync, and understand it shares the production token.
+- The script **refuses any non-local target** (the URL must contain `localhost`
+  or `127.0.0.1`); it only ever reads from the source.
+
+### Verifying a change against seeded data
+
+```sh
+make seed-local SEED_ARGS="--activities 20"
+docker compose up -d postgres redis        # if not already up
+cd backend && .venv/bin/python -m uvicorn app.main:app --port 8000
+# then: curl http://localhost:8000/api/activities, or run `next dev` and browse.
+```

--- a/project-context.md
+++ b/project-context.md
@@ -111,7 +111,8 @@ Data flow: Strava API → strava_ingestion → Activity/ActivityStream rows → 
 `frontend/lib/types/` holds domain types (`activity`, `chat`, `coach`, `metrics`, `profile`, `trends`); `frontend/lib/types.ts` is the barrel.
 `frontend/scripts/smoke.mjs` is the readiness smoke harness that boots a mock API and Next dev server.
 `docker-compose.yml` defines Postgres 16 and Redis 7 services for local development.
-`Makefile` exposes `smoke`, `backend-smoke`, `frontend-smoke`, `test`, `backend-test`, `frontend-test`.
+`Makefile` exposes `smoke`, `backend-smoke`, `frontend-smoke`, `test`, `backend-test`, `frontend-test`, `seed-local`.
+`make seed-local` runs `backend/scripts/seed_from_prod.py`, which resets the local schema and copies a production snapshot (Strava tokens redacted by default) so local testing uses real data without a Strava OAuth link; the two local/deployed testing paths are documented in `docs/testing/local-seed.md`.
 
 ## Testing Overview
 

--- a/project-context.md
+++ b/project-context.md
@@ -112,7 +112,6 @@ Data flow: Strava API → strava_ingestion → Activity/ActivityStream rows → 
 `frontend/scripts/smoke.mjs` is the readiness smoke harness that boots a mock API and Next dev server.
 `docker-compose.yml` defines Postgres 16 and Redis 7 services for local development.
 `Makefile` exposes `smoke`, `backend-smoke`, `frontend-smoke`, `test`, `backend-test`, `frontend-test`, `seed-local`.
-`make seed-local` runs `backend/scripts/seed_from_prod.py`, which resets the local schema and copies a production snapshot (Strava tokens redacted by default) so local testing uses real data without a Strava OAuth link; the two local/deployed testing paths are documented in `docs/testing/local-seed.md`.
 
 ## Testing Overview
 
@@ -126,6 +125,16 @@ CI runs via `.github/workflows/deploy.yml` (workflow name `ci`) on push and pull
 Major gap: no automated frontend unit or component tests beyond the build-time lint and smoke route checks.
 Major gap: no end-to-end test that exercises a real Strava-to-coach-report flow.
 
+## Real-Data Verification
+
+There is no Strava OAuth application for dev or local, so the connect-then-sync path cannot bootstrap data outside production; real-data verification therefore uses one of the two paths below, both documented in `docs/testing/local-seed.md`.
+Path 1 (deployed): the production Vercel app (`https://ai-running-coach-eta.vercel.app/`) and the per-branch preview deployments are publicly reachable and render real synced data because the frontend injects the backend's HTTP Basic credentials server-side, so browser automation against them verifies any UI or read-path change with no local setup.
+Preview deployments are not isolated environments: they point at the same single production backend and Postgres/Redis as production, so any write triggered on a preview (sync, destructive migration, delete) mutates production data.
+Path 2 (local): `make seed-local` runs `backend/scripts/seed_from_prod.py`, which resets the local schema to the branch's migration head and copies a production snapshot (users, profile, Strava account, activities, streams, derived metrics, coach reports, chat, check-ins) so the analyze -> coach -> frontend chain runs offline against real data; `SEED_ARGS="--activities N"` bounds the snapshot.
+The seed redacts Strava tokens by default so local cannot call Strava and cannot rotate the production refresh token, which means the home page "Sync Now" action fails on a seeded local DB; `SEED_ARGS="--with-live-tokens"` is the opt-in for exercising a real sync and shares the production token.
+`seed_from_prod.py` reads the source URL from `SEED_SOURCE_URL` (the `make` target injects Railway's `DATABASE_PUBLIC_URL` via the project token at `~/.railway_token`), only ever reads from the source, and refuses any target URL that is not `localhost`/`127.0.0.1`.
+Local verification runs the backend via `uvicorn app.main:app --port 8000` and the frontend via `npm run dev` (port 3000) against the docker-compose Postgres/Redis; `BasicAuthMiddleware` is a no-op locally when `BASIC_AUTH_USER`/`BASIC_AUTH_PASSWORD` are unset, so local API calls need no credentials.
+
 ## Maintenance Checklist
 
 Update this file when a new top-level path is added under `backend/app/`, `frontend/app/`, `frontend/components/`, or `frontend/lib/`.
@@ -134,4 +143,5 @@ Update this file when a direct dependency is added or removed in `backend/pyproj
 Update this file when the deterministic policy validator's rule set materially changes or a new policy gate is introduced.
 Update this file when the Strava ingestion, processing pipeline, or coach pipeline gains or loses a stage.
 Update this file when the local runtime topology (ports, services, env vars) changes.
+Update the Real-Data Verification section when the seeding script, its safety defaults, or the deployed/preview environment topology changes, or when a dev/local Strava OAuth path is added.
 Update this file when planned-workout capture is implemented and `_extract_planned_workout` starts returning real data.


### PR DESCRIPTION
## Why

There is no Strava OAuth app for dev/local, so the usual connect → sync path cannot bootstrap data outside production. This made it hard to verify changes properly. But Strava is only a port: once `Activity`/`ActivityStream` rows exist locally, the whole analyze → coach → frontend chain runs with zero Strava dependency.

## What

Two testing paths, documented in `docs/testing/local-seed.md`:

1. **Drive the deployed app** (no setup) — prod + per-branch previews are publicly reachable and render real data.
2. **Seed local from a prod snapshot** — `make seed-local`.

`backend/scripts/seed_from_prod.py`:
- Reads the source via the SQLAlchemy ORM (version-agnostic vs the local v14 / prod v16 client mismatch).
- Resets the local schema to the branch's migration head (`DROP SCHEMA public CASCADE` + `alembic upgrade head`), so the load is deterministic even when local is stamped at another branch's revision.
- Copies users, profile, Strava account, activities + streams, derived metrics, coach reports, chat, check-ins in FK order. `--activities N` bounds the snapshot.

### Safety
- **Strava tokens redacted by default** — local cannot call real Strava and cannot rotate/invalidate prod's live refresh token. `--with-live-tokens` opts in.
- **Refuses any non-local target** (URL must contain localhost/127.0.0.1); only ever reads from source.

## Verification
- Ran `make seed-local SEED_ARGS="--activities 20"` against real prod → local: 20 activities, each with derived metrics + streams, 16 coach reports, tokens confirmed redacted.
- Booted the app on the seeded DB: `/api/health`, `/api/activities`, `/api/activities/{id}` (metrics + real stream types + splits), and `/api/activities/{id}/coach-report` all serve real data.
- Backend baseline green: 255 passed.

### Not verified
- `--with-live-tokens` path (deliberately not exercised — would call real Strava).
- Default full-snapshot run and `--no-reset-schema` (only the 20-activity reset path was run end-to-end).