### PR TITLE
Hide null RPE/pain rows in the check-in summary (#229)

### DIFF
--- a/frontend/components/CheckInForm.tsx
+++ b/frontend/components/CheckInForm.tsx
@@ -123,14 +123,18 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
                        </span>
                   </dd>
               </div>
-              <div className="flex justify-between border-b border-green-100 pb-1">
-                  <dt className="text-green-800 opacity-80">RPE</dt>
-                  <dd className="font-medium">{existingCheckIn.rpe}/10</dd>
-              </div>
-              <div className="flex justify-between border-b border-green-100 pb-1">
-                  <dt className="text-green-800 opacity-80">Pain</dt>
-                  <dd className="font-medium">{existingCheckIn.pain_score}/10</dd>
-              </div>
+              {existingCheckIn.rpe != null && (
+                  <div className="flex justify-between border-b border-green-100 pb-1">
+                      <dt className="text-green-800 opacity-80">RPE</dt>
+                      <dd className="font-medium">{existingCheckIn.rpe}/10</dd>
+                  </div>
+              )}
+              {existingCheckIn.pain_score != null && (
+                  <div className="flex justify-between border-b border-green-100 pb-1">
+                      <dt className="text-green-800 opacity-80">Pain</dt>
+                      <dd className="font-medium">{existingCheckIn.pain_score}/10</dd>
+                  </div>
+              )}
               {existingCheckIn.notes && (
                   <div className="col-span-2 pt-1">
                        <dt className="text-xs font-bold uppercase tracking-wider text-green-800 opacity-60 mb-1">Notes</dt>


### PR DESCRIPTION
Closes #229.

A Telegram tap writes a one-score check-in (`rpe` set, `pain_score` null), and the Activity Report summary rendered the absent metric as a dangling `Pain /10`. Each metric row now renders only when its value is present — null-checked rather than truthy-checked, so a legitimate pain score of 0 still shows. Matches the existing conditional Notes row.

Verification: `npm run test` (lint + build) green before and after; real-data render check on this branch's Vercel preview against the 2026-06-10 run (the tap-created `rpe=9, pain=null` check-in) — RPE row shows, no dangling Pain row. No component-test infra exists (known gap), so the render check is the runtime evidence.