### PR TITLE
fix(frontend): make dashboard and nav mobile-friendly

### DIFF
--- a/frontend/app/activity/[id]/page.tsx
+++ b/frontend/app/activity/[id]/page.tsx
@@ -30,7 +30,7 @@ export default async function ActivityDetail({ params }: { params: { id: string 
         <div className="flex justify-between items-start">
             <div>
                 <h1 className="text-3xl font-bold text-gray-900">{activity.name}</h1>
-                <div className="flex gap-4 mt-2 text-gray-600 items-center">
+                <div className="flex flex-wrap gap-x-4 gap-y-2 mt-2 text-gray-600 items-center">
                     <span>{format(new Date(activity.start_date), 'PPPP p')}</span>
                     <span>{formatDistanceKm(activity.distance_m)}</span>
                     {activity.metrics?.headline && (

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
-import Link from 'next/link';
+import NavBar from '@/components/NavBar';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -18,18 +18,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.className} min-h-screen flex flex-col`}>
-        <nav className="border-b border-gray-200 bg-white sticky top-0 z-10">
-          <div className="max-w-4xl mx-auto px-4 h-16 flex items-center justify-between">
-            <div className="flex items-center gap-6">
-              <Link href="/" className="font-bold text-xl tracking-tight text-blue-600">
-                AI Coach
-              </Link>
-              <Link href="/trends" className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">
-                Trends
-              </Link>
-            </div>
-          </div>
-        </nav>
+        <NavBar />
         <main className="flex-1 max-w-4xl w-full mx-auto px-4 py-8">
           {children}
         </main>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,6 @@
 import { fetchFromAPI } from '@/lib/api';
 import ActivityList from '@/components/ActivityList';
 import SyncButton from '@/components/SyncButton';
-import Link from 'next/link';
 
 // Force dynamic since we fetch user data (no static cache for dashboard)
 export const dynamic = 'force-dynamic';
@@ -29,19 +28,13 @@ export default async function Dashboard() {
 
   return (
     <div className="space-y-8">
-      <header className="flex justify-between items-start">
+      <header className="flex flex-col gap-4 sm:flex-row sm:justify-between sm:items-start">
         <div>
             <h1 className="text-3xl font-bold text-gray-900">Weekly Summary</h1>
             <p className="text-gray-600 mt-1">Here is what is happening this week.</p>
         </div>
-        <div className="flex gap-3">
+        <div className="shrink-0">
             <SyncButton />
-            <Link href="/trends" className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50">
-                Trends
-            </Link>
-            <Link href="/profile" className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50">
-                Edit Profile
-            </Link>
         </div>
       </header>
 

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -91,7 +91,7 @@ export default function TrendsPage() {
             Track your progress over time.
           </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           <ActivityTypeFilter
             available={availableTypes}
             selected={selectedTypes}
@@ -119,7 +119,7 @@ export default function TrendsPage() {
 
       {data && (
         <div className="space-y-6">
-          <div className="grid grid-cols-4 gap-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <div className="bg-white p-4 rounded-lg border shadow-sm">
               <div className="text-sm text-gray-500">Total Distance</div>
               <div className="text-2xl font-bold">

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const LINKS = [
+  { href: '/trends', label: 'Trends' },
+  { href: '/profile', label: 'Profile' },
+];
+
+export default function NavBar() {
+  const pathname = usePathname();
+
+  const isActive = (href: string) =>
+    href === '/' ? pathname === '/' : pathname.startsWith(href);
+
+  return (
+    <nav className="border-b border-gray-200 bg-white sticky top-0 z-10">
+      <div className="max-w-4xl mx-auto px-4 h-16 flex items-center justify-between gap-4">
+        <Link
+          href="/"
+          className="font-bold text-xl tracking-tight text-blue-600 shrink-0"
+        >
+          AI Coach
+        </Link>
+        <div className="flex items-center gap-1 sm:gap-2">
+          {LINKS.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              className={`flex items-center min-h-[44px] px-3 rounded-md text-sm font-medium transition-colors ${
+                isActive(href)
+                  ? 'text-blue-600 bg-blue-50'
+                  : 'text-gray-600 hover:text-blue-600 hover:bg-gray-50'
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
The dashboard header kept its action buttons (Sync Now / Trends / Edit
Profile) in a non-wrapping row next to the title, so on phone-width
screens they crowded the title and the rightmost button was clipped
off-screen. Navigation was also duplicated and inconsistent: Trends
lived in both the top nav and the header, while Edit Profile was only
reachable from the clipped header row.

- Introduce a NavBar client component as the single navigation hub
  (Dashboard / Trends / Profile) with active states and ~44px touch
  targets; render it from the root layout.
- Stack the dashboard header on mobile and drop the duplicated
  Trends/Edit Profile buttons (now in the nav), keeping the
  page-specific Sync Now action.
- Make the Trends summary grid responsive (2 cols on mobile, 4 on
  desktop) and let its filter/range controls wrap.
- Let the activity-detail header metadata row wrap instead of
  overflowing at narrow widths.

Closes #157