### PR TITLE
Make notification tests hermetic against ambient channel config (#129)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,9 +4,26 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from app.core.config import settings
 from app.main import app
 from app.db.session import get_db
 from app.db.base import Base
+
+
+@pytest.fixture(autouse=True)
+def _isolate_notification_channels(monkeypatch):
+    """Pin notification-channel settings off by default.
+
+    Channel selection (`_active_channel`) reads `settings`, which loads from
+    `backend/.env`. Without this, a developer `.env` that has Telegram or SMTP
+    configured leaks into tests and flips channel selection, so the email-path
+    tests fail (and CI passes only because CI has none of these set). Resetting
+    them here makes every test start from "no channel configured"; tests that
+    need a channel opt in via their own monkeypatch. Autouse fixtures run before
+    a test's explicitly-requested fixtures, so per-test overrides still win.
+    """
+    for var in ("TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID", "SMTP_HOST", "NOTIFY_TO"):
+        monkeypatch.setattr(settings, var, "")
 
 # Use an in-memory SQLite database for tests, or a separate test DB
 # For simplicity with SQLAlchemy features, an in-memory SQLite is easiest 


### PR DESCRIPTION
Fixes #129.

## Problem
After #127 merged, `make backend-test` fails 3 tests on `main` whenever `backend/.env` has `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` set:
- `test_pipeline_end_to_end::test_webhook_create_triggers_one_email_and_dedupes_on_replay`
- `test_process_new_activity_job::test_pipeline_sends_email_on_happy_path`
- `test_process_new_activity_job::test_pipeline_skips_when_notify_to_unset`

`_active_channel()` reads `settings` (loaded from `.env`). The email-path tests set `SMTP_HOST`/`NOTIFY_TO` but never pin `TELEGRAM_*` off, so when those vars are present the channel resolves to `telegram` and the assertions fail. CI passed only because CI has no `TELEGRAM_*` — a green bar that depended on the absence of an env var.

## Fix
Autouse fixture in `tests/conftest.py` resets `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `SMTP_HOST`, `NOTIFY_TO` to empty before each test. Tests opt into a channel explicitly; autouse runs before a test's own fixtures so per-test overrides still win.

## Verification
- Full suite: 267 passed with `TELEGRAM_*` present in `.env` (the previously-failing condition).
- Also passes with hostile channel vars forced via process env, proving hermeticity regardless of source.
- No production code touched — test-only change.