### PR TITLE
fix(analysis): stop interval-detection signals lowering non-interval confidence (#169)

### DIFF
--- a/backend/app/services/analysis/_orchestrator.py
+++ b/backend/app/services/analysis/_orchestrator.py
@@ -68,8 +68,13 @@ def compute_confidence(activity, streams_dict, check_in, interval_structure=None
     if not check_in:
         reasons.append("no_user_checkin")
 
-    # Interval-specific sanity checks
-    if workout_match:
+    # Interval-specific sanity checks. These reasons (no_intervals_detected,
+    # rep variability, match mismatch) only describe an interval session, so
+    # they must not lower the overall confidence of a non-interval activity
+    # (#169). The orchestrator nulls interval_structure when the structure axis
+    # did not resolve to intervals, so its presence is the "is interval session"
+    # gate; without it, workout_match's reasons stay confined to workout_match.
+    if interval_structure and workout_match:
         match_reasons = workout_match.get("confidence_reasons", [])
         for r in match_reasons:
             if r not in reasons:

--- a/backend/tests/snapshots/analysis/process_activity_default_fixture.json
+++ b/backend/tests/snapshots/analysis/process_activity_default_fixture.json
@@ -1,8 +1,7 @@
 {
   "confidence": "medium",
   "confidence_reasons": [
-    "no_gps_data",
-    "no_intervals_detected"
+    "no_gps_data"
   ],
   "duration_class": "standard",
   "efficiency_analysis": {

--- a/backend/tests/test_compute_confidence.py
+++ b/backend/tests/test_compute_confidence.py
@@ -61,3 +61,60 @@ def test_stream_sourced_structure_still_penalised():
     assert "work_time_implausibly_high" in reasons
     assert "no_warmup_detected" in reasons
     assert level == "medium"  # one critical hit
+
+
+# --- #169: interval-detection signals must not leak into the overall
+# confidence of a non-interval activity. When the structure axis did not
+# resolve to intervals, the orchestrator nulls interval_structure before this
+# call, so workout_match still reports "no_intervals_detected" but it must not
+# merge into the activity-level reasons.
+
+def test_non_interval_activity_does_not_carry_no_intervals_detected():
+    # A steady run: no interval structure, but match_planned_to_detected still
+    # produced its "no_intervals_detected" reason. It must not leak through.
+    workout_match = {
+        "confidence_reasons": ["no_intervals_detected"],
+        "match_score": None,
+    }
+
+    level, reasons = compute_confidence(
+        _activity(), _full_streams(), check_in=SimpleNamespace(),
+        interval_structure=None, workout_match=workout_match,
+    )
+
+    assert "no_intervals_detected" not in reasons
+
+
+def test_non_interval_activity_with_complete_data_stays_high():
+    # Otherwise-complete continuous activity (HR + GPS streams + check-in): the
+    # only thing that could drop it from high is the leaked interval reason.
+    workout_match = {
+        "confidence_reasons": ["no_intervals_detected"],
+        "match_score": None,
+    }
+
+    level, reasons = compute_confidence(
+        _activity(), _full_streams(), check_in=SimpleNamespace(),
+        interval_structure=None, workout_match=workout_match,
+    )
+
+    assert reasons == []
+    assert level == "high"
+
+
+def test_interval_session_still_merges_its_reasons():
+    # When the activity IS an interval session, the workout-match reasons and
+    # the match-score mismatch check still flow into overall confidence.
+    interval_structure = {"summary": {"total_work_time_s": 600}, "warmup_duration_s": 120}
+    workout_match = {
+        "confidence_reasons": ["high_rep_distance_variability"],
+        "match_score": 0.5,  # < 0.7 -> interval_structure_mismatch
+    }
+
+    level, reasons = compute_confidence(
+        _activity(), _full_streams(), check_in=SimpleNamespace(),
+        interval_structure=interval_structure, workout_match=workout_match,
+    )
+
+    assert "high_rep_distance_variability" in reasons
+    assert "interval_structure_mismatch" in reasons


### PR DESCRIPTION
Closes #169.

## What

Interval-detection confidence reasons (`no_intervals_detected`, rep-variability, match-mismatch) were leaking into the **overall** analysis confidence of every activity, not just interval sessions. Across the 25-activity real-data sample that surfaced this, 23 non-interval activities (every steady run, walk, ride, row, strength session) carried `no_intervals_detected` in their overall `confidence_reasons`, which can demote an otherwise-high continuous run and surfaces a misleading caveat the coach then repeats to the runner.

## Root cause

`compute_confidence` (`_orchestrator.py`) blind-merged `workout_match["confidence_reasons"]` into the overall reasons under a bare `if workout_match:`. Since `match_planned_to_detected` is called unconditionally and returns `["no_intervals_detected"]` whenever there is no interval structure, that reason leaked into every non-interval activity.

## Fix

Gate the merge on the activity actually being an interval session. The orchestrator already nulls `interval_structure` when the structure axis does not resolve to intervals (line 179-181), so its presence at the `compute_confidence` call site is the correct "is interval session" gate: `if interval_structure and workout_match:`.

- `match_planned_to_detected` is unchanged and still called unconditionally; `workout_match.confidence_reasons` still records `no_intervals_detected` on **its own** field for downstream consumers. Only the leak into activity-level confidence is closed.
- Composes cleanly with #170: the recorded-laps interval path keeps `interval_structure` present, so its reasons still merge and the existing source-aware block continues to protect it.

## Acceptance criteria

- [x] Interval-detection signals only affect overall confidence when the activity is an interval session.
- [x] A non-interval activity is never marked down for lacking intervals.
- [x] A continuous activity with otherwise-complete data is not demoted from high solely for having no interval structure.

## Tests / verification

- Three new regression tests in `test_compute_confidence.py`: non-interval activity drops the leaked reason, complete-data continuous activity stays `high`, and an interval session still merges its real reasons + `interval_structure_mismatch`. Red before the fix, green after.
- Full-pipeline snapshot (`test_analysis_interface.py`) regenerated: the **only** change to the DerivedMetric output is the single intended removal from top-level `confidence_reasons`; the `workout_match` sub-field is untouched.
- Full backend suite: 644 passed (641 baseline + 3 new). `make eval-selftest` green.

## Coverage gap that let it ship

The snapshot fixture had **captured** the buggy `confidence_reasons` value as expected truth, so the characterisation test green-lit the leak rather than catching it. The new unit tests now pin the corrected behaviour independently of the snapshot.

## Not done this PR

Did not re-run analysis over the real seeded dataset (needs `make seed-local`); the deterministic full-pipeline snapshot plus unit cases cover the logic, but a real-data reanalysis would be the strongest confirmation the ~23 affected activities now drop the reason. Happy to run it on request.
