### PR TITLE
Gate fuller turn on the two-stage prompt so rollback is inert (#216)

### DIFF
--- a/backend/app/jobs/process_new_activity.py
+++ b/backend/app/jobs/process_new_activity.py
@@ -275,6 +275,17 @@ async def process_fuller_turn(
     completion; a notify-retry re-sends the cached fuller without re-generating.
     A fallback fuller is not notified (and leaves the sentinel null), consistent
     with the single-shot fallback rule."""
+    # #216 / AC8 rollback inertness: a fuller scheduled via enqueue_in before a
+    # rollback to a single-shot prompt can still fire up to the stage-two delay
+    # after the flip. Gate it like every other A4 trigger so the stale timer is
+    # a no-op instead of leaking a wrong-prompt generation + notification.
+    if not is_two_stage_prompt(settings.COACH_PROMPT_ID):
+        logger.info(
+            "Skipping fuller turn for activity %s: active prompt %s is single-shot",
+            activity.strava_activity_id, settings.COACH_PROMPT_ID,
+        )
+        return None
+
     db.refresh(activity)
     if activity.coach_notification_sent_at is not None:
         logger.info(

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -326,8 +326,17 @@ async def generate_fuller(
     row exists (preserving the opener prose so both halves survive), else inserts a
     fresh row. Fires the learning-loop write-back + Consolidation on completion
     (non-fallback only). A complete (fuller) row is returned from cache unless
-    `force`. Returns None when the activity has no metrics.
+    `force`. Returns None when the activity has no metrics, or when the active
+    prompt is not the two-stage one (a stale caller after a rollback must not run
+    the fuller-mode prose call under a single-shot prompt — #216).
     """
+    if not is_two_stage_prompt(settings.COACH_PROMPT_ID):
+        logger.info(
+            "generate_fuller skipped: active prompt %s is single-shot",
+            settings.COACH_PROMPT_ID,
+        )
+        return None
+
     activity_uuid = _coerce_uuid(activity_id)
 
     existing = get_active_report_row(db, activity_uuid)

--- a/backend/tests/test_two_stage_pipeline.py
+++ b/backend/tests/test_two_stage_pipeline.py
@@ -281,6 +281,38 @@ async def test_two_notifications_max_opener_then_fuller(db, configured, notifier
     assert activity.coach_notification_sent_at is not None
 
 
+# --- rollback inertness (#216) -------------------------------------------------
+
+
+async def test_scheduled_fuller_is_inert_after_rollback_to_single_shot(
+    db, configured, notifier, monkeypatch
+):
+    # #216 / AC8: a fuller scheduled under coach_message_v2 that fires AFTER the
+    # owner rolls COACH_PROMPT_ID back to a single-shot prompt must be a no-op —
+    # no generation, no notification, no learning-loop write-back.
+    activity = _seed(db)
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_opener_blocks(schedule=True)))), \
+         patch.object(pna, "_schedule_fuller_turn"):
+        await _run_opener_stage(db=db, activity=activity,
+                                strava_activity_id=activity.strava_activity_id, notifier=notifier)
+    assert len(notifier.sent) == 1  # the opener went out before the rollback
+
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_report_v10")  # rollback
+    with patch("app.services.coach.service.AnthropicClient") as client_cls, \
+         patch("app.services.coach.service.write_back_beliefs") as wb, \
+         patch("app.services.coach.service.enqueue_consolidation") as ec:
+        result = await process_fuller_turn(db=db, activity=activity, notifier=notifier)
+
+    assert result is None
+    assert len(notifier.sent) == 1   # no stray single-shot notification
+    client_cls.assert_not_called()   # no generation at all
+    wb.assert_not_called()
+    ec.assert_not_called()
+    db.refresh(activity)
+    assert activity.coach_notification_sent_at is None
+
+
 # --- the scheduler wiring (enqueue_in) ----------------------------------------
 
 

--- a/backend/tests/test_two_stage_service.py
+++ b/backend/tests/test_two_stage_service.py
@@ -381,3 +381,16 @@ async def test_fuller_persistent_fallback_stays_opener_only_and_recovers(db, _v2
     assert row2.is_fallback is False
     assert row2.report["message"].startswith("Aerobically")
     assert row2.report["opener_message"].startswith("Nice work")
+
+
+async def test_generate_fuller_noops_under_single_shot_prompt(db, _v2, monkeypatch):
+    # #216: generate_fuller is meaningful only under the two-stage prompt. After a
+    # rollback to a single-shot id it must refuse to run — no LLM call, nothing
+    # persisted — so a stale scheduled fuller cannot leak a wrong-path report.
+    activity = _seed(db)
+    monkeypatch.setattr(_v2, "COACH_PROMPT_ID", "coach_report_v10")
+    with patch("app.services.coach.service.AnthropicClient") as client_cls:
+        read = await generate_fuller(db, str(activity.id))
+    assert read is None
+    client_cls.assert_not_called()
+    assert _stored(db, activity) is None  # nothing written under the rolled-back id


### PR DESCRIPTION
Closes #216.

## Problem
A4 documents rollback (flipping `COACH_PROMPT_ID` back to a single-shot id) as fully inert, but a fuller turn already scheduled via `enqueue_in` could still fire up to `EXCHANGE_STAGE2_DELAY_SECONDS` (3h) after the flip. It then ran `generate_fuller` under the now-active single-shot prompt: cache miss on the new `(prompt_id, 1.2)` key, a fresh wrong-path generation (the fuller-mode prose call under a possibly structured prompt), a stray `stage="fuller"` notification, and an M4-M10 learning-loop write-back.

## Fix
Add the existing `is_two_stage_prompt` gate, matching every other A4 trigger (opener stage, `maybe_enqueue_fuller_turn`, `get_or_generate_coach_report`):
- `process_fuller_turn` (job seam): a stale timer- or reply-fired fuller logs and no-ops.
- `generate_fuller` (service): refuses to run under a single-shot prompt regardless of caller, closing the wrong-prompt prose-call hazard.

## Tests
- `test_scheduled_fuller_is_inert_after_rollback_to_single_shot` (pipeline seam): opener under `coach_message_v2`, prompt flipped to `coach_report_v10`, fired fuller asserts no LLM client, no notification, no write-back, sentinel null. Failed before the fix, passes after.
- `test_generate_fuller_noops_under_single_shot_prompt` (service seam): no LLM call, nothing persisted. Failed before, passes after.
- Full suite 940 passed (baseline 938 + the 2 new); `make eval-selftest` green both shapes.

Residual risk: gates exercised in-process at the established stubbed-LLM job seam; no real Redis/rq-scheduler run, but the change adds no new job signature or scheduling, only an early return.