### PR TITLE
docs: coaching-relationship north-star vision and roadmap

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,6 +2,56 @@
 
 Definitions resolved during design discussions. Implementation details belong in code; this file is the shared vocabulary only.
 
+## Coaching relationship
+
+The durable, per-runner relationship the coach maintains over time: one continuous coaching memory and narrative per `User`, not a pile of per-activity artifacts. A finished `Activity` is an *event* within the relationship that may prompt the coach to speak, never the unit of the relationship itself. The relationship holds the runner-model the coach carries forward (the narrative so far, what it has learned via `Belief` and `Preference profile`, and the open threads), and every coach touchpoint reads from and writes back to this one shared memory, so each touchpoint is a continuation rather than a fresh start. Distinct from a single `Coach report generation`, which under this model is one *form* a turn in the relationship can take, not the relationship itself.
+_Avoid_: treating the coach's output as a standalone per-activity report; the protagonist is the relationship, and a report is a move within an ongoing conversation, not the conversation itself.
+
+## Exchange
+
+One coach↔runner turn-or-burst within a `Coaching relationship`, anchored to an event (most often a finished `Activity`, but also a `CheckIn` or a chat reply). The default post-activity exchange is two-stage: an immediate light, input-free opener (a brief human reaction plus tappable `Perceived effort`/pain prompts, never blocking, never nagging for missing data), then a fuller turn triggered by the runner's reply or a timer, whichever comes first, folding in any input that arrived. The coach decides the depth of each stage from whether the event warrants it: silence or a one-liner on an unremarkable run, depth on an interesting one. Every exchange reads from and writes back to the relationship's memory. A `Coach report generation` is one heavyweight form an exchange can take, not a synonym for it.
+_Avoid_: equating "exchange" with "report"; a report is one shape an exchange can take, and many exchanges are light or silent.
+
+## Working context
+
+The bounded set of information assembled into the prompt for one `Exchange`: the relationship's narrative summary plus this event's headline facts, kept deliberately lean. It is not the whole of what the coach can know: the coach pulls deeper detail from the raw store on demand (retrieval) rather than receiving a fixed, pre-decided pack. Distinct from `Durable memory` (what persists across exchanges) and the raw store (the append-only source of truth, never loaded wholesale). The thing context engineering protects: small by default, deep on demand.
+_Avoid_: equating working context with "everything we know about the runner"; it is the lean slice assembled for one turn, not the memory itself.
+
+## Durable memory
+
+The per-runner relationship memory that persists across exchanges and is carried forward, split into two layers with different authority. The deterministic layer holds rule-derived, auditable facts the coach grounds claims on (`Belief`, `Preference profile`, training load, confirmed confounds) and is authoritative for facts. The narrative layer is an LLM-consolidated, bounded story of the relationship (the arc so far, tone that lands, soft observations, open threads) and is authoritative for voice but is colour, never fact. The boundary is absolute: the narrative layer can never override a re-derived `DerivedMetric` or a deterministic fact, and can never be the cited source of a factual claim. Maintained by `Consolidation`.
+_Avoid_: letting the narrative layer harden into fact, or treating durable memory as a transcript of raw runs; it is a gated, decaying generalisation, and the raw store remains the source of truth the current run always re-derives from.
+
+## Consolidation
+
+The background process that updates `Durable memory` after an `Exchange`, decoupled from producing the exchange itself so the user-facing turn never waits on it. It re-derives the deterministic facts (auditable, as today) and re-consolidates the narrative layer from those facts plus recent exchange history, so the narrative self-corrects against ground truth rather than drifting. The compaction mechanism that keeps the relationship's history bounded without discarding it: detail stays queryable in the raw store via retrieval.
+_Avoid_: coupling consolidation to exchange generation, or letting it invent facts the deterministic layer does not support.
+
+## Voice
+
+How the coach talks, as a personalization dial independent of `Coaching stance`: warm vs blunt, cheerleader vs drill-sergeant, terse vs expansive, playful vs clinical. Declared by the runner at onboarding and then adapted by the `Coaching relationship` from how the runner actually responds (the `Preference profile` loop generalised from advice-themes to tone). Voice may flex freely: it reshapes framing and delivery only, never the facts, the safety floor, or the data the coach grounds on.
+_Avoid_: conflating voice with `Coaching stance`, or letting a preferred voice soften a data-warranted message; tone changes, substance does not.
+
+## Coaching stance
+
+What the coach focuses on and the training philosophy behind it, as a personalization dial independent of `Voice`: e.g. an ultra-endurance durability/fuelling lens, a "cardio serves the lifting" lens for a strength athlete, an enjoyment-and-consistency lens for a recreational runner. Declared at onboarding and refined over time, but unlike `Voice`, stance is tethered: it adapts only within the bounds of the runner's actual goal and what the data supports, and never overrides the safety/grounding floor. The coach does not give a runner training that contradicts their real goal because a stance was selected.
+_Avoid_: letting stance license advice the data does not support, or treating it as fixed; it is goal-tethered and refined by the relationship.
+
+## Coaching corpus
+
+The retrievable knowledge layer the coach grounds its coaching *judgment* in (as opposed to its *facts*, which come from the data): a compact set of always-present house coaching principles, a deeper retrievable library of training schools of thought (selected and weighted by `Coaching stance`), and the runner's own `User materials`. Distinct from `Durable memory` (what the relationship has learned about THIS runner) and the raw store (measured data): the corpus is coaching knowledge, not runner state.
+_Avoid_: treating the corpus as fact (it informs judgment, not grounding), or letting corpus text issue instructions to the coach.
+
+## User materials
+
+Coaching content the runner supplies to the relationship: their own methodology, a human coach's plan, a physio rehab protocol, race-day plans, a book passage that resonates. Ingested into the `Coaching corpus` as a high-authority source for `Coaching stance` (it beats the house philosophy, since it is *their* coach), but per `Authority tiering` never overrides measured data or the safety floor, and always treated as reference data the coach reasons about, never as instructions it obeys (untrusted input).
+_Avoid_: treating user materials as commands, as fact, or as able to lower the safety floor.
+
+## Authority tiering
+
+The explicit precedence order resolving conflicts between the coach's knowledge sources, highest first: the safety/grounding floor; this run's measured data (`DerivedMetric`); deterministic durable facts (`Belief`, training load); user-asserted facts; `User materials` and philosophy; house principles; the schools corpus; base-model generic knowledge. The load-bearing calls: user materials beat the house philosophy for `Coaching stance`, but never override measured data or the safety floor, and user-asserted facts yield to measured data on a factual conflict. Mirrors the standing rule that a `Belief` never overrides today's re-derived `DerivedMetric`.
+_Avoid_: letting any lower tier (corpus, materials, user assertions, generic knowledge) override measured data or the safety floor.
+
 ## Notification
 
 A side-channel delivery of a `CoachReport` to the runner — distinct from the in-app artifact. The `CoachReport` is the structured analysis stored in the DB and rendered by the frontend; a notification is one transmission of that report (or a representation of it) to an external channel such as email.
