### PR TITLE
docs: coach report update brief + improvement plan

### DIFF
--- a/docs/coach-report-improvement-plan.md
+++ b/docs/coach-report-improvement-plan.md
@@ -1,0 +1,227 @@
+# Running Coach — Report Plan: From Metric Narrator to Continuous-Improvement Coach
+
+> Status: design plan for product-owner review. Schema-touching items are flagged **[ASK-FIRST]** per the project's Boundary Rules and must be approved before implementation. Code claims below were verified against `backend/app/services/coach/`, `models/`, `schemas/`, and `services/trends.py` on the current `main`.
+>
+> Produced by a multi-perspective design workflow: a research sweep (sports science, AI personalization/memory, competitive landscape, LLM health-report design) feeding a six-voice panel debate (Coach/physiologist, Data Scientist, AI Product Designer, Runner, Safety Skeptic, Systems Architect), synthesized here.
+
+---
+
+## 1. Vision
+
+The Coach Report stops being a four-box thermometer reading of one run and becomes a short, opinionated coaching note that situates today's effort inside the runner's own trajectory: it leads with a verdict, corrects numbers that the conditions made misleading, references what it told you last time and whether you acted on it, and ends with one prioritized action tied to your goal. Each report is simultaneously an artifact the runner reads and a state-update that makes the next report better — the report *writes back* what it now believes about this runner (confirmed confounds, adherence, working philosophy) so report N+1 is provably built on report N's outcome. That write-back loop, fed by per-second stream signals and persistent personal context a chatbot never sees, is the heart of a system whose entire purpose is to make this specific runner measurably fitter over a season.
+
+---
+
+## 2. The core insight / moat
+
+A cold AI handed the same single run can already produce a confident headline, correct an inflated HR if you *tell* it the temperature, and write nice prose. Those moves are copyable in a week. The two things it structurally cannot do:
+
+1. **Persistent context captured once, applied automatically every run** — the amber-foot rehab block, "fitness is ahead of tissue," the stimulant's HR effect, the auto-ingested weather — on top of per-second HR/pace/power/cadence streams it never sees.
+2. **A closed learning loop** — each report records its prioritized next-step; the *next Strava activity reveals for free* whether it was followed; that adherence outcome plus the runner's own rolling baseline feed the following report.
+
+The moat is operational, not model-based: it is the *fusion* of deterministic stream metrics with a curated, gated per-runner memory, plus the discipline to keep refreshing it. The prompt and the model are swappable; the durable assets are the deterministic confounder-correction layer, the computed RunnerBaseline/trend layer, and the gated memory store. The product owner's bar — "better than any single AI given the same run data" — is met precisely at the points where the app holds context and history the cold AI cannot.
+
+**Honest note for the owner:** today *none of the moat exists in code*. `context.py` (160 lines) feeds the LLM one activity, its metrics, the check-in, the profile, and three volume tallies. It never reads `average_temp` (the string appears nowhere in `backend/app/`), never loads a prior `CoachReport`, never reads `RunnerBaseline` — whose own docstring says *"Schema-only for now. Computation logic will be added in a future phase."* The substrate the owner believes exists is an empty table. This plan is mostly about building the moat, not polishing prose.
+
+---
+
+## 3. The key debates
+
+### Debate A — Opinionated voice vs. safety hedging
+**Runner, Coach, Data Scientist, Architect:** The timidity is a *product defect located in the prompt*, not a safety property. Verified: prompt rule 6 is literally "Be concise," rule 8 "be conservative. Never recommend risky volume jumps," and the schema forces `min_length=2, max_length=4` equal-weight `key_takeaways`. "It depends" is the answer runners quit over.
+**Safety Skeptic:** Confidence is dangerous; the validator has four rules and *none* forbid medical directives (verified). A confident coach with no scope gate is a liability.
+
+**Resolution:** Both are right about different things. Hedging-as-tone goes; hedging-as-grounding stays. Confidence becomes a *per-claim router off the existing `DerivedMetric.confidence`/`confidence_reasons`* — loud where grounded, explicitly "not enough data" where not — rather than one uniform softening. This is structurally safer than today, because today the report states an inflated HR drift as durability signal with no correction at all. The Safety Skeptic wins their actual demand: a **deterministic medical-scope rule added to the validator ships *before* any opinionated feature**, and it is the validator (not the prompt) that enforces "no dose advice, no diagnosis verbs, never escalate one wearable number into a health claim." Opinionated-where-grounded is compatible with a hard scope gate. The validator gate is mandatory per `ai-workflow.md` and is never bypassed.
+
+### Debate B — Single-run depth vs. longitudinal narrative
+**Coach, Data Scientist, AI Designer:** A run only means something against the runner's recent history; lead with the 4-week aerobic trend before any single-run number.
+**Architect:** You cannot narrate a "4-week aerobic trend" on top of a `RunnerBaseline` table that contains zero computation. Anyone promising it next sprint is selling vapor.
+
+**Resolution:** The longitudinal vision is the spine, but it has a hard dependency the others gloss over. Sequence it honestly: the **trend layer (compute RunnerBaseline + persist per-run EF/decoupling/HRR bucketed by comparable conditions) is mid-horizon, not near.** Near-term, the cheap proxy is injecting the **previous 1–2 CoachReports as contrast** so the report *feels* longitudinal without fabricating a trend line. Confident trend claims must **abstain until `sample_count` crosses a threshold** — the report narrates in blocks and refuses to trend two runs. (Note: `trends.py` has weekly-bucketing machinery and a `build_efficiency_trend` that emits a *per-activity* speed/HR point series — but no like-sessions bucketing, baseline-relative delta, or abstention; the trended, condition-controlled EF layer is genuinely new code built on that primitive, not a wiring job.)
+
+### Debate C — Memory richness vs. overfitting/parroting
+**AI Designer:** Persistent memory is the moat.
+**Data Scientist & Architect:** Unbounded "remember everything" collapsed an agent to 13% accuracy; memory induces parroting and preference drift. The deterministic `DerivedMetric` must stay the ground truth each report *re-derives* from.
+
+**Resolution:** No real conflict on the destination, only on the discipline. Memory is **write-gated** (non-redundant, quality-thresholded, contradiction-resolved), **TTL-tiered by semantic class** (immutable `max_hr_source`/structural injury ≈ infinite; transient "on a stimulant this week" / "amber-foot block" short; preferences in between), and **prior reports enter the prompt only as CONTRAST, never as a template** with an explicit "advance the narrative, do not restate" instruction. Memory ships **last, behind an eval harness**, because without offline quality measurement we cannot detect the drift the literature documents.
+
+### Debate D — "Ship the new shape first" vs. "shape on a cold pack is just a prettier chatbot"
+**Runner, Coach:** The output reshape is the change felt first and touches no deterministic metric — ship it now.
+**AI Designer, Architect:** A confident report on a stateless context pack is a *better-dressed one-run chatbot* that will now state misleading HR numbers with more conviction. Tone must ride on grounding.
+
+**Resolution:** Ship the reshape near-term **but pair it in the same horizon with the deterministic confounder-correction stage**, so the new confidence rides on a corrected number from day one. The reshape alone is necessary, cheap, and de-risks the prompt-versioning work; it is explicitly *not* declared "the fix." Confidence and grounding land together.
+
+### Debate E — Automation vs. runner control
+**AI Designer:** Adherence is inferable for free from the next Strava activity; instrument it automatically.
+**Runner & Safety Skeptic (implicit):** Inferring "you ignored the easy-day advice" from one noisy activity can be wrong and erodes trust.
+
+**Resolution:** Automate the *signal*, keep the *verdict* advisory. Adherence labels require **comparable conditions** before firing, stay conservative, and **CheckIn / chat pushback overrides the implicit label.** Cheap explicit channels (a per-report "this was off / useful" control; chat pushback as a labeled correction) are weighted above noisy implicit signals. No long onboarding form — run informative-by-default off the existing profile + first sync, and spend the existing 0–4 questions channel on the 1–3 highest-information asks only.
+
+---
+
+## 4. What the report becomes
+
+**Today** (verified `CoachReportContent`): `key_takeaways` (2–4, equal weight), `next_steps` (1–3), `risks` (0+), `questions` (0–4). No framing field, fixed cardinality, prompt ordered to be concise and conservative → flat hedged list, identical box-shape for a recovery jog and a race.
+
+**Becomes** a narrative spine layered *on top of* the existing fields (legacy coercion already exists in the schema's `model_validator`, so additive growth is safe):
+
+- **`headline`** — the one-line verdict, reusing the ADR-0007 composed Headline. *"Strong tempo despite the heat — your HR is lying to you."* Two-second read.
+- **`thesis`** — one opinionated sentence placing the run in the block. *"Solid threshold long run; ignore the high average HR, it's the 28 °C and the climbing — your aerobic durability is actually trending up."*
+- **`lead_argument`** — the single highest-load point with its strongest evidence ref, ranked above everything. For any session with `interval_structure`, this is the **interval KPIs** (rep CV, `recovery_quality_per_60s`, `first_vs_last_fade`, `work_rest_ratio`) — the exact thing Strava admits it "struggles with."
+- **Number correction, baked in** — when the deterministic `discount_signals` field fires (heat + hills + medication inflating HR), the report says so out loud: *"discount this drift number."* This is grounded and pipeline-owned, never LLM improvisation.
+- **Longitudinal thread** — leads with a trend verdict when `sample_count` permits, and references the prior report as contrast: *"drift down from your Tuesday long run"; "last time I asked you to keep the easy run easy — you did, and decoupling dropped."*
+- **One prioritized next action** — concrete dose + "why" tied to `goal_type`/`target_date`, plus whether the last one landed.
+- **Re-ranked supporting points** — `key_takeaways` ordered by evidence strength, not presented as peers.
+- **Variable shape** — easy runs are three sentences; hard structured sessions go deep on rep fade. The rigid 2–4 cardinality is what flattens playbook nuance back into sameness.
+- **Per-claim confidence** — loud where `DerivedMetric.confidence` is high, plain "insufficient data" where low, instead of one uniform hedge.
+
+The evidence-ref discipline (the genuine edge over Strava's "wrong about zones" output) and the policy validator both stay intact. What changes is **shape, time horizon, and confidence routing — not the safety floor.**
+
+---
+
+## 5. The personalization & memory architecture
+
+A flat report log is the wrong design (it collapses quality). The architecture is **layered**:
+
+**What it remembers (the durable `CoachingContext` layer — the user-profile layer) [ASK-FIRST]:**
+- Training-block intent ("amber-foot rehab block, fitness ahead of tissue")
+- Medication/physiology notes (stimulants/beta-blockers — they change what HR *means*)
+- Coaching philosophy / risk tolerance the runner endorses
+- Environmental sensitivities; structural injury history
+- Prior-report corrections the runner accepted or rejected
+
+Captured **once**, injected into **every** context pack. This is the single highest-leverage change for "gets better over time," and it is what makes the confounder-correction and woven-context moves fire automatically instead of needing a manual paste. Today `ProfileContext` carries only `injury_notes`; there is nowhere for block intent, medication, or philosophy to live.
+
+**What signals it learns from:**
+- **Adherence (implicit, free, proprietary)** — for each emitted `next_step`, label the subsequent comparable activity *acted-on / ignored / contradicted* from Strava data. Zero extra runner effort.
+- **CheckIn** (`rpe`, `pain_score`, `pain_location`, `sleep_quality`) — sparse but precise; `rpe`-vs-`effort_score` divergence and `pain_score` trend are first-class signals (extending the ADR-0007 "the gap is the signal" philosophy from intent-vs-execution to RPE-vs-HR).
+- **Explicit feedback** — a per-report "this was off / useful" control; `CoachChatMessage` pushback as a labeled correction. Optional, but weighted above noisy implicit signals.
+
+**How it feeds the next report:** Each report writes back a small **structured belief delta** (confirmed confound: "this runner's HR inflates ~6 bpm above 25 °C"; "responds to easy-day discipline"; "amber-foot block still active") into the gated store. The next report reads it. The `CoachReport` history stops being a pile of artifacts and becomes the runner-model.
+
+**Cold-start:** No questionnaire. Run informative-by-default off the existing `UserProfile` + first-sync `DerivedMetric`, and spend the existing 0–4 questions channel on the highest-information-gain asks only (block intent, current niggle, medication).
+
+**Anti-staleness / anti-overfitting / anti-repetition — the non-negotiable disciplines:**
+- **Write gates:** non-redundant, quality-thresholded, contradiction-resolved. Never append every run.
+- **TTL by semantic class:** immutable vs. transient vs. preference; never-retrieved memories decay below threshold; useful ones reinforce.
+- **Confidence/recency tags on every retrieved memory** so the LLM hedges old context appropriately — reusing the app's existing `confidence_reasons` machinery; prevents the "changed jobs six months ago" stale-fact bug.
+- **Prior reports as CONTRAST only**, with `DerivedMetric` as the re-derived ground truth each run — prevents parroting and preference drift.
+- **Anti-repetition digest** — pass the last N *lead arguments* (not full reports) with an "advance the narrative" instruction; this also bounds token/cost growth.
+
+**Multi-user from day one:** Per-user memory curation that is trivial for one user becomes a privacy/scaling problem at scale (ADR 0005). Memory keys and write-gates are **user-scoped now**, designed for the Phase 2 transition, even though we ship single-user.
+
+**Retrieval, not fine-tuning:** The 2025–26 consensus and this single-user codebase both point to structured memory + retrieval. A lightweight per-runner preference model (T-POP style, no base-model fine-tune) is a *long-horizon-only* option after the adherence dataset and eval harness exist.
+
+---
+
+## 6. The longitudinal / health layer
+
+Single runs roll up into a fitness trajectory through a **cross-run trend layer** built on a finally-computed `RunnerBaseline`. The signals that actually move over a 4–12 week block:
+
+- **Efficiency Factor** (normalized-graded-pace / HR on steady aerobic runs) rising at matched conditions = real aerobic gain.
+- **HR/pace decoupling** under ~5% on long steady runs = durability; climbing = pace above current aerobic ceiling.
+- **Heart-rate recovery** (60s post-effort drop) improving over 6–8 weeks.
+- **Resting-HR proxy** trend.
+
+**The critical methodological constraint:** these are only valid across **LIKE sessions**. Trends bucket by **effort band, `is_hilly`, and temperature band** — and the app's orthogonal classification axes plus the new `average_temp` field are *exactly* the controls that make the comparison valid rather than noise. The report **leads with the longitudinal verdict** when `sample_count` permits (*"over 4 weeks your EF rose 6% at the same easy HR — that's real aerobic gain"*), and **reasons in blocks, refusing to over-read one run** — itself a trust-building, anti-cold-AI move.
+
+**Load/distribution is framing, not verdict.** Use `training_context` (intensity distribution, `days_since_last_hard`, `hard_sessions_this_week`) to talk 80/20 and tissue-readiness as *conversation*. Do **not** present ACWR or TSB as precise injury/readiness numbers — the evidence base is contested and weakest exactly for recreational runners. Reserve confident language for the individually-supported trends (EF, decoupling, HRR, resting HR vs. *this runner's own* baseline); label population thresholds (5%/10% drift bands, heat curves) as the heuristics they are, and migrate toward RunnerBaseline-relative deltas as the personal "expected HR for these conditions" model accrues.
+
+**Tissue-load as a first-class longitudinal narrative**, not a conditional block that only fires on flags: combine `risk_level`/`risk_reasons` + `training_context` + stated injury memory into a repeated, confident tissue-readiness call. This addresses the industry's universal failure (Garmin/Runna: plans that respect the heart but not the tissue) — the exact "fitness is ahead of tissue" philosophy in the motivating example.
+
+A **non-diagnostic referral layer** sits *separate* from coaching: deterministic flags for red-flag patterns (sustained unexplained resting-HR rise, persistently elevated post-exercise HR, performance drop after illness) produce a *"consider seeing a clinician"* nudge — owned by the pipeline, never a diagnosis — keeping the product inside the general-wellness lane.
+
+---
+
+## 7. Phased roadmap
+
+Sequencing principle (from the Architect, and agreed): **cheap+visible first, moat last behind eval.** Reshape and confounder-correction land together so confidence rides on grounding. Memory/learning loop is last because without the eval harness and version-aware cache it becomes the maintenance swamp that rots the product.
+
+### Near horizon (concrete enough to become issues)
+
+**N1 — Version-aware CoachReport caching; retain-on-supersede.** *(Architect)*
+*What:* Change the cache identity from `unique=True` on `activity_id` to `(activity_id, prompt_id, schema_version)`; retain prior versions; auto-regenerate-on-read when the active version moves; stop `?force=true` from destructively deleting. *Why:* Verified — the cache key has no version dimension and `force=true` deletes the row, so any new report shape silently serves stale-shaped reports across all history with no A/B. *Dependency:* none; it is the seam that lets every later change ship incrementally. **[ASK-FIRST: schema/migration]**
+
+**N2 — Add a deterministic medical-scope rule to the policy validator.** *(Safety Skeptic — non-negotiable, ships before any opinionated feature)*
+*What:* Fifth validator rule rejecting dose advice and diagnosis verbs; forbid escalating a single wearable number into a health claim; permit context-aware metric correction. *Why:* Verified — the validator has four rules, none medical-scope; confident features are unsafe without it. *Dependency:* none.
+
+**N3 — Reshape `CoachReportContent` + flip the prompt objective.** *(Runner, Coach, Data Scientist, Architect)*
+*What:* Add `headline` (reuse composed ADR-0007 Headline), `thesis`, single ranked `lead_argument` above the existing fields; re-rank takeaways by evidence strength; relax fixed 2–4 cardinality so length varies by activity; rewrite prompt rules 6/8 from "concise/conservative" to "state the strongest claim the evidence supports; confident where `DerivedMetric.confidence` is high, abstain where low." Keep evidence refs and the validator. *Why:* The schema structurally forces the flat hedged list; verified the validator keys off context fields and text patterns, not bullet structure, so this is pure schema+prompt. *Dependency:* N1 (version-aware cache), N2 (scope rule first). **[ASK-FIRST: public schema/shared contract]**
+
+**N4 — Deterministic confounder-correction stage → `discount_signals`.** *(Coach, Data Scientist, Architect, Runner — "lowest-risk, highest-leverage")*
+*What:* New stage in `services/analysis/` that joins `average_temp` (parse from `raw_summary`), `is_hilly`, and a new medication/physiology context field against `hr_drift`/`effort_score`, emitting a structured `discount_signals` annotation on `DerivedMetric` ("hr_drift_likely_inflated_by: [heat_28C, hills, stimulant]"); pass it into the context pack as evidence; instruct the LLM to honor it. Degrade gracefully (no temp → no heat discount, lower confidence rather than assert). *Why:* `average_temp` is in `raw_summary` but never read; this is the cold-chat's signature move made guaranteed, deterministic, fixture-testable, and policy-safe. *Dependency:* the new medication field is **[ASK-FIRST]**; the temp join is not.
+
+### Mid horizon
+
+**M1 — Compute `RunnerBaseline` for real + persist the cross-run trend layer.** *(Coach, Data Scientist, AI Designer, Architect — the real engineering spine)*
+*What:* Implement the baseline computation the table's docstring defers; persist per-run EF / HR-pace decoupling / HRR / drift trends bucketed by effort band, `is_hilly`, temperature band; abstain on trend claims until `sample_count` crosses threshold. *Why:* The entire longitudinal vision has no substrate today (empty table; `trends.py` has weekly bucketing and a per-activity `build_efficiency_trend`, but no like-sessions-bucketed, baseline-relative, abstaining EF trend). *Dependency:* N4 (temperature field enables temp-band bucketing).
+
+**M2 — Durable `CoachingContext` layer, write-gated and TTL-tiered.** *(AI Designer, Runner, Coach)*
+*What:* New user-scoped table for block intent, philosophy, medication/physiology, environmental sensitivities, structural injury; injected into every context pack; write gates + TTL by semantic class. *Why:* The persistent-context moat; makes N4's correction fire automatically every run. *Dependency:* designed user-scoped for ADR-0005. **[ASK-FIRST: schema]**
+
+**M3 — Prior CoachReports + baseline into the pack as CONTRAST.** *(Runner — "I don't need the cathedral," AI Designer)*
+*What:* Inject the last 1–2 reports' `lead_argument` + `next_step` and baseline deltas with an explicit "advance the narrative, do not restate" instruction; `DerivedMetric` stays re-derived ground truth. *Why:* Cheapest longitudinal feel; the prior report already sits in the DB keyed by activity. *Dependency:* M1 for baseline deltas; M3 alone (reports-only) can land earlier.
+
+**M4 — Offline eval harness (15–20 seeded real activities + rubric).** *(Architect — the un-sexy precondition)*
+*What:* Via `make seed-local`, freeze real activities with rubric assertions: did it lead with a headline, discount an inflated HR, avoid medical overreach, advance rather than parrot the prior report. *Why:* "Better than a cold AI" and "gets better over time" are unmeasurable without it; it is the precondition that lets confidence-routing and memory evolve safely and detects preference-drift. *Dependency:* N3/N4 give it something to score; **gates everything in the Long horizon.**
+
+**M5 — Surface RPE-vs-HR divergence + pain-score trend as explicit signals.** *(Coach, Data Scientist)*
+*What:* Compare `CheckIn.rpe` against `effort_score`; weight RPE over HR when a confounder is flagged (RPE survives HR distortion); trend `pain_score`. *Why:* The app uniquely holds both sides; reuses ADR-0007 philosophy. *Dependency:* N4 (confounder flags).
+
+### Long horizon
+
+**L1 — Adherence learning loop.** *(AI Designer, Coach — the literal "gets better over time")*
+*What:* Label each `next_step` acted-on/ignored/contradicted from the subsequent comparable activity; store as retrievable memory; next report references it. Advisory, comparable-conditions-gated, overridable by CheckIn/chat. *Why:* The strongest behaviour-change lever and the uncrossable HITL dataset, free from Strava. *Dependency:* M2, M3, M4.
+
+**L2 — Belief-state write-back per report.** *(AI Designer, Architect)*
+*What:* Each report writes a structured belief delta (confirmed confounds, adherence, working philosophy) into the gated store the next report reads. *Why:* The architectural heart of the moat. *Dependency:* M2, M4.
+
+**L3 — Self-calibrating personal "expected HR for these conditions" model + non-diagnostic referral layer.** *(Coach, Data Scientist, Safety Skeptic)*
+*What:* Turn confounder correction from population rules of thumb into RunnerBaseline-relative individualized anomalies; add the deterministic clinician-nudge layer. *Why:* The analytical moat compounds and becomes uncrossable; keeps the product responsible. *Dependency:* M1, M4.
+
+**L4 — Per-runner preference model (T-POP, no base-model fine-tune).** *(AI Designer; Data Scientist & Architect both gate this hard)*
+*What:* Once adherence + explicit signals accumulate, a lightweight reward model that reranks framing toward advice this runner acts on. *Why:* Compounding personalization. *Dependency:* L1, M4 — **only after** the dataset and eval exist.
+
+---
+
+## 8. Risks & guardrails
+
+**Safety Skeptic's non-negotiables (accepted in full):**
+- **Medical-scope validator rule ships first (N2)**, before any opinionated feature. Reject dose advice and diagnosis verbs; never escalate one wearable number (off up to ~50% in some situations) into a health claim. Medication context is permitted as *interpretive correction* ("your HR reads high partly due to X, so this drift overstates fatigue") and forbidden as *directive*.
+- **Confounder correction is a deterministic templated relay**, pipeline-owned, never LLM discretion — so it is auditable and the validator can catch fabrication.
+- **Confidence is a validator-enforceable router** off the existing `confidence` field, not a "be-confident" tone.
+- **Load ratios are framing; the validator forbids precise injury probabilities.**
+- **Longitudinal memory ships behind decay, recency tags, and `DerivedMetric`-as-override.**
+
+**Other guardrails:**
+- **Population thresholds labeled as heuristics**; migrate to RunnerBaseline-relative deltas (L3) so the confident tone never outruns the evidence.
+- **Trend abstention until `sample_count` crosses threshold** — never trend two runs.
+- **`average_temp` degrades gracefully** — absent/wrong temp → no heat discount + lower confidence, never a fabricated confound.
+- **Parroting/preference-drift**: prior reports as contrast only + anti-repetition lead-argument digest + `DerivedMetric` re-derived each run.
+- **Token/cost bloat** (`max_tokens=1024` output, full pack as user JSON): retrieve a digest (last N lead-arguments), not full reports, or the pack grows unbounded as it gets richer.
+- **Preview-deploy hazard**: previews point at the *production* backend/Postgres (per project notes) — every schema add (N1, N4 field, M2) must be migrated and verified carefully; a careless test write on a preview mutates real data.
+- **Multi-user from day one**: memory user-scoped now, or the loop does not survive ADR-0005.
+
+**How the validator evolves:** from four rules to five+ — add the medical-scope rule (N2), then confidence-routing enforcement and a precise-injury-probability ban (M-horizon). The existing interval-claim/zone/flag/null-checkin rules stay. The gate is never bypassed (`ai-workflow.md`).
+
+---
+
+## 9. Open questions for the product owner
+
+1. **Schema approval [ASK-FIRST].** Several load-bearing items add tables/fields and touch the public `CoachReportContent` contract: version-aware caching (N1), the medication/physiology field (N4), the durable `CoachingContext` table (M2), the belief-state store (L2). These cross the project's Ask-First boundary. Approve in principle, and confirm the migration discipline given that previews share the production DB?
+
+2. **Sequencing call.** Architect says reshape-first-but-grounded-concurrently; AI Designer warns shape-on-a-cold-pack is a prettier chatbot. The plan pairs N3+N4 in the near horizon. Do you accept landing them together, or do you want the *felt* win (N3 reshape) shipped alone first even knowing it rides an un-corrected number until N4?
+
+3. **Medication/physiology capture.** Storing "on a stimulant," beta-blocker context, etc. is what enables the signature correction move and is *safer* than today's behaviour — but it is health-adjacent data on a non-medical product. Are you comfortable capturing it, given the validator scope gate and the strict interpretive-not-directive boundary?
+
+4. **Confidence threshold for the trend narrative.** How many comparable sessions before the report is allowed to assert "your EF is rising"? This sets where the moat becomes visible vs. where it would over-read. (Engineering can propose; the risk tolerance is yours.)
+
+5. **Eval before learning loop — accept the gate?** The Architect and Data Scientist insist memory/adherence (L1–L2) ship *only after* the eval harness (M4). That defers the most exciting "gets better over time" feature. Do you accept that gate, or do you want a faster, riskier path to the learning loop accepting un-measured drift?
+
+6. **Per-report explicit feedback control.** Adding a "this was off / useful" control is the cheapest high-value explicit signal. In scope for this product, or noise you would rather not add to the UI?
+
+7. **How opinionated, exactly?** The Runner wants a bold verdict headline; the Safety Skeptic wants confidence strictly routed off `DerivedMetric.confidence`. The plan routes per-claim. Where do you want the default lever set on a *medium-confidence* run — lead with a confident verdict, or lead by naming the data gap?
+
+---
+
+**Files that anchor this plan:** `backend/app/services/coach/context.py`, `backend/app/services/coach/prompts.py`, `backend/app/services/coach/validator.py`, `backend/app/schemas/coach.py`, `backend/app/models/coach_report.py`, `backend/app/models/runner_baseline.py`, `backend/app/models/user_profile.py`, `backend/app/services/trends.py`, `backend/app/services/analysis/_orchestrator.py`.

--- a/docs/coach-report-update-brief.md
+++ b/docs/coach-report-update-brief.md
@@ -1,0 +1,271 @@
+# Coach Report — Update Brief
+
+> Execution-facing companion to `coach-report-improvement-plan.md`. That document holds the vision, the moat argument, and the six-voice debates (the *why*). This brief holds the *what* and *in what order*: milestones with explicit scope, intent, test discipline, success criteria, dependencies, and the skills that apply.
+>
+> **Read first:** the design plan's section 2 honest note — *today none of the moat exists in code*. This brief builds the moat; it does not polish prose.
+>
+> **Boundary discipline:** items flagged **[ASK-FIRST]** touch schema, migrations, or the public `CoachReportContent` contract and must be approved by the product owner before implementation (per `ai-workflow.md`). The deterministic policy validator gate is never bypassed. Previews share the production DB, so every migration is verified with that hazard in mind.
+
+---
+
+## How to use this brief
+
+Each milestone is a coherent shippable unit. Work them in dependency order, not necessarily number order — the dependency graph below is authoritative. Before starting any milestone:
+
+1. Confirm its **[ASK-FIRST]** items are approved (see Open Questions in the design plan, section 9).
+2. Run `aiw-planning` (baseline + modality + oracle) for that milestone.
+3. Establish the oracle with `aiw-ground-truth` before writing fixtures.
+4. Gate the "done" claim through `aiw-verification`.
+
+Milestone IDs map 1:1 to the design plan's roadmap (N1–N4, M1–M5, L1–L4) so the two documents stay reconcilable. Foundation pairs are merged where the plan says they ship together.
+
+---
+
+## Dependency graph
+
+```
+M0 (N1 cache seam) ─┐
+M0 (N2 scope rule) ─┼─→ M1 (N3 reshape + N4 confounder) ─→ M2 (RunnerBaseline)
+                    │                       │                     │
+                    │                       ├─→ M6 (RPE-vs-HR)     │
+                    │                       │                     ├─→ M4 (contrast pack)
+                    │                       └─────────────────────┤
+                    │                                             ▼
+                    └──────────────────────────────────→ M5 (EVAL HARNESS) ── gate ──┐
+                                                                                      │
+                                       Long horizon, all gated by M5:                 │
+                                       M7 (adherence loop) ←── M3, M4 ────────────────┤
+                                       M8 (belief write-back) ←── M3 ─────────────────┤
+                                       M9 (self-calibrating + referral) ←── M2 ───────┤
+                                       M10 (preference model) ←── M7 ─────────────────┘
+```
+
+**The gate that matters most:** nothing in the Long horizon (M7–M10) starts until M5 (eval harness) exists. "Better than a cold AI" and "gets better over time" are unmeasurable without it, and the literature documents preference-drift that only an offline rubric catches.
+
+---
+
+# NEAR HORIZON
+
+## M0 — Safety & versioning foundations *(plan: N1 + N2)*
+
+**Intent.** Lay the two seams every later change rides on: a cache that can hold more than one report shape per activity, and a validator that refuses medical overreach. Both are pure infrastructure with no user-visible output on their own. They ship first because the reshape (M1) is unsafe without the scope rule and unshippable-incrementally without the versioned cache.
+
+**In scope.**
+- N1: change `CoachReport` cache identity from `unique=True` on `activity_id` to `(activity_id, prompt_id, schema_version)`; retain prior versions; auto-regenerate-on-read when the active version moves; stop `?force=true` from destructively deleting. **[ASK-FIRST: schema/migration]**
+- N2: add a fifth deterministic rule to `services/coach/validator.py` rejecting dose advice and diagnosis verbs, forbidding escalation of a single wearable number into a health claim, while *permitting* context-aware metric correction.
+
+**Out of scope.** Any change to report shape or prompt (that is M1). Any new metric. Confidence-routing enforcement in the validator (deferred to M-horizon). Touching the existing four validator rules beyond leaving them intact.
+
+**TDD.** Validator is the textbook deterministic-oracle case: write red tests first from hand-authored positive/negative report fixtures (dose-advice string → reject; interpretive correction → permit; diagnosis verb → reject). Ground-truth comes from the medical-scope boundary stated in plan section 8, not from the LLM. For N1, characterise current cache behaviour with a test that proves `force=true` deletes today, then drive the version-keyed behaviour test-first; assert old versions survive and read auto-regenerates on version bump.
+
+**Success looks like.** A report shape can change without silently overwriting history; both shapes coexist keyed by version. The validator rejects a crafted dose-advice report and a crafted diagnosis report while still passing a legitimate "discount this HR drift" correction. All existing validator tests stay green.
+
+**Links.** Hard prerequisite for M1 (reshape needs the version seam to ship incrementally and the scope rule to be safe). The scope rule is extended later in M9 (referral layer) and by the M-horizon confidence-routing enforcement.
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth` (oracle = stated medical boundary), `aiw-testing`, `aiw-security-testing` (the scope rule is a trust-boundary control), `aiw-verification`, `aiw-github`. Schema items: `grill-with-docs` to pin the migration decision against ADR/CONTEXT before approval; `aiw-project-context-management` to update `project-context.md` after the migration lands.
+
+---
+
+## M1 — Grounded reshape *(plan: N3 + N4)*
+
+**Intent.** The change felt first by the runner, paired in the same horizon with the deterministic correction so the new confidence rides on a corrected number from day one. Reshape alone would be a better-dressed one-run chatbot stating misleading HR with more conviction; correction makes the confidence honest. They land together.
+
+**In scope.**
+- N3: add `headline` (reuse the ADR-0007 composed Headline), `thesis`, and a single ranked `lead_argument` above the existing `CoachReportContent` fields; re-rank `key_takeaways` by evidence strength; relax the fixed 2–4 cardinality so length varies by activity; rewrite prompt rules 6/8 from "concise/conservative" to "state the strongest claim the evidence supports — confident where `DerivedMetric.confidence` is high, abstain where low." Keep evidence refs and the validator. **[ASK-FIRST: public schema/shared contract]**
+- N4: new stage in `services/analysis/` that joins `average_temp` (parsed from `raw_summary`), `is_hilly`, and a new medication/physiology context field against `hr_drift`/`effort_score`, emitting a structured `discount_signals` annotation on `DerivedMetric`; pass it into the context pack as evidence; instruct the LLM to honor it. Degrade gracefully (no temp → no heat discount, lower confidence, never a fabricated confound). The new medication field is **[ASK-FIRST]**; the temp join is not.
+
+**Out of scope.** Any longitudinal/trend claim (needs M2). Reading prior reports (M4). Computing `RunnerBaseline` (M2). The medication *capture* UI — N4 reads a field; populating it durably is M2. Population thresholds become RunnerBaseline-relative only at M9.
+
+**TDD.** N4 is deterministic and fixture-testable: author input fixtures (activity with 28 °C + hills + stimulant flag → expect `hr_drift_likely_inflated_by: [...]`; activity with no temp → expect no heat discount + lowered confidence). This is the strongest TDD candidate in the brief. For N3, the testable surface is schema validation (additive fields, legacy coercion via the existing `model_validator`) and that the validator still keys off context fields/text patterns rather than bullet structure — prove the reshape does not break the gate. Prompt-objective change is verified through the eval rubric (M5) and the frontend render, not unit assertions.
+
+**Success looks like.** A heat-inflated run produces a report that says "discount this drift number" because the pipeline told it to, not because the LLM improvised. A recovery jog renders as three sentences; a structured interval session goes deep on rep fade. The `headline`/`thesis`/`lead_argument` fields populate and render. Frontend coach-report panel renders the new shape (verified on a seeded local DB or a preview, read-only). Validator and all existing tests stay green.
+
+**Links.** Depends on M0 (both items). Feeds M5 (gives the eval harness something to score). N4's `discount_signals` are consumed by M6 (RPE-vs-HR weighting), M9 (individualized correction). The new `average_temp` join enables temp-band bucketing in M2.
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth`, `aiw-testing`, `aiw-verification`, `aiw-security-testing` (parsing untrusted `raw_summary`; medication = health-adjacent data crossing a boundary), `aiw-github`. `verify` / `run` to confirm the new shape renders against real seeded data. `grill-with-docs` for the schema contract change. `aiw-project-context-management` after the analysis-pipeline stage is added (the maintenance checklist requires it).
+
+---
+
+# MID HORIZON
+
+## M2 — Trend substrate: compute `RunnerBaseline` *(plan: M1)*
+
+**Intent.** The real engineering spine. The entire longitudinal vision sits on an empty table whose docstring says computation is deferred. Build it. Persist the per-run signals that actually move over a 4–12 week block, bucketed so comparisons are valid rather than noise.
+
+**In scope.** Implement the baseline computation; persist per-run Efficiency Factor, HR/pace decoupling, heart-rate recovery, and drift trends, bucketed by effort band, `is_hilly`, and temperature band; abstain on any trend claim until `sample_count` crosses a threshold (the threshold value is an Open Question for the owner — plan section 9, item 4). **[ASK-FIRST: schema if new columns/table]**
+
+> **Verified against `main` (not greenfield):** `trends.py:362` already has `build_efficiency_trend` — but only a *per-activity* point series (`speed / avg_hr`, filtered to >1km with valid HR), with no bucketing, no baseline-relative delta, no abstention. Build M2 *on top of* that primitive rather than re-implementing it; the new work is the like-sessions bucketing, the cross-run trend, and the `sample_count` gate. Also note `RunnerBaseline.sample_count` already exists as a column, so the abstention gate needs no new field for that counter.
+
+**Out of scope.** Injecting trends into the report (that is M4). ACWR/TSB as precise numbers (explicitly forbidden — framing only). The self-calibrating "expected HR for these conditions" model (M9). Anything that asserts a trend on fewer than threshold comparable sessions.
+
+**TDD.** Ground-truth is the hard part: EF/decoupling/HRR are defined formulas, so author fixtures from hand-computed expected values over synthetic-but-realistic streams (oracle = the formula applied by hand, recorded with provenance per `aiw-ground-truth`). Test the bucketing logic separately (like-sessions only) and the abstention gate (below threshold → no trend emitted). Characterise against real seeded activities for sanity, not as the primary oracle.
+
+**Success looks like.** Given N comparable easy runs, the layer reports an EF trend with a direction and magnitude; given two runs it abstains. Buckets never mix a hilly hot interval session with a flat cool easy run. Numbers reconcile with hand computation on the fixtures.
+
+**Links.** Depends on M1 (temperature field enables temp-band bucketing). Feeds M4 (baseline deltas in the pack), M9 (RunnerBaseline-relative individualized correction). Without it, M4's longitudinal claims have no substrate.
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth` (formula-based oracle, document provenance), `aiw-testing`, `aiw-performance-profiling` (cross-run aggregation is a heavy data loop), `aiw-verification`, `aiw-github`, `aiw-project-context-management` (new model/migration triggers the checklist).
+
+---
+
+## M3 — *(reserved — see M4)*
+
+> The design plan numbers prior-reports-as-contrast as M3 and the eval harness as M4. This brief orders by dependency: the contrast pack is **M4** below and the eval harness is **M5**, because the harness gates the long horizon and is conceptually a precondition, not a peer. IDs are kept aligned to the plan via the parenthetical *(plan: …)* tags.
+
+---
+
+## M4 — Longitudinal contrast in the pack *(plan: M3)*
+
+**Intent.** The cheapest longitudinal *feel*. Make the report reference what it told you last time and whether the conditions moved — without fabricating a trend line. The prior report already sits in the DB keyed by activity; this is mostly a wiring + prompt-discipline job, plus baseline deltas once M2 lands.
+
+**In scope.** Inject the last 1–2 reports' `lead_argument` + `next_step` and (when available) M2 baseline deltas into the context pack, with an explicit "advance the narrative, do not restate" instruction. `DerivedMetric` stays the re-derived ground truth each run. Pass a *digest* (last N lead-arguments), never full reports, to bound token growth.
+
+**Out of scope.** Labeling whether the runner acted on the advice (that is the adherence loop, M7). Writing belief deltas back (M8). Any memory store beyond reading existing `CoachReport` rows.
+
+**TDD.** Reports-only path can land before M2: test that the pack contains the prior `lead_argument`/`next_step` digest and not the full report body (token bound), and that the anti-restate instruction is present. The "advance vs parrot" quality is scored by the M5 rubric, not unit-asserted. For the baseline-delta path, fixture a runner with a known M2 trend and assert the delta reaches the pack.
+
+**Success looks like.** Report N references report N-1 as contrast ("drift down from your Tuesday long run") rather than repeating it. Pack size stays bounded as history grows. Parroting is caught by the M5 rubric.
+
+**Links.** Depends on M0/M1 (versioned reports exist in the new shape); reports-only sub-path can ship before M2; baseline-delta sub-path depends on M2. Feeds M7 (adherence references prior next_step) and M8 (write-back reads the same slot).
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth`, `aiw-testing`, `aiw-performance-profiling` (token/cost bound is a first-class concern here), `aiw-verification`, `aiw-github`.
+
+---
+
+## M5 — Offline eval harness *(plan: M4) — THE GATE*
+
+**Intent.** The un-sexy precondition for everything that follows. Without an offline rubric, "better than a cold AI" and "gets better over time" are vibes, and the preference-drift the literature documents is invisible. This gates the entire Long horizon.
+
+**In scope.** Via `make seed-local`, freeze 15–20 real activities with rubric assertions: did the report lead with a headline; did it discount an inflated HR when `discount_signals` fired; did it avoid medical overreach; did it advance rather than parrot the prior report; did it abstain on a trend with too few comparable sessions. Produce a repeatable score.
+
+**Out of scope.** Any learning/memory feature (those are what the harness gates). A live A/B in production. Automated frontend tests beyond what already exists.
+
+**TDD.** The harness *is* a test artifact, so the discipline inverts: ground-truth is real seeded activities (path 2 in the design plan's Real-Data Verification) plus a human-authored rubric. The rubric assertions are the oracle; author them from the milestone success criteria above. Validate the harness itself by running it against a deliberately-bad report (should fail the rubric) and a known-good one (should pass).
+
+**Success looks like.** One command scores a frozen set of real reports against the rubric and flags regressions. A reshaped-but-overreaching report fails; a grounded one passes. The score is stable enough to detect drift between prompt/model versions (which M0's versioned cache makes comparable).
+
+**Links.** Depends on M1 (needs reshaped reports to score) and benefits from M4. **Gates M7, M8, M9, M10.** This is the single most important sequencing constraint in the brief.
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth` (real activities + human rubric = the authoritative oracle), `aiw-testing`, `aiw-verification`, `aiw-github`. Local real-data path via `make seed-local` (see plan's Real-Data Verification). `tdd` skill for the rubric-first loop.
+
+---
+
+## M6 — RPE-vs-HR divergence + pain-score trend *(plan: M5)*
+
+**Intent.** Surface a signal only this app holds both sides of: compare subjective `CheckIn.rpe` against the measured `effort_score`, and weight RPE over HR when a confounder is flagged (RPE survives HR distortion). Extends the ADR-0007 "the gap is the signal" philosophy from intent-vs-execution to perception-vs-physiology.
+
+**In scope.** Compute RPE-vs-`effort_score` divergence; when N4's `discount_signals` flag an HR confounder, weight RPE above HR in the report's reasoning; trend `pain_score` over time.
+
+**Out of scope.** Any diagnosis from pain (the M9 referral layer owns the non-diagnostic nudge). Acting on adherence (M7). Requiring a CheckIn — the signal is sparse-but-precise and degrades gracefully when absent.
+
+**TDD.** Deterministic divergence calc is fixture-testable: author CheckIn + DerivedMetric pairs with known RPE/effort gaps and assert the divergence value and the weighting decision (confounder present → RPE weighted up). Null-checkin path must stay safe (an existing validator rule already covers null check-ins — do not regress it).
+
+**Success looks like.** A run where the runner reported high RPE but HR looked easy (heat-suppressed) is reasoned about with RPE in the lead. Pain trend is computed without ever asserting a diagnosis. Sparse/absent CheckIns degrade cleanly.
+
+**Links.** Depends on M1 (N4 confounder flags). Independent of the trend substrate. Feeds the richer signal set the long-horizon learning loop draws on.
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth`, `aiw-testing`, `aiw-security-testing` (pain/health-adjacent data; keep it inside the wellness lane), `aiw-verification`, `aiw-github`.
+
+---
+
+# LONG HORIZON — all gated by M5
+
+## M7 — Adherence learning loop *(plan: L1)*
+
+**Intent.** The literal "gets better over time." For each emitted `next_step`, label the subsequent comparable activity acted-on / ignored / contradicted from Strava data — zero extra runner effort. The uncrossable proprietary dataset. Advisory, not accusatory.
+
+**In scope.** Label each `next_step` from the next comparable activity; store as retrievable memory; next report references it. Comparable-conditions-gated (never fire on a noisy non-comparable run); overridable by CheckIn/chat pushback (explicit beats noisy implicit).
+
+**Out of scope.** Belief-state write-back of confounds/philosophy (M8). The preference reward model (M10). Firing a verdict when conditions are not comparable. Any non-overridable automatic accusation.
+
+**TDD.** Fixture a `next_step` ("keep the easy run easy") + a subsequent comparable activity that does/does not comply; assert the label and that a non-comparable activity yields *no* label. Assert CheckIn/chat pushback overrides the implicit label. Run the M5 rubric to confirm references advance rather than nag.
+
+**Success looks like.** Report references whether the prior action landed, only on comparable conditions, and a runner's explicit "that was off" flips the implicit label. M5 rubric shows no parroting/preference-drift regression.
+
+**Links.** Depends on M2, M4, **and M5 (gate)**. Feeds M10 (the preference model trains on this dataset). Pairs with M8 (the two halves of the write-back loop).
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth`, `aiw-testing`, `aiw-security-testing` (per-user memory, user-scoped keys for ADR-0005), `aiw-verification`, `aiw-performance-profiling` (memory retrieval cost), `aiw-github`.
+
+---
+
+## M8 — Belief-state write-back per report *(plan: L2)*
+
+**Intent.** The architectural heart of the moat. Each report writes a small structured belief delta (confirmed confound: "HR inflates ~6 bpm above 25 °C"; "responds to easy-day discipline"; active block) into the gated store the next report reads. The `CoachReport` history stops being a pile of artifacts and becomes the runner-model.
+
+**In scope.** Per-report structured belief delta written into the **[ASK-FIRST]** gated store; write gates (non-redundant, quality-thresholded, contradiction-resolved); TTL by semantic class (immutable injury ≈ infinite, transient "on a stimulant this week" short, preferences between); confidence/recency tags on every retrieved memory; never append every run.
+
+**Out of scope.** The base-model fine-tune or reward model (M10). Anything that lets memory override the re-derived `DerivedMetric` ground truth (forbidden by design). Unbounded "remember everything" (the literature's 13%-accuracy failure mode).
+
+**TDD.** Test the write gates as deterministic logic: redundant delta → not written; contradicting delta → resolved per rule; TTL expiry → memory decays below retrieval threshold; never-retrieved memory decays, reinforced memory persists. Assert retrieved memories carry confidence/recency tags. The drift it is meant to prevent is measured by M5 — run it.
+
+**Success looks like.** Report N+1 is provably built on report N's recorded beliefs; stale facts decay; contradictions resolve rather than accumulate; `DerivedMetric` still overrides memory each run. M5 rubric detects no drift.
+
+**Links.** Depends on M2, **M5 (gate)**, and the M2 durable-context layer (the design plan's M2 `CoachingContext` table — its **[ASK-FIRST]** approval applies here). Pairs with M7.
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth`, `aiw-testing`, `aiw-security-testing` (gated memory, user-scoped, PII/health-adjacent), `aiw-verification`, `aiw-performance-profiling` (token/cost of the memory digest), `aiw-github`, `aiw-project-context-management` (new store = schema/structure change).
+
+---
+
+## M9 — Self-calibrating correction + non-diagnostic referral *(plan: L3)*
+
+**Intent.** Turn confounder correction from population rules-of-thumb into RunnerBaseline-relative individualized anomalies ("expected HR for *these* conditions for *this* runner"), and add the deterministic clinician-nudge layer that keeps the product responsibly inside the general-wellness lane.
+
+**In scope.** Individualize correction against the M2 baseline; migrate population thresholds (5%/10% drift bands, heat curves) toward personal deltas; add a separate deterministic referral layer for red-flag patterns (sustained resting-HR rise, persistently elevated post-exercise HR, performance drop after illness) producing a "consider seeing a clinician" nudge — pipeline-owned, never a diagnosis.
+
+**Out of scope.** Any diagnosis verb (the M0 validator scope rule forbids it and is extended here). The preference model (M10). Replacing population heuristics before enough personal baseline accrues — labeled-as-heuristic until then.
+
+**TDD.** Fixture a runner with an established baseline and an anomalous run; assert the correction is computed relative to that baseline, not a population constant. Fixture red-flag patterns and assert the referral nudge fires *and* that it never contains a diagnosis verb (reuses/extends the M0 validator tests). Confirm graceful fallback to labeled heuristics when baseline is thin.
+
+**Success looks like.** Correction speaks in this runner's own expected values once baseline is sufficient; the referral nudge fires on red-flag patterns as a nudge, never a diagnosis, and passes the medical-scope validator. M5 rubric confirms no overreach.
+
+**Links.** Depends on M2 (baseline) and **M5 (gate)**. Extends M0's validator scope rule.
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth`, `aiw-testing`, `aiw-security-testing` (medical-scope is the core risk here), `aiw-verification`, `aiw-github`.
+
+---
+
+## M10 — Per-runner preference model *(plan: L4)*
+
+**Intent.** Compounding personalization: a lightweight reward model (T-POP style, **no base-model fine-tune**) that reranks report framing toward advice this runner demonstrably acts on. The capstone — only meaningful once the adherence dataset and the eval harness exist.
+
+**In scope.** A per-runner preference/reward model that reranks framing using accumulated adherence (M7) + explicit feedback signals. Retrieval/reranking, not fine-tuning.
+
+**Out of scope.** Fine-tuning the base model (explicitly excluded). Shipping before the dataset and eval exist (Data Scientist and Architect gate this hard). Letting the reranker override `DerivedMetric` ground truth.
+
+**TDD.** Hardest oracle in the brief — defer detailed test design until M7's dataset shape is known. Minimum: hold-out evaluation through the M5 harness showing the reranked framing scores no worse on safety/grounding and better on adherence-relevant framing. No regression on the medical-scope or trend-abstention rubric items.
+
+**Success looks like.** Reranked framing measurably improves the adherence-relevant rubric score on held-out data without degrading safety/grounding scores. Demonstrated through M5, not asserted.
+
+**Links.** Depends on M7 (dataset) and **M5 (gate)**. Terminal milestone.
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth`, `aiw-testing`, `aiw-performance-profiling`, `aiw-verification`, `aiw-security-testing`, `aiw-github`. `claude-api` if the reranking touches the Anthropic model layer.
+
+---
+
+## Cross-cutting guardrails (apply to every milestone)
+
+- **Validator gate is never bypassed** (`ai-workflow.md`). It grows from four rules to five+ (M0 scope rule, then M-horizon confidence-routing and precise-injury-probability bans).
+- **Trend abstention until `sample_count` crosses threshold** — never trend two runs (M2 onward).
+- **`average_temp` degrades gracefully** — absent/wrong temp → no heat discount + lower confidence, never a fabricated confound (M1 onward).
+- **Parroting / preference-drift** — prior reports as contrast only, anti-repetition lead-argument digest, `DerivedMetric` re-derived each run (M4, M7, M8).
+- **Token / cost bound** — retrieve a digest, never full reports; the pack must not grow unbounded as it gets richer (M4, M8). `aiw-performance-profiling` applies.
+- **Preview-deploy hazard** — previews point at the production backend/Postgres; every schema add (M0, M1 field, M2, M8) is migrated and verified with that hazard in mind. A careless write on a preview mutates real data.
+- **Multi-user from day one** — memory keys and write-gates are user-scoped now, designed for the ADR-0005 Phase 2 transition (M7, M8).
+
+## Open questions blocking start (from design plan section 9)
+
+These must be resolved with the product owner before the dependent milestones begin:
+
+| Question | Blocks |
+| --- | --- |
+| Schema approval in principle + migration discipline given preview/prod shared DB | M0, M1 (med field), M2, M8 |
+| Land N3+N4 together vs reshape-alone-first | M1 sequencing |
+| Comfort capturing medication/physiology data | M1 (N4 field), M8 |
+| `sample_count` threshold for trend assertions | M2 |
+| Accept the eval-before-learning-loop gate | M7, M8, M10 |
+| Per-report explicit feedback control in scope? | M7 (explicit signal weighting) |
+| Default opinion lever on a medium-confidence run | M1 prompt objective |
+
+---
+
+**Anchor files:** `backend/app/services/coach/{context,prompts,validator,service}.py`, `backend/app/schemas/coach.py`, `backend/app/models/{coach_report,runner_baseline,user_profile}.py`, `backend/app/services/trends.py`, `backend/app/services/analysis/_orchestrator.py`.


### PR DESCRIPTION
## What this lands

Two new design documents for the Coach Report update, committed so that the milestone issues and PRs that follow can link to them:

- **`docs/coach-report-update-brief.md`** — the execution-facing spec: milestones M0–M10 with explicit scope / out-of-scope, TDD oracle, success criteria, dependency graph, and the skills that apply to each.
- **`docs/coach-report-improvement-plan.md`** — the vision and the six-voice design debates (the *why*): the moat argument, the honest "none of the moat exists in code yet" note, and the roadmap (N1–N4, M1–M5, L1–L4) that the brief's IDs map to 1:1.

## Decisions & notes for reviewer

- **M2 drift correction (already applied):** the brief and plan were corrected against `main` before this commit. `trends.py` already has a per-activity `build_efficiency_trend` (a `speed/avg_hr` point series, no bucketing, no baseline delta, no abstention). M2 is now framed as building the like-sessions bucketing, cross-run trend, and `sample_count` abstention gate *on top of* that primitive, not greenfield. `RunnerBaseline.sample_count` already exists as a column.
- **Docs only.** No code, schema, or test changes. Backend baseline remains `298 passed, 2 deselected`.
- `claude-running-report.md` at repo root is unrelated to this work and is intentionally left untracked.

## Next

This PR is the anchor for the milestone backlog. M0–M10 issues will link the relevant brief section; M0 (safety & versioning foundations) is built first.
