### PR TITLE
fix: recover a fuller turn from a transient empty-prose LLM fallback (#217)

### DIFF
--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -77,6 +77,12 @@ _MESSAGE_MAX_TOKENS = 8192
 # than the fuller turn. Tunable.
 _OPENER_MAX_TOKENS = 2048
 
+# #217: total attempts at the prose call before degrading to a fallback. The prose
+# response is occasionally empty (no text block) but recovers on an immediate
+# re-run, so one retry (2 attempts) reclaims that transient failure. Both stages
+# (opener and fuller) share it.
+_EMPTY_PROSE_ATTEMPTS = 2
+
 # Token budget for the legacy structured JSON report. Was 1024, which truncated
 # under claude-sonnet-4-6 (more verbose JSON than the retired model) — the report
 # hit stop_reason=max_tokens mid-object and the partial/fenced text failed to
@@ -369,7 +375,19 @@ async def generate_fuller(
     # Preserve the opener prose on the evolving row — the fuller LLM does not emit
     # opener_message, so carry it forward so the two-line thread (opener + fuller)
     # survives in storage and on the frontend.
-    if opener_prose:
+    if outcome.is_fallback and opener_prose:
+        # #217: a fuller fallback must NOT lock the exchange. The fuller-shaped
+        # fallback carries a non-empty `message`, which would make the row complete
+        # (not opener-only) and defeat both recovery paths: generate_fuller would
+        # cache-hit it and the reply path's is_opener_only gate would reject it, so a
+        # safety-forced (red-flag) turn dies on one transient LLM failure. Keep the
+        # row OPENER-ONLY instead (message empty, opener prose preserved) — exactly
+        # the opener-fallback pattern — so the reply/force/timer paths regenerate the
+        # substantive turn. The row stays is_fallback (not notified, no learning loop).
+        outcome.report_dump = CoachMessageReport(
+            message="", opener_message=opener_prose, tail_degraded=True
+        ).model_dump()
+    elif opener_prose:
         outcome.report_dump["opener_message"] = opener_prose
 
     return _persist_report(
@@ -674,40 +692,57 @@ async def _generate_message(
     max_tokens = _OPENER_MAX_TOKENS if is_opener else _MESSAGE_MAX_TOKENS
     merge = merge_opener if is_opener else merge_report
     fallback = _opener_fallback_outcome if is_opener else _message_fallback_outcome
-    try:
-        result = await _call_message(client, system_prompt, user_message, max_tokens=max_tokens)
-        if result.stop_reason == "refusal":
-            logger.warning("coach message refused; storing fallback")
+    # #217: the prose call occasionally returns no text block at all (an empty-prose
+    # response, observed as transient — an immediate re-run recovers it). A single
+    # in-process retry turns that one hiccup into a real turn instead of a fallback,
+    # which matters most for the safety-forced fuller turn whose substantive coaching
+    # would otherwise be silently dropped. The retry is scoped to that specific
+    # failure; refusal / max_tokens / tail-skip keep their existing one-shot handling.
+    report = None
+    raw_response = ""
+    for attempt in range(_EMPTY_PROSE_ATTEMPTS):
+        try:
+            result = await _call_message(client, system_prompt, user_message, max_tokens=max_tokens)
+            if result.stop_reason == "refusal":
+                logger.warning("coach message refused; storing fallback")
+                return fallback()
+            if result.stop_reason == "max_tokens":
+                logger.info("coach message truncated (max_tokens); retrying once")
+                retried = await _call_message(
+                    client, system_prompt, user_message, max_tokens=max_tokens
+                )
+                if retried.stop_reason != "refusal":
+                    result = retried
+
+            parsed = parse_blocks(result.content_blocks)
+            # Tail-skip corrective retry: the model is allowed to skip the tool under
+            # tool_choice=auto. One nudge before accepting a degraded tail.
+            if parsed.tail is None and result.stop_reason == "end_turn":
+                logger.info("coach message skipped the tail tool; one corrective retry")
+                nudge = f"{user_message}\n\n{_TAIL_REMINDER}"
+                result2 = await _call_message(
+                    client, system_prompt, nudge, max_tokens=max_tokens
+                )
+                parsed2 = parse_blocks(result2.content_blocks)
+                if parsed2.tail is not None and parsed2.message.strip():
+                    parsed, result = parsed2, result2
+
+            raw_response = _serialize_blocks(result.content_blocks)
+            report = merge(parsed)
+            break
+        except EmptyMessageError:
+            if attempt + 1 < _EMPTY_PROSE_ATTEMPTS:
+                logger.warning(
+                    "coach response carried no prose message; retrying once (#217)"
+                )
+                continue
+            logger.warning(
+                "coach response carried no prose message after retry; storing fallback"
+            )
             return fallback()
-        if result.stop_reason == "max_tokens":
-            logger.info("coach message truncated (max_tokens); retrying once")
-            retried = await _call_message(
-                client, system_prompt, user_message, max_tokens=max_tokens
-            )
-            if retried.stop_reason != "refusal":
-                result = retried
-
-        parsed = parse_blocks(result.content_blocks)
-        # Tail-skip corrective retry: the model is allowed to skip the tool under
-        # tool_choice=auto. One nudge before accepting a degraded tail.
-        if parsed.tail is None and result.stop_reason == "end_turn":
-            logger.info("coach message skipped the tail tool; one corrective retry")
-            nudge = f"{user_message}\n\n{_TAIL_REMINDER}"
-            result2 = await _call_message(
-                client, system_prompt, nudge, max_tokens=max_tokens
-            )
-            parsed2 = parse_blocks(result2.content_blocks)
-            if parsed2.tail is not None and parsed2.message.strip():
-                parsed, result = parsed2, result2
-
-        raw_response = _serialize_blocks(result.content_blocks)
-        report = merge(parsed)
-    except EmptyMessageError:
-        logger.warning("coach response carried no prose message; storing fallback")
-        return fallback()
-    except anthropic.APIError as e:
-        logger.error("coach message transport error: %s", e)
-        return fallback()
+        except anthropic.APIError as e:
+            logger.error("coach message transport error: %s", e)
+            return fallback()
 
     violations = validate_message_policy(report, pack)
     if violations:

--- a/backend/tests/test_two_stage_pipeline.py
+++ b/backend/tests/test_two_stage_pipeline.py
@@ -8,7 +8,7 @@ stubbed; the scheduler helper is patched (then exercised separately).
 """
 
 from datetime import datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
 import pytest
@@ -18,10 +18,13 @@ from app.jobs import process_new_activity as pna
 from app.jobs.process_new_activity import (
     _run_opener_stage,
     _schedule_fuller_turn,
+    maybe_enqueue_fuller_turn,
     process_fuller_turn,
 )
 from app.models import Activity, DerivedMetric, StravaAccount, User, UserProfile
 from app.services.coach.llm import MessageResult
+from app.services.coach.output_contract import is_opener_only
+from app.services.coach.service import get_active_report_row
 from app.services.notifications import set_notifier
 from app.services.notifications.in_memory_adapter import InMemoryNotifier
 
@@ -212,6 +215,50 @@ async def test_fuller_turn_idempotent_racing_timer_noops(db, configured, notifie
     assert first is not None
     assert second is None  # timer-after-reply is a harmless no-op
     assert len(notifier.sent) == 1  # exactly one fuller notification
+
+
+async def test_safety_forced_fuller_fallback_stays_recoverable(db, configured, notifier):
+    # #217: a red-flag run forces a fuller turn. If that forced fuller's LLM call
+    # falls back persistently (both prose attempts empty), the turn must NOT be
+    # silently abandoned: no fuller notification fires, the fuller sentinel stays
+    # null, and the row stays opener-only so a reply re-opens the exchange and the
+    # substantive coaching can still land — the safety floor's guarantee survives.
+    activity = _seed(db, flags=["illness_or_extreme_fatigue"])
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_opener_blocks(schedule=False)))), \
+         patch.object(pna, "_schedule_fuller_turn"):
+        await _run_opener_stage(db=db, activity=activity,
+                                strava_activity_id=activity.strava_activity_id, notifier=notifier)
+    assert len(notifier.sent) == 1  # opener only
+
+    empty = [_tail(headline="x", next_steps=[], risks=[], questions=[])]
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(empty), _result(empty))), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        result = await process_fuller_turn(db=db, activity=activity, notifier=notifier)
+    assert result is None              # a fallback fuller is not notified
+    assert len(notifier.sent) == 1     # still just the opener
+    db.refresh(activity)
+    assert activity.coach_notification_sent_at is None  # sentinel left open for retry
+    row = get_active_report_row(db, activity.id)
+    assert is_opener_only(row.report) is True  # recoverable, not a stuck fallback
+
+    # A reply re-opens the exchange — the recovery path the stuck fallback used to
+    # defeat (the row is opener-only, so maybe_enqueue_fuller_turn re-fires).
+    with patch("app.jobs.process_new_activity.queue", Mock()):
+        assert maybe_enqueue_fuller_turn(db, activity.id) is True
+
+    # And the re-fired fuller now produces and notifies the real substantive turn.
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_fuller_blocks()))), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        recovered = await process_fuller_turn(db=db, activity=activity, notifier=notifier)
+    assert recovered is not None
+    assert len(notifier.sent) == 2
+    db.refresh(activity)
+    assert activity.coach_notification_sent_at is not None
 
 
 async def test_two_notifications_max_opener_then_fuller(db, configured, notifier):

--- a/backend/tests/test_two_stage_service.py
+++ b/backend/tests/test_two_stage_service.py
@@ -310,3 +310,74 @@ async def test_fallback_opener_schedules_recovery_fuller(db, _v2):
     assert opener.schedule_fuller_turn is True  # recovery, despite no LLM judgment
     row = _stored(db, activity)
     assert is_opener_only(row.report) is True  # opener-shaped fallback
+
+
+# --- #217: fuller-fallback recovery (no silently-abandoned safety-forced turn) -
+
+
+def _empty_prose_blocks():
+    # A response that carries a tail but NO prose text block: parse yields an empty
+    # message, so merge raises EmptyMessageError (the observed transient #217 failure,
+    # logged as "coach response carried no prose message"). A tail is present so the
+    # tail-skip corrective retry does not fire and consume an extra stubbed result.
+    return [_tail(headline="x", next_steps=[], risks=[], questions=[])]
+
+
+async def test_fuller_retries_once_on_transient_empty_prose(db, _v2):
+    # #217: the fuller LLM occasionally returns no prose block (transient — an
+    # immediate re-run recovers it). One in-process retry turns that single hiccup
+    # into a real turn instead of a silently-dropped fallback.
+    activity = _seed(db)
+    fake = _client(_result(_empty_prose_blocks()), _result(_fuller_blocks()))
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        read = await generate_fuller(db, str(activity.id))
+    assert read is not None
+    assert fake.generate_coach_message.call_count == 2  # retried once
+    row = _stored(db, activity)
+    assert row.is_fallback is False
+    assert row.report["message"].startswith("Aerobically")
+
+
+async def test_fuller_persistent_fallback_stays_opener_only_and_recovers(db, _v2):
+    # #217: when BOTH fuller attempts return no prose, the fallback must not lock the
+    # exchange as a complete (fuller-shaped) fallback. It stays opener-only — message
+    # empty, opener prose preserved, is_fallback, no digest, no learning loop — so the
+    # reply/force/timer paths can still produce the substantive turn. Mirrors
+    # test_opener_medical_overreach_stays_opener_only_and_recovers for the fuller side.
+    activity = _seed(db)
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_opener_blocks(schedule=True)))):
+        await generate_opener(db, str(activity.id))
+    opener_row_id = _stored(db, activity).id
+
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_empty_prose_blocks()),
+                                     _result(_empty_prose_blocks()))), \
+         patch("app.services.coach.service.write_back_beliefs") as wb, \
+         patch("app.services.coach.service.enqueue_consolidation") as ec:
+        read = await generate_fuller(db, str(activity.id))
+
+    assert read is not None
+    row = _stored(db, activity)
+    assert row.id == opener_row_id            # same evolving row
+    assert row.is_fallback is True
+    assert is_opener_only(row.report) is True  # NOT a stuck fuller-shaped fallback
+    assert row.report["message"] == ""
+    assert row.report["opener_message"].startswith("Nice work")  # preserved
+    assert row.digest is None                  # opener-only carries no digest
+    wb.assert_not_called()                     # learning loop never fires on fallback
+    ec.assert_not_called()
+
+    # The exchange is still open: a subsequent fuller turn regenerates a real report
+    # (it does NOT cache-hit the stuck fallback) and preserves the opener half.
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_fuller_blocks()))), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        await generate_fuller(db, str(activity.id))
+    row2 = _stored(db, activity)
+    assert row2.is_fallback is False
+    assert row2.report["message"].startswith("Aerobically")
+    assert row2.report["opener_message"].startswith("Nice work")


### PR DESCRIPTION
Closes #217.

## Problem
On a red-flag run the deterministic safety override forces a fuller turn even when the opener LLM says `schedule_fuller_turn=false`. But if that forced fuller's own LLM call returned an empty-prose fallback, the substantive coaching was silently dropped: the runner kept only the benign templated opener on a run the safety logic flagged as warranting depth.

The fuller-shaped fallback (`_message_fallback_outcome`) carries a non-empty `message`, so once written onto the opener's evolving row the row stopped being opener-only. That single state fact defeated both recovery paths (`generate_fuller` cache-hit the fallback; `maybe_enqueue_fuller_turn`'s `is_opener_only` gate rejected the reply) and the timer is one-shot, so nothing re-fired. Live evidence in the issue shows the empty-prose response is transient (an immediate re-run produced correct prose).

## Fix (owner-chosen scope: in-process retry + keep-recoverable)
- **`_generate_message`** retries the prose call once on the observed transient empty-prose response (`EmptyMessageError`) before degrading. Shared by opener, fuller, and single-shot paths; refusal / max_tokens / tail-skip keep their existing one-shot handling.
- **`generate_fuller`** keeps a fuller fallback **opener-only** when an opener row exists (message empty, opener prose preserved, `is_fallback`) instead of a complete fuller-shaped fallback, so the reply / force / timer paths can still regenerate the substantive turn. This mirrors the existing opener-fallback-stays-opener-only pattern (`test_opener_medical_overreach_stays_opener_only_and_recovers`).

No bounded reschedule was added (the heavier option in the issue); a rare double-LLM-failure on a no-reply run stays recoverable (reply/force) rather than auto-re-firing.

## Tests
- `test_fuller_retries_once_on_transient_empty_prose` — one retry recovers the transient case.
- `test_fuller_persistent_fallback_stays_opener_only_and_recovers` — the fuller-stage analogue of the opener recovery test (the missing coverage that let this ship).
- `test_safety_forced_fuller_fallback_stays_recoverable` — pipeline-level: a forced fuller fallback fires no notification, leaves the sentinel null, stays opener-only, and a reply re-fires the real turn.

Both new service tests were confirmed red-before / green-after. Full backend suite 938 passed (935 baseline + 3 new); `eval-selftest` green both shapes.

## Not verified (named risk)
- No live Anthropic call: the transient response is simulated (it's non-deterministic); the fixture maps to the issue's logged `EmptyMessageError` path.
- No real Redis/worker run: job functions exercised in-process with a mocked queue.
- Frontend: a fuller fallback now renders as opener-only (an already-shipped render state); not visually re-checked.