### PR TITLE
refactor(coach): extract policy validator rules into shared rule bodies (A3 step 1)

### DIFF
--- a/backend/app/services/coach/validator.py
+++ b/backend/app/services/coach/validator.py
@@ -170,23 +170,24 @@ def _has_asserted_health_claim(text: str) -> bool:
     return False
 
 
-def validate_policy(
-    content: CoachReportContent,
-    context_pack: CoachContextPack,
-) -> List[PolicyViolation]:
-    """
-    Run deterministic policy checks on LLM output.
-    Returns list of violations (empty = all checks passed).
-    """
-    violations = []
+# --- Shared rule bodies ----------------------------------------------------
+# Each of the six rules is a standalone function over the primitives it needs
+# (a text surface, structured flags/questions/evidence, the relevant pack
+# facts) rather than the CoachReportContent shape. validate_policy below
+# assembles those primitives from a structured report; a future prose entry
+# point assembles the same primitives from the message + tail. The rule logic,
+# violation order, and every detail/fix_instruction string live here once, so
+# both entry points police an identical surface. (A3 step 1: this extraction is
+# behaviour-preserving — validate_policy emits byte-identical violations.)
 
-    # Rule 1: If all check_in fields are null and questions is empty → must ask questions
-    check_in = context_pack.check_in
+
+def check_missing_questions(check_in, num_questions: int) -> List[PolicyViolation]:
+    """Rule 1: a null check-in with no questions must prompt for input."""
     all_null = all(
         getattr(check_in, field) is None for field in type(check_in).model_fields
     )
