### PR TITLE
Retry the pipeline job so a worker crash cannot strand an exchange (#215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Health check: `curl http://localhost:8000/api/health`
 ### 4) Run worker
 In a second terminal (from `backend/`, venv activated):
 ```bash
-rq worker --url $REDIS_URL
+rq worker --with-scheduler --url $REDIS_URL
 ```
 
 ### 4b) Run the polling scheduler (optional, enables ASAP coach-report emails)

--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -10,7 +10,7 @@ from app.core.config import settings
 from app.db.session import get_db
 from app.models import Activity, StravaAccount
 from app.core.queue import queue
-from app.jobs.process_new_activity import process_new_activity_job
+from app.jobs.process_new_activity import PIPELINE_RETRY, process_new_activity_job
 from app.jobs.strava_sync import sync_activity_job
 from app.schemas import CheckInCreate
 from app.services.checkins import write_checkin
@@ -138,6 +138,7 @@ async def receive_webhook(
             strava_activity_id=event.object_id,
             job_id=job_id,
             result_ttl=3600,
+            retry=PIPELINE_RETRY,
         )
         return {"status": "processed", "action": "enqueued_pipeline"}
 

--- a/backend/app/jobs/polling.py
+++ b/backend/app/jobs/polling.py
@@ -73,7 +73,7 @@ async def poll_for_new_activities(
 
 
 def _enqueue_pipeline(athlete_id: int, activity_id: int) -> None:
-    from app.jobs.process_new_activity import process_new_activity_job
+    from app.jobs.process_new_activity import PIPELINE_RETRY, process_new_activity_job
 
     queue.enqueue(
         process_new_activity_job,
@@ -81,6 +81,7 @@ def _enqueue_pipeline(athlete_id: int, activity_id: int) -> None:
         strava_activity_id=activity_id,
         job_id=f"pipeline_poll_{activity_id}",
         result_ttl=3600,
+        retry=PIPELINE_RETRY,
     )
 
 

--- a/backend/app/jobs/process_new_activity.py
+++ b/backend/app/jobs/process_new_activity.py
@@ -19,6 +19,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
+from rq import Retry
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -49,6 +50,15 @@ from app.services.strava_ingestion import (
 )
 
 logger = logging.getLogger(__name__)
+
+# #215: the recovery trigger for a worker crash mid-pipeline. Once ingest has
+# persisted the Activity row, polling treats it as known and never re-picks it,
+# so without a retry a crash between ingest and the opener notify/schedule
+# permanently strands the exchange. Every stage is idempotent on re-entry
+# (opener row reuse, per-stage sentinels, fuller sentinel), so a re-run is safe.
+# RQ 2.x honours retries_left for failed, horse-dead, AND abandoned jobs (the
+# whole-worker SIGKILL of a Railway deploy), re-enqueueing on registry cleanup.
+PIPELINE_RETRY = Retry(max=3, interval=[60, 300, 900])
 
 
 def _notify(

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -23,7 +23,11 @@ def main() -> None:
     logger.info("Worker booting; listening on %s", ",".join(LISTEN))
     queues = [Queue(name, connection=redis_conn) for name in LISTEN]
     worker = Worker(queues, connection=redis_conn)
-    worker.work()
+    # with_scheduler: RQ's retry intervals (#215 PIPELINE_RETRY) park retried jobs
+    # in the ScheduledJobRegistry, which only a worker-embedded scheduler thread
+    # moves back onto the queue. Without it an interval retry is stranded forever.
+    # Independent of the separate rq-scheduler process (polling/fuller timers).
+    worker.work(with_scheduler=True)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_polling_job.py
+++ b/backend/tests/test_polling_job.py
@@ -92,6 +92,13 @@ async def test_polling_enqueues_pipeline_for_each_new_activity(db, fake_queue):
     assert kwargs["strava_athlete_id"] == 555
     assert kwargs["strava_activity_id"] == 1001
 
+    # #215: the polling enqueue carries the same bounded Retry policy as the
+    # webhook path, so a worker crash mid-pipeline is re-run rather than
+    # stranding the already-ingested activity forever.
+    from app.jobs.process_new_activity import PIPELINE_RETRY
+
+    assert kwargs["retry"] is PIPELINE_RETRY
+
 
 @pytest.mark.asyncio
 async def test_polling_with_no_new_activities_enqueues_nothing(db, fake_queue):

--- a/backend/tests/test_two_stage_pipeline.py
+++ b/backend/tests/test_two_stage_pipeline.py
@@ -313,6 +313,37 @@ async def test_scheduled_fuller_is_inert_after_rollback_to_single_shot(
     assert activity.coach_notification_sent_at is None
 
 
+# --- crash recovery via job retry (#215) ---------------------------------------
+
+
+async def test_opener_crash_before_schedule_recovers_on_rerun(db, configured, notifier):
+    # #215: a worker crash after the opener row is committed but before the fuller
+    # is scheduled and the opener notified must be recoverable by re-running the
+    # job (the RQ retry). The re-run completes the exchange — fuller scheduled,
+    # opener notified — without a second LLM call (generate_opener re-enters on
+    # the stored row). This pins the re-entrancy the retry policy relies on.
+    activity = _seed(db)
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_opener_blocks(schedule=True)))), \
+         patch.object(pna, "_schedule_fuller_turn", side_effect=RuntimeError("worker died")):
+        with pytest.raises(RuntimeError):
+            await _run_opener_stage(db=db, activity=activity,
+                                    strava_activity_id=activity.strava_activity_id, notifier=notifier)
+    assert len(notifier.sent) == 0  # crashed before notify
+
+    with patch("app.services.coach.service.AnthropicClient") as client_cls, \
+         patch.object(pna, "_schedule_fuller_turn") as sched:
+        result = await _run_opener_stage(db=db, activity=activity,
+                                         strava_activity_id=activity.strava_activity_id, notifier=notifier)
+
+    assert result is not None
+    client_cls.assert_not_called()  # idempotent re-entry, no fresh generation
+    sched.assert_called_once_with(str(activity.id))
+    assert len(notifier.sent) == 1
+    db.refresh(activity)
+    assert activity.opener_notification_sent_at is not None
+
+
 # --- the scheduler wiring (enqueue_in) ----------------------------------------
 
 

--- a/backend/tests/test_webhook_dispatch.py
+++ b/backend/tests/test_webhook_dispatch.py
@@ -82,6 +82,22 @@ class TestDispatchForAuthenticEvents:
         assert kwargs["strava_athlete_id"] == CONNECTED_ATHLETE_ID
         assert kwargs["strava_activity_id"] == 7777
 
+    def test_create_enqueue_carries_retry_policy(
+        self, client, fake_queue, connected_account
+    ):
+        # #215: a worker crash mid-pipeline (after ingest, before the opener is
+        # scheduled/notified) strands the exchange unless RQ re-runs the job —
+        # polling never re-picks an already-ingested activity. The pipeline
+        # enqueue must carry the shared bounded Retry policy.
+        from app.jobs.process_new_activity import PIPELINE_RETRY
+
+        response = _post(client, aspect_type="create")
+        assert response.status_code == 200
+
+        _, kwargs = fake_queue.enqueue.call_args
+        assert kwargs["retry"] is PIPELINE_RETRY
+        assert PIPELINE_RETRY.max >= 1
+
     def test_update_enqueues_existing_sync_activity_job(
         self, client, fake_queue, connected_account
     ):

--- a/docs/deployment/topology.md
+++ b/docs/deployment/topology.md
@@ -105,7 +105,7 @@ Vercel before relying on them.
 | Postgres | `docker compose up -d postgres redis` | host `5433` → container `5432` |
 | Redis | (same compose) | `6379` |
 | Backend web | `uvicorn app.main:app --reload --port 8000` | `8000` |
-| Backend worker | `rq worker --url $REDIS_URL` | — |
+| Backend worker | `rq worker --with-scheduler --url $REDIS_URL` | — |
 | Backend scheduler (optional) | `python -m app.jobs.scheduler` then `rqscheduler --url $REDIS_URL` | — |
 | Frontend | `npm run dev` | `3000` |
 


### PR DESCRIPTION
Closes #215.

## Problem
A worker restart (routine Railway deploy, OOM, SIGKILL) during the opener stage, after `ingest_activity_by_id` persists the `Activity` but before `_schedule_fuller_turn` + the opener notify, permanently strands the exchange: polling's `new_ids` diff treats the ingested row as known and never re-picks it, and neither enqueue point set an RQ retry policy.

## Fix (direction chosen with the owner: RQ retry, not a sweep or polling re-pick)
- Shared `PIPELINE_RETRY = Retry(max=3, interval=[60, 300, 900])` on both pipeline enqueue points (webhook `create` and polling `_enqueue_pipeline`). Only jobs genuinely enqueued get re-run, so manual-sync/backfill imports can never retroactively grow exchanges.
- `worker.work(with_scheduler=True)`: a runtime probe showed interval retries park in RQ's ScheduledJobRegistry, which only the worker-embedded scheduler thread drains; a plain worker strands the retried job in SCHEDULED forever. One line, in-repo, independent of the separate rq-scheduler process. Local-dev `rq worker` commands in README/topology gain `--with-scheduler`.

The pipeline was already idempotent at every crash point (opener re-entry without a second LLM call, per-stage sentinels, idempotent fuller); the retry is the missing re-entry trigger.

## Evidence
- TDD: both enqueue tests failed before (no `retry` kwarg) and pass after.
- New re-entrancy pin: crash after opener-row commit but before schedule/notify, then a re-run completes the exchange (no second LLM call, one notification, fuller scheduled).
- Runtime probe against a real Redis + worker: SIGKILL mid-job -> abandoned-job cleanup re-enqueues with `retries_left` decremented (RQ 2.6.1 `registry.py`), and retried jobs execute under `work(with_scheduler=True)` (verified stuck without it).
- Full suite 940 passed (baseline 938 + 2 new); `make eval-selftest` green both shapes.

Residual: probe ran on macOS, not the Linux prod image; recovery latency for an abandoned job is job-timeout + up-to-10-min worker maintenance tick; 3 lost retries in a row (~21 min of repeated kills) would still strand - bounded retry is the deliberate trade.