### PR TITLE
Fix intent selector defaulting to 'Easy Run' (#137)

### DIFF
--- a/backend/app/schemas/activity.py
+++ b/backend/app/schemas/activity.py
@@ -52,4 +52,6 @@ class ActivityRead(ActivityBase):
 
 
 class ActivityIntentUpdate(BaseModel):
-    user_intent: str
+    # Optional: null clears the stated intent (the runner is leaving the
+    # activity to the measured classification rather than overriding it).
+    user_intent: Optional[str] = None

--- a/backend/tests/test_intent_update.py
+++ b/backend/tests/test_intent_update.py
@@ -1,0 +1,58 @@
+"""The activity intent endpoint accepts an explicit type and a null clear (#137)."""
+
+import uuid
+from datetime import datetime, timezone
+
+from app.models import Activity, User
+
+
+def _make_activity(db) -> Activity:
+    user_id = uuid.uuid4()
+    db.add(User(id=user_id, email=f"intent_{user_id}@example.com"))
+    db.flush()
+    a = Activity(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        strava_activity_id=abs(hash(str(uuid.uuid4()))) % 10**9,
+        name="Afternoon Run",
+        type="Run",
+        start_date=datetime(2026, 6, 2, 14, 57, tzinfo=timezone.utc),
+        distance_m=3660,
+        moving_time_s=1200,
+        elapsed_time_s=1300,
+        elev_gain_m=20.0,
+        avg_hr=166.0,
+        max_hr=190.0,
+    )
+    db.add(a)
+    db.commit()
+    return a
+
+
+def test_intent_sets_explicit_type(client, db):
+    a = _make_activity(db)
+    resp = client.put(f"/api/activities/{a.id}/intent", json={"user_intent": "Tempo"})
+    assert resp.status_code == 200, resp.text
+    db.refresh(a)
+    assert a.user_intent == "Tempo"
+
+
+def test_intent_null_clears_stated_intent(client, db):
+    a = _make_activity(db)
+    client.put(f"/api/activities/{a.id}/intent", json={"user_intent": "Easy Run"})
+    db.refresh(a)
+    assert a.user_intent == "Easy Run"
+
+    # Submitting an unset selection clears it rather than recording a type.
+    resp = client.put(f"/api/activities/{a.id}/intent", json={"user_intent": None})
+    assert resp.status_code == 200, resp.text
+    db.refresh(a)
+    assert a.user_intent is None
+
+
+def test_intent_omitted_is_treated_as_unset(client, db):
+    a = _make_activity(db)
+    resp = client.put(f"/api/activities/{a.id}/intent", json={})
+    assert resp.status_code == 200, resp.text
+    db.refresh(a)
+    assert a.user_intent is None

--- a/frontend/components/CheckInForm.tsx
+++ b/frontend/components/CheckInForm.tsx
@@ -45,8 +45,10 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
   const [notes, setNotes] = useState(existingCheckIn?.notes ?? '');
   
   // Intent State. Stated intent is independent of the measured classification
-  // (ADR 0007), so it is not pre-seeded from the detected headline.
-  const [intent, setIntent] = useState(currentType || typeOptions[0]);
+  // (ADR 0007), so it is not pre-seeded from the detected headline. Empty means
+  // "not set — use the detected classification", a neutral default rather than a
+  // misleading specific type.
+  const [intent, setIntent] = useState(currentType || "");
 
   const [submitting, setSubmitting] = useState(false);
 
@@ -58,8 +60,8 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
       setNotes(existingCheckIn.notes || '');
     }
     // Also sync intent if it changes externally or on load
-    setIntent(currentType || typeOptions[0]);
-  }, [existingCheckIn, currentType, typeOptions]);
+    setIntent(currentType || "");
+  }, [existingCheckIn, currentType]);
   
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -81,7 +83,9 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
             }),
             fetchFromAPI(`/api/activities/${activityId}/intent`, {
                 method: 'PUT',
-                body: JSON.stringify({ user_intent: intent }),
+                // Empty selection clears the intent rather than recording a type
+                // the runner never chose.
+                body: JSON.stringify({ user_intent: intent === "" ? null : intent }),
             }),
         ]);
 
@@ -113,9 +117,9 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
               <div className="col-span-2 flex justify-between border-b border-green-100 pb-1">
                   <dt className="text-green-800 opacity-80">Type</dt>
                   <dd className="font-medium text-right">
-                       {intent}
+                       {currentType || headline || 'Auto-detected'}
                        <span className="text-[10px] block opacity-60 font-normal">
-                         {currentType ? '(Manual)' : '(Auto)'}
+                         {currentType ? '(Manual)' : '(Auto-detected)'}
                        </span>
                   </dd>
               </div>
@@ -157,13 +161,14 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
           onChange={(e) => setIntent(e.target.value)}
           className="w-full border border-gray-300 rounded p-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all bg-white"
         >
+          <option value="">{headline ? `Auto-detected: ${headline}` : "Auto-detected"}</option>
           {typeOptions.map(type => (
               <option key={type} value={type}>{type}</option>
           ))}
         </select>
         {headline && (
             <p className="text-xs text-gray-400 mt-1">
-                Detected as: {headline}
+                Detected as: {headline}{intent === "" ? "" : " · overridden below"}
             </p>
         )}
       </div>
@@ -214,7 +219,7 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
               setPain(existingCheckIn.pain_score);
               setEffort(existingCheckIn.rpe);
               setNotes(existingCheckIn.notes || '');
-              setIntent(currentType || typeOptions[0]);
+              setIntent(currentType || "");
               setIsEditing(false);
             }}
             className="px-3 py-2 rounded text-sm font-medium text-gray-600 hover:bg-gray-200 border border-gray-300 transition-colors"


### PR DESCRIPTION
Closes #137. Regression from the orthogonal-classification work (#133).

## Problem
The "Activity Type" selector fell back to the first list option ("Easy Run") whenever no intent was set, so a run detected as e.g. *Intervals (hard)* still showed "Easy Run" in the selector — looking like a misclassification. Worse, the form always submitted the selector value, so checking in without touching it **fabricated** \`user_intent="Easy Run"\` and triggered a false intent-vs-effort mismatch.

## Fix
- The selector now has a neutral **Auto-detected** option, selected when no intent is set, with the measured headline shown alongside.
- Submitting with nothing chosen sends \`user_intent: null\` instead of a fabricated type (\`ActivityIntentUpdate.user_intent\` is now optional/nullable).
- View mode shows the detected headline when no manual intent was set.

## Verification
- New \`test_intent_update.py\`: explicit type sets intent; null clears it; omitted is treated as unset.
- \`make backend-test\`: 298 passed. Frontend \`npm run test\` (lint + build): passes.

## Note
The measured classification was always correct ("Detected as: …"); this was purely the intent selector misrepresenting an unset state. No reclassification or backfill needed.