@@ -109,3 +159,13 @@ _Avoid_: treating the referral nudge as a diagnosis, a screening result, or a cl
 
 The per-runner signal of which kinds of advice the runner demonstrably acts on, ignores, or is mixed on, derived from the accumulated `Adherence` record. The coach uses it to RERANK and FRAME its `next_steps` toward what lands: lead with advice in themes the runner acts on, reframe (not just repeat) advice in themes they ignore. It is preference-conditioned framing, not a trained reward model and not a base-model fine-tune; the "reward signal" is the runner's own follow-through. It biases selection and framing ONLY: it never overrides the re-derived `Activity analysis`, never fabricates advice the data does not support (a needed session the runner usually skips is still given, reframed), and safety/grounding always win over preference. It is already explicit-feedback-aware, because a `Disputed` outcome never reinforced the adherence beliefs it is built from.
 _Avoid_: letting preference suppress data-warranted advice, or treating it as a model that generates advice; it only reranks and frames advice the data already supports.
+
+## Training load
+
+The deterministic read of the runner's current condition (fresh, fatigued, ramping, detraining), built as our own acute (≈7d) / chronic (≈28-42d) / balance model from the per-activity load primitive (`effort_score`), so it is device-independent and auditable. A tier-3 deterministic durable fact (see `Authority tiering`): it grounds the coach's judgment of readiness but never overrides this run's measured data or the safety floor. Platform numbers (Strava Relative Effort/Fitness, Garmin Training Load) are used only to cold-start the chronic baseline for a new runner and to validate our computation, never as the authoritative value, and a divergence is a signal to fix our model, not to defer to theirs. Depends on a correct per-activity load primitive (the `effort_score` fix).
+_Avoid_: treating a platform's load number as our source of truth, or building the model on the unfixed per-activity primitive.
+
+## Block
+
+A deterministically-detected group of temporally-contiguous activities treated as one training event: the walk→run→row→bike done back-to-back in a morning is one block; a solo run is a block of one. Grouping is by time-gap clustering (auditable); per-activity `Activity analysis` is unchanged underneath (each activity's measured metrics remain the truth), and the block adds an aggregate layer (combined load, the sequence and shape of the bout). The coach reasons and speaks about the block, not each sub-activity: one `Exchange` per block, fired once the block looks complete. The runner can split or merge a grouping the detector got wrong.
+_Avoid_: treating a block as a replacement for per-activity analysis (it composes it, never overrides it), or assuming the time-gap grouping is always right.

--- a/docs/vision/coach-build-protocol.md
+++ b/docs/vision/coach-build-protocol.md
@@ -1,0 +1,43 @@
+# Coach Build Protocol (semi-unattended autonomous build)
+
+How the coaching-relationship roadmap (`coach-north-star.md`, epic #177) is executed as a semi-unattended autonomous build. The protocol is the proven M0-M10 model, written down here instead of living only in session memory.
+
+## Mode
+
+Semi-unattended. The agent runs autonomously through each milestone; the **owner is reachable at the phase and PR boundaries**, and the **PR is the approval gate**. The agent never merges. The owner merges, and decides when a phase is complete.
+
+## Per-milestone loop
+
+One concern per milestone, one issue and one PR each.
+
+1. **Start:** pick the next unblocked milestone from epic #177. Read its issue and the relevant glossary terms and decisions in `coach-north-star.md` / `CONTEXT.md`. Branch off `main` (aiw-github).
+2. **Plan:** aiw-planning. Establish the baseline, modality, oracle, and verification approach before code.
+3. **Build:** TDD throughout. aiw-ground-truth and aiw-testing as work proceeds. Real-data checks via `make seed-local` where behaviour depends on real activities.
+4. **Verify:** the aiw-verification justification step before any "done" claim. Run `make backend-test` (and `make eval` / `eval-selftest` for coach-output changes).
+5. **PR:** open one PR per milestone. Document every ASK-FIRST decision under a "Decisions and ASK-FIRST items for reviewer" heading. Reference the epic and the milestone issue. No author or assistant attributions in commits or PRs; commit with `git commit -F <file>`.
+6. **Gate:** the policy hook (`./.ai-policy/scripts/run-validation.sh`) must pass before commit and push. Never commit to `main`. Never merge; leave that to the owner.
+7. **Track:** check the milestone off in epic #177 as its PR opens, and again when the owner merges.
+
+## ASK-FIRST handling
+
+Because this is semi-unattended (owner reachable, not absent), prefer to **ask at the phase or PR boundary** for genuinely load-bearing ASK-FIRST items (new dependency, schema or contract change, architecture deviation). Default-and-document is the fallback only when the owner is not reachable in time and the milestone would otherwise block. This is the one change from the fully-unattended M0-M10 mode.
+
+## Sequencing and readiness gate
+
+- **Foundation-first.** Phase 0 (correctness) lands before Phase 1. Within a phase, independent milestones may run in parallel.
+- **A phase enters the autonomous build only when it is build-ready:** its blocking design questions resolved, a per-milestone brief written, and its foundational ADRs drafted and approved. Phase 0 is build-ready now. Phase 1+ requires a design-and-brief pass first (the vision doc briefs the why, not yet the bounded what/how).
+
+## Resumability
+
+- **Standing memory** (`project_coach_report_build.md`) carries the run state across sessions.
+- **Epic #177** is the live tracker; the checklist is the source of truth for what is done and what is next.
+- Each session: re-read CLAUDE.md's three files, the standing memory, the epic, and this protocol before acting.
+
+## Hard rules (from ai-workflow.md and owner standing rules)
+
+- Never merge; the owner merges.
+- Never commit to `main`; always a feature branch and PR.
+- The policy hook must pass; it is not optional.
+- No author or assistant attributions anywhere (commits, PRs, docs).
+- No em-dashes in prose.
+- Do not bypass the deterministic policy validator or weaken tests.

--- a/docs/vision/coach-north-star.md
+++ b/docs/vision/coach-north-star.md
@@ -1,0 +1,132 @@
+# Coach North-Star: Vision, Decisions, and Roadmap
+
+Status: drafted 2026-06-09 from an interactive design session (grill-with-docs). Holds the owner's vision, the decisions taken, the layered map of how they link, and a dependency-ordered roadmap. Glossary terms resolved in this session live in `CONTEXT.md`; this doc is the why and the plan, not the vocabulary.
+
+This supersedes nothing yet. The M0-M10 build (see `project-context.md`) is the shipped baseline. Everything here is forward-looking and not started.
+
+---
+
+## 1. The essence (preserved verbatim)
+
+The owner's original brain-dump, kept word-for-word so nothing is lost in summarisation. Everything below in this doc is derived from it.
+
+> I would like to discuss the AI system. I've read the latest running trace for v7 and the judge report, and reviewed the last week of activities with their reports. I'm not exactly sure how to articulate what we should talk about, so I'm just going to dump a load of thoughts in here, in no particular order, and you can help me sort them out.
+>
+> I've been thinking about how the AI coach should feel, its purpose, and what it could be. The reports and analysis are coming out very samey, and I would not say they are particularly useful, entertaining, or instructive. I think we need to think of this more as building a relationship, the same way a person would build any relationship with another person. I would like more personality, for it to feel like the best of what a machine can do and the best of what an AI can do. I think this means rethinking the interface between the AI system and the user.
+>
+> I have a belief that AI products like this should feel very personalised and flexible to the user. Case scenario: 64-year-old woman running with Run Club every week; 26-year-old man running as part of an active lifestyle and training for a half marathon; 35-year-old woman just trying to keep fit, primary focus is not running, just good cardiovascular fitness; 29-year-old man bodybuilder; 50-year-old man who enjoys ultra endurance events like ultramarathons and ultratriathlons. All these people require different types of AI coach. Some may want the coach to be more encouraging, kind, fun, less data and more sentiment-driven. Others may want more accountability, motivation, advice, data analysis.
+>
+> Another thing I've alluded to above is the interface between the user and the AI coach. I very much like the Telegram message coming in immediately. However, that interface with the message box right below the report instantly makes me think that I can chat with the coach; this feels like it would be a good addition. It makes me think that in fact any touch points for the AI should be a continuation of a conversation between the AI and the user. However, having had the Telegram running for a bit, I noticed that immediately after an activity my cognitive capacity is low. I am also wondering whether the report should in fact wait until the user has reported on key information: RPE, pain, and notes. The AI coach often currently seems to complain or note about not having this data. I think though it would be a shame, or a blocker, that this should be required. So I'm wondering if there's a way to do a light analysis or quick coach message that doesn't require the user input.
+>
+> Continuing with the theme of low cognitive effort on the user's part, I think it would be good if, when the AI coach has any questions, we should have pre-prepared options the user can just tap on, or a "chat about this" option.
+>
+> Another topic that comes to mind is the current training load. In Strava and Garmin they have deterministic measures of this. Strava has Fitness and Relative Effort. Garmin has Training Load, Exercise Load, and Load Focus. I think this would be a good metric to reproduce in our system, so our AI can more accurately determine the user's current condition.
+>
+> The next thing I've been thinking about is data and memory. This is a stateful system. I think the system is doing well at recording the raw data, but I'm not sure it's making the best use of it. We are condensing a lot of the stream data into one value or an amalgamated metric. However, we do need to be careful about context bloat. This is a context-engineering problem. I am training to become an AI engineer and how we manage data/memory in a sophisticated system is important. I also have a lot of learning and research I've been doing that would be very useful for this project but I'm not sure how exactly to utilise it. For example, I learned recently that forcing the AI to return a structured output before it's allowed to do its own thinking can hurt the response. That's just one example of many learnings and research I've been doing. Oh, one thing I forgot to say about memory and data is about summarisation and compaction, to protect the context window.
+>
+> We also need to be careful about some of our deterministic aspects of the system. I've been adding some issues about this to GitHub, and you have also noticed some things and added them to the judge report. Example: "interpretation": "This HR drift is likely inflated by terrain; discount it as a fatigue signal." And "Splits (5 min)" but in the table: Duration = 4 min.
+>
+> Another thing that comes to mind is what the AI coach relies upon for its philosophy. There are, of course, many schools of thought on training. I myself am currently listening to Born to Run on audiobook. There are many different avenues for learning and development, not just for how the AI responds but also what the user would respond to well. I think our system prompt is too conservative, too preoccupied with correctness, and doesn't feel human. There could also be an over-reliance on the deterministic values we are deriving, which again puts a strong need to make sure these deterministic mechanisms are correct.
+>
+> I myself often do multi-activity sessions, where I might do a walk and then a run and then some indoor rowing and indoor biking, all within the space of two hours. Currently the coach analysis makes no mention of this. I don't know exactly how it should, or should do anything with this, but I guess I'm wanting it to understand the pattern without being told. Everyone has their own training and we can't predict every situation.
+>
+> Moving forwards: the dump I just provided is a lot of information and is unstructured. I don't place priority, or indicate how we should use this. There's too much here to handle in one session or brief or report, but we do need to organise and scope into specific concerns. We need to decide what we are going to do next and how to handle the project going forwards. We need a clean understanding of how everything links together. This may lead to more research, briefs, milestones, tasks. What I don't want is to lose the essence of what I've dumped here.
+
+---
+
+## 2. The reframe, in one line
+
+The coach is an ongoing **`Coaching relationship`**, not a per-activity report generator. A finished activity is one event within the relationship that may prompt the coach to speak. Almost every concern above resolves once this is the spine.
+
+---
+
+## 3. Decisions taken this session
+
+Each maps to a glossary term in `CONTEXT.md`.
+
+1. **Spine: relationship, not report.** The protagonist is the `Coaching relationship`; a `CoachReport` becomes one form a turn can take, not the system's output.
+2. **Topology: hybrid.** One shared relationship memory, many activity-anchored entry points; every touchpoint reads from and writes back to the one memory.
+3. **Cadence: two-stage + coach-decided depth.** The default post-event rhythm is a light, input-free opener now, then a fuller turn on the runner's reply or a timer (whichever first); the coach decides the depth of each (silence or a one-liner on an unremarkable event, depth on an interesting one). Unit: `Exchange`.
+4. **Output: reason then structure, one call.** Extended thinking, then the human message (the product), then a thin structured tail (tappable options, optional citations). Belief/adherence write-back stays deterministic and off the LLM. Structure carries affordances and memory hooks, never content.
+5. **Memory access: hybrid pull.** A lean `Working context` per exchange plus retrieval of deeper detail on demand from the raw store. Stops both context bloat and lossy pre-crushing.
+6. **Durable memory: split.** Deterministic facts (auditable, authoritative for grounding) plus an LLM-consolidated narrative (authoritative for voice, never fact). Maintained by a background `Consolidation` job. Narrative never overrides measured data.
+7. **Personalization: two dials, declared + adaptive.** `Voice` (how it talks) and `Coaching stance` (what it focuses on and its training philosophy) are independent dials, declared at onboarding and refined by the relationship. Voice flexes freely; stance stays tethered to the runner's real goal and the data.
+8. **Knowledge: a `Coaching corpus`.** House principles (now) plus a retrievable schools-of-thought library (later) plus `User materials`. Conflicts resolved by an explicit `Authority tiering` (safety/data win; user materials beat house philosophy for stance; nothing lower overrides measured data or the safety floor). User-supplied content is untrusted input: data to reason about, never instructions to obey.
+9. **Current condition: `Training load`.** Build our own deterministic acute/chronic/balance model from the per-activity load primitive (device-independent, auditable). Use platform numbers (Strava/Garmin) only for cold-start initialisation and validation, never as the source of truth. Depends on fixing `effort_score`.
+10. **Event unit: `Block`.** Deterministically group temporally-contiguous activities into one training event; the coach reasons and speaks about the block (one exchange per block), not each sub-activity. Per-activity analysis is unchanged underneath.
+11. **Sequencing: foundation-first.** Fix the deterministic substrate before the architecture reframe, because the new design leans on that substrate harder, not less.
+
+---
+
+## 4. How it all links (the layered map)
+
+Four layers, bottom-up. Each depends on the one below.
+
+1. **Foundation (correctness).** The deterministic mechanisms the whole product grounds on. Blocks everything above.
+2. **Architecture (the reframe).** `Coaching relationship` -> `Exchange` -> prose output -> memory (`Working context` / split `Durable memory` / `Consolidation`, pull-based) -> `Block` as the event unit.
+3. **Intelligence and personalization.** `Voice` + `Coaching stance` (declared + adaptive) -> `Coaching corpus` (house, schools, `User materials`) under `Authority tiering` -> `Training load`.
+4. **Interaction.** Two-stage cadence, tappable low-effort input, chat-as-continuation, wait-for-input-with-timer.
+
+---
+
+## 5. Dependency-ordered roadmap
+
+One concern per milestone, in the M0-M10 style (one issue + one PR each). Order respects the dependency map.
+
+### Phase 0: Foundation (correctness). Ships on the current architecture.
+- **F1. Per-activity load primitive (`effort_score`).** Use athlete-max HR, separate load from intensity. Foundation for `Training load`. (Issue #168.)
+- **F2. discount_signals magnitude gate.** Do not instruct a discount when drift is not actually elevated; align the eval rubric assertion. (Judge-report finding, unfiled.)
+- **F3. Confidence-reasons leak.** Keep interval/`no_intervals_detected` reasons out of overall confidence. (Issue #169.)
+- **F4. Interval detection from recorded laps + framing.** Use Strava laps as the structure source; stop the coach over-indexing on low detection confidence. (Issues #170, #171.)
+- **F5. Splits label/duration display bug.** "Splits (5 min)" vs Duration 4 min. (Unfiled.)
+
+These are largely independent and parallelisable; several are already filed.
+
+### Phase 1: Architecture reframe. Large; decomposed.
+- **A1. Relationship + Block model.** Data model for `Coaching relationship`, `Block` grouping (time-gap detection, split/merge), and `Exchange` records.
+- **A2. Memory architecture.** `Working context` / split `Durable memory` / `Consolidation` background job; pull/retrieval over the raw store. Reworks the M4-M10 learning loop into the new memory model (the loop needs updating here anyway). Verify and migrate the deterministic write-back seam.
+- **A3. Output reframe.** Reason -> message -> thin tail; demote the structured `CoachReport` to a prose `Exchange`; confirm the policy validator governs prose; frontend renders a message. (ADR.)
+- **A4. Cadence + pipeline.** Two-stage exchange, coach-decided depth, block-complete trigger, never block on input. Reworks the Process-new-activity pipeline.
+
+### Phase 2: Intelligence and personalization.
+- **P1. Voice + Coaching stance dials.** Onboarding declaration + adaptive refinement (generalises `Preference profile` to tone).
+- **P2. Coaching corpus + Authority tiering.** House principles first; schools library + retrieval later. Enforce tiering in prompt and code.
+- **P3. Training load model.** Acute/chronic/balance; platform numbers for init + validation. Depends on F1.
+- **P4. User materials ingestion.** Untrusted-input-safe retrieval into the corpus.
+
+### Phase 3: Interaction surface.
+- **I1. Tappable low-effort input.** Quick RPE/pain options on the opener.
+- **I2. Chat-as-continuation.** Unify chat into the relationship (shared memory), not per-activity silos.
+- **I3. Conversation-first frontend.**
+
+---
+
+## 6. Open leaf-questions (deferred, not lost)
+
+- Stage-2 timer duration; `Block` time-gap threshold and tuning.
+- Whether `Consolidation`'s narrative is LLM-written or templated, and how often it runs.
+- Retrieval implementation (tool-use vs RAG); the exact contents of the lean default `Working context`.
+- Onboarding flow for declaring `Voice` and `Coaching stance`.
+- Scope of the frontend rework.
+- The learning-loop write-back seam: confirm it reads only deterministic signals before A2 (deferred during the session).
+- Exact `effort_score` reformulation; relationship to capturing resting HR / HR recovery (#166).
+- How all of this interacts with the Phase-2 multi-user plan (ADR 0005).
+- How to channel the owner's ongoing AI research (e.g. reason-before-structure, already adopted) into specific milestones.
+
+---
+
+## 7. ADR candidates
+
+Write each when its milestone is picked up, not before. Each meets the bar (hard to reverse, surprising without context, a real trade-off):
+- **The coach is a `Coaching relationship`, not per-activity reports** (the spine). Defines the domain going forward.
+- **Coach output is a prose `Exchange`; the structured `CoachReport` is demoted to one optional shape.** Trades per-claim machine-traceability for humanity and reasoning quality. (Tied to A3.)
+- Possible: **split `Durable memory` (deterministic facts vs LLM narrative) with pull-based retrieval.** (Tied to A2.)
+- Possible: **`Block` as the event unit.** (Tied to A1.)
+
+---
+
+## 8. Glossary terms added this session
+
+In `CONTEXT.md`: `Coaching relationship`, `Exchange`, `Working context`, `Durable memory`, `Consolidation`, `Voice`, `Coaching stance`, `Coaching corpus`, `User materials`, `Authority tiering`, `Training load`, `Block`.
+
+Reconciliation pending: the existing `Notification`, `Process new activity`, and `CoachReport`-centric entries are written with the artifact as protagonist and will need updating once the reframe lands.


### PR DESCRIPTION
## What

Docs-only change capturing the design session that reframes the coach from a per-activity report generator into an ongoing **coaching relationship**.

- **`docs/vision/coach-north-star.md`** — the owner's brief verbatim (essence preserved), the 11 decisions taken, the layered map of how they link, the dependency-ordered roadmap (Phases 0-3, foundation-first), the deferred leaf-questions, and the ADR candidates.
- **`CONTEXT.md`** — 12 new glossary terms: Coaching relationship, Exchange, Working context, Durable memory, Consolidation, Voice, Coaching stance, Coaching corpus, User materials, Authority tiering, Training load, Block.

## Why

The shipped M0-M10 coach produces samey, one-shot reports. This sets the direction for the next era: a stateful relationship with personality, a two-stage conversational cadence, prose output (reason then message then thin structured tail), split durable memory with pull-based retrieval, per-runner voice/stance dials, a coaching-knowledge corpus, training-load sensing, and multi-activity block grouping.

## Sequencing

Foundation-first: fix the deterministic substrate before the architecture reframe, because the new design leans on that substrate harder, not less. Tracked in epic #177.

## Notes for review

- Vision and glossary only. No code, schema, or behaviour change.
- The legacy `CoachReport`-centric glossary entries (`Notification`, `Process new activity`) still describe the artifact as protagonist and are flagged in the doc for reconciliation once the reframe lands; not changed here.
- Phase 1-3 remain intent-level in epic #177 until each phase begins, to avoid pegging issues to code that is about to change.
