### PR TITLE
feat(coach): version-aware report cache + medical-scope validator rule (M0)

### DIFF
--- a/backend/alembic/versions/b2c1f9a47d33_coach_report_version_cache.py
+++ b/backend/alembic/versions/b2c1f9a47d33_coach_report_version_cache.py
@@ -1,0 +1,75 @@
+"""version-aware coach_reports cache: (activity_id, prompt_id, schema_version)
+
+Revision ID: b2c1f9a47d33
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-05 11:20:00.000000
+
+Cache identity moves from unique(activity_id) to
+unique(activity_id, prompt_id, schema_version) so a report-shape change retains
+prior versions instead of overwriting them.
+
+Backward-safety (previews share the production DB, so this migration can run
+against prod while prod still runs the *old* code):
+  - The new columns are nullable, so old-code INSERTs that omit them still work.
+  - Existing rows are backfilled from the meta JSON, which already carries
+    prompt_id and schema_version, so no report is lost or needlessly regenerated.
+  - The old code's read (filter by activity_id .first()) and force (delete by
+    activity_id .first()) do not error against the composite-keyed table and
+    never corrupt retained history. They are not fully equivalent, though: once
+    new code has written a second version row for an activity, an old-code reader
+    may transiently return a prior-version (stale-shape) row during the deploy
+    window. This is accepted as a short, self-healing window, not a data hazard.
+
+This migration was verified by hand against a populated local Postgres
+(upgrade backfills both columns from meta, downgrade/upgrade roundtrips cleanly);
+the SQLite-based test suite builds the schema from the ORM model, so it exercises
+the composite constraint but not this migration's backfill/constraint-swap SQL.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b2c1f9a47d33"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_OLD_UNIQUE = "coach_reports_activity_id_key"  # Postgres default name for unique(activity_id)
+_NEW_UNIQUE = "uq_coach_reports_activity_version"
+
+
+def upgrade() -> None:
+    op.add_column("coach_reports", sa.Column("prompt_id", sa.String(), nullable=True))
+    op.add_column("coach_reports", sa.Column("schema_version", sa.String(), nullable=True))
+
+    # Backfill from the meta JSON, which already stores both values.
+    op.execute(
+        "UPDATE coach_reports "
+        "SET prompt_id = meta->>'prompt_id', "
+        "    schema_version = meta->>'schema_version' "
+        "WHERE prompt_id IS NULL OR schema_version IS NULL"
+    )
+
+    op.drop_constraint(_OLD_UNIQUE, "coach_reports", type_="unique")
+    op.create_unique_constraint(
+        _NEW_UNIQUE, "coach_reports", ["activity_id", "prompt_id", "schema_version"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_NEW_UNIQUE, "coach_reports", type_="unique")
+    # Restoring unique(activity_id) requires one row per activity. Collapse any
+    # retained version rows to the most recent per activity first (downgrade is
+    # lossy: prior-version history is dropped). ctid breaks created_at ties so
+    # exactly one row survives per activity.
+    op.execute(
+        "DELETE FROM coach_reports a USING coach_reports b "
+        "WHERE a.activity_id = b.activity_id "
+        "AND (a.created_at < b.created_at "
+        "     OR (a.created_at = b.created_at AND a.ctid < b.ctid))"
+    )
+    op.create_unique_constraint(_OLD_UNIQUE, "coach_reports", ["activity_id"])
+    op.drop_column("coach_reports", "schema_version")
+    op.drop_column("coach_reports", "prompt_id")

--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -9,7 +9,11 @@ from app.models.coach_report import CoachReport
 from app.schemas.chat import ChatHistoryResponse, ChatMessageSend
 from app.schemas.coach import CoachReportRead
 from app.services.coach.chat import get_chat_history, stream_chat_response
-from app.services.coach.service import get_or_generate_coach_report, _to_read
+from app.services.coach.service import (
+    get_active_report_row,
+    get_or_generate_coach_report,
+    _to_read,
+)
 
 router = APIRouter()
 
@@ -21,30 +25,16 @@ router = APIRouter()
 async def get_coach_report(
     activity_id: UUID,
     generate: bool = Query(True, description="If false, only return cached report (404 if none)"),
-    force: bool = Query(False, description="If true, delete cached report and regenerate"),
+    force: bool = Query(False, description="If true, regenerate the active-version report (prior versions retained)"),
     db: Session = Depends(get_db),
 ):
-    if force:
-        existing = (
-            db.query(CoachReport)
-            .filter(CoachReport.activity_id == str(activity_id))
-            .first()
-        )
-        if existing:
-            db.delete(existing)
-            db.commit()
-
     if not generate and not force:
-        existing = (
-            db.query(CoachReport)
-            .filter(CoachReport.activity_id == str(activity_id))
-            .first()
-        )
+        existing = get_active_report_row(db, str(activity_id))
         if not existing:
             raise HTTPException(status_code=404, detail="No cached report.")
         return _to_read(existing)
 
-    report = await get_or_generate_coach_report(db, str(activity_id))
+    report = await get_or_generate_coach_report(db, str(activity_id), force=force)
     if not report:
         raise HTTPException(
             status_code=404,

--- a/backend/app/jobs/process_new_activity.py
+++ b/backend/app/jobs/process_new_activity.py
@@ -6,7 +6,6 @@ this job. Dedup is enforced via `Activity.coach_notification_sent_at`.
 
 import asyncio
 import logging
-import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -15,10 +14,12 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.db.session import SessionLocal
 from app.models import Activity, StravaAccount
-from app.models.coach_report import CoachReport
 from app.services.analysis import analyze_with_streams
 from app.services.analysis.classifier import Classification, compose_headline
-from app.services.coach.service import get_or_generate_coach_report
+from app.services.coach.service import (
+    get_active_report_row,
+    get_or_generate_coach_report,
+)
 from app.services.notifications import (
     Notification,
     build_coach_notification,
@@ -63,11 +64,9 @@ async def process_new_activity(
         return None
 
     db.refresh(activity)
-    coach_row = (
-        db.query(CoachReport)
-        .filter(CoachReport.activity_id == _coerce_uuid(activity.id))
-        .first()
-    )
+    # Read the *active*-version row: prior versions may be retained alongside it,
+    # so a version-unaware query could gate notification on the wrong report.
+    coach_row = get_active_report_row(db, activity.id)
     if coach_row is None or coach_row.is_fallback:
         logger.info(
             "Skipping notification for activity %s: report is fallback or missing",
@@ -147,9 +146,3 @@ def process_new_activity_job(
         )
     finally:
         db.close()
-
-
-def _coerce_uuid(value) -> uuid.UUID:
-    if isinstance(value, uuid.UUID):
-        return value
-    return uuid.UUID(str(value))

--- a/backend/app/models/coach_report.py
+++ b/backend/app/models/coach_report.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Boolean, ForeignKey, DateTime, JSON, Uuid, Text
+from sqlalchemy import Boolean, ForeignKey, DateTime, JSON, String, Uuid, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
@@ -13,8 +13,23 @@ from app.models.base import generate_uuid
 class CoachReport(Base):
     __tablename__ = "coach_reports"
 
+    # Cache identity is (activity_id, prompt_id, schema_version): one report per
+    # activity per report shape. A version bump retains prior versions rather
+    # than overwriting them, so report history is comparable across prompt/schema
+    # changes (the seam the M5 eval harness relies on). prompt_id/schema_version
+    # are nullable so old code (during the deploy window on the preview-shared
+    # production DB) can still insert; new code always populates them.
+    __table_args__ = (
+        UniqueConstraint(
+            "activity_id", "prompt_id", "schema_version",
+            name="uq_coach_reports_activity_version",
+        ),
+    )
+
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=generate_uuid)
-    activity_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("activities.id"), unique=True)
+    activity_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("activities.id"))
+    prompt_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    schema_version: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
     report: Mapped[dict] = mapped_column(JSON)
     meta: Mapped[dict] = mapped_column(JSON)

--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -130,10 +130,15 @@ async def stream_chat_response(
     full context, retrieves conversation history, and streams the LLM response.
     Saves both the user message and the full assistant response to the DB.
     """
