### PR TITLE
Redact Telegram bot token from logs (#131)

### DIFF
--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sys
 from datetime import datetime, timezone
 from typing import Any
@@ -36,6 +37,44 @@ _STANDARD_LOG_RECORD_FIELDS = frozenset(
         "relativeCreated", "stack_info", "thread", "threadName", "taskName",
     }
 )
+
+
+# Telegram bot tokens look like `bot<numeric-id>:<35-char secret>` and ride in
+# the Bot API URL path, which httpx logs at INFO. Mask the secret part, keeping
+# the (non-secret) numeric bot id so the log line stays useful. See #131.
+_TELEGRAM_TOKEN_RE = re.compile(r"(bot\d+):[A-Za-z0-9_-]+")
+_TELEGRAM_TOKEN_REPLACEMENT = r"\1:<redacted>"
+
+
+def _redact_secrets(value: Any) -> Any:
+    """Mask known secrets in a log value, preserving type when nothing matches.
+
+    Operates on the string form so it also catches non-str args (e.g. an
+    `httpx.URL`). Returns the original object unchanged when no secret is
+    present, so normal log formatting (and arg types) are untouched.
+    """
+    text = value if isinstance(value, str) else str(value)
+    redacted = _TELEGRAM_TOKEN_RE.sub(_TELEGRAM_TOKEN_REPLACEMENT, text)
+    return redacted if redacted != text else value
+
+
+class SecretRedactingFilter(logging.Filter):
+    """Strip secrets from log records before they are formatted.
+
+    Attached to the root handler (not a logger) so it also sees records that
+    propagate up from third-party loggers such as `httpx`. Mutating the record
+    is safe here: the record is only emitted by this one handler.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str):
+            record.msg = _redact_secrets(record.msg)
+        if record.args:
+            if isinstance(record.args, dict):
+                record.args = {k: _redact_secrets(v) for k, v in record.args.items()}
+            else:
+                record.args = tuple(_redact_secrets(a) for a in record.args)
+        return True
 
 
 class JSONFormatter(logging.Formatter):
@@ -74,6 +113,7 @@ def init_logging() -> None:
         handler.setFormatter(
             logging.Formatter("%(asctime)s %(levelname)-8s %(name)s: %(message)s")
         )
+    handler.addFilter(SecretRedactingFilter())
     root.addHandler(handler)
     root.setLevel(logging.INFO)
 

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -191,6 +191,81 @@ class TestSentryCaptureActive:
         assert observability.sentry_capture_active() is True
 
 
+class TestSecretRedaction:
+    """Telegram bot tokens ride in the Bot API URL path, which httpx logs at
+    INFO. The redaction filter must mask the secret without dropping the line
+    or touching other (safe) request logs. See #131."""
+
+    FAKE_TOKEN = "bot123456789:AAFakeSecret_tokenPART-xyz123"
+
+    def test_redacts_token_in_plain_string(self):
+        out = observability._redact_secrets(f"sent via {self.FAKE_TOKEN} ok")
+        assert "AAFakeSecret_tokenPART-xyz123" not in out
+        assert "bot123456789:<redacted>" in out
+
+    def test_redacts_token_inside_url(self):
+        url = f"https://api.telegram.org/{self.FAKE_TOKEN}/sendMessage"
+        assert (
+            observability._redact_secrets(url)
+            == "https://api.telegram.org/bot123456789:<redacted>/sendMessage"
+        )
+
+    def test_leaves_non_matching_string_as_same_object(self):
+        s = "https://www.strava.com/api/v3/athlete/activities?page=1"
+        # Strava uses header auth, no secret in the URL: must be untouched.
+        assert observability._redact_secrets(s) is s
+
+    def test_preserves_non_string_type_when_no_secret(self):
+        result = observability._redact_secrets(200)
+        assert result == 200 and isinstance(result, int)
+
+    def test_filter_masks_httpx_style_record(self):
+        # Mirrors how httpx emits a request log: msg with %s, URL in args.
+        record = logging.LogRecord(
+            name="httpx",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='HTTP Request: %s %s "%s"',
+            args=("POST", f"https://api.telegram.org/{self.FAKE_TOKEN}/sendMessage", "HTTP/1.1 200 OK"),
+            exc_info=None,
+        )
+        assert observability.SecretRedactingFilter().filter(record) is True
+        message = record.getMessage()
+        assert "AAFakeSecret_tokenPART-xyz123" not in message
+        assert "bot123456789:<redacted>" in message
+
+    def test_filter_masks_non_string_url_arg(self):
+        # httpx passes an httpx.URL object, not a str; redaction works on str().
+        class _FakeURL:
+            def __str__(self):
+                return f"https://api.telegram.org/{TestSecretRedaction.FAKE_TOKEN}/sendMessage"
+
+        record = logging.LogRecord(
+            name="httpx", level=logging.INFO, pathname=__file__, lineno=1,
+            msg="HTTP Request: %s", args=(_FakeURL(),), exc_info=None,
+        )
+        observability.SecretRedactingFilter().filter(record)
+        assert "AAFakeSecret_tokenPART-xyz123" not in record.getMessage()
+
+    def test_init_logging_wires_redaction_end_to_end(self, monkeypatch):
+        monkeypatch.setattr(settings, "APP_ENV", "production")
+        observability.init_logging()
+        buffer = io.StringIO()
+        logging.getLogger().handlers[0].stream = buffer
+
+        logging.getLogger("httpx").info(
+            'HTTP Request: %s %s "%s"',
+            "POST",
+            f"https://api.telegram.org/{self.FAKE_TOKEN}/sendMessage",
+            "HTTP/1.1 200 OK",
+        )
+
+        out = buffer.getvalue()
+        assert "AAFakeSecret_tokenPART-xyz123" not in out
+        assert "bot123456789:<redacted>" in out
+
+
 @pytest.fixture(autouse=True)
 def _restore_logging_after_each_test():
     """Tests mutate the root logger; restore baseline afterwards."""


### PR DESCRIPTION
Fixes #131.

## Problem
`httpx` logs request URLs at INFO, and the Telegram Bot API carries the token in the URL path (`/bot<token>/sendMessage`). After #127, the worker logged the full bot token on every coach notification (confirmed in Railway worker logs). Low severity (private logs) but a live credential in logs.

## Fix
`SecretRedactingFilter` on the root log handler masks the secret portion of Telegram bot tokens (`bot<id>:<redacted>`). Attached to the handler (not a logger) so it also catches records propagating up from third-party loggers like `httpx`. Operates on the string form so it handles non-str args (e.g. `httpx.URL`), and returns the original object unchanged when nothing matches, so normal logs and arg types are untouched.

## Verification
- 274 passed (was 267; +7 redaction tests): plain string, URL, `httpx`-style record (msg + URL arg), non-string URL object, end-to-end via `init_logging`, and that non-matching/Strava logs pass through unchanged (same object, type preserved).
- No new dependency (stdlib `logging` + `re`).

Note: existing log lines already emitted before this deploys still contain the token; rotating the bot token via BotFather `/revoke` is the way to invalidate those if desired.