### PR TITLE
fix(splits): time-split durations match the 5-min title (#174)

### DIFF
--- a/backend/app/services/analysis/splits.py
+++ b/backend/app/services/analysis/splits.py
@@ -327,7 +327,17 @@ def _compute_time_split_metrics(
     watts_stream,
 ) -> Dict[str, Any]:
     t_start = time_stream[start_idx]
-    t_end = time_stream[end_idx - 1] if end_idx > 0 else 0
+    # The split covers samples [start_idx, end_idx); its duration runs up to the
+    # boundary sample (the first sample past the interval mark), which is shared
+    # as the start of the next split. Using end_idx - 1 here excluded that
+    # boundary, so each full split spanned one sample-interval short of the
+    # target and consecutive splits left an unaccounted gap (#174). For the
+    # final partial split end_idx == len(time_stream), so fall back to the last
+    # sample.
+    if end_idx < len(time_stream):
+        t_end = time_stream[end_idx]
+    else:
+        t_end = time_stream[-1]
     time_diff = t_end - t_start
     if time_diff <= 0:
         time_diff = 1

--- a/backend/tests/test_time_splits.py
+++ b/backend/tests/test_time_splits.py
@@ -1,0 +1,46 @@
+"""Time-based split duration correctness (#174).
+
+When an activity has a `time` stream but no `distance` stream, splits fall
+back to fixed 5-minute (300 s) windows. The boundary handling used to exclude
+the crossing sample, so each full split spanned ~299 s instead of 300 s — which
+then floored to "4 min" in the UI under a "Splits (5 min)" title. A full split
+must span the whole interval and consecutive splits must be contiguous (their
+durations sum to the total activity duration).
+"""
+
+from types import SimpleNamespace
+
+from app.services.analysis.splits import calculate_splits
+
+
+def _stream(stream_type, data):
+    return SimpleNamespace(stream_type=stream_type, data=data)
+
+
+def _time_only_streams(total_s):
+    # 1 Hz time stream, no distance stream -> time-based split fallback.
+    return [_stream("time", list(range(total_s + 1)))]
+
+
+def test_full_time_splits_span_the_whole_interval():
+    # 11 minutes -> two full 5-min splits + a 1-min partial.
+    splits = calculate_splits(_time_only_streams(660))
+
+    assert [s["split_type"] for s in splits] == ["time", "time", "time"]
+    full = [s for s in splits[:2]]
+    assert all(s["elapsed_time"] == 300 for s in full), [s["elapsed_time"] for s in full]
+
+
+def test_partial_last_split_keeps_its_true_duration():
+    splits = calculate_splits(_time_only_streams(660))
+
+    # 660 s total - 600 s of full splits = 60 s remainder.
+    assert splits[-1]["elapsed_time"] == 60
+
+
+def test_time_splits_are_contiguous_no_gap_between_them():
+    # The durations of all splits must sum to the full activity duration; the
+    # off-by-one previously dropped one sample-interval per full split.
+    splits = calculate_splits(_time_only_streams(660))
+
+    assert sum(s["elapsed_time"] for s in splits) == 660

--- a/frontend/components/SplitsPanel.tsx
+++ b/frontend/components/SplitsPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Split } from '@/lib/types/activity';
-import { formatPace, formatDistanceKm, formatDuration } from '@/lib/format';
+import { formatPace, formatDistanceKm, formatSplitDuration } from '@/lib/format';
 
 interface SplitsPanelProps {
   splits?: Split[];
@@ -72,7 +72,7 @@ export function SplitsPanel({ splits }: SplitsPanelProps) {
                 )}
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
                   {isTimeBased
-                    ? formatDuration(split.elapsed_time)
+                    ? formatSplitDuration(split.elapsed_time)
                     : split.distance != null
                       ? formatPace(split.distance, split.elapsed_time)
                       : '-'}

--- a/frontend/lib/format.ts
+++ b/frontend/lib/format.ts
@@ -22,6 +22,22 @@ export function formatDuration(seconds: number): string {
   return `${m} min`;
 }
 
+/**
+ * Format a split duration as "m:ss" (e.g. "5:00", "4:59").
+ *
+ * Splits are short and near a round interval, so flooring to whole minutes
+ * (formatDuration) misleadingly renders a 5:00 split as "4 min" / hides the
+ * remainder of a partial split. The seconds precision keeps the value honest
+ * and consistent with the "Splits (5 min)" title (#174).
+ */
+export function formatSplitDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  // A rounded-up 60 s belongs to the next minute.
+  if (s === 60) return `${m + 1}:00`;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
 /** Format metres to km with two decimal places. */
 export function formatDistanceKm(metres: number): string {
   return `${(metres / 1000).toFixed(2)} km`;


### PR DESCRIPTION
Closes #174.

## What

On the activity detail page, the **Splits** card was titled **"Splits (5 min)"** for time-based splits (activities with a `time` stream but no `distance` — treadmill/indoor/non-GPS), while every row's **Duration** read **"4 min"**. The title and the rows disagreed.

## Root cause (two compounding bugs)

1. **Backend off-by-one** in `_compute_time_split_metrics` (`splits.py`): `t_end` used `time[end_idx - 1]` — the last sample *before* the interval boundary — so each full split spanned ≈299 s instead of 300 s, and a sample-interval gap between consecutive splits went unaccounted (cumulative under-count).
2. **Frontend flooring**: `formatDuration` floors `~299 s` to `"4 min"`.

## Fix

- **Backend:** the split now spans up to the boundary sample `time[end_idx]` (shared as the next split's start), falling back to the last sample for the final partial split. Full splits are now a true 300 s and per-split durations sum to the full activity duration. Only the time-split path changed; the distance-split function is untouched.
- **Frontend:** added a dedicated `formatSplitDuration` (`m:ss`) used **only** by the splits table, so a full split reads `5:00` and a partial split shows its true value (e.g. `1:00`). The shared `formatDuration` and its 4 other callers (StopsPanel, trends, activity detail) are deliberately untouched.
- The hardcoded `"Splits (5 min)"` title is now accurate, so it was left as-is.

## Acceptance criteria

- [x] Split duration shown in the table matches the interval named in the title (5-min splits read `5:00`).
- [x] Title and rows are consistent.

## Tests / verification

- The splits module had **no** direct tests. Added `test_time_splits.py`: full splits span 300 s (red→green on the off-by-one), the partial last split keeps its true duration, and all split durations sum to the full activity time (`660 s`, was `658 s`).
- Full backend suite: 647 passed (644 baseline + 3 new), including the `analyze` snapshot test — confirms distance splits are unaffected.
- Frontend `npm run test` (lint + `next build`) green; the new helper is a pure addition.

## Not done this PR

- No real-data reanalysis of a no-GPS activity (needs `seed-local`); the tests use a 1 Hz time stream, the exact shape the real path consumes.
- The visual `5:00`-under-`Splits (5 min)` confirmation is a UI/real-device judgement (no frontend component-test runner exists). Worth an eyeball on a treadmill/indoor activity.

## Out of scope (flagged, not changed)

The distance-split function (`_compute_split_metrics`) shares the same `end_idx - 1` pattern internally, but its displayed value is *pace* (a self-consistent ratio over the covered samples), so it is not the reported defect.