-    if all_null and len(content.questions) == 0:
-        violations.append(PolicyViolation(
+    if all_null and num_questions == 0:
+        return [PolicyViolation(
             rule="missing_questions_for_null_checkin",
             detail="All check_in fields are null but no questions were generated",
             fix_instruction=(
@@ -194,14 +195,16 @@ def validate_policy(
                 "runner felt during the session. Example: 'How did you feel during "
                 "the session?' with reason 'No check-in data available'."
             ),
-        ))
+        )]
+    return []
 
-    # Rule 2: If zones_calibrated=false and output mentions Z1/Z2/Z3/Z4/Z5
-    if not context_pack.metrics.zones_calibrated:
-        full_text = _extract_all_text(content)
+
+def check_uncalibrated_zones(zones_calibrated: bool, full_text: str) -> List[PolicyViolation]:
+    """Rule 2: no Z1-Z5 references when the runner's zones are not calibrated."""
+    if not zones_calibrated:
         zone_pattern = re.compile(r"\bZ[1-5]\b")
         if zone_pattern.search(full_text):
-            violations.append(PolicyViolation(
+            return [PolicyViolation(
                 rule="uncalibrated_zone_reference",
                 detail="Output references HR zones but zones_calibrated is false",
                 fix_instruction=(
@@ -210,51 +213,57 @@ def validate_policy(
                     "effort' (RPE 4-5), 'comfortably hard' (RPE 6-7), 'hard "
                     "threshold effort' (RPE 8), 'maximum effort' (RPE 9-10)."
                 ),
-            ))
+            )]
+    return []
 
-    # Rule 3: If risk references a flag not in the flags array
-    valid_flags = set(context_pack.metrics.flags)
-    for risk in content.risks:
-        if risk.flag not in valid_flags:
+
+def check_invalid_risk_flags(valid_flags: set, risk_flags: List[str]) -> List[PolicyViolation]:
+    """Rule 3: every risk must reference a flag present in the metrics flags."""
+    violations: List[PolicyViolation] = []
+    for flag in risk_flags:
+        if flag not in valid_flags:
             violations.append(PolicyViolation(
                 rule="invalid_risk_flag",
-                detail=f"Risk references flag '{risk.flag}' not in flags array {valid_flags}",
+                detail=f"Risk references flag '{flag}' not in flags array {valid_flags}",
                 fix_instruction=(
-                    f"Remove the risk entry for '{risk.flag}' or only reference "
+                    f"Remove the risk entry for '{flag}' or only reference "
                     f"flags from: {sorted(valid_flags)}"
                 ),
             ))
+    return violations
 
-    # Rule 4: If detection_confidence < high and LLM claims specific interval execution
-    workout_match = context_pack.metrics.workout_match
-    if workout_match:
-        det_conf = workout_match.get("detection_confidence", "low")
-        match_score = workout_match.get("match_score")
-        low_confidence = det_conf == "low" or (
-            match_score is not None and match_score < 0.7
-        )
-        if low_confidence:
-            full_text = _extract_all_text(content)
-            for pattern in _INTERVAL_CLAIM_PATTERNS:
-                if pattern.search(full_text):
-                    violations.append(PolicyViolation(
-                        rule="ungated_interval_claim",
-                        detail=(
-                            f"LLM claims specific interval execution but "
-                            f"detection_confidence={det_conf}, match_score={match_score}"
-                        ),
-                        fix_instruction=(
-                            "Detection confidence is low. Do NOT claim specific rep counts, "
-                            "distances, or interval structure as fact. Instead say: "
-                            "'Your data suggests the intervals were not consistently detected. "
-                            "Consider using the lap button or running on a track for better "
-                            "rep-by-rep feedback.' Treat all rep statistics as approximate."
-                        ),
-                    ))
-                    break  # One violation is enough
 
-    # Rule 5: medical-scope boundary — reject medical overreach (plan section 8).
-    full_text = _extract_all_text(content)
+def check_ungated_interval_claim(workout_match, full_text: str) -> List[PolicyViolation]:
+    """Rule 4: no specific interval-execution claims under low detection confidence."""
+    if not workout_match:
+        return []
+    det_conf = workout_match.get("detection_confidence", "low")
+    match_score = workout_match.get("match_score")
+    low_confidence = det_conf == "low" or (
+        match_score is not None and match_score < 0.7
+    )
+    if low_confidence:
+        for pattern in _INTERVAL_CLAIM_PATTERNS:
+            if pattern.search(full_text):
+                return [PolicyViolation(
+                    rule="ungated_interval_claim",
+                    detail=(
+                        f"LLM claims specific interval execution but "
+                        f"detection_confidence={det_conf}, match_score={match_score}"
+                    ),
+                    fix_instruction=(
+                        "Detection confidence is low. Do NOT claim specific rep counts, "
+                        "distances, or interval structure as fact. Instead say: "
+                        "'Your data suggests the intervals were not consistently detected. "
+                        "Consider using the lap button or running on a track for better "
+                        "rep-by-rep feedback.' Treat all rep statistics as approximate."
+                    ),
+                )]  # One violation is enough
+    return []
+
+
+def check_medical_overreach(full_text: str) -> List[PolicyViolation]:
+    """Rule 5: medical-scope boundary — reject medical overreach (plan section 8)."""
     medical_reason = None
     if _DOSE_PATTERN.search(full_text):
         medical_reason = "contains dose advice (a pharmaceutical dose or dosage instruction)"
@@ -265,7 +274,7 @@ def validate_policy(
     elif _has_asserted_health_claim(full_text):
         medical_reason = "asserts a clinical condition about the runner"
     if medical_reason:
-        violations.append(PolicyViolation(
+        return [PolicyViolation(
             rule="medical_overreach",
             detail=f"Output {medical_reason}, which is outside the coaching scope",
             fix_instruction=(
@@ -276,15 +285,17 @@ def validate_policy(
                 "it was hot, so it overstates fatigue') and you MAY suggest seeing a "
                 "clinician as a non-diagnostic nudge. Rephrase to remove the overreach."
             ),
-        ))
+        )]
+    return []
 
-    # Rule 6: the durable-memory narrative is voice only — never cite it as fact.
+
+def check_narrative_evidence(evidence_field_paths: List[str]) -> List[PolicyViolation]:
+    """Rule 6: the durable-memory narrative is voice only — never cited as fact."""
     narrative_fields = [
-        f for f in _collect_evidence_fields(content)
-        if _NARRATIVE_FIELD_PATTERN.match(f)
+        f for f in evidence_field_paths if _NARRATIVE_FIELD_PATTERN.match(f)
     ]
     if narrative_fields:
-        violations.append(PolicyViolation(
+        return [PolicyViolation(
             rule="narrative_cited_as_fact",
             detail=(
                 "Evidence cites the relationship narrative as a factual source: "
@@ -298,7 +309,39 @@ def validate_policy(
                 "deterministic facts, or drop the claim. The narrative may shape "
                 "your tone but must never be cited as evidence."
             ),
-        ))
+        )]
+    return []
+
+
+def validate_policy(
+    content: CoachReportContent,
+    context_pack: CoachContextPack,
+) -> List[PolicyViolation]:
+    """
+    Run deterministic policy checks on structured LLM output.
+    Returns list of violations (empty = all checks passed).
+
+    Assembles the rule primitives from the structured report and delegates each
+    rule to its shared body. The violation order (rules 1-6) and every emitted
+    string are preserved from the prior inline implementation.
+    """
+    full_text = _extract_all_text(content)
+    violations: List[PolicyViolation] = []
+
+    # Rule 1: null check-in with no questions → must ask questions.
+    violations += check_missing_questions(context_pack.check_in, len(content.questions))
+    # Rule 2: uncalibrated zones must not surface Z1-Z5.
+    violations += check_uncalibrated_zones(context_pack.metrics.zones_calibrated, full_text)
+    # Rule 3: risks must reference real flags.
+    violations += check_invalid_risk_flags(
+        set(context_pack.metrics.flags), [risk.flag for risk in content.risks]
+    )
+    # Rule 4: gate specific interval claims on detection confidence.
+    violations += check_ungated_interval_claim(context_pack.metrics.workout_match, full_text)
+    # Rule 5: medical-scope boundary.
+    violations += check_medical_overreach(full_text)
+    # Rule 6: narrative is voice only, never cited evidence.
+    violations += check_narrative_evidence(_collect_evidence_fields(content))
 
     return violations
 

--- a/backend/tests/test_policy_validator.py
+++ b/backend/tests/test_policy_validator.py
@@ -2,7 +2,15 @@
 
 from app.schemas.coach import CoachReportContent, CoachTakeaway, CoachNextStep, CoachRisk, CoachQuestion
 from app.schemas.coach_context import CoachContextPack
-from app.services.coach.validator import validate_policy
+from app.services.coach.validator import (
+    validate_policy,
+    check_missing_questions,
+    check_uncalibrated_zones,
+    check_invalid_risk_flags,
+    check_ungated_interval_claim,
+    check_medical_overreach,
+    check_narrative_evidence,
+)
 
 
 def _make_content(**overrides):
@@ -600,3 +608,80 @@ class TestMedicalScopeRule:
         )
         violations = validate_policy(content, _make_pack())
         assert "medical_overreach" not in [v.rule for v in violations]
+
+
+class TestSharedRuleBodies:
+    """The six rules are extracted into shared functions over primitives so a
+    future prose entry point can reuse them. These exercise each body directly
+    (the reuse contract); the byte-equivalence of the assembled validate_policy
+    is pinned by the rest of this file's 46 behaviour tests staying green."""
+
+    def _null_check_in(self):
+        return _make_pack(check_in={
+            "rpe": None, "pain_score": None, "pain_location": None,
+            "sleep_quality": None, "notes": None,
+        }).check_in
+
+    def _populated_check_in(self):
+        return _make_pack().check_in  # rpe=6, etc.
+
+    # Rule 1
+    def test_missing_questions_fires_on_null_checkin_no_questions(self):
+        v = check_missing_questions(self._null_check_in(), 0)
+        assert [x.rule for x in v] == ["missing_questions_for_null_checkin"]
+
+    def test_missing_questions_silent_with_questions_present(self):
+        assert check_missing_questions(self._null_check_in(), 2) == []
+
+    def test_missing_questions_silent_when_checkin_populated(self):
+        assert check_missing_questions(self._populated_check_in(), 0) == []
+
+    # Rule 2
+    def test_uncalibrated_zones_fires_on_zone_reference(self):
+        v = check_uncalibrated_zones(False, "You spent time in Z3 today.")
+        assert [x.rule for x in v] == ["uncalibrated_zone_reference"]
+
+    def test_uncalibrated_zones_silent_when_calibrated(self):
+        assert check_uncalibrated_zones(True, "You spent time in Z3 today.") == []
+
+    def test_uncalibrated_zones_silent_without_zone_tokens(self):
+        assert check_uncalibrated_zones(False, "Easy conversational effort.") == []
+
+    # Rule 3
+    def test_invalid_risk_flags_fires_per_unknown_flag(self):
+        v = check_invalid_risk_flags({"hr_drift"}, ["hr_drift", "made_up", "also_fake"])
+        assert [x.rule for x in v] == ["invalid_risk_flag", "invalid_risk_flag"]
+        assert "made_up" in v[0].detail and "also_fake" in v[1].detail
+
+    def test_invalid_risk_flags_silent_when_all_valid(self):
+        assert check_invalid_risk_flags({"hr_drift", "stops"}, ["hr_drift"]) == []
+
+    # Rule 4
+    def test_ungated_interval_claim_fires_on_low_confidence(self):
+        wm = {"detection_confidence": "low", "match_score": None}
+        v = check_ungated_interval_claim(wm, "You ran 8x400m today.")
+        assert [x.rule for x in v] == ["ungated_interval_claim"]
+
+    def test_ungated_interval_claim_silent_on_high_confidence(self):
+        wm = {"detection_confidence": "high", "match_score": 1.0}
+        assert check_ungated_interval_claim(wm, "You ran 8x400m today.") == []
+
+    def test_ungated_interval_claim_silent_without_workout_match(self):
+        assert check_ungated_interval_claim(None, "You ran 8x400m today.") == []
+
+    # Rule 5
+    def test_medical_overreach_fires_on_dose(self):
+        v = check_medical_overreach("Take 200mg of iron daily.")
+        assert [x.rule for x in v] == ["medical_overreach"]
+
+    def test_medical_overreach_silent_on_clean_text(self):
+        assert check_medical_overreach("Nice steady aerobic run.") == []
+
+    # Rule 6
+    def test_narrative_evidence_fires_on_narrative_path(self):
+        v = check_narrative_evidence(["metrics.hr_drift", "narrative.tone"])
+        assert [x.rule for x in v] == ["narrative_cited_as_fact"]
+        assert "narrative.tone" in v[0].detail
+
+    def test_narrative_evidence_silent_on_real_paths(self):
+        assert check_narrative_evidence(["metrics.hr_drift", "training_context.x"]) == []


### PR DESCRIPTION
## A3 step 1: extract policy validator rules into shared rule bodies

First PR of the A3 split (#205, design in #204 / ADR 0009). A pure, behaviour-preserving refactor of the deterministic safety gate, landed ahead of the feature work so the new prose-generation path reviews against an already-proven base.

### What changed

The six policy rules lived inline inside `validate_policy`. Each is now a standalone `check_*` function over the primitives it needs — a text surface, structured risk flags / question count, evidence field paths, and the relevant pack facts — rather than the `CoachReportContent` shape. `validate_policy` now assembles those primitives from the structured report and delegates to the shared bodies, in the same rule order (1-6).

This is the seam A3 needs: the upcoming `validate_message_policy` will assemble the **same** primitives from the prose message + structured tail, so both entry points police one identical rule surface instead of duplicating six rules.

### Behaviour preservation

- Rule logic, violation order, and every `rule` / `detail` / `fix_instruction` string are copied verbatim. Emitted violations are byte-identical.
- The oracle is the existing **46 characterization tests** asserting exact violations and detail strings across all six rules; they stay green.
- 15 new unit tests exercise each extracted body directly (the reuse contract that justifies the extraction).
- Full backend suite: **735 passed**, 2 deselected (was 720). Eval-selftest green (the rubric reuses rule 5).

### Scope decision for the reviewer

I kept this PR to the validator extraction only. The brief's step 1 also mentions turning `SCHEMA_VERSION` into a prompt-family map; I deferred that to the A3 feature PR, where it gains an actual consumer (the `coach_message` family). Landing a single-entry family map now would be dead infra. No prompt / schema / SCHEMA_VERSION / migration change in this PR.

### Verification

Refactor modality: oracle = captured behaviour of the current validator (the 46 tests). Validator is deterministic pure logic exercised through `service.py` and the eval rubric in the full suite; no live-LLM run applies. Risk: low (mechanical extraction, comprehensive characterization).

Refs #205. Part of epic #177 (A3).
