### PR TITLE
Render classification headline + axes (frontend) — #133

### DIFF
--- a/frontend/app/activity/[id]/page.tsx
+++ b/frontend/app/activity/[id]/page.tsx
@@ -30,9 +30,14 @@ export default async function ActivityDetail({ params }: { params: { id: string 
         <div className="flex justify-between items-start">
             <div>
                 <h1 className="text-3xl font-bold text-gray-900">{activity.name}</h1>
-                <div className="flex gap-4 mt-2 text-gray-600">
+                <div className="flex gap-4 mt-2 text-gray-600 items-center">
                     <span>{format(new Date(activity.start_date), 'PPPP p')}</span>
                     <span>{formatDistanceKm(activity.distance_m)}</span>
+                    {activity.metrics?.headline && (
+                        <span className="inline-block px-2 py-0.5 rounded-full bg-blue-100 text-blue-800 text-sm font-medium">
+                            {activity.metrics.headline}
+                        </span>
+                    )}
                 </div>
             </div>
             {/* IntentSelector moved to main content */}
@@ -49,7 +54,7 @@ export default async function ActivityDetail({ params }: { params: { id: string 
               activityId={activity.id} 
               existingCheckIn={activity.check_in} 
               currentType={activity.user_intent ?? null}
-              assignedClass={activity.metrics?.activity_class}
+              headline={activity.metrics?.headline}
               sportType={activity.raw_summary?.sport_type || activity.raw_summary?.type || 'Run'}
           />
           

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -23,7 +23,7 @@ export default async function Dashboard() {
   const totalTime = activities.reduce((sum: number, act: any) => sum + (act.moving_time_s || 0), 0);
   const hardDays = activities.filter((act: any) => {
       // Very crude "hard day" check if HR > 150 or label contains Hard/Tempo
-      // Ideally check derived metric "activity_class"
+      // Ideally use the derived effort axis once the list endpoint exposes it.
       return (act.avg_hr && act.avg_hr > 155) || (act.name && act.name.match(/Tempo|Interval|Race/i));
   }).length;
 

--- a/frontend/components/ActivityList.tsx
+++ b/frontend/components/ActivityList.tsx
@@ -9,7 +9,6 @@ interface Activity {
   start_date: string;
   distance_m: number;
   moving_time_s: number;
-  activity_class?: string; 
 }
 
 export default function ActivityList({ activities }: { activities: Activity[] }) {

--- a/frontend/components/CheckInForm.tsx
+++ b/frontend/components/CheckInForm.tsx
@@ -22,11 +22,11 @@ interface Props {
   activityId: string;
   existingCheckIn?: CheckInData | null;
   currentType?: string | null;
-  assignedClass?: string;
+  headline?: string | null; // measured classification headline (ADR 0007)
   sportType?: string; // e.g. "Run", "Walk"
 }
 
-export default function CheckInForm({ activityId, existingCheckIn, currentType, assignedClass, sportType = "Run" }: Props) {
+export default function CheckInForm({ activityId, existingCheckIn, currentType, headline, sportType = "Run" }: Props) {
   const router = useRouter();
   
   // Determine available options based on sport type
@@ -44,8 +44,9 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
   const [effort, setEffort] = useState<number | ''>(existingCheckIn?.rpe ?? '');
   const [notes, setNotes] = useState(existingCheckIn?.notes ?? '');
   
-  // Intent State
-  const [intent, setIntent] = useState(currentType || assignedClass || "Easy Run");
+  // Intent State. Stated intent is independent of the measured classification
+  // (ADR 0007), so it is not pre-seeded from the detected headline.
+  const [intent, setIntent] = useState(currentType || typeOptions[0]);
 
   const [submitting, setSubmitting] = useState(false);
 
@@ -57,8 +58,8 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
       setNotes(existingCheckIn.notes || '');
     }
     // Also sync intent if it changes externally or on load
-    setIntent(currentType || assignedClass || typeOptions[0]);
-  }, [existingCheckIn, currentType, assignedClass, typeOptions]); 
+    setIntent(currentType || typeOptions[0]);
+  }, [existingCheckIn, currentType, typeOptions]);
   
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -160,9 +161,9 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
               <option key={type} value={type}>{type}</option>
           ))}
         </select>
-        {assignedClass && typeOptions.includes(assignedClass) && (
+        {headline && (
             <p className="text-xs text-gray-400 mt-1">
-                Detected as: {assignedClass}
+                Detected as: {headline}
             </p>
         )}
       </div>
@@ -213,7 +214,7 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
               setPain(existingCheckIn.pain_score);
               setEffort(existingCheckIn.rpe);
               setNotes(existingCheckIn.notes || '');
-              setIntent(currentType || assignedClass || typeOptions[0]);
+              setIntent(currentType || typeOptions[0]);
               setIsEditing(false);
             }}
             className="px-3 py-2 rounded text-sm font-medium text-gray-600 hover:bg-gray-200 border border-gray-300 transition-colors"

--- a/frontend/lib/types/metrics.ts
+++ b/frontend/lib/types/metrics.ts
@@ -20,7 +20,13 @@ export interface EfficiencyAnalysis {
 }
 
 export interface DerivedMetric {
-  activity_class: string;
+  // Orthogonal classification axes (ADR 0007) + the derived headline.
+  headline?: string | null;
+  effort?: string | null;
+  duration_class?: string | null;
+  structure?: string | null;
+  is_hilly?: boolean | null;
+  is_race?: boolean | null;
   effort_score: number;
   flags: string[];
   confidence: string;


### PR DESCRIPTION
Frontend half of #133, stacked on the backend PR (#134). **Merge #134 first**, then this retargets to main.

Moves the frontend off the dropped \`activity_class\` onto the classification axes (ADR 0007).

## Changes
- \`lib/types/metrics.ts\`: \`DerivedMetric\` carries \`headline\` + \`effort\` / \`duration_class\` / \`structure\` / \`is_hilly\` / \`is_race\`.
- \`activity/[id]/page.tsx\`: shows the headline as a badge in the activity header and passes it to the check-in panel.
- \`CheckInForm.tsx\`: takes the measured \`headline\` ("Detected as: …") separately from the stated-intent dropdown, which is no longer pre-seeded from the measured label (intent ≠ executed, per ADR 0007).
- \`ActivityList.tsx\`: drop the unused \`activity_class\` field.

## Verification
- \`npm run test\` (next lint + next build): passes, types valid.
- Live API check against the migrated local DB: the detail endpoint returns \`metrics.headline\` + axes, the contract this PR consumes.
- Visual render not eyeballed in a browser (noted for reviewer).

## Follow-up
- Home activity list still shows no class label (the list endpoint doesn't return metrics); tracked separately.