### PR TITLE
feat(coach): compute RunnerBaseline trend substrate (M2)

### DIFF
--- a/backend/alembic/versions/d7e2b4a1c8f9_add_bucketed_trends_to_runner_baseline.py
+++ b/backend/alembic/versions/d7e2b4a1c8f9_add_bucketed_trends_to_runner_baseline.py
@@ -1,0 +1,32 @@
+"""add bucketed_trends to runner_baselines
+
+Revision ID: d7e2b4a1c8f9
+Revises: c4d8e1f60a92
+Create Date: 2026-06-05 13:00:00.000000
+
+M2 trend substrate: runner_baselines.bucketed_trends holds the context-bucketed
+per-run signal trends (efficiency factor, hr drift) keyed by
+"{effort}|{terrain}|{temp_band}".
+
+Backward-safety (previews share the production DB, so this can run against prod
+while prod still runs the old code): the column is nullable, so old-code writes
+that omit it still work, and the (currently empty) table needs no backfill.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d7e2b4a1c8f9"
+down_revision: Union[str, None] = "c4d8e1f60a92"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("runner_baselines", sa.Column("bucketed_trends", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("runner_baselines", "bucketed_trends")

--- a/backend/app/models/runner_baseline.py
+++ b/backend/app/models/runner_baseline.py
@@ -8,7 +8,7 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import String, Float, Integer, ForeignKey, DateTime, Uuid
+from sqlalchemy import String, Float, Integer, ForeignKey, DateTime, JSON, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
@@ -28,6 +28,12 @@ class RunnerBaseline(Base):
     typical_weekly_distance_m: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     typical_weekly_run_count: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     typical_efficiency: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    # M2 trend substrate: context-bucketed per-run signal trends keyed by
+    # "{effort}|{terrain}|{temp_band}". Each bucket either abstains (too few
+    # samples) or carries efficiency-factor and hr-drift trend dicts. Nullable
+    # and backward-safe: rows written by older code simply leave it NULL.
+    bucketed_trends: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
 
     computed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     sample_count: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)

--- a/backend/app/services/analysis/_orchestrator.py
+++ b/backend/app/services/analysis/_orchestrator.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from typing import Optional
 from sqlalchemy.orm import Session
@@ -10,6 +11,8 @@ from app.services.analysis.flags import generate_flags
 from app.services.analysis.intervals import detect_intervals
 from app.services.analysis.risk import compute_risk_score
 from app.services.analysis.workout_matching import match_planned_to_detected, build_interval_kpis
+
+logger = logging.getLogger(__name__)
 
 def _extract_planned_workout(check_in) -> dict | None:
     """
@@ -245,4 +248,15 @@ def analyze(db: Session, activity_id: str) -> Optional[DerivedMetric]:
 
     db.commit()
     db.refresh(dm)
+
+    # 11. Recompute the runner baseline trend substrate (M2). Runs after the
+    # DerivedMetric commit so the just-analysed activity is included. Wrapped so
+    # a baseline failure never breaks analysis — the baseline is a derived
+    # convenience, not part of the activity's own analysis contract.
+    try:
+        from app.services.analysis.baseline import recompute_runner_baseline
+        recompute_runner_baseline(db, activity.user_id)
+    except Exception:  # noqa: BLE001 — baseline is best-effort, must not break analyze
+        logger.exception("runner baseline recompute failed for user %s", activity.user_id)
+
     return dm

