### PR TITLE
I1b: Telegram tappable RPE/pain input (#220)

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -9,6 +9,7 @@ from app.db.session import get_db
 from app.models import Activity, StravaAccount, CheckIn
 from app.schemas import ActivityRead, ActivityDetailRead, CheckInCreate, CheckInRead, SyncResponse, ActivityIntentUpdate, DerivedMetricRead
 from app.services import activity_queries, analysis
+from app.services.checkins import write_checkin
 from app.services.analysis.classifier import Classification, compose_headline
 from app.services.analysis.splits import calculate_splits
 from app.services.strava_ingestion import get_strava_port, ingest_recent_activities
@@ -177,26 +178,6 @@ def create_checkin(
     checkin_data: CheckInCreate,
     db: Session = Depends(get_db)
 ):
-    # 1. Upsert CheckIn
-    existing = db.query(CheckIn).filter(CheckIn.activity_id == activity_id).first()
-    if existing:
-        for k, v in checkin_data.dict(exclude_unset=True).items():
-            setattr(existing, k, v)
-        db_obj = existing
-    else:
-        db_obj = CheckIn(activity_id=activity_id, **checkin_data.dict())
-        db.add(db_obj)
-    
-    db.commit()
-    db.refresh(db_obj)
-
-    # 2. Trigger Re-Processing to incorporate user feedback
-    analysis.analyze(db, str(activity_id))
-
-    # 3. A4: a check-in is a reply — if the two-stage exchange is still open, fire
-    # the fuller turn early (best-effort; never breaks the check-in write).
-    from app.jobs.process_new_activity import maybe_enqueue_fuller_turn
-
-    maybe_enqueue_fuller_turn(db, activity_id)
-
-    return db_obj
+    # Shared with the Telegram inbound callback path (I1b) so both writes are
+    # identical: upsert + re-analyze + conditional A4 fuller-turn trigger.
+    return write_checkin(db, activity_id, checkin_data)

--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -1,6 +1,7 @@
 import logging
+import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from sqlalchemy.orm import Session
 from sqlalchemy import select, update
 from pydantic import BaseModel
@@ -11,6 +12,10 @@ from app.models import Activity, StravaAccount
 from app.core.queue import queue
 from app.jobs.process_new_activity import process_new_activity_job
 from app.jobs.strava_sync import sync_activity_job
+from app.schemas import CheckInCreate
+from app.services.checkins import write_checkin
+from app.services.notifications import get_notifier
+from app.services.notifications.callback_token import decode as decode_callback_token
 
 logger = logging.getLogger(__name__)
 
@@ -149,3 +154,134 @@ async def receive_webhook(
         return {"status": "processed", "action": "enqueued_sync"}
 
     return {"status": "ignored", "reason": "unknown_aspect"}
+
+
+# --- Telegram inbound callback (I1b, #220) -------------------------------------
+# The runner taps an RPE/pain button on the opener message in Telegram; Telegram
+# POSTs a callback_query here. The endpoint is BasicAuth-exempt (the /api/webhooks
+# prefix) so Telegram can reach it, so it must authenticate the request itself
+# before any side effect, mirroring the Strava-webhook posture above.
+
+
+class _TgChat(BaseModel):
+    id: int = 0
+
+
+class _TgMessage(BaseModel):
+    chat: _TgChat = _TgChat()
+
+
+class _TgCallbackQuery(BaseModel):
+    id: str
+    data: str | None = None
+    message: _TgMessage | None = None
+
+
+class TelegramUpdate(BaseModel):
+    # Telegram sends every update type to one webhook URL; we only act on
+    # callback_query (a button tap) and ignore the rest. Extra fields are dropped.
+    update_id: int = 0
+    callback_query: _TgCallbackQuery | None = None
+
+
+def _callback_is_authentic(
+    secret_header: str | None, callback: _TgCallbackQuery
+) -> bool:
+    """Authenticate an inbound Telegram callback before any side effect.
+
+    Two checks, mirroring the Strava posture:
+
+    1. The `X-Telegram-Bot-Api-Secret-Token` header must equal our configured
+       secret. Telegram echoes the `secret_token` set at webhook registration on
+       every request, so it is the stronger (secret) check. When the secret is
+       unconfigured the check is skipped for local dev, but it fails closed in
+       production so an empty secret never silently opens the endpoint.
+    2. The callback's chat id must match our configured TELEGRAM_CHAT_ID. Chat
+       ids are guessable, so this is the weaker check, but it is always available
+       and ties the action to the one connected runner.
+    """
+    expected_secret = settings.TELEGRAM_WEBHOOK_SECRET
+    if expected_secret:
+        if secret_header != expected_secret:
+            logger.warning("telegram_callback_rejected_secret_mismatch")
+            return False
+    elif settings.APP_ENV == "production":
+        logger.critical("telegram_webhook_secret_missing_in_production")
+        return False
+
+    chat_id = callback.message.chat.id if callback.message else 0
+    expected_chat = str(settings.TELEGRAM_CHAT_ID).strip()
+    if not expected_chat or str(chat_id) != expected_chat:
+        logger.warning(
+            "telegram_callback_rejected_chat_mismatch",
+            extra={"chat_id": chat_id},
+        )
+        return False
+
+    return True
+
+
+def _answer_callback(callback_query_id: str, *, text: str = "") -> None:
+    """Best-effort acknowledge the tap so Telegram clears the button spinner.
+
+    Only the Telegram notifier can answer; any other active channel (email,
+    no-op, in-memory) has no callback to answer, so this is a guarded no-op
+    there. Never raises into the request path."""
+    notifier = get_notifier()
+    answer = getattr(notifier, "answer_callback", None)
+    if answer is None:
+        return
+    try:
+        answer(callback_query_id, text=text)
+    except Exception:
+        logger.exception("failed to answer telegram callback %s", callback_query_id)
+
+
+@router.post("/webhooks/telegram")
+def receive_telegram_callback(
+    update: TelegramUpdate,
+    db: Session = Depends(get_db),
+    secret_header: str | None = Header(
+        default=None, alias="X-Telegram-Bot-Api-Secret-Token"
+    ),
+):
+    """Handle a runner tapping an RPE/pain button on the Telegram opener (I1b).
+
+    Authenticate first, then turn the tap into the same CheckIn the in-app path
+    writes (via the shared `write_checkin`), which also fires the A4 fuller turn
+    when the exchange is open. Always returns 200 to a malformed-but-authentic or
+    non-callback update so Telegram does not retry; rejects an unauthenticated
+    request with 403 before any side effect."""
+    callback = update.callback_query
+    if callback is None:
+        # Not a button tap (a plain message, etc.): nothing to do.
+        return {"status": "ignored", "reason": "not_callback"}
+
+    if not _callback_is_authentic(secret_header, callback):
+        raise HTTPException(status_code=403, detail="Unauthenticated callback")
+
+    action = decode_callback_token(callback.data or "")
+    if action is None:
+        logger.warning("telegram_callback_unparseable_token")
+        _answer_callback(callback.id)
+        return {"status": "ignored", "reason": "bad_token"}
+
+    try:
+        activity_uuid = uuid.UUID(action.activity_id)
+    except ValueError:
+        _answer_callback(callback.id)
+        return {"status": "ignored", "reason": "bad_activity"}
+
+    activity = db.query(Activity).filter(Activity.id == activity_uuid).first()
+    if activity is None:
+        _answer_callback(callback.id)
+        return {"status": "ignored", "reason": "unknown_activity"}
+
+    # Build the validated CheckIn payload from the token (range-checked the same
+    # as the in-app path), then write through the shared helper.
+    checkin_data = CheckInCreate(**{action.field: action.value})
+    write_checkin(db, activity_uuid, checkin_data)
+
+    label = "RPE" if action.kind == "rpe" else "pain"
+    _answer_callback(callback.id, text=f"Got it — {label} {action.value} recorded.")
+    return {"status": "processed", "action": "checkin_written"}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -42,6 +42,13 @@ class Settings(BaseSettings):
     # instead. Both must be set for the channel to activate.
     TELEGRAM_BOT_TOKEN: str = ""
     TELEGRAM_CHAT_ID: str = ""
+    # Secret for authenticating inbound Telegram callback_query webhooks (I1b,
+    # #220). Set as Telegram's per-webhook `secret_token` at registration and
+    # echoed back in the `X-Telegram-Bot-Api-Secret-Token` header on every
+    # callback; the inbound endpoint rejects a request whose header does not
+    # match (the stronger, secret-ish check, paired with a chat_id match).
+    # Empty disables the secret check (local dev), leaving only the chat_id gate.
+    TELEGRAM_WEBHOOK_SECRET: str = ""
 
     # Email notifications (legacy/local channel; SMTP is unreachable from the
     # Railway worker, kept for local use and Pro-plan deployments).

--- a/backend/app/services/checkins.py
+++ b/backend/app/services/checkins.py
@@ -1,0 +1,46 @@
+"""Shared CheckIn write path.
+
+Both entry points that record a post-run check-in — the in-app POST
+`/activities/{id}/checkin` and the Telegram inbound callback (I1b, #220) — go
+through `write_checkin`, so the two cannot drift: an in-app RPE tap and a
+Telegram RPE tap produce the same CheckIn, the same re-analysis, and the same
+A4 fuller-turn trigger.
+"""
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models import CheckIn
+from app.schemas import CheckInCreate
+from app.services import analysis
+
+
+def write_checkin(db: Session, activity_id: UUID, checkin_data: CheckInCreate) -> CheckIn:
+    """Upsert the activity's CheckIn, re-analyze to fold in the feedback, and
+    fire the A4 fuller turn early when the two-stage exchange is still open.
+
+    A check-in is one CheckIn per activity, so a second write updates the first
+    (only the fields the caller set, leaving the rest intact). Returns the row."""
+    existing = db.query(CheckIn).filter(CheckIn.activity_id == activity_id).first()
+    if existing:
+        for k, v in checkin_data.dict(exclude_unset=True).items():
+            setattr(existing, k, v)
+        db_obj = existing
+    else:
+        db_obj = CheckIn(activity_id=activity_id, **checkin_data.dict())
+        db.add(db_obj)
+
+    db.commit()
+    db.refresh(db_obj)
+
+    # Re-process to incorporate the subjective feedback (perceived-effort, pain).
+    analysis.analyze(db, str(activity_id))
+
+    # A4: a check-in is a reply — if the two-stage exchange is still open, fire
+    # the fuller turn early (best-effort; never breaks the check-in write).
+    from app.jobs.process_new_activity import maybe_enqueue_fuller_turn
+
+    maybe_enqueue_fuller_turn(db, activity_id)
+
+    return db_obj

--- a/backend/app/services/notifications/__init__.py
+++ b/backend/app/services/notifications/__init__.py
@@ -1,9 +1,47 @@
 from typing import Optional
 
 from app.schemas.coach import CoachReportRead
+from app.services.notifications.callback_token import encode as encode_callback_token
 from app.services.notifications.in_memory_adapter import InMemoryNotifier
 from app.services.notifications.noop_adapter import NoOpNotifier
-from app.services.notifications.port import Notification, NotifierPort
+from app.services.notifications.port import (
+    Notification,
+    NotificationAction,
+    NotifierPort,
+)
+
+
+def _opener_actions(report: CoachReportRead) -> tuple[NotificationAction, ...]:
+    """Build tappable RPE/pain actions from a message report's questions (I1b).
+
+    Mirrors the in-app contract (`CoachReportPanel.handleOptionTap`): only `rpe`
+    and `pain` options are tappable, and a tap carries the option's numeric
+    payload. Skips any option whose payload is not an integer (so a malformed
+    option drops out rather than producing a dead button). Returns empty for the
+    structured legacy shape or a report with no tappable options."""
+    content = report.report
+    questions = getattr(content, "questions", None)
+    if not questions:
+        return ()
+    actions: list[NotificationAction] = []
+    for q in questions:
+        for opt in getattr(q, "options", []) or []:
+            if opt.kind not in ("rpe", "pain"):
+                continue
+            try:
+                value = int(opt.payload)
+            except (TypeError, ValueError):
+                continue
+            try:
+                token = encode_callback_token(
+                    kind=opt.kind,
+                    activity_id=str(report.activity_id),
+                    value=value,
+                )
+            except ValueError:
+                continue
+            actions.append(NotificationAction(label=opt.label, token=token))
+    return tuple(actions)
 
 _active: NotifierPort | None = None
 
@@ -95,12 +133,16 @@ def build_coach_notification(
             app_base_url=app_base_url,
             stage=stage,
         )
+        # I1b: only the opener carries tappable RPE/pain buttons (the fuller turn
+        # is the response to that input, so it has no quick-reply affordances).
+        actions = _opener_actions(report) if stage == "opener" else ()
         return Notification(
             to=str(settings.TELEGRAM_CHAT_ID),
             subject=subject,
             html="",
             text=text,
             url=url,
+            actions=actions,
         )
     if channel == "email":
         from app.services.notifications.email_template import (

--- a/backend/app/services/notifications/callback_token.py
+++ b/backend/app/services/notifications/callback_token.py
@@ -1,0 +1,73 @@
+"""Opaque token codec for Telegram inline-keyboard taps (I1b, #220).
+
+A tap echoes back a self-contained token (Telegram's `callback_data`, capped at
+64 bytes), so the inbound webhook can resolve the action with no server-side
+state. The token carries the three facts a tap needs to become a CheckIn: which
+question kind was answered (`rpe`/`pain`), which activity, and the chosen value.
+
+One module owns both ends — `encode` (outbound composer) and `decode` (inbound
+webhook) — so the wire format cannot drift between them.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple, Optional
+
+# Versioned prefix so a future format change is detectable rather than silently
+# misparsed. Pipe is a safe separator: it appears in neither a UUID nor an int.
+_PREFIX = "cb1"
+_SEP = "|"
+
+# Only the I1a kinds are tappable-to-CheckIn (matches the in-app path); reply/
+# dispute/custom stay non-interactive (deferred to I2).
+_FIELD_BY_KIND = {"rpe": "rpe", "pain": "pain_score"}
+
+# Telegram hard-caps callback_data at 64 bytes.
+_MAX_BYTES = 64
+
+
+class CallbackAction(NamedTuple):
+    kind: str          # "rpe" | "pain"
+    activity_id: str   # activity UUID as string
+    value: int         # the chosen RPE/pain value
+    field: str         # the CheckIn column the value writes to
+
+
+def encode(*, kind: str, activity_id: str, value: int) -> str:
+    """Build a callback token for an RPE/pain option tap.
+
+    Raises ValueError for an unsupported kind or a token that would exceed
+    Telegram's 64-byte limit, so an over-long token fails at build time (a bug)
+    rather than being silently truncated on the wire (a security/correctness
+    hazard at decode).
+    """
+    if kind not in _FIELD_BY_KIND:
+        raise ValueError(f"non-tappable callback kind: {kind!r}")
+    token = _SEP.join((_PREFIX, kind, activity_id, str(int(value))))
+    if len(token.encode("utf-8")) > _MAX_BYTES:
+        raise ValueError(f"callback token exceeds {_MAX_BYTES} bytes: {token!r}")
+    return token
+
+
+def decode(token: str) -> Optional[CallbackAction]:
+    """Parse a callback token back into an action, or None if it is malformed.
+
+    Returns None (never raises) for any unrecognised, wrong-arity, wrong-prefix,
+    unknown-kind, or non-integer-value token, so the inbound webhook treats a
+    garbage callback as a clean no-op rather than a 500."""
+    if not token:
+        return None
+    parts = token.split(_SEP)
+    if len(parts) != 4:
+        return None
+    prefix, kind, activity_id, raw_value = parts
+    if prefix != _PREFIX:
+        return None
+    field = _FIELD_BY_KIND.get(kind)
+    if field is None or not activity_id:
+        return None
+    try:
+        value = int(raw_value)
+    except ValueError:
+        return None
+    return CallbackAction(kind=kind, activity_id=activity_id, value=value, field=field)

--- a/backend/app/services/notifications/port.py
+++ b/backend/app/services/notifications/port.py
@@ -1,5 +1,18 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class NotificationAction:
+    """A channel-agnostic tappable affordance carried on a Notification (I1b,
+    #220). `label` is the button text; `token` is an opaque, self-contained
+    payload a channel echoes back when tapped so the inbound handler can resolve
+    the action without server-side state. The Telegram adapter renders these as
+    an inline keyboard (token -> callback_data); channels without buttons (email)
+    ignore them."""
+
+    label: str
+    token: str
 
 
 @dataclass(frozen=True)
@@ -12,6 +25,9 @@ class Notification:
     # carry it out of band (e.g. Telegram) read it from here. Optional so the
     # field stays backward-compatible with email-only callers.
     url: str | None = None
+    # Tappable quick-reply affordances (I1b). Empty for every existing caller;
+    # populated only for the A4 opener so its RPE/pain options become buttons.
+    actions: tuple["NotificationAction", ...] = field(default_factory=tuple)
 
 
 @runtime_checkable

--- a/backend/app/services/notifications/telegram_adapter.py
+++ b/backend/app/services/notifications/telegram_adapter.py
@@ -35,22 +35,55 @@ class TelegramNotifier:
 
     def send(self, notification: Notification) -> None:
         url = f"{self.api_base}/bot{self.bot_token}/sendMessage"
-        response = httpx.post(
-            url,
-            json={
-                "chat_id": self.chat_id,
-                "text": self._format(notification),
-                "parse_mode": "HTML",
-                "disable_web_page_preview": True,
-            },
-            timeout=self.timeout,
-        )
+        body = {
+            "chat_id": self.chat_id,
+            "text": self._format(notification),
+            "parse_mode": "HTML",
+            "disable_web_page_preview": True,
+        }
+        reply_markup = self._reply_markup(notification)
+        if reply_markup is not None:
+            body["reply_markup"] = reply_markup
+        response = httpx.post(url, json=body, timeout=self.timeout)
         response.raise_for_status()
         payload = response.json()
         if not payload.get("ok", False):
             raise RuntimeError(
                 f"Telegram API rejected the message: {payload.get('description', 'unknown error')}"
             )
+
+    def answer_callback(self, callback_query_id: str, *, text: str = "") -> None:
+        """Acknowledge a tapped inline-keyboard button (I1b).
+
+        Telegram shows the button as a spinner until the bot answers; this clears
+        it (optionally with a brief toast). Best-effort by the caller's contract,
+        but still raises on a hard transport/API error so failures are visible in
+        logs rather than silently swallowed here."""
+        url = f"{self.api_base}/bot{self.bot_token}/answerCallbackQuery"
+        body: dict = {"callback_query_id": callback_query_id}
+        if text:
+            body["text"] = text
+        response = httpx.post(url, json=body, timeout=self.timeout)
+        response.raise_for_status()
+        payload = response.json()
+        if not payload.get("ok", False):
+            raise RuntimeError(
+                f"Telegram API rejected answerCallbackQuery: {payload.get('description', 'unknown error')}"
+            )
+
+    @staticmethod
+    def _reply_markup(notification: Notification) -> dict | None:
+        """Build an inline keyboard from the notification's actions, or None.
+
+        One button per action, each on its own row (RPE/pain scales read better
+        vertically on a phone), `callback_data` carrying the opaque token."""
+        if not notification.actions:
+            return None
+        keyboard = [
+            [{"text": action.label, "callback_data": action.token}]
+            for action in notification.actions
+        ]
+        return {"inline_keyboard": keyboard}
 
     def _format(self, notification: Notification) -> str:
         """Build the HTML-mode message body: bold title, text, link."""

--- a/backend/tests/test_telegram_callback.py
+++ b/backend/tests/test_telegram_callback.py
@@ -1,0 +1,353 @@
+"""Telegram tappable RPE/pain input (I1b, #220).
+
+Two halves of the deployed-channel input loop:
+- Outbound: the A4 opener notification carries an inline keyboard built from its
+  RPE/pain options (the composer + adapter).
+- Inbound: a tapped button POSTs a callback_query here; the endpoint authenticates
+  it (secret header + chat_id, mirroring the Strava posture), then writes the same
+  CheckIn the in-app path writes (parity) and fires the A4 fuller turn.
+
+The inbound endpoint is BasicAuth-exempt (the /api/webhooks prefix), so the auth
+checks below are the only thing standing between an untrusted POST and a DB write.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.config import settings
+from app.models import Activity, CheckIn, User
+from app.schemas.coach import (
+    CoachMessageQuestion,
+    CoachMessageReport,
+    CoachReportDebug,
+    CoachReportMeta,
+    CoachReportRead,
+    TappableOption,
+)
+from app.services.notifications import build_coach_notification
+from app.services.notifications.callback_token import (
+    CallbackAction,
+    decode,
+    encode,
+)
+
+
+# --- Token codec ---------------------------------------------------------------
+
+
+class TestCallbackTokenCodec:
+    def test_round_trip_rpe(self):
+        aid = str(uuid4())
+        action = decode(encode(kind="rpe", activity_id=aid, value=7))
+        assert action == CallbackAction(
+            kind="rpe", activity_id=aid, value=7, field="rpe"
+        )
+
+    def test_round_trip_pain_maps_to_pain_score(self):
+        aid = str(uuid4())
+        action = decode(encode(kind="pain", activity_id=aid, value=3))
+        assert action.field == "pain_score"
+        assert action.value == 3
+
+    def test_encode_rejects_non_tappable_kind(self):
+        with pytest.raises(ValueError):
+            encode(kind="reply", activity_id=str(uuid4()), value=1)
+
+    def test_token_stays_within_telegram_64_byte_limit(self):
+        # A real UUID activity id is the longest field; the token must still fit.
+        token = encode(kind="pain", activity_id=str(uuid4()), value=10)
+        assert len(token.encode("utf-8")) <= 64
+
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "",
+            "garbage",
+            "cb1|rpe|abc",            # wrong arity
+            "cb1|rpe|abc|7|extra",    # wrong arity
+            "cb0|rpe|abc|7",          # wrong prefix
+            "cb1|reply|abc|7",        # non-tappable kind
+            "cb1|rpe||7",             # empty activity id
+            "cb1|rpe|abc|notanint",   # non-integer value
+        ],
+    )
+    def test_decode_returns_none_for_malformed(self, token):
+        assert decode(token) is None
+
+
+# --- Outbound: opener keyboard composition -------------------------------------
+
+
+def _opener_with_options(options) -> CoachReportRead:
+    report = CoachMessageReport(
+        message="",
+        opener_message="Nice work! How did that feel?",
+        questions=[
+            CoachMessageQuestion(
+                question="How hard did that feel?",
+                reason="Calibrate effort against HR.",
+                options=options,
+            )
+        ],
+    )
+    meta = CoachReportMeta(
+        confidence="medium", model_id="claude-sonnet-4-6", prompt_id="coach_message_v2",
+        schema_version="2.0", input_hash="abc", generated_at=datetime.now(),
+    )
+    return CoachReportRead(
+        id=uuid4(), activity_id=uuid4(), report=report, meta=meta,
+        debug=CoachReportDebug(context_pack={}, system_prompt="", raw_llm_response=None),
+        created_at=datetime.now(),
+    )
+
+
+@pytest.fixture
+def telegram_configured(monkeypatch):
+    monkeypatch.setattr(settings, "TELEGRAM_BOT_TOKEN", "123:ABC")
+    monkeypatch.setattr(settings, "TELEGRAM_CHAT_ID", "42")
+
+
+class TestOpenerKeyboardComposition:
+    def test_opener_carries_rpe_and_pain_buttons(self, telegram_configured):
+        read = _opener_with_options(
+            [
+                TappableOption(id="r6", label="Easy (6)", kind="rpe", payload=6),
+                TappableOption(id="r8", label="Hard (8)", kind="rpe", payload=8),
+                TappableOption(id="p0", label="No pain", kind="pain", payload=0),
+            ]
+        )
+        notification = build_coach_notification(
+            report=read, headline="Easy Run", distance_m=5000,
+            app_base_url="https://app.example.com", stage="opener",
+        )
+        assert [a.label for a in notification.actions] == ["Easy (6)", "Hard (8)", "No pain"]
+        # Each token decodes back to the right activity + kind + value.
+        decoded = [decode(a.token) for a in notification.actions]
+        assert decoded[0] == CallbackAction("rpe", str(read.activity_id), 6, "rpe")
+        assert decoded[2] == CallbackAction("pain", str(read.activity_id), 0, "pain_score")
+
+    def test_non_rpe_pain_options_are_skipped(self, telegram_configured):
+        read = _opener_with_options(
+            [
+                TappableOption(id="rep", label="Reply", kind="reply", payload=None),
+                TappableOption(id="dis", label="That's wrong", kind="dispute", payload=None),
+                TappableOption(id="r7", label="RPE 7", kind="rpe", payload=7),
+            ]
+        )
+        notification = build_coach_notification(
+            report=read, headline="Easy Run", distance_m=5000,
+            app_base_url="https://app.example.com", stage="opener",
+        )
+        assert [a.label for a in notification.actions] == ["RPE 7"]
+
+    def test_option_with_non_numeric_payload_is_dropped(self, telegram_configured):
+        read = _opener_with_options(
+            [TappableOption(id="bad", label="?", kind="rpe", payload="not-a-number")]
+        )
+        notification = build_coach_notification(
+            report=read, headline="Easy Run", distance_m=5000,
+            app_base_url="https://app.example.com", stage="opener",
+        )
+        assert notification.actions == ()
+
+    def test_fuller_stage_has_no_buttons(self, telegram_configured):
+        # The fuller turn is the response to the input, so it carries no keyboard.
+        read = _opener_with_options(
+            [TappableOption(id="r7", label="RPE 7", kind="rpe", payload=7)]
+        )
+        notification = build_coach_notification(
+            report=read, headline="Easy Run", distance_m=5000,
+            app_base_url="https://app.example.com", stage="fuller",
+        )
+        assert notification.actions == ()
+
+
+# --- Inbound: callback webhook -------------------------------------------------
+
+_SECRET = "tg-secret"
+
+
+def _seed_activity(db) -> Activity:
+    uid = uuid4()
+    db.add(User(id=uid, email=f"u-{uid}@example.com"))
+    db.flush()
+    a = Activity(
+        id=uuid4(), user_id=uid, strava_activity_id=abs(hash(str(uuid4()))) % 10**9,
+        start_date=datetime(2026, 5, 27, 10, 0, 0), type="Run", name="Run",
+        distance_m=5000, moving_time_s=1500, elapsed_time_s=1500, elev_gain_m=10.0,
+        avg_hr=140, raw_summary={},
+    )
+    db.add(a)
+    db.commit()
+    return a
+
+
+def _update(token: str, *, chat_id=42, cbq_id="cbq-1") -> dict:
+    return {
+        "update_id": 1,
+        "callback_query": {
+            "id": cbq_id,
+            "data": token,
+            "message": {"chat": {"id": chat_id}},
+        },
+    }
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setattr(settings, "TELEGRAM_BOT_TOKEN", "123:ABC")
+    monkeypatch.setattr(settings, "TELEGRAM_CHAT_ID", "42")
+    monkeypatch.setattr(settings, "TELEGRAM_WEBHOOK_SECRET", _SECRET)
+    monkeypatch.setattr(settings, "APP_ENV", "local")
+
+
+@pytest.fixture
+def isolate_side_effects():
+    """Stub the re-analyze + fuller-turn enqueue + Telegram answer so the inbound
+    tests focus on auth + the CheckIn write (those side effects are covered by
+    their own suites)."""
+    answer = MagicMock()
+    notifier = MagicMock()
+    notifier.answer_callback = answer
+    with patch("app.services.checkins.analysis.analyze"), patch(
+        "app.jobs.process_new_activity.maybe_enqueue_fuller_turn"
+    ) as fuller, patch(
+        "app.api.webhooks.get_notifier", return_value=notifier
+    ):
+        yield {"answer": answer, "fuller": fuller}
+
+
+class TestInboundAuth:
+    def test_missing_secret_header_is_rejected_before_write(
+        self, client, db, configured, isolate_side_effects
+    ):
+        a = _seed_activity(db)
+        token = encode(kind="rpe", activity_id=str(a.id), value=7)
+        resp = client.post("/api/webhooks/telegram", json=_update(token))
+        assert resp.status_code == 403
+        assert db.query(CheckIn).filter(CheckIn.activity_id == a.id).first() is None
+        isolate_side_effects["answer"].assert_not_called()
+
+    def test_wrong_secret_is_rejected(self, client, db, configured, isolate_side_effects):
+        a = _seed_activity(db)
+        token = encode(kind="rpe", activity_id=str(a.id), value=7)
+        resp = client.post(
+            "/api/webhooks/telegram",
+            json=_update(token),
+            headers={"X-Telegram-Bot-Api-Secret-Token": "wrong"},
+        )
+        assert resp.status_code == 403
+        assert db.query(CheckIn).filter(CheckIn.activity_id == a.id).first() is None
+
+    def test_wrong_chat_id_is_rejected(self, client, db, configured, isolate_side_effects):
+        a = _seed_activity(db)
+        token = encode(kind="rpe", activity_id=str(a.id), value=7)
+        resp = client.post(
+            "/api/webhooks/telegram",
+            json=_update(token, chat_id=999),
+            headers={"X-Telegram-Bot-Api-Secret-Token": _SECRET},
+        )
+        assert resp.status_code == 403
+        assert db.query(CheckIn).filter(CheckIn.activity_id == a.id).first() is None
+
+    def test_empty_secret_in_production_fails_closed(
+        self, client, db, monkeypatch, isolate_side_effects
+    ):
+        monkeypatch.setattr(settings, "TELEGRAM_BOT_TOKEN", "123:ABC")
+        monkeypatch.setattr(settings, "TELEGRAM_CHAT_ID", "42")
+        monkeypatch.setattr(settings, "TELEGRAM_WEBHOOK_SECRET", "")
+        monkeypatch.setattr(settings, "APP_ENV", "production")
+        a = _seed_activity(db)
+        token = encode(kind="rpe", activity_id=str(a.id), value=7)
+        resp = client.post(
+            "/api/webhooks/telegram",
+            json=_update(token),
+            headers={"X-Telegram-Bot-Api-Secret-Token": ""},
+        )
+        assert resp.status_code == 403
+        assert db.query(CheckIn).filter(CheckIn.activity_id == a.id).first() is None
+
+
+class TestInboundWrite:
+    def _post(self, client, token, chat_id=42):
+        return client.post(
+            "/api/webhooks/telegram",
+            json=_update(token, chat_id=chat_id),
+            headers={"X-Telegram-Bot-Api-Secret-Token": _SECRET},
+        )
+
+    def test_rpe_tap_writes_checkin_and_answers_callback(
+        self, client, db, configured, isolate_side_effects
+    ):
+        a = _seed_activity(db)
+        token = encode(kind="rpe", activity_id=str(a.id), value=7)
+        resp = self._post(client, token)
+        assert resp.status_code == 200
+        row = db.query(CheckIn).filter(CheckIn.activity_id == a.id).first()
+        assert row is not None and row.rpe == 7 and row.pain_score is None
+        isolate_side_effects["answer"].assert_called_once()
+        isolate_side_effects["fuller"].assert_called_once()
+
+    def test_pain_tap_writes_pain_score(
+        self, client, db, configured, isolate_side_effects
+    ):
+        a = _seed_activity(db)
+        token = encode(kind="pain", activity_id=str(a.id), value=4)
+        resp = self._post(client, token)
+        assert resp.status_code == 200
+        row = db.query(CheckIn).filter(CheckIn.activity_id == a.id).first()
+        assert row.pain_score == 4 and row.rpe is None
+
+    def test_unknown_activity_is_ignored_without_write(
+        self, client, db, configured, isolate_side_effects
+    ):
+        token = encode(kind="rpe", activity_id=str(uuid4()), value=7)
+        resp = self._post(client, token)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ignored"
+        assert db.query(CheckIn).count() == 0
+
+    def test_bad_token_is_ignored_and_answered(
+        self, client, db, configured, isolate_side_effects
+    ):
+        resp = self._post(client, "cb1|reply|x|1")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ignored"
+        assert db.query(CheckIn).count() == 0
+        isolate_side_effects["answer"].assert_called_once()
+
+    def test_non_callback_update_is_ignored(
+        self, client, db, configured, isolate_side_effects
+    ):
+        resp = client.post(
+            "/api/webhooks/telegram",
+            json={"update_id": 1, "message": {"text": "hello"}},
+            headers={"X-Telegram-Bot-Api-Secret-Token": _SECRET},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["reason"] == "not_callback"
+
+
+class TestParityWithInApp:
+    """A Telegram RPE tap and an in-app RPE post must produce the same CheckIn."""
+
+    def test_telegram_and_in_app_rpe_write_identical_fields(
+        self, client, db, configured, isolate_side_effects
+    ):
+        a_app = _seed_activity(db)
+        a_tg = _seed_activity(db)
+
+        client.post(f"/api/activities/{a_app.id}/checkin", json={"rpe": 7})
+        client.post(
+            "/api/webhooks/telegram",
+            json=_update(encode(kind="rpe", activity_id=str(a_tg.id), value=7)),
+            headers={"X-Telegram-Bot-Api-Secret-Token": _SECRET},
+        )
+
+        in_app = db.query(CheckIn).filter(CheckIn.activity_id == a_app.id).first()
+        via_tg = db.query(CheckIn).filter(CheckIn.activity_id == a_tg.id).first()
+        assert in_app.rpe == via_tg.rpe == 7
+        assert in_app.pain_score == via_tg.pain_score

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 from app.services.notifications import Notification, NotifierPort
+from app.services.notifications.port import NotificationAction
 from app.services.notifications.telegram_adapter import TelegramNotifier
 
 
@@ -96,3 +97,66 @@ def test_send_raises_when_api_reports_not_ok():
     ):
         with pytest.raises(RuntimeError, match="chat not found"):
             _notifier().send(_notification())
+
+
+def test_send_without_actions_omits_reply_markup():
+    with patch(
+        "app.services.notifications.telegram_adapter.httpx.post",
+        return_value=_ok_response(),
+    ) as post:
+        _notifier().send(_notification())
+    assert "reply_markup" not in post.call_args.kwargs["json"]
+
+
+def test_send_renders_inline_keyboard_from_actions():
+    notification = Notification(
+        to="42",
+        subject="How did that feel?",
+        html="",
+        text="Quick check-in.",
+        url=None,
+        actions=(
+            NotificationAction(label="RPE 6", token="cb1|rpe|abc|6"),
+            NotificationAction(label="RPE 8", token="cb1|rpe|abc|8"),
+        ),
+    )
+    with patch(
+        "app.services.notifications.telegram_adapter.httpx.post",
+        return_value=_ok_response(),
+    ) as post:
+        _notifier().send(notification)
+
+    markup = post.call_args.kwargs["json"]["reply_markup"]
+    # One button per row, label + opaque token carried as callback_data.
+    assert markup == {
+        "inline_keyboard": [
+            [{"text": "RPE 6", "callback_data": "cb1|rpe|abc|6"}],
+            [{"text": "RPE 8", "callback_data": "cb1|rpe|abc|8"}],
+        ]
+    }
+
+
+def test_answer_callback_posts_to_answer_endpoint():
+    with patch(
+        "app.services.notifications.telegram_adapter.httpx.post",
+        return_value=_ok_response(),
+    ) as post:
+        _notifier().answer_callback("cbq-1", text="Got it — RPE 7 recorded.")
+
+    assert post.call_args.args[0] == (
+        "https://api.telegram.org/bot123:ABC/answerCallbackQuery"
+    )
+    body = post.call_args.kwargs["json"]
+    assert body == {"callback_query_id": "cbq-1", "text": "Got it — RPE 7 recorded."}
+
+
+def test_answer_callback_raises_when_api_reports_not_ok():
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"ok": False, "description": "query is too old"}
+    with patch(
+        "app.services.notifications.telegram_adapter.httpx.post",
+        return_value=response,
+    ):
+        with pytest.raises(RuntimeError, match="query is too old"):
+            _notifier().answer_callback("cbq-1")


### PR DESCRIPTION
Closes #220. The deployed-channel half of the I1 milestone (epic #177). I1a (in-app taps) shipped in #219; this makes the same RPE/pain options answerable from inside the Telegram opener message, which is where the runner actually reads it (Telegram is the production channel because Railway blocks SMTP).

## What this does
A tap on a Telegram RPE/pain button does what an in-app tap already does: writes a CheckIn and lets the open A4 exchange fire its fuller turn.

**Outbound** — the A4 opener notification carries an inline keyboard built from its rpe/pain options. A new channel-agnostic `Notification.actions` field (`NotificationAction{label, token}`) carries them; the Telegram adapter renders `reply_markup.inline_keyboard`, email ignores the field. Only the opener stage gets buttons (the fuller turn is the response to that input).

**Inbound** — `POST /api/webhooks/telegram` receives the `callback_query`, authenticates it before any side effect, writes the CheckIn via the shared helper, and answers the callback so the runner's button spinner clears.

**Shared write path** — extracted `app/services/checkins.py::write_checkin` (upsert + re-analyze + `maybe_enqueue_fuller_turn`) from `create_checkin`. The API route and the webhook both call it, so an in-app tap and a Telegram tap cannot drift (pinned by a parity test).

**Token codec** — `notifications/callback_token.py` owns both ends of an opaque `cb1|kind|uuid|value` token carrying `(kind, activity_id, value)` within Telegram's 64-byte `callback_data` limit. Decode returns `None` for any malformed token, so a garbage callback is a clean no-op, never a 500.

## Trust boundary (security)
The inbound endpoint is BasicAuth-exempt (the `/api/webhooks` prefix) so Telegram can reach it, so it authenticates itself before any DB write, mirroring the Strava-webhook posture:
1. `X-Telegram-Bot-Api-Secret-Token` header must equal the configured `TELEGRAM_WEBHOOK_SECRET` (the stronger, secret check). Fail-closed in production on an empty secret; skipped only for local dev.
2. The callback's chat_id must equal `TELEGRAM_CHAT_ID`.

Tests assert rejection (403, no write) for a missing secret, a wrong secret, a wrong chat_id, and the prod-empty-secret case.

## Scope
RPE/pain only, matching I1a. Conversational reply/dispute/custom taps remain I2.

## Verification
- **935 backend tests pass** (was 905; +30). New `test_telegram_callback.py` covers the token codec, opener keyboard composition, inbound auth rejection, the CheckIn write, and in-app-vs-Telegram parity; adapter tests pin the exact `reply_markup` and `answerCallbackQuery` JSON.
- Existing `test_checkin_validation.py` still green (the refactor shares the same `analysis` module object, so its patch targets still resolve).
- **Not exercised:** the real Telegram Bot API was never hit (all Telegram HTTP is mocked). This is the Configure-modality gap and is owner-gated — see below.

## Owner actions required after merge
1. Set `TELEGRAM_WEBHOOK_SECRET` on the Railway **web** service (the inbound endpoint runs in `web`, not the worker).
2. Register the bot webhook: Telegram `setWebhook` at `<backend>/api/webhooks/telegram` with `secret_token` = that secret.

The outbound keyboard ships as soon as this deploys; the inbound half lights up once the webhook is registered. The real end-to-end tap is the final verification to run after step 2.

## Notes
- No new dependency. No migration (`Notification.actions` is in-memory; the token is stateless).
- `project-context.md` is not updated here (it already predates I1a's in-app delivery); a `aiw-project-context-management` refresh covering the new `/api/webhooks/telegram` route and the `checkins.py` / `callback_token.py` modules is warranted separately.