### PR TITLE
I1a: in-app tappable RPE/pain input + checkin range validation

### DIFF
--- a/backend/app/schemas/checkin.py
+++ b/backend/app/schemas/checkin.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class CheckInBase(BaseModel):
@@ -14,7 +14,12 @@ class CheckInBase(BaseModel):
 
 
 class CheckInCreate(CheckInBase):
-    pass
+    # Server-side range validation at the write boundary (#156). Domain ranges
+    # per CONTEXT.md: RPE 1-10 (Borg), pain_score 0-10. Out-of-range input is
+    # rejected (422) rather than silently stored and clamped downstream. The
+    # read model stays permissive so any legacy out-of-range row still serialises.
+    rpe: Optional[int] = Field(default=None, ge=1, le=10)
+    pain_score: Optional[int] = Field(default=None, ge=0, le=10)
 
 
 class CheckInRead(CheckInBase):

--- a/backend/tests/test_checkin_validation.py
+++ b/backend/tests/test_checkin_validation.py
@@ -1,0 +1,78 @@
+"""Server-side range validation at the check-in write boundary (#156).
+
+Tappable RPE/pain input (I1a) is a new write path for these exact fields, so the
+schema must reject out-of-range values (422) rather than store them and let the
+downstream perceived-effort code clamp silently. Domain ranges per CONTEXT.md:
+RPE 1-10 (Borg), pain_score 0-10.
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from app.models import Activity, User
+
+
+def _user(db):
+    u = User(id=uuid4(), email=f"u-{uuid4()}@example.com")
+    db.add(u)
+    db.flush()
+    return u.id
+
+
+def _activity(db, uid):
+    a = Activity(
+        id=uuid4(), user_id=uid, strava_activity_id=abs(hash(str(uuid4()))) % 10**9,
+        start_date=datetime(2026, 5, 27, 10, 0, 0), type="Run", name="Run",
+        distance_m=5000, moving_time_s=1500, elapsed_time_s=1500, elev_gain_m=10.0,
+        avg_hr=140, raw_summary={},
+    )
+    db.add(a)
+    db.flush()
+    return a
+
+
+@pytest.fixture
+def activity_id(db):
+    a = _activity(db, _user(db))
+    db.commit()
+    return a.id
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"rpe": 0},          # below Borg floor
+        {"rpe": 11},         # above Borg ceiling
+        {"rpe": -3},
+        {"pain_score": -1},  # below floor
+        {"pain_score": 11},  # above ceiling
+    ],
+)
+def test_out_of_range_is_rejected(db, client, activity_id, payload):
+    resp = client.post(f"/api/activities/{activity_id}/checkin", json=payload)
+    assert resp.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"rpe": 1},
+        {"rpe": 10},
+        {"pain_score": 0},
+        {"pain_score": 10},
+        {"rpe": 7, "pain_score": 2},
+        {"rpe": None, "pain_score": None},  # null is still allowed (no check-in value)
+        {"notes": "felt easy"},             # other fields unaffected
+    ],
+)
+def test_in_range_is_accepted(db, client, activity_id, payload):
+    # Isolate the validation boundary from the endpoint's downstream side effects
+    # (re-analysis + reply-path enqueue), which are exercised elsewhere.
+    with patch("app.api.activities.analysis.analyze"), patch(
+        "app.jobs.process_new_activity.maybe_enqueue_fuller_turn"
+    ):
+        resp = client.post(f"/api/activities/{activity_id}/checkin", json=payload)
+    assert resp.status_code == 200

--- a/frontend/components/CoachReportPanel.tsx
+++ b/frontend/components/CoachReportPanel.tsx
@@ -27,6 +27,36 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
   const [status, setStatus] = useState<'checking' | 'idle' | 'loading' | 'loaded' | 'error'>('checking');
   const [errorMsg, setErrorMsg] = useState('');
 
+  // I1a: tappable RPE/pain input. One answer per question; key by question index.
+  // A tap writes a CheckIn (rpe → rpe, pain → pain_score) and the server fires the
+  // fuller turn when the exchange is open. Conversational reply/dispute options are
+  // out of scope here (they belong to I2 chat-as-continuation).
+  const [tapState, setTapState] = useState<Record<number, 'sending' | 'sent' | 'error'>>({});
+  const [chosenOption, setChosenOption] = useState<Record<number, string>>({});
+
+  const handleOptionTap = useCallback(
+    async (qIndex: number, opt: { id: string; kind: string; payload?: unknown }) => {
+      if (opt.kind !== 'rpe' && opt.kind !== 'pain') return;
+      const value = Number(opt.payload);
+      if (!Number.isFinite(value)) return;
+      const field = opt.kind === 'rpe' ? 'rpe' : 'pain_score';
+      setChosenOption((prev) => ({ ...prev, [qIndex]: opt.id }));
+      setTapState((prev) => ({ ...prev, [qIndex]: 'sending' }));
+      try {
+        const res = await fetch(`/api/activities/${activityId}/checkin`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ [field]: value }),
+        });
+        if (!res.ok) throw new Error(`Failed (${res.status})`);
+        setTapState((prev) => ({ ...prev, [qIndex]: 'sent' }));
+      } catch {
+        setTapState((prev) => ({ ...prev, [qIndex]: 'error' }));
+      }
+    },
+    [activityId],
+  );
+
   const fetchReport = useCallback(async (generateIfMissing: boolean, force = false) => {
     setStatus('loading');
     setErrorMsg('');
@@ -239,15 +269,46 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
                       <p className="text-blue-900 text-sm font-medium">{q.question}</p>
                       <p className="text-blue-600 text-xs mt-1 italic">{q.reason}</p>
                       {q.options.length > 0 && (
-                        <div className="flex flex-wrap gap-2 mt-2">
-                          {q.options.map((opt) => (
-                            <span
-                              key={opt.id}
-                              className="inline-flex items-center rounded-full border border-blue-300 bg-white px-3 py-1 text-xs font-medium text-blue-700"
-                            >
-                              {opt.label}
-                            </span>
-                          ))}
+                        <div className="flex flex-wrap items-center gap-2 mt-2">
+                          {q.options.map((opt) => {
+                            // I1a delivers RPE/pain taps (the milestone's "quick
+                            // RPE/pain options"); other kinds render as before.
+                            const interactive = opt.kind === 'rpe' || opt.kind === 'pain';
+                            const answered = tapState[i] === 'sent';
+                            const sending = tapState[i] === 'sending';
+                            const isChosen = chosenOption[i] === opt.id;
+                            if (!interactive) {
+                              return (
+                                <span
+                                  key={opt.id}
+                                  className="inline-flex items-center rounded-full border border-blue-300 bg-white px-3 py-1 text-xs font-medium text-blue-700"
+                                >
+                                  {opt.label}
+                                </span>
+                              );
+                            }
+                            return (
+                              <button
+                                key={opt.id}
+                                type="button"
+                                disabled={sending || answered}
+                                onClick={() => handleOptionTap(i, opt)}
+                                className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors disabled:cursor-default ${
+                                  isChosen && answered
+                                    ? 'border-green-400 bg-green-100 text-green-800'
+                                    : 'border-blue-300 bg-white text-blue-700 hover:bg-blue-100 disabled:opacity-50'
+                                }`}
+                              >
+                                {opt.label}
+                              </button>
+                            );
+                          })}
+                          {tapState[i] === 'sent' && (
+                            <span className="text-xs text-green-700">Thanks — got it</span>
+                          )}
+                          {tapState[i] === 'error' && (
+                            <span className="text-xs text-red-600">Couldn’t save — tap to retry</span>
+                          )}
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
Closes #218. Folds in #156. Part of the I1 milestone (Phase 3) under epic #177.

## What
The A4 opener already emits typed `TappableOption`s on its coach questions, and the frontend already rendered them — but as dead chips. This makes the **RPE/pain** options tappable in the web app:

- An `rpe` chip → button that POSTs a `CheckIn` `{rpe}`; a `pain` chip → `{pain_score}`.
- Both reuse the existing `POST /api/activities/{id}/checkin` endpoint, which already calls `maybe_enqueue_fuller_turn`, so a tap fires the A4 fuller turn when the exchange is open. No new pipeline wiring.
- The button disables after a tap and shows a brief confirmation; an error is retryable.
- Other option kinds (`reply`/`dispute`/`custom`) render unchanged as non-interactive chips.

## Scope
Narrowed to the epic's own I1 definition — "tappable low-effort input (**quick RPE/pain options**)". Conversational `reply`/`dispute` taps are deferred to **I2 (chat-as-continuation)**, which owns folding chat into the relationship; routing them through the streaming chat endpoint here would duplicate that surface. Telegram inline-keyboard delivery is **I1b** (separate follow-up).

## Folds in #156
Tappable RPE/pain is a new write path for those exact fields, and `CheckInCreate` had no server-side range validation. Added range validation (RPE 1-10, pain_score 0-10) at the write boundary so out-of-range input is rejected (422) rather than stored and clamped downstream. `CheckInRead` stays permissive so any legacy out-of-range row still serialises.

## Verification
- New `backend/tests/test_checkin_validation.py` — 12 cases (422 out-of-range, 200 in-range). Full backend suite **905 pass** (+12). Frontend `next lint` + `next build` clean.
- **Runtime, real data**: against the seeded local DB, opened a schema-2.0 report with an RPE question, tapped "Hard (7-8)" → `POST /checkin` 200 → DB persisted `rpe=7`. Confirmed RPE options are interactive buttons, `custom` options stay non-interactive, buttons disable after the tap.

### Unverified surface
- The `pain`-kind tap was not exercised live (identical code path to `rpe`; backend pain validation is unit-tested).
- The confirmation/error-retry text was not visually asserted (cosmetic).
- Telegram delivery is out of scope (I1b).