### PR TITLE
docs: A2 memory-and-retrieval settled design, ADR 0008, build brief

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,8 +14,13 @@ _Avoid_: equating "exchange" with "report"; a report is one shape an exchange ca
 
 ## Working context
 
-The bounded set of information assembled into the prompt for one `Exchange`: the relationship's narrative summary plus this event's headline facts, kept deliberately lean. It is not the whole of what the coach can know: the coach pulls deeper detail from the raw store on demand (retrieval) rather than receiving a fixed, pre-decided pack. Distinct from `Durable memory` (what persists across exchanges) and the raw store (the append-only source of truth, never loaded wholesale). The thing context engineering protects: small by default, deep on demand.
+The bounded set of information assembled into the prompt for one `Exchange`: a lean `B baseline` always present (the relationship's narrative summary, this run's measured facts, the relevant deterministic facts, the last exchange's digest) plus a trigger-scoped focus payload about whatever the exchange is anchored to, kept deliberately lean. It is a **view, not a store**: assembled per turn from the raw store, the `Processed artifacts` layer, and `Durable memory`, with deeper detail pulled on demand (retrieval) rather than received as a fixed, pre-decided pack. Distinct from `Durable memory` (what persists across exchanges) and the raw store (the append-only source of truth, never loaded wholesale). The thing context engineering protects: small by default, deep on demand.
 _Avoid_: equating working context with "everything we know about the runner"; it is the lean slice assembled for one turn, not the memory itself.
+
+## Processed artifacts
+
+The layer of pre-digested, retrievable records derived from the raw store on ingestion, the moment data lands, so that retrieval later is cheap (the "do the work on ingestion" principle, attributed to Karpathy's LLM knowledge bases). Holds the per-run measured facts (`DerivedMetric`), the consolidated stream view (a small downsampled HR/pace/grade/cadence snapshot of one activity), the digest of each past `Exchange` (headline, lead argument, commitments), and the deterministic signals extracted from user responses (RPE-vs-HR divergence, pain trend, pushback). Distinct from the raw store (it is derived, not truth), from `Durable memory` (it is per-event detail, not cross-exchange generalisation), and from `Working context` (it is stored, not assembled fresh per turn). `Working context` pulls from it on demand; raw streams themselves never enter context, only their processed view does.
+_Avoid_: treating a processed artifact as ground truth that overrides a re-derived `DerivedMetric`, or loading it wholesale; it is a retrieval-shaped convenience over the raw store, pulled only when the turn needs it.
 
 ## Durable memory
 

--- a/docs/adr/0008-coach-memory-is-a-four-layer-pull-model.md
+++ b/docs/adr/0008-coach-memory-is-a-four-layer-pull-model.md
@@ -1,0 +1,27 @@
+# Coach memory is a four-layer pull model, not one pre-built context pack
+
+Today the coach builds its entire context fresh on every call: `context.py` re-derives a single `CoachContextPack` from the raw store each time, crushing per-sample streams into one number per metric and assembling every section (longitudinal, perceived-effort, adherence, beliefs, calibration, preference) in one pass. That worked for a per-activity report, but it scales badly into the coaching relationship: it either bloats (carry everything) or pre-crushes (lose detail), and it re-derives the same digests on every touchpoint. The relationship needs memory that persists, stays lean in view, and keeps detail reachable.
+
+We adopt a **four-layer memory model with pull-based retrieval**, and we **split durable memory** into deterministic facts and an LLM narrative. The layers (full detail in `docs/vision/coach-memory-retrieval-design.md`):
+
+1. **Raw store** — append-only truth, never loaded wholesale.
+2. **Processed artifacts** — derived on ingestion, stored, pulled on demand (metrics, consolidated stream view, exchange digests, extracted subjective signals). The "do the work on ingestion so retrieval is cheap" layer.
+3. **Durable memory** — persists across exchanges, split: **deterministic facts** (beliefs, baselines, training load, derived preferences — authoritative for grounding) and an **LLM narrative** (the relationship story — authoritative for voice, never fact, re-grounded from facts by a background `Consolidation` job).
+4. **Working context** — not a store; the lean view assembled per exchange (a `B baseline` always present + a trigger-scoped focus payload pulled on demand).
+
+The boundary that makes the split safe is absolute and mirrors the standing belief rule: **the narrative can never override a re-derived `DerivedMetric` or a deterministic fact, and can never be the cited source of a factual claim.** Deterministic write-back stays off the LLM and auditable.
+
+## Considered options
+
+- **Keep the single pre-built context pack, just grow it.** Rejected: this is the bloat-vs-pre-crush dilemma. Carrying the whole relationship balloons the prompt (violates lean); pre-summarising everything loses the detail the coach occasionally needs and bakes staleness in.
+- **One durable memory, not split.** Rejected: a single store either lets LLM-written colour harden into cited fact (unauditable, ungrounded) or forbids narrative entirely (loses the voice the relationship needs). The authority split is the point — facts ground, narrative colours, and they never cross.
+- **Let the coach write its own narrative inline per exchange.** Rejected: couples consolidation to producing the turn (slows the user-facing reply) and lets the story drift without re-grounding against facts. A decoupled background job re-grounds every time.
+- **Three layers (fold processed artifacts into raw store).** Rejected: the pre-digested layer is structurally distinct (derived, not truth; stored, not assembled fresh; per-event detail, not cross-exchange generalisation) and is the heart of the reframe. Naming it keeps the model honest.
+
+## Consequences
+
+- New persistence: a processed-artifacts layer (consolidated stream view, stored exchange digests, extracted signals) and a durable-memory narrative store, with migrations. Beliefs (`CoachingContext`) and norms (`RunnerBaseline`) already exist as the deterministic-facts half.
+- `context.py` is refactored from "build the whole pack" to "assemble a lean baseline + pull focus payload on demand" — a read-path retrieval seam.
+- The M4–M10 learning loop is re-plumbed onto the new model; the deterministic write-back fires on the exchange boundary and is confirmed (seam audit, 2026-06-09) to read only deterministic signals. The thin structured tail must keep commitments/next-steps machine-readable or the loop breaks.
+- This ADR is scoped to memory (A2). It assumes "a block is one activity" (A1 deferred) and keeps the structured `CoachReport` as the exchange record (A3 deferred). It depends on the Phase 0 foundation fixes landing first.
+- Future reviews should not re-suggest a single flat context pack or a single unsplit memory: the four layers and the facts/narrative authority split are the design, not an accident.

--- a/docs/coach-memory-retrieval-brief.md
+++ b/docs/coach-memory-retrieval-brief.md
@@ -1,0 +1,119 @@
+# Coach Memory and Retrieval (A2) — Build Brief
+
+> Execution-facing companion to `docs/vision/coach-memory-retrieval-design.md` (the *what* and *why* of the memory model) and `docs/adr/0008-coach-memory-is-a-four-layer-pull-model.md` (the decision). This brief holds the *in what order*: milestones with explicit scope, intent, test discipline, success criteria, dependencies, and the skills that apply. Same shape as `coach-report-update-brief.md`.
+>
+> **Scope discipline.** A2 is **memory and retrieval only.** It assumes "a block is one activity" (A1/Block deferred), keeps the structured `CoachReport` as the exchange record (A3 output reframe deferred), and does not own *when* the coach speaks (A4 cadence). See design doc §6.
+>
+> **Boundary discipline.** Items flagged **[ASK-FIRST]** touch schema, migrations, a new background job, or a public contract and must be approved by the product owner before implementation (per `ai-workflow.md`). The deterministic policy validator gate is never bypassed. Previews share the production DB, so every migration is verified with that hazard in mind.
+
+---
+
+## How to use this brief
+
+Each milestone is a coherent shippable unit: one issue, one PR, TDD throughout. Work them in dependency order. Before starting any milestone:
+
+1. Confirm its **[ASK-FIRST]** items are approved.
+2. Run `aiw-planning` (baseline + modality + oracle) for that milestone.
+3. Establish the oracle with `aiw-ground-truth` before writing fixtures.
+4. Gate the "done" claim through `aiw-verification`.
+
+---
+
+## Dependency graph
+
+```
+Phase 0 foundation (#168 etc.) ──▶ A2a (processed-artifacts layer) ──┬─▶ A2b (working-context view + retrieval) ──┐
+                                                                     │                                            ├─▶ A2d (re-plumb learning loop + write-back)
+                                                                     └─▶ A2c (split durable memory + narrative) ──┘
+```
+
+**The order that matters most:** Phase 0 lands first — the new memory leans on the deterministic substrate (effort_score, discount gate, confidence/interval fixes) *harder*, not less. A2a is the substrate for the rest of A2: nothing can be pulled on demand until ingestion stores it. A2d is last because it migrates the existing M4–M10 loop onto everything the earlier three build.
+
+---
+
+## A2a — The processed-artifacts layer
+
+**Intent.** Stand up the "do the work on ingestion so retrieval is cheap" layer. Make ingestion produce and *store* the pre-digested artifacts as first-class, retrievable records, instead of re-deriving them inside `context.py` on every call.
+
+**In scope.**
+- New **consolidated stream view** artifact: a small, downsampled, aligned snapshot (HR, pace, grade, cadence) per activity, produced during analysis, stored, retrievable. **[ASK-FIRST: schema/migration]**
+- Persist the **exchange digest** (headline, lead argument, commitments) as a stored artifact rather than the in-memory digest M4 recomputes. **[ASK-FIRST: schema/migration]**
+- Persist the **extracted subjective signals** (RPE-vs-HR divergence, pain trend, pushback flag) from user responses. May begin read-time and move to ingestion-time as an optimisation. **[ASK-FIRST: schema if stored]**
+- Derived metrics already exist; this milestone names them as the measured artifact, no change.
+
+**Out of scope.** The retrieval seam that *reads* these (A2b). The narrative layer (A2c). Any change to how the loop consumes digests (A2d). Block grouping. Raw-stream sandbox compute.
+
+**TDD.** Stream-view downsampling is a pure-function oracle: hand-author a stream input, assert the downsampled output is aligned, bounded in point count, and preserves the shape (peaks/grades survive). Ground-truth for the digest fields is the existing M4 digest contents (characterise current behaviour first, then prove the stored artifact matches). Migrations verified up/down against local Postgres (SQLite tests do not exercise migration SQL).
+
+**Success looks like.** After an activity is analysed, its consolidated stream view and (after an exchange) its digest exist as stored rows, retrievable by id, lean (tens of points, not thousands). No coach behaviour changes yet — this is substrate.
+
+**Links.** Prerequisite for A2b and A2c. Resolution of the stream view (per-split vs fixed point count) is a build-time tuning detail (design doc §7).
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth`, `aiw-testing`, `aiw-performance-profiling` (downsampling is a hot data loop), `aiw-verification`, `aiw-github`, `grill-with-docs` (pin migrations against ADR/CONTEXT), `aiw-project-context-management`.
+
+---
+
+## A2b — Working context as an assembled view + retrieval seam
+
+**Intent.** Refactor `context.py` from "build the whole pack fresh" into "assemble a lean `B baseline` + pull a trigger-scoped focus payload on demand." Introduce the retrieval seam that reads A2a's artifacts.
+
+**In scope.**
+- Define and assemble the **B baseline** (design doc §4): this run's measured facts, narrative summary slot, relevant deterministic facts (beliefs/baseline/preference/load), last exchange digest, this run's subjective signals.
+- Implement the **focus payload** as a pull: given a subject activity, retrieve its full metrics + splits + consolidated stream view + check-in.
+- The **retrieval seam** itself: pull a specific activity's artifacts and older exchanges on demand, not preloaded. Raw streams never enter context.
+- Subject resolution for conversation triggers: timing hint + content + clarifying-question fallback (design doc §5) — the *memory* half; the cadence/release half is A4.
+
+**Out of scope.** Producing the artifacts (A2a). The narrative content (A2c). Migrating the learning-loop sections to read from the view (A2d). Output shape (A3).
+
+**TDD.** Assert the assembled B baseline contains exactly the agreed fields and *omits* the bulky ones (no raw streams, no full stream view unless an activity is the subject). Assert a focus-payload pull for activity X returns X's artifacts and nothing for an unrelated activity. Characterise the current `CoachContextPack` first so the refactor is provably behaviour-preserving where it should be.
+
+**Success looks like.** Context assembly is measurably leaner by default (no full-detail-for-every-activity), the focus payload appears only for the subject, and a deep-dive on a specific activity pulls its stream view on demand.
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth`, `aiw-testing`, `aiw-performance-profiling` (context-assembly is on the request path), `aiw-verification`, `aiw-github`.
+
+---
+
+## A2c — Split durable memory: narrative layer + consolidation job
+
+**Intent.** Formalise durable memory as the two-authority split, and add the genuinely new piece: the LLM narrative and the background `Consolidation` job that maintains it, re-grounded from the deterministic facts every time.
+
+**In scope.**
+- New **narrative store**: one bounded per-runner relationship narrative in durable memory. **[ASK-FIRST: schema/migration]**
+- New background **`Consolidation` job**: after exchanges, re-writes the narrative from deterministic facts + recent exchange digests; decoupled so the user-facing turn never waits on it. **[ASK-FIRST: new background job + RQ wiring]**
+- Enforce the authority boundary in code and prompt: the narrative is voice-only, never cited as fact, never overrides a re-derived `DerivedMetric`.
+- Name the existing beliefs (`CoachingContext`) + norms (`RunnerBaseline`) + derived preferences as the deterministic-facts half (no change to them here).
+
+**Out of scope.** Declared Voice/Stance (Phase 2 / P1; reserve the slot only). The learning-loop re-plumb (A2d). Consolidation cadence tuning and cheap-model selection (build-time details, design doc §7).
+
+**TDD.** The decoupling is testable: assert the exchange path does not block on consolidation. The authority boundary reuses the validator discipline — assert a narrative string can never become a cited factual claim and that a narrative contradicting today's `DerivedMetric` does not change the metric. Consolidation input is deterministic facts + digests; assert it never reads raw LLM output as fact. Narrative generation itself is LLM-backed: gate with the M5 eval discipline, not a brittle string assertion.
+
+**Success looks like.** A per-runner narrative exists and updates in the background after exchanges; it visibly re-grounds (a stale narrative claim is corrected once the facts move); the user-facing exchange never waits on it; no narrative text can override measured data.
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth`, `aiw-testing`, `aiw-security-testing` (the facts/narrative authority boundary is a trust boundary), `aiw-verification`, `aiw-github`, `grill-with-docs`, `aiw-project-context-management`.
+
+---
+
+## A2d — Re-plumb the learning loop + write-back seam
+
+**Intent.** Migrate the existing M4–M10 learning loop onto the new memory model: read from the assembled view and stored artifacts instead of re-deriving from raw each time, and confirm the deterministic write-back fires on the exchange boundary reading only deterministic signals.
+
+**In scope.**
+- Point M4 (longitudinal), M7 (adherence), M8 (beliefs), M9 (calibration), M10 (preference) at the new working-context view + stored processed artifacts.
+- Re-plumb the deterministic **write-back** (`belief_store.write_back_beliefs`) to fire on the exchange boundary. The 2026-06-09 seam audit confirms it reads only deterministic pack signals; this milestone preserves that and adds a test that pins it.
+- Preserve the hard constraint: commitments/next-steps stay **machine-readable** in the thin structured tail (M4/M7 read them). **[ASK-FIRST if the tail contract changes]**
+
+**Out of scope.** Output reframe to prose (A3) — the structured `CoachReport` stays the exchange record here. New belief kinds. Block grouping.
+
+**TDD.** Regression-first: the M5 eval harness is the gate — the re-plumbed loop must score no worse than the current loop on the existing rubric (run `make eval` before and after). Add a test that proves the write-back reads only deterministic inputs (feed it adversarial LLM prose; assert no belief delta derives from it). Prove a learning-loop section produces the same output reading from the stored artifact as it did re-deriving from raw (behaviour-preserving migration).
+
+**Success looks like.** The full M4–M10 loop runs against the new memory model with no eval regression; the deterministic write-back is provably LLM-free and fires once per exchange; commitments survive as structured data.
+
+**Links.** Depends on A2a (artifacts), A2b (view), A2c (durable-memory split). The M5 eval gate (`make eval`) is the regression guard. The seam audit is recorded in `coach-north-star.md` open-questions and the project memory.
+
+**Useful skills.** `aiw-planning`, `aiw-ground-truth`, `aiw-testing`, `aiw-verification` (eval-as-gate), `aiw-security-testing` (write-back is the auditability boundary), `aiw-github`.
+
+---
+
+## Open build-time tuning (not milestone-blocking)
+
+Carried from design doc §7: stream-view resolution; Telegram reply-window length; consolidation cadence and model tier; whether subjective-signal extraction moves fully to ingestion-time; the deferred raw-stream sandbox compute. Decide each inside the milestone that hits it; none blocks starting.

--- a/docs/vision/coach-memory-retrieval-design.md
+++ b/docs/vision/coach-memory-retrieval-design.md
@@ -1,0 +1,130 @@
+# Coach Memory and Retrieval: settled design (Phase 1 / A2)
+
+Status: settled 2026-06-09 from the interactive design session that resumed the inputs in `coach-memory-retrieval-notes.md`. This is the design A2 builds to. The inputs doc is now superseded by this one for everything it covers; it is kept only for provenance. Vocabulary lives in `CONTEXT.md`; the roadmap and the why live in `coach-north-star.md`.
+
+The frame, in one line: the coach has **per-data-type ingestion pipelines that do the hard work in the background the moment data lands, shaping each type into a cheap-to-retrieve form, feeding one lean working context the coach reads from.** Retrieval is cheap because ingestion already paid the cost.
+
+---
+
+## 1. The five principles (how LLMs handle data best)
+
+The design's guardrails. Every decision below is an application of one of these, and any later decision can be tested against them.
+
+1. **Lean beats complete.** The model reasons better over a small relevant slice than a big dump. The right context, not more context.
+2. **Pre-digested beats raw.** Give the model something already shaped for the question (a summary, a comparison, a flag), not raw material it must crunch itself. (Karpathy's "do the work on ingestion.")
+3. **Reason before structure.** Let the model think in prose first, emit structure second. Forcing structured output up front hurts the reasoning. (Already adopted.)
+4. **Pull beats preload.** Start lean, fetch specific detail only when the moment needs it.
+5. **Fresh data wins over remembered data.** When a stored belief or summary disagrees with what this run measured, today's measurement wins.
+
+The tension to keep honest: **2 vs 5.** Pre-digesting on ingestion lets stored summaries go stale. The split-memory design (section 3) handles it — deterministic facts are always re-derived; only the narrative is allowed to be soft, and it is re-grounded from facts on every consolidation.
+
+---
+
+## 2. The four-layer memory model
+
+The glossary named three layers (raw store, working context, durable memory). The data-type framing surfaced a fourth that the three-layer view folded into "raw store": the **processed-artifacts layer**, which is the whole point of the reframe. The settled model is four layers.
+
+1. **Raw store** — append-only source of truth. Never loaded wholesale. The current run always re-derives from it.
+2. **Processed artifacts** — derived on ingestion from raw, stored, pulled on demand. The "do the work on ingestion so retrieval is cheap" layer.
+3. **Durable memory** — persists across exchanges. Split into deterministic facts (authoritative for grounding) and an LLM narrative (authoritative for voice, never fact).
+4. **Working context** — *not a store*. The lean view assembled per exchange from the three layers above.
+
+```
+                          ┌─────────────────────────────────────┐
+   data lands ──ingest──▶ │ RAW STORE (append-only truth)        │
+                          └─────────────────────────────────────┘
+                                        │ background processing (immediate)
+                                        ▼
+                          ┌─────────────────────────────────────┐
+                          │ PROCESSED ARTIFACTS (pre-digested)   │
+                          │  metrics · stream view · digests ·   │
+                          │  extracted subjective signals        │
+                          └─────────────────────────────────────┘
+        deterministic write-back │            │ pull on demand
+                                  ▼            │
+                          ┌──────────────────┐ │
+                          │ DURABLE MEMORY   │ │
+                          │  facts │ narrative│ │
+                          └──────────────────┘ │
+                                  │ always-on   │
+                                  ▼            ▼
+                          ┌─────────────────────────────────────┐
+                          │ WORKING CONTEXT (assembled view)     │
+                          │  B baseline + trigger focus payload  │
+                          └─────────────────────────────────────┘
+                                        │
+                                        ▼ reason → prose → thin tail
+                                     EXCHANGE
+```
+
+---
+
+## 3. Data type → layer map
+
+The ten data types from the inputs doc, placed. "Today" marks what already exists in code.
+
+| Data type | Layer | Ingestion produces | Notes |
+|---|---|---|---|
+| Raw Strava activities + streams | Raw store | — | never in context |
+| Derived metrics | Processed artifacts | per-run measured facts (today) | the measured layer; re-derived each run; authoritative |
+| Consolidated stream view | Processed artifacts | small downsampled aligned HR/pace/grade/cadence | **new**; pulled only when an activity is the subject |
+| User responses (check-in/chat/Telegram) | Raw store (+ extract) | divergence, pain trend, pushback flag | raw kept; signals extracted (today at read-time, moving to ingestion) |
+| Past coach output (exchanges) | Raw store (+ digest) | digest: headline, lead argument, **commitments** | full prose kept; commitments stay machine-readable (load-bearing) |
+| Summarised activity history | (not a new store) | — | numeric = rollups (exist); prose = narrative layer |
+| Constructed memory (beliefs, norms) | Durable memory (facts) | belief/baseline deltas (today, deterministic) | write-back re-plumbed to fire on exchange boundary |
+| User preferences | Durable memory (facts) | derived profile (today); declared Voice/Stance (Phase 2 slot) | declared and derived kept separate |
+| LLM narrative | Durable memory (narrative) | the relationship story | **new**; background consolidation job, re-grounded from facts |
+| Uploaded materials / future types | (reserved slot) | — | Phase 2 / future; architecture must accept a new pipeline without redesign |
+
+---
+
+## 4. Working context: B baseline + focus payload
+
+Working context is assembled per exchange, lean by default, deep on demand. It has two parts.
+
+**B baseline (always present):** this run's measured facts; the narrative summary; the relevant deterministic facts (active beliefs with confidence/recency tags, matching baseline/calibration bucket, derived preference profile, training load); the last exchange's digest; this run's subjective signals if present.
+
+**Focus payload (trigger-scoped):** rich detail about whatever the exchange is anchored to, pulled on demand. For an activity-anchored exchange this is that activity's full metrics + splits + **consolidated stream view** + its check-in. For a general chat it is empty until the conversation references something.
+
+Pulled only on demand (never preloaded): older exchanges' full prose, deeper history, raw streams, and later the corpus/materials. Raw streams never enter context at all; the consolidated stream view is the retrievable middle tier.
+
+---
+
+## 5. Trigger points
+
+Two families. The **channel** (Telegram vs in-app) is orthogonal — same handler, different delivery adapter.
+
+**Event triggers** run real background work and may cause the coach to speak:
+
+- **New activity lands.** Memory work fires **immediately** in the background (ingest → analyze → produce consolidated stream view → extract signals) so retrieval is ready. The *exchange* fires later at block-complete (A1/A4 own the timing). Focus payload when it fires: the block (each activity's metrics + stream view) + B baseline.
+- **Check-in submitted.** Ingests (store raw + extract subjective signals) *and* can release a waiting stage-two exchange (the cadence reply case). Focus payload: that activity + the new signals + B baseline.
+
+**Conversation triggers** store the message, extract any light signal (pushback → "disputed"), and assemble a focus payload from what the message is about:
+
+- **In-app chat on an activity.** Continuation of the one relationship; reads shared memory, writes back only the deterministic pushback signal. Focus payload: that activity + the thread + B baseline.
+- **Telegram chat.** Same handler as in-app. The reply lacks a structural anchor, so the **subject is resolved intelligently:** a reply-window timing *hint* pre-loads the likely subject, the coach confirms or redirects from content (pulling the real subject on demand), and asks a quick clarifying question when genuinely ambiguous.
+- **General chat (no activity).** The residual case: B baseline only, no focus payload, pull a specific activity on demand if the conversation turns to one. Still knows the runner (beliefs, preferences, narrative).
+
+---
+
+## 6. What A2 owns, and the boundaries
+
+A2 is **memory and retrieval only.** It deliberately does not pull in the neighbouring milestones:
+
+- **A1 (Block detection)** is deferred. A2 treats "a block is a single activity" as a placeholder, exactly as `_extract_planned_workout` returns `None` today. When Block detection lands, blocks start grouping — additive, no A2 rework.
+- **A3 (output reframe)** is deferred. A2 keeps the current structured `CoachReport` as the exchange record. A3 later demotes it to a prose `Exchange`. A2's only constraint on A3: the commitments/next-steps in the thin tail must stay machine-readable, because the learning loop reads them.
+- **A4 (cadence + pipeline)** owns *when* the coach speaks (block-complete, two-stage opener/timer, releasing a waiting turn). A2 owns the memory the cadence reads and writes, not the timing.
+
+So A2's deliverables: the processed-artifacts layer; working context as an assembled view with a retrieval seam; split durable memory with the new narrative layer and its background consolidation job; and re-plumbing the M4–M10 learning loop onto the new memory model with the deterministic write-back firing on the exchange boundary.
+
+**Sequencing:** Phase 0 (foundation fixes, #168 etc.) lands first — the new memory leans on the deterministic substrate harder. Then A2. Then A1/Block, A3, A4.
+
+---
+
+## 7. Open build-time tuning details (decide during the build, not now)
+
+- Consolidated stream view resolution (per-split vs fixed point count).
+- Telegram reply-window length; the stage-2 timer duration (A4).
+- Consolidation cadence (every exchange vs batched) and whether it uses a cheaper model than the coaching message (coach defaults to Opus 4.8; consolidation is a candidate for a cheaper tier).
+- Whether subjective-signal extraction moves fully to ingestion-time (optimisation) or stays read-time at first.
+- The on-demand raw-stream sandbox compute (principle 2 deepened) — a real future capability, explicitly not an A2 dependency.

--- a/docs/vision/coach-memory-retrieval-notes.md
+++ b/docs/vision/coach-memory-retrieval-notes.md
@@ -1,6 +1,6 @@
 # Memory and Data Retrieval System: design inputs (Phase 1 / A2)
 
-Status: design input captured 2026-06-09, not yet a settled design. This is the starting point for a fresh session that will design the coach's memory-and-data-retrieval system (milestone A2 in `coach-north-star.md`). Nothing here is decided beyond what the "Settled so far" section marks.
+Status: **superseded 2026-06-09 by `coach-memory-retrieval-design.md`**, which holds the settled A2 design. This doc is kept only for provenance: it captured the raw design inputs and the owner's verbatim thought-dump before the decisions were made. For what A2 builds to, read the design doc, `docs/adr/0008-coach-memory-is-a-four-layer-pull-model.md`, and `docs/coach-memory-retrieval-brief.md`.
 
 ## How to run the next session (owner preference)
 

--- a/docs/vision/coach-memory-retrieval-notes.md
+++ b/docs/vision/coach-memory-retrieval-notes.md
@@ -1,0 +1,64 @@
+# Memory and Data Retrieval System: design inputs (Phase 1 / A2)
+
+Status: design input captured 2026-06-09, not yet a settled design. This is the starting point for a fresh session that will design the coach's memory-and-data-retrieval system (milestone A2 in `coach-north-star.md`). Nothing here is decided beyond what the "Settled so far" section marks.
+
+## How to run the next session (owner preference)
+
+Present every decision as: one short paragraph of framing, then a clear list of options, then a recommendation with rationale. Keep it plain. Do not dump unexplained terminology; define any term in plain language the first time it appears. Long jargon-heavy responses lose the owner and cause drift. This is a hard preference, recorded in memory as well.
+
+## The reframe (the angle to design from)
+
+Frame the system by **data type** and by **trigger point**, with the organizing principle that the hard work happens **on ingestion, in the background**, not when the coach asks. Each data type is shaped when it arrives into a form that is cheap and easy to retrieve later (the "process at ingestion so retrieval is easy" idea, attributed by the owner to Andrej Karpathy's LLM knowledge-bases). So the system is: per-data-type ingestion pipelines that pre-process and store, feeding one easy retrieval layer that the coach reads from.
+
+## Owner thought-dump (verbatim, 2026-06-09)
+
+> I think we need to frame this from another angle. However I'm worried that we've used too much of your context in this chat session. But I'm going to do a thought dump here now: One thing that occurs to me is the data types we have or could have. We have the raw data from strava, we have LLM responses, we have user metrics, we have User preferences, we have uploaded materials, we have LLM constructed narrative, We have summarised activity history, we have user resposes, we have a constructed memory, there could be more types I don't know yet or future types like raw health sleep data. The other thing that occurs to me is the Initialisation point, we have events like a new activity landing, or user submiting Activity Check-In, or chat in telegram, or chat with coach in app on an activity, we also could have a general chat not tied to a specific activity. It also occurs to me that some processes for data and memory can be run in the background, "Andrej Karpathy's LLM Knowledge Bases" has a layer that process on ingestion To make it easier for the LLM on retrieval. This leads me to another thought about How LLMs handle data best.
+
+(The trailing thought, "how LLMs handle data best," was not finished and should be drawn out at the start of the next session.)
+
+## Data types in play (owner's list, to be organised)
+
+- Raw Strava data (activities, streams)
+- LLM responses (the coach's own past output)
+- User metrics (derived metrics)
+- User preferences
+- Uploaded materials (the runner's own coaching content)
+- LLM-constructed narrative (the relationship story)
+- Summarised activity history
+- User responses (check-ins, chat replies)
+- Constructed memory (the durable runner-model)
+- Future / unknown types (e.g. raw health and sleep data)
+
+## Trigger points (when ingestion or retrieval fires)
+
+- A new activity landing
+- User submitting an activity check-in
+- Chat in Telegram
+- In-app chat with the coach on a specific activity
+- A general chat not tied to any activity
+- (Future triggers as new data sources are added)
+
+## Settled so far (from the design session, plain language)
+
+- The coach is an ongoing relationship, not a per-activity report (see `coach-north-star.md`).
+- Retrieval model: the coach starts with a lean summary and looks up specific detail on demand, rather than being pre-loaded with everything (Q5 in the session).
+- Durable memory is split: deterministic, auditable facts (beliefs, preferences, training load) plus an LLM-written narrative that is colour, never fact (Q6).
+- Output is prose first, with a thin structured tail carrying only what the system reads back later (the advice/commitments), so the learning loop keeps working (confirmed by a code audit: the belief write-back already reads only deterministic signals, but the loop reads the prior advice's structured next-steps, so that structure must survive).
+
+## Candidate mechanics raised but NOT decided (keep plain next time)
+
+These came up and were judged too jargon-heavy for the owner mid-session. Reintroduce only in plain language, one at a time, and only if needed:
+
+- How the coach varies depth per run (two fixed gears vs an adaptive spending limit). Leaning: two fixed gears first.
+- Letting the coach compute over raw streams in a sandbox so raw samples never fill its view (the answer to "we crush streams to one number, but raw is too bulky").
+- Keeping a stable, reusable chunk of the prompt cached to save cost.
+- Using a cheaper, faster model for the background ingestion/summarising work and the strongest model for the coaching message itself.
+- Where the narrative gets written: by the coach itself, or by a separate background job we control.
+
+## Open questions to resume on
+
+1. Finish the owner's "how LLMs handle data best" thought.
+2. For each data type, what does ingestion-time processing produce, and where is it stored?
+3. What does the lean default summary contain, and what is left to look up on demand?
+4. Which trigger points run background processing, and what does each one do?
+5. How do the data types map onto the layers already named in the glossary (raw store, working context, durable memory)?


### PR DESCRIPTION
## What

Captures the owner's design-input thought-dump for the coach **memory and data retrieval system** (milestone A2 in the north-star roadmap), so the next session starts from a clean, durable brief.

## Why

This session reframed the system around **data types** and **trigger points**, with the organizing principle that processing happens **on ingestion in the background** so retrieval is cheap (the "LLM knowledge base" idea). It also surfaced a plain-language communication preference and a set of mechanics that were too jargon-heavy to settle mid-session.

## Contents

- The owner's thought-dump, verbatim.
- The data-type and trigger-point lists to organise.
- What is settled so far (lean-summary-plus-lookup retrieval, split durable memory, prose-first output).
- Candidate mechanics deliberately deferred, to reintroduce in plain language.
- Open questions to resume on.

Docs-only. No code or behaviour change.
