### PR TITLE
chore(coach): move default model to claude-sonnet-4-6

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -29,7 +29,7 @@ class Settings(BaseSettings):
 
     # Coach AI
     ANTHROPIC_API_KEY: str = ""
-    COACH_MODEL_ID: str = "claude-sonnet-4-20250514"
+    COACH_MODEL_ID: str = "claude-sonnet-4-6"
     COACH_PROMPT_ID: str = "coach_report_v9"
 
     # Coach-report notifications. Channel selection (see

--- a/backend/app/services/coach/llm.py
+++ b/backend/app/services/coach/llm.py
@@ -25,7 +25,7 @@ class LLMClient(Protocol):
 class AnthropicClient:
     """Anthropic Claude client for JSON generation."""
 
-    def __init__(self, api_key: str, model: str = "claude-sonnet-4-20250514"):
+    def __init__(self, api_key: str, model: str = "claude-sonnet-4-6"):
         import anthropic
 
         self.client = anthropic.AsyncAnthropic(api_key=api_key)

--- a/backend/tests/test_email_template.py
+++ b/backend/tests/test_email_template.py
@@ -46,7 +46,7 @@ def _build_report(*, headline: str = "Easy", confidence: str = "medium") -> Coac
         ),
         meta=CoachReportMeta(
             confidence=confidence,
-            model_id="claude-sonnet-4-20250514",
+            model_id="claude-sonnet-4-6",
             prompt_id="coach_report_v1",
             schema_version="1.1",
             input_hash="abc123",


### PR DESCRIPTION
Closes #198.

## What
Moves the default coach model off the **deprecated** `claude-sonnet-4-20250514` (retires 2026-06-15) to `claude-sonnet-4-6` — the vendor drop-in replacement at the **same Sonnet price tier** ($3/$15 per MTok), newer and stronger, 1M context.

Three spots:
- `app/core/config.py` — `COACH_MODEL_ID` default (drives both the report path in `service.py` and the chat path in `chat.py`)
- `app/services/coach/llm.py` — `AnthropicClient` fallback default
- `tests/test_email_template.py` — fixture string (cosmetic)

## Why it's a clean swap
`llm.py` sends only `temperature` (valid on Sonnet 4.6) plus a single user message — no last-turn assistant prefill, no `budget_tokens`, no `top_p`. None of the parameters that 400 on Sonnet 4.6 are in play, so no request-shape migration is needed.

## Scope
Deliberately standalone and **pre-A2c**, so the model swap's effect on report wording stays isolated from the upcoming narrative work and from the M5 eval baseline.

## Verification
- `make backend-test`: **691 passed**, 2 deselected (unchanged from main's baseline).
- Repo grep confirms no other production code referenced the old model string (only the SDK's own model enum in `.venv`, untouched).
- **Not verified (deferred, quota-conscious):** live report quality under Sonnet 4.6. The M5 `make eval` scores *stored* reports, so it's model-independent; a true before/after needs a paid `make eval --regenerate` or a preview run. Happy to run it on request.

## Prod action required (owner)
Production's actual model depends on Railway's `COACH_MODEL_ID` env var. If it's pinned to the old string there, **update or unset it** for prod to pick up Sonnet 4.6 — this PR only changes the code default + local/dev.