### PR TITLE
chore(coach): monitor tail_degraded via a greppable prod log line

### DIFF
--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -172,6 +172,19 @@ async def get_or_generate_coach_report(
     else:
         outcome = await _generate_structured(client, system_prompt, user_message, pack)
 
+    # Monitoring (A3): one greppable WARNING per stored degraded tail — a real prose
+    # message produced but no usable structured tail (the loop abstains on it). This
+    # is the single chokepoint covering every degrade path, so it surfaces the
+    # `tail_degraded` rate in prod logs / Sentry without a batch job; the eval
+    # scorecard's tail_degraded counter is the complementary batch view.
+    if outcome.tail_degraded:
+        logger.warning(
+            "coach_tail_degraded: stored a prose message with a degraded tail "
+            "(activity=%s, prompt=%s); the learning loop abstains on this report",
+            activity_uuid,
+            prompt_id,
+        )
+
     meta = CoachReportMeta(
         confidence=pack.metrics.confidence,
         model_id=settings.COACH_MODEL_ID,

--- a/backend/tests/test_message_service.py
+++ b/backend/tests/test_message_service.py
@@ -239,6 +239,31 @@ class TestMessageServicePath:
         assert "couldn't put together" in stored.report["message"]
 
     @pytest.mark.asyncio
+    async def test_degraded_tail_emits_monitor_warning(self, db, _message_prompt, caplog):
+        """The single greppable monitor signal: a stored degraded tail logs a
+        `coach_tail_degraded` WARNING (visible in prod logs / Sentry)."""
+        import logging
+        activity = _seed_activity_with_metrics(db)
+        blocks = [_text("Good easy run, nothing to flag.")]  # no tail block -> degrades
+        with caplog.at_level(logging.WARNING, logger="app.services.coach.service"):
+            with patch("app.services.coach.service.AnthropicClient", return_value=_message_client(blocks)):
+                await get_or_generate_coach_report(db, str(activity.id))
+        assert any("coach_tail_degraded" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_clean_tail_does_not_emit_monitor_warning(self, db, _message_prompt, caplog):
+        import logging
+        activity = _seed_activity_with_metrics(db)
+        blocks = [
+            _text("Solid steady run. You held the effort well."),
+            _tail(headline="Solid run", next_steps=[], risks=[], questions=[]),
+        ]
+        with caplog.at_level(logging.WARNING, logger="app.services.coach.service"):
+            with patch("app.services.coach.service.AnthropicClient", return_value=_message_client(blocks)):
+                await get_or_generate_coach_report(db, str(activity.id))
+        assert not any("coach_tail_degraded" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
     async def test_message_family_does_not_writeback_on_fallback(self, db, _message_prompt):
         """Fallbacks must not feed the learning loop (no digest stored)."""
         activity = _seed_activity_with_metrics(db)


### PR DESCRIPTION
Implements the agreed monitoring for the A3 prose path (we kept strict-tool OFF, so the degrade-not-withhold path is the safety net we want to watch).

A degraded tail — a real prose message produced but no usable structured tail, on which the M7 learning loop abstains — is now logged once at the storage chokepoint as `coach_tail_degraded` (with activity + prompt). This makes the degrade rate visible in Railway logs / Sentry passively, with no batch job. It complements the eval scorecard's existing `tail_degraded` counter (the batch view, via `make eval` on seeded data).

The live rehearsal measured a 0% degrade rate over 10 real generations, so this is a watchdog, not a fix for an active problem; if the prod rate climbs it's the concrete signal to revisit enabling the strict tool.

- One WARNING at the single chokepoint covering every degrade path.
- 2 caplog tests: fires on a degraded tail, silent on a clean one.
- 807 backend pass; policy gate 22/22. No behaviour change beyond the log line.