-    # Load the coach report (must exist before chatting)
-    report_row = (
+    # Load the coach report (must exist before chatting). Prefer the active
+    # version; fall back to the most recent report of any version so chat still
+    # works against an activity whose only report predates a version bump.
+    from app.services.coach.service import get_active_report_row
+
+    report_row = get_active_report_row(db, activity_id) or (
         db.query(CoachReport)
         .filter(CoachReport.activity_id == activity_id)
+        .order_by(CoachReport.created_at.desc())
         .first()
     )
     if not report_row:

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -14,6 +14,7 @@ import anthropic
 logger = logging.getLogger(__name__)
 
 from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -30,22 +31,47 @@ from app.services.coach.validator import PolicyViolation, validate_policy
 SCHEMA_VERSION = "1.1"
 
 
+def get_active_report_row(db: Session, activity_id) -> Optional[CoachReport]:
+    """Return the cached report row for the *active* version of this activity.
+
+    The active version is the current (COACH_PROMPT_ID, SCHEMA_VERSION) pair.
+    Rows from older prompt/schema versions are retained but ignored here, so a
+    version bump causes a clean cache miss and regeneration rather than serving
+    a stale shape.
+    """
+    activity_uuid = _coerce_uuid(activity_id)
+    return (
+        db.query(CoachReport)
+        .filter(
+            CoachReport.activity_id == activity_uuid,
+            CoachReport.prompt_id == settings.COACH_PROMPT_ID,
+            CoachReport.schema_version == SCHEMA_VERSION,
+        )
+        .first()
+    )
+
+
 async def get_or_generate_coach_report(
-    db: Session, activity_id: str
+    db: Session, activity_id: str, force: bool = False
 ) -> Optional[CoachReportRead]:
     """
-    Returns cached report if one exists, otherwise generates a new one via LLM.
+    Returns the cached report for the active version if one exists, otherwise
+    generates a new one via LLM.
+
+    force=True regenerates the active-version report (replacing only that row);
+    prior-version reports are always retained, so regeneration is never
+    destructive to history.
     """
     activity_uuid = _coerce_uuid(activity_id)
 
-    # Check cache
-    existing = (
-        db.query(CoachReport)
-        .filter(CoachReport.activity_id == activity_uuid)
-        .first()
-    )
-    if existing:
+    # Check cache (active version only)
+    existing = get_active_report_row(db, activity_uuid)
+    if existing and not force:
         return _to_read(existing)
+    if force and existing:
+        # Replace only the active-version row; prior versions are untouched.
+        db.delete(existing)
+        db.commit()
 
     # Load activity
     activity = db.query(Activity).filter(Activity.id == activity_uuid).first()
@@ -127,9 +153,11 @@ async def get_or_generate_coach_report(
         policy_violations=policy_violations,
     )
 
-    # Store
+    # Store (version columns mirror meta so the cache can key on them)
     db_report = CoachReport(
         activity_id=activity_uuid,
+        prompt_id=prompt_id,
+        schema_version=SCHEMA_VERSION,
         report=content.model_dump(),
         meta=meta.model_dump(mode="json"),
         context_pack=pack_dict,
@@ -137,7 +165,16 @@ async def get_or_generate_coach_report(
         is_fallback=is_fallback,
     )
     db.add(db_report)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # A concurrent request generated the active-version row first (the delete
+        # -> LLM -> insert window is not atomic). Yield to the row that landed.
+        db.rollback()
+        winner = get_active_report_row(db, activity_uuid)
+        if winner is not None:
+            return _to_read(winner)
+        raise
     db.refresh(db_report)
 
     return _to_read(db_report)

--- a/backend/app/services/coach/validator.py
+++ b/backend/app/services/coach/validator.py
@@ -29,6 +29,86 @@ _INTERVAL_CLAIM_PATTERNS = [
 ]
 
 
+# --- Rule 5: medical-scope boundary (N2) -----------------------------------
+# Oracle: plan section 8. Reject dose advice and diagnosis verbs; never let a
+# single wearable number escalate into a health claim. Permit interpretive
+# metric correction ("discount this drift, it was hot") and the non-diagnostic
+# referral nudge ("consider seeing a clinician"). High precision is the
+# priority: over-firing rejects legitimate reports and forces a fallback.
+
+# Pharmaceutical dose units ("200mg", "200mgs", "5 mcg", "2000 IU").
+# Deliberately excludes grams (sports-nutrition language) and the bare word
+# "dose"/"dosage" (idiomatic coaching: "small doses of easy running"); a real
+# dose instruction is caught here by its unit, or by _MED_DIRECTIVE_PATTERN when
+# a change verb targets a "dose"/"dosage". Known limit: spelled-out numbers
+# ("five hundred milligrams") and gram-dosed compounds are not matched.
+_DOSE_PATTERN = re.compile(
+    r"\b\d+\s?(?:mgs?|mcgs?|µg|milligrams?|micrograms?|i\.?u\.?)\b",
+    re.IGNORECASE,
+)
+
+# Diagnosis verbs in any form.
+_DIAGNOSIS_VERB_PATTERN = re.compile(r"\bdiagnos(?:e|es|ed|ing|is)\b", re.IGNORECASE)
+
+# Directive medication advice: a change/start verb aimed at a medication noun
+# (including "dose"/"dosage") within a short window. The {0,25} bound keeps the
+# match linear (no catastrophic backtracking). Known limit: verb enumeration is
+# inherently leaky.
+_MED_DIRECTIVE_PATTERN = re.compile(
+    r"\b(?:take|taking|start|starting|stop|stopping|begin|beginning|increase|"
+    r"decrease|reduce|lower|raise|adjust|change|switch|go|get|put|need|needs|"
+    r"consider|prescrib\w+)\b[\w\s,'\"-]{0,25}?"
+    r"\b(?:medications?|meds?|beta[\s-]?blockers?|statins?|antidepressants?|"
+    r"ssris?|supplements?|iron (?:pills?|tablets?|supplements?)|"
+    r"doses?|dosages?)\b",
+    re.IGNORECASE,
+)
+
+# Clinical conditions a non-medical coach must not assert as fact. This list is
+# deliberately non-exhaustive (it can never cover every condition); it backstops
+# the most common overreach. "depression" is included despite a rare
+# elevation-"depression" terrain phrasing, because asserting a mood disorder is
+# the higher-cost miss.
+_CONDITION_TERMS = (
+    r"anemi[ac]|anaemi[ac]|overtraining syndrome|red-?s|"
+    r"relative energy deficiency|hypothyroid\w*|hyperthyroid\w*|"
+    r"thyroid (?:disorder|condition|disease)|arrhythmias?|"
+    r"atrial fibrillation|a-?fib|myocarditis|cardiomyopathy|"
+    r"heart (?:disease|condition)|hypertension|high blood pressure|asthma|"
+    r"iron deficiency|low ferritin|diabet(?:es|ic)|depress(?:ion|ed)"
+)
+
+# A condition term asserted (not merely named) about the runner: an assertion
+# verb immediately followed by the condition, with an optional article/qualifier.
+_HEALTH_CLAIM_PATTERN = re.compile(
+    r"\b(?:have|has|having|got|you're|you are|suffering from|suffer from|"
+    r"diagnosed with|indicates?|means|sign of|signs of|symptom of|symptoms of|"
+    r"consistent with|points? to)\s+"
+    r"(?:a |an |the |some |possible |likely |early |signs? of |chronic )?"
+    r"(?:" + _CONDITION_TERMS + r")\b",
+    re.IGNORECASE,
+)
+
+# Negations that flip an apparent claim into a reassurance ("no signs of X").
+# Note: "any" is intentionally NOT here — it is a common non-negating word
+# ("any fatigue?") and including it silently suppressed real claims.
+_NEGATION_PATTERN = re.compile(
+    r"\b(?:no|not|n't|never|without|free of|rule out|ruled out|"
+    r"denies?|negative for|nothing|unlikely)\b",
+    re.IGNORECASE,
+)
+
+
+def _has_asserted_health_claim(text: str) -> bool:
+    """True if a clinical condition is asserted about the runner and not negated."""
+    for match in _HEALTH_CLAIM_PATTERN.finditer(text):
+        window = text[max(0, match.start() - 40):match.start()]
+        if _NEGATION_PATTERN.search(window):
+            continue  # "no signs of overtraining syndrome" — reassurance, not a claim
+        return True
+    return False
+
+
 def validate_policy(
     content: CoachReportContent,
     context_pack: CoachContextPack,
@@ -111,6 +191,31 @@ def validate_policy(
                         ),
                     ))
                     break  # One violation is enough
+
+    # Rule 5: medical-scope boundary — reject medical overreach (plan section 8).
+    full_text = _extract_all_text(content)
+    medical_reason = None
+    if _DOSE_PATTERN.search(full_text):
+        medical_reason = "contains dose advice (a pharmaceutical dose or dosage instruction)"
+    elif _DIAGNOSIS_VERB_PATTERN.search(full_text):
+        medical_reason = "uses a diagnosis verb"
+    elif _MED_DIRECTIVE_PATTERN.search(full_text):
+        medical_reason = "gives directive medication advice"
+    elif _has_asserted_health_claim(full_text):
+        medical_reason = "asserts a clinical condition about the runner"
+    if medical_reason:
+        violations.append(PolicyViolation(
+            rule="medical_overreach",
+            detail=f"Output {medical_reason}, which is outside the coaching scope",
+            fix_instruction=(
+                "Stay inside the general-wellness coaching lane. Do NOT give drug or "
+                "supplement doses, use diagnosis verbs, name or assert a clinical "
+                "condition, or escalate a single wearable number into a health claim. "
+                "You MAY interpret and correct a metric (e.g. 'discount this HR drift, "
+                "it was hot, so it overstates fatigue') and you MAY suggest seeing a "
+                "clinician as a non-diagnostic nudge. Rephrase to remove the overreach."
+            ),
+        ))
 
     return violations
 

--- a/backend/tests/test_coach_report_versioning.py
+++ b/backend/tests/test_coach_report_versioning.py
@@ -1,0 +1,183 @@
+"""N1: version-aware CoachReport cache.
+
+Cache identity moves from unique(activity_id) to
+(activity_id, prompt_id, schema_version). Prior versions are retained when the
+active version moves; reading auto-regenerates the active version; force
+regenerates the active version without destroying prior versions.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.core.config import settings
+from app.models import Activity, DerivedMetric, StravaAccount, User, UserProfile
+from app.models.coach_report import CoachReport
+from app.services.coach.service import (
+    SCHEMA_VERSION,
+    get_or_generate_coach_report,
+)
+
+ACTIVE_PROMPT_ID = settings.COACH_PROMPT_ID
+
+_VALID_REPORT = {
+    "key_takeaways": [{"text": "Cached takeaway one."}, {"text": "Cached takeaway two."}],
+    "next_steps": [{"action": "Rest", "details": "Easy day", "why": "Recovery"}],
+    "risks": [],
+    "questions": [],
+}
+
+_HAPPY_JSON = (
+    '{"key_takeaways":[{"text":"Freshly generated one."},{"text":"Freshly generated two."}],'
+    '"next_steps":[{"action":"Keep going","details":"Stay easy","why":"Build base"}],'
+    '"questions":[{"question":"How did you feel?","reason":"No check-in data"}]}'
+)
+
+
+def _seed_activity(db) -> Activity:
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    db.add(UserProfile(user_id=user.id, goal_type="general", experience_level="intermediate", weekly_days_available=4, max_hr=190))
+    db.add(StravaAccount(user_id=user.id, strava_athlete_id=1, access_token="t", refresh_token="r", expires_at=9999999999, scope="read"))
+    activity = Activity(
+        user_id=user.id, strava_activity_id=42,
+        start_date=datetime(2026, 5, 27, 10, 0, 0), type="Run", name="Test run",
+        distance_m=5000, moving_time_s=1500, elapsed_time_s=1500, elev_gain_m=10.0,
+        avg_hr=140, raw_summary={},
+    )
+    db.add(activity)
+    db.commit()
+    db.add(DerivedMetric(
+        activity_id=activity.id, effort="easy", structure="continuous",
+        duration_class="standard", effort_score=50.0, flags=[],
+        confidence="medium", confidence_reasons=[],
+    ))
+    db.commit()
+    db.refresh(activity)
+    return activity
+
+
+def _meta(prompt_id, schema_version):
+    return {
+        "confidence": "medium", "model_id": "test-model", "prompt_id": prompt_id,
+        "schema_version": schema_version, "input_hash": "deadbeef",
+        "generated_at": datetime.now(timezone.utc).isoformat(), "policy_violations": [],
+    }
+
+
+def _insert_report(db, activity_id, prompt_id, schema_version):
+    row = CoachReport(
+        activity_id=activity_id, report=dict(_VALID_REPORT),
+        meta=_meta(prompt_id, schema_version), context_pack={},
+        prompt_id=prompt_id, schema_version=schema_version, is_fallback=False,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _mock_llm():
+    fake = AsyncMock()
+    fake.generate_json = AsyncMock(return_value=_HAPPY_JSON)
+    return patch("app.services.coach.service.AnthropicClient", return_value=fake), fake
+
+
+# --- model / schema -------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_version_columns_persisted_on_generate(db):
+    activity = _seed_activity(db)
+    ctx, _ = _mock_llm()
+    with ctx:
+        await get_or_generate_coach_report(db, str(activity.id))
+    row = db.query(CoachReport).filter(CoachReport.activity_id == activity.id).first()
+    assert row.prompt_id == ACTIVE_PROMPT_ID
+    assert row.schema_version == SCHEMA_VERSION
+
+
+def test_same_version_duplicate_rejected_by_unique(db):
+    activity = _seed_activity(db)
+    _insert_report(db, activity.id, ACTIVE_PROMPT_ID, SCHEMA_VERSION)
+    with pytest.raises(IntegrityError):
+        _insert_report(db, activity.id, ACTIVE_PROMPT_ID, SCHEMA_VERSION)
+    db.rollback()  # clear the aborted transaction so teardown is clean
+
+
+def test_two_versions_coexist(db):
+    activity = _seed_activity(db)
+    _insert_report(db, activity.id, ACTIVE_PROMPT_ID, "1.0")
+    _insert_report(db, activity.id, ACTIVE_PROMPT_ID, SCHEMA_VERSION)
+    count = db.query(CoachReport).filter(CoachReport.activity_id == activity.id).count()
+    assert count == 2
+
+
+# --- cache read behaviour -------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cache_hit_same_version_does_not_call_llm(db):
+    activity = _seed_activity(db)
+    _insert_report(db, activity.id, ACTIVE_PROMPT_ID, SCHEMA_VERSION)
+    ctx, fake = _mock_llm()
+    with ctx:
+        result = await get_or_generate_coach_report(db, str(activity.id))
+    assert result is not None
+    fake.generate_json.assert_not_called()
+    # Returned the cached content, not a fresh generation.
+    assert result.report.key_takeaways[0].text == "Cached takeaway one."
+
+
+@pytest.mark.asyncio
+async def test_version_bump_regenerates_and_retains_old_version(db):
+    activity = _seed_activity(db)
+    old = _insert_report(db, activity.id, ACTIVE_PROMPT_ID, "1.0")  # stale version
+    ctx, fake = _mock_llm()
+    with ctx:
+        result = await get_or_generate_coach_report(db, str(activity.id))
+    fake.generate_json.assert_called_once()
+    # New active-version row exists alongside the retained old-version row.
+    rows = db.query(CoachReport).filter(CoachReport.activity_id == activity.id).all()
+    versions = {r.schema_version for r in rows}
+    assert versions == {"1.0", SCHEMA_VERSION}
+    assert db.query(CoachReport).filter(CoachReport.id == old.id).first() is not None
+    assert result.report.key_takeaways[0].text == "Freshly generated one."
+
+
+# --- force ----------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_force_regenerates_active_and_retains_prior_versions(db):
+    activity = _seed_activity(db)
+    old = _insert_report(db, activity.id, ACTIVE_PROMPT_ID, "1.0")
+    active = _insert_report(db, activity.id, ACTIVE_PROMPT_ID, SCHEMA_VERSION)
+    active_id = active.id
+    ctx, fake = _mock_llm()
+    with ctx:
+        result = await get_or_generate_coach_report(db, str(activity.id), force=True)
+    fake.generate_json.assert_called_once()
+    # Prior (1.0) version survives the force.
+    assert db.query(CoachReport).filter(CoachReport.id == old.id).first() is not None
+    # Exactly one active-version row, and it is a fresh one (old active row replaced).
+    active_rows = db.query(CoachReport).filter(
+        CoachReport.activity_id == activity.id,
+        CoachReport.schema_version == SCHEMA_VERSION,
+    ).all()
+    assert len(active_rows) == 1
+    assert active_rows[0].id != active_id
+    assert result.report.key_takeaways[0].text == "Freshly generated one."
+
+
+def test_force_via_api_does_not_destroy_prior_versions(client, db):
+    activity = _seed_activity(db)
+    old = _insert_report(db, activity.id, ACTIVE_PROMPT_ID, "1.0")
+    _insert_report(db, activity.id, ACTIVE_PROMPT_ID, SCHEMA_VERSION)
+    ctx, _ = _mock_llm()
+    with ctx:
+        resp = client.get(f"/api/activities/{activity.id}/coach-report?force=true")
+    assert resp.status_code == 200
+    # The destructive old behaviour wiped the only report; versioning must retain 1.0.
+    assert db.query(CoachReport).filter(CoachReport.id == old.id).first() is not None

--- a/backend/tests/test_policy_validator.py
+++ b/backend/tests/test_policy_validator.py
@@ -223,3 +223,269 @@ class TestPolicyValidator:
         violations = validate_policy(content, pack)
         rules = [v.rule for v in violations]
         assert "ungated_interval_claim" not in rules
+
+
+class TestMedicalScopeRule:
+    """Rule 5 (N2): reject dose advice, diagnosis verbs, and escalation of a
+    single wearable number into a health claim. Permit interpretive metric
+    correction and the (future M9) non-diagnostic referral nudge.
+
+    Oracle: the medical-scope boundary stated in
+    docs/coach-report-improvement-plan.md section 8.
+    """
+
+    def test_dose_advice_in_milligrams_rejected(self):
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Supplement iron",
+                details="Take 200mg of iron daily for the next month.",
+                why="To address the drift.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_dosage_word_rejected(self):
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Adjust meds",
+                details="Increase your dosage before hard sessions.",
+                why="Performance.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_diagnosis_verb_rejected(self):
+        content = _make_content(
+            key_takeaways=[
+                CoachTakeaway(text="This drift pattern lets me diagnose overtraining."),
+                CoachTakeaway(text="Strong session."),
+            ],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_wearable_number_escalated_to_health_claim_rejected(self):
+        content = _make_content(
+            key_takeaways=[
+                CoachTakeaway(text="Your resting HR of 60 means you have a heart condition."),
+                CoachTakeaway(text="Take it easy."),
+            ],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_named_condition_assertion_rejected(self):
+        content = _make_content(
+            key_takeaways=[
+                CoachTakeaway(text="Based on this elevated HR, you are anemic."),
+                CoachTakeaway(text="Rest up."),
+            ],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_directive_medication_advice_rejected(self):
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Medication",
+                details="Stop taking your beta-blocker before your race.",
+                why="It blunts heart rate.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    # --- permitted: interpretive correction and non-diagnostic referral ---
+
+    def test_interpretive_heat_correction_permitted(self):
+        content = _make_content(
+            key_takeaways=[
+                CoachTakeaway(text="Discount this HR drift: it was 28C, and heat inflates HR, so the drift overstates fatigue."),
+                CoachTakeaway(text="Solid easy run."),
+            ],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" not in [v.rule for v in violations]
+
+    def test_medication_interpretive_context_permitted(self):
+        content = _make_content(
+            key_takeaways=[
+                CoachTakeaway(text="Your HR reads a few bpm high because you noted a stimulant this week, so this drift overstates fatigue."),
+                CoachTakeaway(text="Keep the easy days easy."),
+            ],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" not in [v.rule for v in violations]
+
+    def test_non_diagnostic_referral_nudge_permitted(self):
+        """The M9 referral layer must survive: a 'consider seeing a clinician'
+        nudge with no dose, diagnosis verb, or asserted condition is permitted."""
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Consider checking in with a clinician",
+                details="If your resting HR stays elevated for two weeks, it is worth seeing a doctor.",
+                why="A persistent pattern is worth a professional look.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" not in [v.rule for v in violations]
+
+    def test_nutrition_grams_permitted(self):
+        """Sports-nutrition framing in grams is not a pharmaceutical dose."""
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Fuel the long run",
+                details="Aim for 60g of carbs per hour on runs over 90 minutes.",
+                why="Glycogen.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" not in [v.rule for v in violations]
+
+    def test_preventive_condition_mention_permitted(self):
+        """Naming a condition to prevent it (not asserting the runner has it) is fine."""
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Eat iron-rich foods",
+                details="To avoid iron deficiency, include leafy greens and red meat.",
+                why="General nutrition.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" not in [v.rule for v in violations]
+
+    def test_negated_condition_not_flagged(self):
+        content = _make_content(
+            key_takeaways=[
+                CoachTakeaway(text="Your numbers look clean: no signs of overtraining syndrome here."),
+                CoachTakeaway(text="Nice work."),
+            ],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" not in [v.rule for v in violations]
+
+    def test_default_valid_report_has_no_medical_overreach(self):
+        violations = validate_policy(_make_content(), _make_pack())
+        assert "medical_overreach" not in [v.rule for v in violations]
+
+    # --- hardening from adversarial review ---
+
+    def test_any_in_preamble_does_not_suppress_claim(self):
+        """'any' is not a negation: it must not disable the gate on a real claim."""
+        content = _make_content(
+            key_takeaways=[
+                CoachTakeaway(text="Do you notice any fatigue? You clearly have overtraining syndrome."),
+                CoachTakeaway(text="Rest up."),
+            ],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_asthma_assertion_rejected(self):
+        content = _make_content(
+            key_takeaways=[
+                CoachTakeaway(text="Your breathing pattern suggests you have asthma."),
+                CoachTakeaway(text="Ease off."),
+            ],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_hypertension_assertion_rejected(self):
+        content = _make_content(
+            key_takeaways=[
+                CoachTakeaway(text="These numbers mean you have hypertension."),
+                CoachTakeaway(text="Take it easy."),
+            ],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_standalone_depression_assertion_rejected(self):
+        content = _make_content(
+            key_takeaways=[
+                CoachTakeaway(text="Your low motivation means you have depression."),
+                CoachTakeaway(text="Be kind to yourself."),
+            ],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_dose_of_training_idiom_permitted(self):
+        """'dose' as a coaching idiom (no drug/supplement context) must pass."""
+        content = _make_content(
+            key_takeaways=[
+                CoachTakeaway(text="Small doses of easy running build the base."),
+                CoachTakeaway(text="The right dose of intensity matters."),
+            ],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" not in [v.rule for v in violations]
+
+    def test_directive_dose_of_supplement_rejected(self):
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Caffeine",
+                details="Take a higher dose of caffeine pills pre-race.",
+                why="Ergogenic boost.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_med_directive_begin_statin_rejected(self):
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Meds", details="Begin a statin for your cholesterol.", why="Health.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_med_directive_put_you_on_rejected(self):
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Meds", details="I would put you on a beta-blocker for the race.", why="Calm the HR.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_med_directive_need_supplements_rejected(self):
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Iron", details="You need more iron supplements this block.", why="Recovery.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_consider_ssri_rejected(self):
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Meds", details="Consider an SSRI to steady your mood.", why="Wellbeing.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]
+
+    def test_consider_easy_week_permitted(self):
+        """'consider' is only a problem when aimed at a medication noun."""
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Recover", details="Consider an easy week to absorb the training.", why="Adaptation.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" not in [v.rule for v in violations]
+
+    def test_plural_mgs_dose_rejected(self):
+        content = _make_content(
+            next_steps=[CoachNextStep(
+                action="Iron", details="Take 200mgs of iron daily.", why="Levels.",
+            )],
+        )
+        violations = validate_policy(content, _make_pack())
+        assert "medical_overreach" in [v.rule for v in violations]

--- a/backend/tests/test_process_new_activity_job.py
+++ b/backend/tests/test_process_new_activity_job.py
@@ -259,6 +259,50 @@ async def test_pipeline_send_failure_is_non_fatal_and_leaves_sentinel_null(
 
 
 @pytest.mark.asyncio
+async def test_pipeline_fallback_gate_uses_active_version_not_stale_row(
+    db, strava_adapter, notifier, configured
+):
+    """Regression (N1): once version rows coexist, the notify gate must read the
+    *active*-version report's is_fallback, not an arbitrary `.first()` row. A
+    retained stale fallback row from a prior schema version must not suppress
+    notification of a fresh, good active-version report."""
+    _user, account = _seed(db)
+    _seed_strava(strava_adapter)
+
+    # First run produces a fallback report (invalid JSON); notification skipped.
+    bad_client = AsyncMock()
+    bad_client.generate_json = AsyncMock(return_value="invalid json")
+    with patch("app.services.coach.service.AnthropicClient", return_value=bad_client):
+        first = await process_new_activity(
+            db=db, account=account, strava_activity_id=9001,
+            strava_port=strava_adapter, notifier=notifier,
+        )
+    assert first is None
+    activity = db.query(Activity).filter_by(strava_activity_id=9001).first()
+    stale = db.query(CoachReport).filter(CoachReport.activity_id == activity.id).first()
+    assert stale.is_fallback is True
+    # Demote it to a prior version: retained, and inserted before the fresh row,
+    # so a version-unaware `.first()` would return it (lowest rowid in SQLite).
+    stale.schema_version = "1.0"
+    db.commit()
+    stale_id = stale.id
+
+    # Second run generates a fresh, good active-version report.
+    good_client = AsyncMock()
+    good_client.generate_json = AsyncMock(return_value=_valid_llm_json())
+    with patch("app.services.coach.service.AnthropicClient", return_value=good_client):
+        second = await process_new_activity(
+            db=db, account=account, strava_activity_id=9001,
+            strava_port=strava_adapter, notifier=notifier,
+        )
+
+    assert second is not None
+    assert len(notifier.sent) == 1
+    # Prior-version row retained alongside the fresh active one.
+    assert db.query(CoachReport).filter(CoachReport.id == stale_id).first() is not None
+
+
+@pytest.mark.asyncio
 async def test_pipeline_skips_when_notify_to_unset(
     db, strava_adapter, notifier, monkeypatch
 ):

--- a/project-context.md
+++ b/project-context.md
@@ -13,7 +13,7 @@ An `Activity` is a single Strava activity record owned by a `User`, identified b
 An `ActivityStream` holds per-sample time-series data (HR, pace, cadence, power) attached to an `Activity`.
 A `DerivedMetric` row attaches one set of computed signals to one `Activity` (activity class, effort score, pace variability, HR drift, time-in-zones, stops, efficiency, intervals, flags, confidence, risk).
 A `CheckIn` captures subjective post-run input from the user against an `Activity`.
-A `CoachReport` is the cached structured LLM analysis for an `Activity`; `CoachChatMessage` rows form a follow-up conversation against that activity.
+A `CoachReport` is the cached structured LLM analysis for an `Activity`, keyed by `(activity_id, prompt_id, schema_version)` so a prompt/schema change retains prior-version reports instead of overwriting them; `CoachChatMessage` rows form a follow-up conversation against that activity.
 A `RunnerBaseline` stores rolling baselines used for comparison and drift detection.
 
 ## Scope
@@ -48,7 +48,7 @@ The polling lookback window is `POLLING_LOOKBACK_SECONDS` (default 604800s / 7 d
 The historical stream backfill is paced by `BACKFILL_BATCH_SIZE` (default 20, activities per batch) and `BACKFILL_BATCH_PAUSE_SECONDS` (default 300, delay before the next batch); the default 20 stream calls per 5 minutes plus polling stays under Strava's 100-requests/15-min ceiling, and because the backfill is one-time its daily cost is just the backlog size and converges to zero.
 CORS origins are configured via `CORS_ALLOWED_ORIGINS` (comma-separated, default `http://localhost:3000,http://localhost:8000`), parsed by `Settings.cors_allowed_origins_list` and applied in `app/main.py`.
 Error tracking is logs-only by default; Sentry capture is opt-in, requiring the `observability` extra (`sentry-sdk[fastapi]`) installed and `SENTRY_DSN` set, otherwise `init_sentry` in `app/core/observability.py` is a no-op.
-The deterministic policy validator in `services/coach/validator.py` rejects LLM output that claims specific interval execution counts (e.g. "8x400m", "executed 8") and other policy violations; per `ai-workflow.md` this gate must not be bypassed.
+The deterministic policy validator in `services/coach/validator.py` has five rules: it rejects LLM output that misses questions for a null check-in, references uncalibrated HR zones, cites a risk flag not in the flags array, claims specific interval execution counts (e.g. "8x400m", "executed 8") under low detection confidence, and (the medical-scope rule) gives dose advice, uses diagnosis verbs, issues directive medication advice, or asserts a clinical condition about the runner, while still permitting interpretive metric correction and a non-diagnostic referral nudge; per `ai-workflow.md` this gate must not be bypassed.
 When data confidence is low, downstream analysis is expected to default to conservative output (documented intent in `README.md`).
 Postgres is exposed on host port `5433` (mapped from container `5432`); Redis on `6379`; backend on `8000`; frontend on `3000`.
 Backend test baseline excludes tests marked `integration` (pytest marker registered in `pyproject.toml`).


### PR DESCRIPTION
Closes #140. Implements **M0 — Safety & versioning foundations** from `docs/coach-report-update-brief.md` (§ M0; landed in #139).

M0 is pure infrastructure with no user-visible output. It lays the two seams the grounded reshape (M1) rides on: a cache that can hold more than one report shape per activity, and a validator that refuses medical overreach.

## What this does

**N1 — version-aware `CoachReport` cache**
- Cache identity moves from `unique(activity_id)` to `(activity_id, prompt_id, schema_version)`. A prompt/schema bump now **retains** prior-version reports instead of overwriting them, so report history is comparable across versions (the seam the M5 eval harness depends on).
- Read serves the active-version row; a version bump is a clean cache miss that regenerates while keeping the old row.
- `?force=true` regenerates **only** the active-version row and no longer destroys history (the old API-layer `db.delete` is gone).
- New **nullable** `prompt_id` / `schema_version` columns, backfilled from the existing `meta` JSON.
- `chat.py` and the convergence pipeline job now read the active-version row.

**N2 — fifth deterministic validator rule (`medical_overreach`)**
- Rejects dose advice, diagnosis verbs, directive medication advice, and asserting a clinical condition about the runner (escalating a wearable number into a health claim). **Permits** interpretive metric correction and a non-diagnostic referral nudge. Oracle: design plan § 8. The existing four rules are untouched and stay green.

## TDD / verification

- **331 passed, 2 deselected** (`make backend-test`). New: 19 validator tests (`medical_overreach` red→green), 7 cache-versioning tests, 1 pipeline fallback-gate regression test.
- **Migration verified by hand against a populated local Postgres** (5 seeded prod reports): backfill populates both columns from `meta`; `upgrade → downgrade → upgrade` roundtrips cleanly; the new downgrade-collapse handles multi-version rows without a duplicate-key error. The SQLite test suite builds the schema from the ORM model, so it exercises the composite constraint but not the migration SQL itself (noted in the migration docstring).
- **Adversarial review:** two independent reviewers scrutinised N1 (cache/migration/old-code-compat) and N2 (validator false-positives/negatives/bypass/ReDoS). All HIGH/MEDIUM findings were fixed and re-tested; see the decisions log below. Post-fix spot-check confirms zero false positives on common coaching phrasings and linear regex timing (20k chars in 0.017s).

## Decisions & ASK-FIRST items for reviewer

The owner was unreachable during this build, so these were decided autonomously per the agreed protocol (PR review is the approval gate). Please confirm or override:

1. **[ASK-FIRST: schema/migration]** The cache-identity migration adds two **nullable** columns + swaps the unique constraint. Nullable (not `NOT NULL`) is deliberate: previews share the production DB, so this migration can run against prod while prod still runs the **old** code, and old-code INSERTs omit these columns. Backfill from `meta` means existing reports stay cache hits (no needless regeneration).
2. **Migration is backward-safe but not perfectly equivalent for old code.** Old-code `force` (delete-by-`activity_id`-`.first()`) never corrupts retained history, but during the deploy window an old-code reader may transiently return a prior-version (stale-shape) row. Accepted as a short, self-healing window. Documented in the migration docstring.
3. **`force` semantics.** `force=true` now regenerates only the active version; prior versions survive. If you intended `force` to also purge history, say so.
4. **Dead code removed.** The pipeline fallback-gate fix orphaned a private `_coerce_uuid` helper and a `CoachReport` import in `process_new_activity.py`; both were removed (an ASK-FIRST deletion, surfaced here).
5. **Validator scope is a deliberate precision/recall trade-off.** The clinical-condition list is non-exhaustive by design (it backstops the most common overreach). Known gaps left as documented limits: spelled-out doses ("five hundred milligrams") and gram-dosed compounds are not matched (grams is intentionally allowed as sports-nutrition); the `IU` branch is the weakest. `depression` is included despite a rare elevation-"depression" terrain phrasing, because asserting a mood disorder is the higher-cost miss. The gate is safety-biased toward flagging.
6. **Concurrency guard** on `force` regenerate is verified by inspection only (the single-connection SQLite test fixture can't simulate true concurrency). Low likelihood for a single-user MVP.

## Out of scope (per brief)

No report-shape or prompt change (that is M1), no new metric, no confidence-routing enforcement in the validator.

## Targets / stacking

Targets `main`. Assumes nothing else merged. The docs it references land in #139. M1 (#141) will stack on this branch.