--- a/backend/app/services/analysis/baseline.py
+++ b/backend/app/services/analysis/baseline.py
@@ -1,0 +1,371 @@
+"""
+Runner baseline trend substrate (M2).
+
+Computes and persists the `RunnerBaseline` row: per-user rolling scalars plus a
+`bucketed_trends` JSON map of context-bucketed per-run signal trends. Buckets
+group runs by (effort, terrain, temperature band) so a trend only ever compares
+like-for-like efforts; a bucket with fewer than `MIN_SAMPLES_FOR_TREND` samples
+abstains rather than emitting a noisy trend.
+
+This module is pure where it can be (the `temp_band`, `efficiency_factor`,
+`bucket_key`, `compute_trend`, `compute_bucketed_trends`,
+`compute_runner_baseline_scalars` functions take plain values and return plain
+data) and only the `recompute_runner_baseline` persistence service touches the
+DB. It is backend-only: nothing here is exposed via the API (M4 consumes it).
+
+Signal sourcing:
+- Efficiency factor reuses the per-activity `efficiency_analysis.average`
+  already computed by `metrics.calculate_efficiency` when present, falling back
+  to a summary-level speed/HR estimate.
+- Decoupling is the already-computed `hr_drift` on the DerivedMetric; this
+  module does NOT invent a separate decoupling number.
+- Heart-rate recovery (HRR) is intentionally omitted: current activity streams
+  have no post-effort recovery data to derive it from. It is deferred until a
+  data source exists rather than fabricated.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from statistics import median
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, selectinload
+
+from app.models import Activity, DerivedMetric, RunnerBaseline
+
+logger = logging.getLogger(__name__)
+
+# Open-question threshold from the brief: a bucket needs at least this many
+# samples before a trend is trustworthy enough to emit. Owner-tunable.
+MIN_SAMPLES_FOR_TREND = 4
+
+# A magnitude smaller than this (in percent) reads as "no real change".
+_STABLE_PCT = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+def _has_usable_hr(activity) -> bool:
+    """Shared eligibility predicate: the activity has a positive average HR.
+
+    Used for both the bucketed samples and the scalar sample_count so the two
+    can never drift apart.
+    """
+    return bool(activity.avg_hr) and activity.avg_hr > 0
+
+
+def temp_band(average_temp: Optional[float]) -> str:
+    """Bucket an ambient temperature (degrees C) into a coarse band.
+
+    Defensively coerces a non-numeric value (the source is untyped Strava
+    `raw_summary` JSON) to "unknown" rather than raising, mirroring the same
+    guard in `discount_signals.py` for the identical field.
+    """
+    if average_temp is None:
+        return "unknown"
+    try:
+        average_temp = float(average_temp)
+    except (TypeError, ValueError):
+        return "unknown"
+    if average_temp < 10:
+        return "cold"
+    if average_temp < 20:
+        return "cool"
+    if average_temp < 25:
+        return "mild"
+    return "hot"
+
+
+def efficiency_factor(
+    avg_speed_mps: Optional[float],
+    avg_hr: Optional[float],
+    efficiency_analysis: Optional[dict],
+) -> Optional[float]:
+    """Efficiency factor in m/min per bpm.
+
+    Prefers the stream-derived `efficiency_analysis["average"]` when it is a
+    positive number; otherwise estimates from summary speed and HR; returns
+    None when neither is available.
+    """
+    if efficiency_analysis:
+        avg = efficiency_analysis.get("average")
+        if isinstance(avg, (int, float)) and not isinstance(avg, bool) and avg > 0:
+            return float(avg)
+    if avg_speed_mps and avg_hr and avg_hr > 0:
+        return round(avg_speed_mps * 60.0 / avg_hr, 3)
+    return None
+
+
+def bucket_key(
+    effort: Optional[str],
+    is_hilly: Optional[bool],
+    average_temp: Optional[float],
+) -> str:
+    """Composite context bucket: effort | terrain | temperature band."""
+    terrain = "hilly" if is_hilly else "flat"
+    return f"{effort or 'unknown'}|{terrain}|{temp_band(average_temp)}"
+
+
+def compute_trend(values: list[float], *, higher_is_better: bool) -> Optional[dict]:
+    """Least-squares trend over a chronological (oldest-first) value series.
+
+    Returns a dict {direction, magnitude_pct, slope, n} or None when there are
+    fewer than two points. `magnitude_pct` is the percent change between the
+    fitted first and fitted last values; `direction` is "stable" when that
+    magnitude is below `_STABLE_PCT`, otherwise "improving"/"declining"
+    interpreted through `higher_is_better`.
+    """
+    n = len(values)
+    if n < 2:
+        return None
+
+    xs = list(range(n))
+    x_mean = sum(xs) / n
+    y_mean = sum(values) / n
+
+    numerator = sum((x - x_mean) * (y - y_mean) for x, y in zip(xs, values))
+    denominator = sum((x - x_mean) ** 2 for x in xs)
+    slope = numerator / denominator if denominator else 0.0
+    intercept = y_mean - slope * x_mean
+
+    fitted_first = intercept + slope * xs[0]
+    fitted_last = intercept + slope * xs[-1]
+
+    if fitted_first != 0:
+        magnitude_pct = (fitted_last - fitted_first) / abs(fitted_first) * 100.0
+        is_stable = abs(magnitude_pct) < _STABLE_PCT
+    else:
+        # The fitted line crosses 0 at the first point, so percent change is
+        # undefined; judge direction from the slope itself rather than wrongly
+        # collapsing a real slope to "stable".
+        magnitude_pct = 0.0
+        is_stable = abs(slope) < 1e-9
+
+    if is_stable:
+        direction = "stable"
+    else:
+        rising = slope > 0
+        if not higher_is_better:
+            rising = not rising
+        direction = "improving" if rising else "declining"
+
+    return {
+        "direction": direction,
+        "magnitude_pct": round(magnitude_pct, 1),
+        "slope": round(slope, 4),
+        "n": n,
+    }
+
+
+def compute_bucketed_trends(
+    samples: list[dict],
+    min_samples: int = MIN_SAMPLES_FOR_TREND,
+) -> dict:
+    """Group per-run samples by bucket and emit a trend per bucket.
+
+    `samples` is a list of {"date", "bucket", "ef", "hr_drift"} dicts. For each
+    bucket, samples are ordered by date ascending. A bucket with fewer than
+    `min_samples` samples abstains. Otherwise efficiency-factor and hr-drift
+    trends are computed over the non-None values in date order.
+    """
+    grouped: dict[str, list[dict]] = {}
+    for s in samples:
+        grouped.setdefault(s["bucket"], []).append(s)
+
+    result: dict[str, dict] = {}
+    for bucket, items in grouped.items():
+        ordered = sorted(items, key=lambda s: s["date"])
+        count = len(ordered)
+        if count < min_samples:
+            result[bucket] = {"sample_count": count, "abstained": True}
+            continue
+
+        efs = [s["ef"] for s in ordered if s["ef"] is not None]
+        drifts = [s["hr_drift"] for s in ordered if s["hr_drift"] is not None]
+        result[bucket] = {
+            "sample_count": count,
+            "abstained": False,
+            "efficiency_factor": compute_trend(efs, higher_is_better=True),
+            "hr_drift": compute_trend(drifts, higher_is_better=False),
+        }
+    return result
+
+
+def _percentile(values: list[float], pct: float) -> Optional[float]:
+    """Linear-interpolated percentile of a value list (pct in 0..100)."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (pct / 100.0) * (len(ordered) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = rank - lo
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * frac
+
+
+def compute_runner_baseline_scalars(rows: list[tuple]) -> dict:
+    """Compute the scalar baseline fields from (activity, metric) pairs.
+
+    Easy efforts (effort in {recovery, easy} with a positive avg_hr) drive the
+    "typical easy" scalars. Weekly volume averages over the distinct ISO weeks
+    present. Each field defaults to None when it has no supporting data.
+    """
+    easy_hrs: list[float] = []
+    easy_paces: list[float] = []
+    easy_effs: list[float] = []
+
+    long_durations: list[int] = []  # from duration_class == "long"
+    all_durations: list[int] = []   # fallback population for the 90th pct
+
+    weekly_distance: dict[tuple, float] = {}
+    weekly_count: dict[tuple, int] = {}
+
+    eligible = 0
+
+    for activity, metric in rows:
+        if metric is None or not _has_usable_hr(activity):
+            continue
+        eligible += 1
+
+        # Weekly volume — keyed by ISO (year, week).
+        iso_year, iso_week, _ = activity.start_date.isocalendar()
+        wk = (iso_year, iso_week)
+        weekly_distance[wk] = weekly_distance.get(wk, 0.0) + (activity.distance_m or 0)
+        weekly_count[wk] = weekly_count.get(wk, 0) + 1
+
+        if activity.moving_time_s:
+            all_durations.append(activity.moving_time_s)
+        if getattr(metric, "duration_class", None) == "long" and activity.moving_time_s:
+            long_durations.append(activity.moving_time_s)
+
+        # Easy-effort population.
+        if metric.effort in {"recovery", "easy"}:
+            easy_hrs.append(activity.avg_hr)
+            if activity.distance_m and activity.distance_m > 0:
+                easy_paces.append(activity.moving_time_s / (activity.distance_m / 1000.0))
+            ef = efficiency_factor(
+                activity.average_speed_mps, activity.avg_hr,
+                getattr(metric, "efficiency_analysis", None),
+            )
+            if ef is not None:
+                easy_effs.append(ef)
+
+    if long_durations:
+        typical_long = max(long_durations)
+    elif all_durations:
+        p90 = _percentile(all_durations, 90.0)
+        typical_long = int(round(p90)) if p90 is not None else None
+    else:
+        typical_long = None
+
+    n_weeks = len(weekly_distance)
+    typical_weekly_distance_m = (
+        sum(weekly_distance.values()) / n_weeks if n_weeks else None
+    )
+    typical_weekly_run_count = (
+        int(round(sum(weekly_count.values()) / n_weeks)) if n_weeks else None
+    )
+
+    return {
+        "typical_easy_hr": round(median(easy_hrs), 1) if easy_hrs else None,
+        "typical_easy_pace_s_per_km": round(median(easy_paces), 1) if easy_paces else None,
+        "typical_efficiency": round(median(easy_effs), 3) if easy_effs else None,
+        "typical_long_run_duration_s": typical_long,
+        "typical_weekly_distance_m": (
+            round(typical_weekly_distance_m, 1) if typical_weekly_distance_m is not None else None
+        ),
+        "typical_weekly_run_count": typical_weekly_run_count,
+        "sample_count": eligible,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Persistence service
+# ---------------------------------------------------------------------------
+
+def recompute_runner_baseline(db: Session, user_id) -> Optional[RunnerBaseline]:
+    """Recompute and upsert the single RunnerBaseline row for `user_id`.
+
+    Idempotent: queries the user's non-deleted activities (with their
+    DerivedMetric), builds per-run samples for activities that have a metric and
+    an avg_hr, computes scalars + bucketed_trends, and writes them into the one
+    RunnerBaseline row (creating it if absent). Returns the row, or None when the
+    user has no eligible activity at all.
+    """
+    if not isinstance(user_id, uuid.UUID):
+        user_id = uuid.UUID(str(user_id))
+
+    stmt = (
+        select(Activity)
+        .options(selectinload(Activity.metrics))
+        .where(Activity.user_id == user_id)
+        .where(Activity.is_deleted == False)  # noqa: E712
+        .order_by(Activity.start_date.asc())
+    )
+    activities = db.execute(stmt).scalars().all()
+
+    rows: list[tuple] = []
+    samples: list[dict] = []
+    for activity in activities:
+        metric = activity.metrics
+        if metric is None or not _has_usable_hr(activity):
+            continue
+        rows.append((activity, metric))
+
+        average_temp = None
+        if activity.raw_summary:
+            average_temp = activity.raw_summary.get("average_temp")
+
+        samples.append({
+            "date": activity.start_date,
+            "bucket": bucket_key(metric.effort, metric.is_hilly, average_temp),
+            "ef": efficiency_factor(
+                activity.average_speed_mps, activity.avg_hr, metric.efficiency_analysis
+            ),
+            "hr_drift": metric.hr_drift,
+        })
+
+    if not rows:
+        return None
+
+    scalars = compute_runner_baseline_scalars(rows)
+    bucketed = compute_bucketed_trends(samples)
+
+    baseline = (
+        db.query(RunnerBaseline).filter(RunnerBaseline.user_id == user_id).first()
+    )
+    created = baseline is None
+    if created:
+        baseline = RunnerBaseline(user_id=user_id)
+        db.add(baseline)
+
+    baseline.typical_easy_hr = scalars["typical_easy_hr"]
+    baseline.typical_easy_pace_s_per_km = scalars["typical_easy_pace_s_per_km"]
+    baseline.typical_efficiency = scalars["typical_efficiency"]
+    baseline.typical_long_run_duration_s = scalars["typical_long_run_duration_s"]
+    baseline.typical_weekly_distance_m = scalars["typical_weekly_distance_m"]
+    baseline.typical_weekly_run_count = scalars["typical_weekly_run_count"]
+    baseline.sample_count = scalars["sample_count"]
+    baseline.bucketed_trends = bucketed
+    baseline.computed_at = datetime.now(timezone.utc)
+
+    try:
+        db.commit()
+    except IntegrityError:
+        # A concurrent recompute for the same user inserted the row first
+        # (unique(user_id)); retry as an update of the now-existing row.
+        if not created:
+            raise
+        db.rollback()
+        return recompute_runner_baseline(db, user_id)
+    db.refresh(baseline)
+    return baseline

--- a/backend/tests/test_runner_baseline.py
+++ b/backend/tests/test_runner_baseline.py
@@ -1,0 +1,373 @@
+"""
+M2 — RunnerBaseline trend substrate.
+
+Oracle: all expected values for the pure functions are hand-computed from the
+formulas in the design brief (least-squares slope, percent change of the fitted
+endpoints, medians). See inline comments for the arithmetic.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from statistics import median
+
+import pytest
+
+from app.models import User, Activity, DerivedMetric, RunnerBaseline
+from app.services.analysis.baseline import (
+    MIN_SAMPLES_FOR_TREND,
+    temp_band,
+    efficiency_factor,
+    bucket_key,
+    compute_trend,
+    compute_bucketed_trends,
+    compute_runner_baseline_scalars,
+    recompute_runner_baseline,
+)
+
+
+# ---------------------------------------------------------------------------
+# temp_band boundaries
+# ---------------------------------------------------------------------------
+
+def test_temp_band_boundaries():
+    assert temp_band(None) == "unknown"
+    assert temp_band(9.9) == "cold"     # < 10
+    assert temp_band(10) == "cool"      # 10 <= x < 20
+    assert temp_band(19.9) == "cool"
+    assert temp_band(20) == "mild"      # 20 <= x < 25
+    assert temp_band(24.9) == "mild"
+    assert temp_band(25) == "hot"       # >= 25
+    assert temp_band(30) == "hot"
+
+
+# ---------------------------------------------------------------------------
+# efficiency_factor
+# ---------------------------------------------------------------------------
+
+def test_efficiency_factor_prefers_efficiency_analysis_average():
+    # efficiency_analysis.average is present and positive -> used verbatim.
+    ef = efficiency_factor(avg_speed_mps=3.0, avg_hr=150.0,
+                           efficiency_analysis={"average": 1.23, "unit": "m/min/bpm"})
+    assert ef == 1.23
+
+
+def test_efficiency_factor_falls_back_to_speed_times_60_over_hr():
+    # No efficiency_analysis -> compute speed*60/hr.
+    # 3.0 * 60 / 150 = 180 / 150 = 1.2 exactly.
+    ef = efficiency_factor(avg_speed_mps=3.0, avg_hr=150.0, efficiency_analysis=None)
+    assert ef == 1.2
+
+
+def test_efficiency_factor_fallback_rounds_to_3dp():
+    # 2.5 * 60 / 140 = 150 / 140 = 1.0714285... -> round 3dp = 1.071
+    ef = efficiency_factor(avg_speed_mps=2.5, avg_hr=140.0, efficiency_analysis=None)
+    assert ef == 1.071
+
+
+def test_efficiency_factor_none_when_no_hr():
+    assert efficiency_factor(avg_speed_mps=3.0, avg_hr=None, efficiency_analysis=None) is None
+    assert efficiency_factor(avg_speed_mps=3.0, avg_hr=0, efficiency_analysis=None) is None
+
+
+def test_efficiency_factor_ignores_non_positive_analysis_average():
+    # average is zero/invalid -> fall back to speed*60/hr (1.2).
+    ef = efficiency_factor(avg_speed_mps=3.0, avg_hr=150.0,
+                           efficiency_analysis={"average": 0})
+    assert ef == 1.2
+
+
+# ---------------------------------------------------------------------------
+# bucket_key
+# ---------------------------------------------------------------------------
+
+def test_bucket_key_composition():
+    assert bucket_key("easy", False, 15) == "easy|flat|cool"
+    assert bucket_key("hard", True, 28) == "hard|hilly|hot"
+    assert bucket_key(None, False, None) == "unknown|flat|unknown"
+    assert bucket_key("tempo", True, 9.9) == "tempo|hilly|cold"
+
+
+# ---------------------------------------------------------------------------
+# compute_trend  (hand-computed least squares)
+# ---------------------------------------------------------------------------
+
+def test_compute_trend_rising_ef_is_improving():
+    # values = [10, 11, 12, 13], x = [0,1,2,3]
+    # x_mean=1.5, y_mean=11.5
+    # num = sum((x-xm)(y-ym)) = 2.25+0.25+0.25+2.25 = 5.0
+    # den = sum((x-xm)^2)     = 2.25+0.25+0.25+2.25 = 5.0
+    # slope = 1.0; intercept = 11.5 - 1.0*1.5 = 10.0
+    # fitted_first = 10.0; fitted_last = 13.0
+    # magnitude_pct = (13-10)/10*100 = 30.0
+    result = compute_trend([10.0, 11.0, 12.0, 13.0], higher_is_better=True)
+    assert result["direction"] == "improving"
+    assert result["magnitude_pct"] == 30.0
+    assert result["slope"] == 1.0
+    assert result["n"] == 4
+
+
+def test_compute_trend_rising_hr_drift_is_declining():
+    # values = [2, 4, 6, 8], x = [0,1,2,3]
+    # x_mean=1.5, y_mean=5.0
+    # num = (-1.5)(-3)+(-0.5)(-1)+(0.5)(1)+(1.5)(3) = 4.5+0.5+0.5+4.5 = 10.0
+    # den = 5.0 -> slope = 2.0; intercept = 5.0 - 2.0*1.5 = 2.0
+    # fitted_first = 2.0; fitted_last = 8.0
+    # magnitude_pct = (8-2)/2*100 = 300.0
+    # higher_is_better=False, slope>0 -> invert -> "declining"
+    result = compute_trend([2.0, 4.0, 6.0, 8.0], higher_is_better=False)
+    assert result["direction"] == "declining"
+    assert result["magnitude_pct"] == 300.0
+    assert result["slope"] == 2.0
+    assert result["n"] == 4
+
+
+def test_compute_trend_flat_is_stable():
+    result = compute_trend([5.0, 5.0, 5.0, 5.0], higher_is_better=True)
+    assert result["direction"] == "stable"
+    assert result["magnitude_pct"] == 0.0
+    assert result["slope"] == 0.0
+
+
+def test_compute_trend_none_below_two_points():
+    assert compute_trend([], higher_is_better=True) is None
+    assert compute_trend([5.0], higher_is_better=True) is None
+
+
+# ---------------------------------------------------------------------------
+# compute_bucketed_trends
+# ---------------------------------------------------------------------------
+
+def _sample(day, bucket, ef, drift):
+    return {"date": datetime(2026, 1, day, tzinfo=timezone.utc),
+            "bucket": bucket, "ef": ef, "hr_drift": drift}
+
+
+def test_bucketed_trends_abstains_below_threshold():
+    # 3 samples in one bucket -> below MIN_SAMPLES_FOR_TREND (4) -> abstain.
+    samples = [
+        _sample(1, "easy|flat|cool", 10.0, 2.0),
+        _sample(2, "easy|flat|cool", 11.0, 3.0),
+        _sample(3, "easy|flat|cool", 12.0, 4.0),
+    ]
+    out = compute_bucketed_trends(samples)
+    b = out["easy|flat|cool"]
+    assert b["sample_count"] == 3
+    assert b["abstained"] is True
+    assert "efficiency_factor" not in b
+
+
+def test_bucketed_trends_emits_trend_at_threshold():
+    # 4 samples -> at threshold -> compute trends.
+    # EF rising [10,11,12,13] -> improving 30.0 ; drift rising [2,4,6,8] -> declining
+    samples = [
+        _sample(1, "easy|flat|cool", 10.0, 2.0),
+        _sample(2, "easy|flat|cool", 11.0, 4.0),
+        _sample(3, "easy|flat|cool", 12.0, 6.0),
+        _sample(4, "easy|flat|cool", 13.0, 8.0),
+    ]
+    out = compute_bucketed_trends(samples)
+    b = out["easy|flat|cool"]
+    assert b["sample_count"] == 4
+    assert b["abstained"] is False
+    assert b["efficiency_factor"]["direction"] == "improving"
+    assert b["efficiency_factor"]["magnitude_pct"] == 30.0
+    assert b["hr_drift"]["direction"] == "declining"
+    assert b["hr_drift"]["magnitude_pct"] == 300.0
+
+
+def test_bucketed_trends_keeps_distinct_buckets_separate():
+    # A hilly-hot run and a flat-cool run must never merge.
+    samples = [
+        _sample(1, "easy|flat|cool", 10.0, 2.0),
+        _sample(2, "hard|hilly|hot", 5.0, 9.0),
+    ]
+    out = compute_bucketed_trends(samples)
+    assert set(out.keys()) == {"easy|flat|cool", "hard|hilly|hot"}
+    assert out["easy|flat|cool"]["sample_count"] == 1
+    assert out["hard|hilly|hot"]["sample_count"] == 1
+
+
+def test_bucketed_trends_orders_by_date_and_skips_none():
+    # Insert out of date order; trend must use chronological order.
+    # Dates 4,1,3,2 with EF tied to date so chronological EF = [10,20,30,40].
+    samples = [
+        {"date": datetime(2026, 1, 4, tzinfo=timezone.utc), "bucket": "b", "ef": 40.0, "hr_drift": None},
+        {"date": datetime(2026, 1, 1, tzinfo=timezone.utc), "bucket": "b", "ef": 10.0, "hr_drift": 1.0},
+        {"date": datetime(2026, 1, 3, tzinfo=timezone.utc), "bucket": "b", "ef": 30.0, "hr_drift": None},
+        {"date": datetime(2026, 1, 2, tzinfo=timezone.utc), "bucket": "b", "ef": 20.0, "hr_drift": 2.0},
+    ]
+    out = compute_bucketed_trends(samples)
+    b = out["b"]
+    assert b["sample_count"] == 4
+    # EF chronological [10,20,30,40]: slope 10, intercept 10, first 10 last 40
+    # magnitude_pct = (40-10)/10*100 = 300.0 -> improving
+    assert b["efficiency_factor"]["direction"] == "improving"
+    assert b["efficiency_factor"]["magnitude_pct"] == 300.0
+    # hr_drift only has 2 non-None values [1.0, 2.0] -> a valid 2-point trend
+    assert b["hr_drift"]["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# compute_runner_baseline_scalars
+# ---------------------------------------------------------------------------
+
+def _activity(day, *, hr, dist_m, time_s, speed):
+    return Activity(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        strava_activity_id=day,
+        start_date=datetime(2026, 1, day, tzinfo=timezone.utc),
+        type="Run",
+        name=f"Run {day}",
+        distance_m=dist_m,
+        moving_time_s=time_s,
+        elapsed_time_s=time_s,
+        elev_gain_m=0.0,
+        avg_hr=hr,
+        average_speed_mps=speed,
+        raw_summary={},
+    )
+
+
+def _metric(effort, ef_avg=None):
+    return DerivedMetric(
+        id=uuid.uuid4(),
+        activity_id=uuid.uuid4(),
+        effort=effort,
+        effort_score=10.0,
+        confidence="high",
+        is_hilly=False,
+        efficiency_analysis=({"average": ef_avg} if ef_avg is not None else None),
+    )
+
+
+def test_scalars_typical_easy_hr_is_median():
+    # Three easy runs, HR = 140, 150, 160 -> median 150.
+    rows = [
+        (_activity(1, hr=140, dist_m=5000, time_s=1500, speed=3.0), _metric("easy")),
+        (_activity(2, hr=150, dist_m=5000, time_s=1500, speed=3.0), _metric("easy")),
+        (_activity(3, hr=160, dist_m=5000, time_s=1500, speed=3.0), _metric("recovery")),
+    ]
+    scalars = compute_runner_baseline_scalars(rows)
+    assert scalars["typical_easy_hr"] == 150.0
+    # pace = time / (dist/1000) = 1500 / 5 = 300 s/km for all -> median 300.
+    assert scalars["typical_easy_pace_s_per_km"] == 300.0
+
+
+def test_scalars_excludes_non_easy_efforts_from_easy_hr():
+    rows = [
+        (_activity(1, hr=140, dist_m=5000, time_s=1500, speed=3.0), _metric("easy")),
+        (_activity(2, hr=180, dist_m=5000, time_s=1200, speed=4.0), _metric("hard")),
+    ]
+    scalars = compute_runner_baseline_scalars(rows)
+    # Only the easy run (HR 140) counts.
+    assert scalars["typical_easy_hr"] == 140.0
+
+
+# ---------------------------------------------------------------------------
+# recompute_runner_baseline  (DB-backed)
+# ---------------------------------------------------------------------------
+
+def _seed_user(db):
+    user = User(email=f"u-{uuid.uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _seed_activity_with_metric(db, user, day, *, hr, effort, ef_avg=None,
+                               dist_m=5000, time_s=1500, speed=3.0):
+    act = Activity(
+        user_id=user.id,
+        strava_activity_id=int(datetime(2026, 1, day).timestamp()),
+        start_date=datetime(2026, 1, day, tzinfo=timezone.utc),
+        type="Run",
+        name=f"Run {day}",
+        distance_m=dist_m,
+        moving_time_s=time_s,
+        elapsed_time_s=time_s,
+        elev_gain_m=0.0,
+        avg_hr=hr,
+        average_speed_mps=speed,
+        raw_summary={"average_temp": 15.0},
+    )
+    db.add(act)
+    db.commit()
+    db.refresh(act)
+    dm = DerivedMetric(
+        activity_id=act.id,
+        effort=effort,
+        effort_score=10.0,
+        confidence="high",
+        is_hilly=False,
+        hr_drift=2.0,
+        efficiency_analysis=({"average": ef_avg} if ef_avg is not None else None),
+    )
+    db.add(dm)
+    db.commit()
+    return act
+
+
+def test_recompute_persists_baseline_with_abstaining_bucket(db):
+    user = _seed_user(db)
+    # 3 easy/flat/cool runs (temp 15 -> cool) -> below threshold (4) -> abstain.
+    for day, hr in [(1, 140), (2, 150), (3, 160)]:
+        _seed_activity_with_metric(db, user, day, hr=hr, effort="easy", ef_avg=1.2)
+
+    row = recompute_runner_baseline(db, user.id)
+
+    assert isinstance(row, RunnerBaseline)
+    assert row.user_id == user.id
+    assert row.bucketed_trends is not None
+    bucket = "easy|flat|cool"
+    assert bucket in row.bucketed_trends
+    assert row.bucketed_trends[bucket]["sample_count"] == 3
+    assert row.bucketed_trends[bucket]["abstained"] is True
+    # typical_easy_hr median of [140,150,160] = 150
+    assert row.typical_easy_hr == 150.0
+    # sample_count = number of eligible (avg_hr-bearing, metric-bearing) acts.
+    assert row.sample_count == 3
+    assert row.computed_at is not None
+
+
+def test_recompute_emits_trend_at_threshold_and_is_idempotent(db):
+    user = _seed_user(db)
+    # 4 easy/flat/cool runs -> at threshold -> trend computed.
+    for day, hr in [(1, 140), (2, 145), (3, 150), (4, 155)]:
+        _seed_activity_with_metric(db, user, day, hr=hr, effort="easy", ef_avg=1.2)
+
+    row1 = recompute_runner_baseline(db, user.id)
+    bucket = "easy|flat|cool"
+    assert row1.bucketed_trends[bucket]["sample_count"] == 4
+    assert row1.bucketed_trends[bucket]["abstained"] is False
+
+    # Idempotent: re-running upserts the same single row.
+    row2 = recompute_runner_baseline(db, user.id)
+    assert row2.id == row1.id
+    count = db.query(RunnerBaseline).filter(RunnerBaseline.user_id == user.id).count()
+    assert count == 1
+
+
+def test_min_samples_constant_is_four():
+    assert MIN_SAMPLES_FOR_TREND == 4
+
+
+# ---------------------------------------------------------------------------
+# Hardening from the adversarial review
+# ---------------------------------------------------------------------------
+
+def test_temp_band_non_numeric_degrades_to_unknown():
+    """A stray non-numeric average_temp (untyped Strava JSON) must not raise."""
+    assert temp_band("warm") == "unknown"
+    assert temp_band("15") == "cool"   # numeric string still bands (10<=15<20)
+    assert temp_band("20") == "mild"   # 20 is the cool/mild boundary (<20 is cool)
+
+
+def test_compute_trend_zero_first_value_uses_slope_not_stable():
+    """A real slope whose fitted first value is exactly 0 must not read 'stable'."""
+    up = compute_trend([0.0, 1.0, 2.0, 3.0], higher_is_better=True)
+    assert up["direction"] == "improving"
+    # hr_drift rising from 0 is a worsening (lower is better)
+    worse = compute_trend([0.0, 1.0, 2.0, 3.0], higher_is_better=False)
+    assert worse["direction"] == "declining"

--- a/project-context.md
+++ b/project-context.md
@@ -14,7 +14,7 @@ An `ActivityStream` holds per-sample time-series data (HR, pace, cadence, power)
 A `DerivedMetric` row attaches one set of computed signals to one `Activity` (activity class, effort score, pace variability, HR drift, time-in-zones, stops, efficiency, intervals, flags, confidence, risk, discount signals).
 A `CheckIn` captures subjective post-run input from the user against an `Activity`.
 A `CoachReport` is the cached structured LLM analysis for an `Activity`, keyed by `(activity_id, prompt_id, schema_version)` so a prompt/schema change retains prior-version reports instead of overwriting them; `CoachChatMessage` rows form a follow-up conversation against that activity.
-A `RunnerBaseline` stores rolling baselines used for comparison and drift detection.
+A `RunnerBaseline` (one row per user) stores rolling baselines used for comparison and drift detection: per-user scalar typicals plus a `bucketed_trends` JSON map of EF and HR-drift trends bucketed by `effort|terrain|temperature-band`, computed by `services/analysis/baseline.py` and recomputed at the end of `analyze`; a bucket abstains until it has `MIN_SAMPLES_FOR_TREND` (4) like-for-like samples.
 
 ## Scope
 
@@ -96,7 +96,7 @@ Data flow: Strava API → strava_ingestion → Activity/ActivityStream rows → 
 `backend/app/models/` holds one ORM model per file (`activity`, `activity_stream`, `checkin`, `coach_chat_message`, `coach_report`, `derived_metric`, `runner_baseline`, `strava_account`, `user`, `user_profile`) with a barrel `__init__.py`.
 `backend/app/schemas/` holds Pydantic request/response schemas, one file per domain (`activity`, `chat`, `checkin`, `coach`, `detail`, `profile`, `sync`, `trends`, `user`).
 `backend/app/services/strava_ingestion/` holds the Strava port + adapters (`port.py`, `http_adapter.py`, `in_memory_adapter.py`) and the ingestion module (`ingestion.py`) that persists activities and streams.
-`backend/app/services/analysis/` is the metrics pipeline (`_orchestrator.py` composes `smoothing.py`, `metrics.py`, `classifier.py`, `splits.py`, `intervals.py`, `stops.py`, `flags.py`, `risk.py`, `discount_signals.py`, `workout_matching.py`, `_training_context.py`); the public surface is `analyze` and `analyze_with_streams`.
+`backend/app/services/analysis/` is the metrics pipeline (`_orchestrator.py` composes `smoothing.py`, `metrics.py`, `classifier.py`, `splits.py`, `intervals.py`, `stops.py`, `flags.py`, `risk.py`, `discount_signals.py`, `workout_matching.py`, `_training_context.py`); the public surface is `analyze` and `analyze_with_streams`. `baseline.py` is the M2 RunnerBaseline trend substrate (pure bucketing/trend helpers plus a `recompute_runner_baseline` persistence service that `analyze` calls at the end, guarded so a baseline failure never breaks analysis).
 `backend/app/services/coach/` owns the LLM coach (`context.py`, `prompts.py`, `llm.py`, `validator.py`, `service.py`, `chat.py`).
 `backend/app/services/notifications/` owns the notifier port + adapters (`port.py`, `telegram_adapter.py`, `smtp_adapter.py`, `in_memory_adapter.py`, `noop_adapter.py`), the channel selection + composer (`__init__.py`), and the per-channel templates (`email_template.py`, `telegram_template.py`).
 `backend/app/services/trends.py` produces aggregated trend data; `backend/app/services/units/cadence.py` normalises cadence units; `backend/app/services/activity_queries.py` holds shared activity-query helpers.


### PR DESCRIPTION
Closes #142. Implements **M2 — Trend substrate: compute `RunnerBaseline`** from `docs/coach-report-update-brief.md` (§ M2; plan M1). The real engineering spine of the longitudinal vision. Backend-only (M4 consumes it; nothing exposed via API yet).

> Built **on top of** the existing per-activity `trends.py` efficiency primitive (not greenfield), as the brief's "Verified against main" note requires.

## What this does

- New `services/analysis/baseline.py`: pure helpers (`temp_band`, `efficiency_factor`, `bucket_key`, `compute_trend`, `compute_bucketed_trends`, `compute_runner_baseline_scalars`) + a `recompute_runner_baseline` persistence service.
- Per-run signals (**Efficiency Factor**, **HR-drift**) bucketed by `effort | terrain | temperature-band`, so a trend only ever compares like-for-like efforts (a hilly-hot interval never mixes with a flat-cool easy run).
- **Abstention gate**: a bucket emits no trend until it has `MIN_SAMPLES_FOR_TREND` (4) samples; otherwise it computes a least-squares trend with **direction + magnitude**.
- New **nullable** JSON column `runner_baselines.bucketed_trends` (migration `d7e2b4a1c8f9`); one `RunnerBaseline` row per user is kept, with the previously-uncomputed scalar fields now populated.
- Wired into `analyze()` after the `DerivedMetric` commit, **guarded** so a baseline failure never breaks analysis.

## TDD / verification

- **371 passed, 2 deselected**. New `test_runner_baseline.py` (24 tests) with a **hand-computed oracle** (least-squares slope, percent-change of fitted endpoints, medians, temp-band boundaries, abstention off-by-one, no-bucket-mixing, DB recompute).
- Migration `d7e2b4a1c8f9` (down_revision = M1's `c4d8e1f60a92`) verified `upgrade → downgrade → upgrade` on local Postgres; nullable column on the empty prod table is backward-safe.
- **Two adversarial reviewers** (formulas, migration/wiring): no blocker/high. Fixes I then applied (all tested): `temp_band` now guards a non-numeric `average_temp` (mirroring `discount_signals`, which silently killed recompute before); `compute_trend` judges direction from the slope when the fitted first value is exactly 0 (was mislabelling a real slope "stable"); a shared eligibility predicate keeps `sample_count` aligned with the bucketed samples; the recompute upsert guards the `unique(user_id)` race.

## Decisions & ASK-FIRST items for reviewer

1. **[ASK-FIRST: schema]** Stored bucketed trends as a **nullable `bucketed_trends` JSON column** on the existing `RunnerBaseline` (kept one row/user) rather than a new table or a natural-key change. Least-disruptive and backward-safe (table is empty in prod).
2. **`MIN_SAMPLES_FOR_TREND = 4`** is the brief's open-question threshold — a named, owner-tunable constant. Adjust if you want a stricter/looser gate.
3. **HRR deferred:** heart-rate recovery has no data source in current streams (no post-effort samples); it is documented as deferred and **never fabricated**. Decoupling reuses the already-computed `hr_drift`.
4. **Recompute cost:** `recompute_runner_baseline` re-scans the user's full history on every `analyze()` (O(N²) across a backfill). Fine for a single recreational runner; flagging it. Easy to bound to a recent window (e.g. ~12 weeks) if you prefer — say the word.
5. **Wiring:** recompute runs at the end of `analyze()` (guarded). The alternative was the convergence job; in-`analyze` keeps the baseline fresh for both the webhook and deep-process paths.

## Out of scope (per brief)

Injecting trends into the report (M4), ACWR/TSB precise numbers, the self-calibrating "expected HR for these conditions" model (M9). No trend asserted below the threshold.
