### PR TITLE
Mark the tapped Telegram button so a recorded check-in stays visible (#230)

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -170,6 +170,8 @@ class _TgChat(BaseModel):
 
 class _TgMessage(BaseModel):
     chat: _TgChat = _TgChat()
+    message_id: int = 0
+    reply_markup: dict | None = None
 
 
 class _TgCallbackQuery(BaseModel):
@@ -238,6 +240,45 @@ def _answer_callback(callback_query_id: str, *, text: str = "") -> None:
         logger.exception("failed to answer telegram callback %s", callback_query_id)
 
 
+_TAP_MARK = "✓ "
+
+
+def _mark_tapped_button(callback: _TgCallbackQuery) -> None:
+    """Persistently acknowledge a tap in-chat (#230): re-render the opener's
+    inline keyboard with the chosen button check-marked. A re-tap moves the mark
+    (each pass strips old marks first). Only the keyboard is edited — editing the
+    text would strip the HTML title/link, which Telegram does not echo back in
+    the callback payload. Best-effort: never raises into the request path, and
+    skips entirely when the callback carries no keyboard/message id or the active
+    notifier cannot edit (email, no-op)."""
+    msg = callback.message
+    if msg is None or not msg.message_id or not msg.reply_markup:
+        return
+    edit = getattr(get_notifier(), "edit_message_reply_markup", None)
+    if edit is None:
+        return
+
+    keyboard = msg.reply_markup.get("inline_keyboard") or []
+    marked = []
+    for row in keyboard:
+        new_row = []
+        for button in row:
+            label = (button.get("text") or "").removeprefix(_TAP_MARK)
+            if button.get("callback_data") == callback.data:
+                label = _TAP_MARK + label
+            new_row.append({**button, "text": label})
+        marked.append(new_row)
+    if marked == keyboard:
+        return  # same button re-tapped: Telegram rejects a no-change edit
+
+    try:
+        edit(message_id=msg.message_id, reply_markup={"inline_keyboard": marked})
+    except Exception:
+        logger.exception(
+            "failed to mark tapped telegram button on message %s", msg.message_id
+        )
+
+
 @router.post("/webhooks/telegram")
 def receive_telegram_callback(
     update: TelegramUpdate,
@@ -284,5 +325,6 @@ def receive_telegram_callback(
     write_checkin(db, activity_uuid, checkin_data)
 
     label = "RPE" if action.kind == "rpe" else "pain"
+    _mark_tapped_button(callback)
     _answer_callback(callback.id, text=f"Got it — {label} {action.value} recorded.")
     return {"status": "processed", "action": "checkin_written"}

--- a/backend/app/services/notifications/telegram_adapter.py
+++ b/backend/app/services/notifications/telegram_adapter.py
@@ -71,6 +71,27 @@ class TelegramNotifier:
                 f"Telegram API rejected answerCallbackQuery: {payload.get('description', 'unknown error')}"
             )
 
+    def edit_message_reply_markup(
+        self, *, message_id: int, reply_markup: dict
+    ) -> None:
+        """Replace an existing message's inline keyboard (the #230 tap mark).
+
+        Same error contract as answer_callback: best-effort by the caller, but
+        raises on transport/API errors so failures land in logs."""
+        url = f"{self.api_base}/bot{self.bot_token}/editMessageReplyMarkup"
+        body = {
+            "chat_id": self.chat_id,
+            "message_id": message_id,
+            "reply_markup": reply_markup,
+        }
+        response = httpx.post(url, json=body, timeout=self.timeout)
+        response.raise_for_status()
+        payload = response.json()
+        if not payload.get("ok", False):
+            raise RuntimeError(
+                f"Telegram API rejected editMessageReplyMarkup: {payload.get('description', 'unknown error')}"
+            )
+
     @staticmethod
     def _reply_markup(notification: Notification) -> dict | None:
         """Build an inline keyboard from the notification's actions, or None.

--- a/backend/tests/test_telegram_callback.py
+++ b/backend/tests/test_telegram_callback.py
@@ -185,14 +185,29 @@ def _seed_activity(db) -> Activity:
     return a
 
 
-def _update(token: str, *, chat_id=42, cbq_id="cbq-1") -> dict:
+def _update(
+    token: str, *, chat_id=42, cbq_id="cbq-1", message_id=0, reply_markup=None
+) -> dict:
+    message: dict = {"chat": {"id": chat_id}}
+    if message_id:
+        message["message_id"] = message_id
+    if reply_markup is not None:
+        message["reply_markup"] = reply_markup
     return {
         "update_id": 1,
         "callback_query": {
             "id": cbq_id,
             "data": token,
-            "message": {"chat": {"id": chat_id}},
+            "message": message,
         },
+    }
+
+
+def _keyboard(*buttons: tuple[str, str]) -> dict:
+    return {
+        "inline_keyboard": [
+            [{"text": label, "callback_data": token}] for label, token in buttons
+        ]
     }
 
 
@@ -217,7 +232,7 @@ def isolate_side_effects():
     ) as fuller, patch(
         "app.api.webhooks.get_notifier", return_value=notifier
     ):
-        yield {"answer": answer, "fuller": fuller}
+        yield {"answer": answer, "fuller": fuller, "notifier": notifier}
 
 
 class TestInboundAuth:
@@ -351,3 +366,90 @@ class TestParityWithInApp:
         via_tg = db.query(CheckIn).filter(CheckIn.activity_id == a_tg.id).first()
         assert in_app.rpe == via_tg.rpe == 7
         assert in_app.pain_score == via_tg.pain_score
+
+
+class TestTapAcknowledgment:
+    """#230: a successful tap is acknowledged persistently in-chat by check-marking
+    the chosen button on the opener's inline keyboard (only the keyboard is edited;
+    editing the text would strip the HTML title/link Telegram does not echo back).
+    """
+
+    def _post(self, client, token, **update_kwargs):
+        return client.post(
+            "/api/webhooks/telegram",
+            json=_update(token, **update_kwargs),
+            headers={"X-Telegram-Bot-Api-Secret-Token": _SECRET},
+        )
+
+    def test_tap_marks_the_chosen_button(self, client, db, configured, isolate_side_effects):
+        a = _seed_activity(db)
+        t5 = encode(kind="rpe", activity_id=str(a.id), value=5)
+        t9 = encode(kind="rpe", activity_id=str(a.id), value=9)
+        kb = _keyboard(("Cruising (RPE 5-6)", t5), ("Really pushing (RPE 9+)", t9))
+
+        resp = self._post(client, t9, message_id=555, reply_markup=kb)
+
+        assert resp.status_code == 200
+        edit = isolate_side_effects["notifier"].edit_message_reply_markup
+        edit.assert_called_once()
+        kwargs = edit.call_args.kwargs
+        assert kwargs["message_id"] == 555
+        rows = kwargs["reply_markup"]["inline_keyboard"]
+        assert rows[0][0]["text"] == "Cruising (RPE 5-6)"          # untouched
+        assert rows[1][0]["text"] == "✓ Really pushing (RPE 9+)"  # marked
+        assert rows[1][0]["callback_data"] == t9                   # token preserved
+
+    def test_retap_moves_the_mark(self, client, db, configured, isolate_side_effects):
+        a = _seed_activity(db)
+        t5 = encode(kind="rpe", activity_id=str(a.id), value=5)
+        t9 = encode(kind="rpe", activity_id=str(a.id), value=9)
+        kb = _keyboard(("✓ Cruising (RPE 5-6)", t5), ("Really pushing (RPE 9+)", t9))
+
+        resp = self._post(client, t9, message_id=555, reply_markup=kb)
+
+        assert resp.status_code == 200
+        rows = isolate_side_effects["notifier"].edit_message_reply_markup \
+            .call_args.kwargs["reply_markup"]["inline_keyboard"]
+        assert rows[0][0]["text"] == "Cruising (RPE 5-6)"              # mark removed
+        assert rows[1][0]["text"] == "✓ Really pushing (RPE 9+)"  # mark moved
+
+    def test_same_button_retap_skips_the_noop_edit(self, client, db, configured, isolate_side_effects):
+        # Telegram rejects an edit that does not change the markup, so an
+        # already-marked button must not trigger a redundant API call.
+        a = _seed_activity(db)
+        t9 = encode(kind="rpe", activity_id=str(a.id), value=9)
+        kb = _keyboard(("✓ Really pushing (RPE 9+)", t9))
+
+        resp = self._post(client, t9, message_id=555, reply_markup=kb)
+
+        assert resp.status_code == 200
+        isolate_side_effects["notifier"].edit_message_reply_markup.assert_not_called()
+
+    def test_missing_keyboard_or_message_id_skips_marking(
+        self, client, db, configured, isolate_side_effects
+    ):
+        a = _seed_activity(db)
+        token = encode(kind="rpe", activity_id=str(a.id), value=7)
+
+        resp = self._post(client, token)  # no message_id, no reply_markup
+
+        assert resp.status_code == 200
+        row = db.query(CheckIn).filter(CheckIn.activity_id == a.id).first()
+        assert row is not None and row.rpe == 7  # the write still happened
+        isolate_side_effects["notifier"].edit_message_reply_markup.assert_not_called()
+
+    def test_marking_failure_never_breaks_the_request(
+        self, client, db, configured, isolate_side_effects
+    ):
+        a = _seed_activity(db)
+        token = encode(kind="rpe", activity_id=str(a.id), value=7)
+        kb = _keyboard(("Comfortably hard (RPE 7-8)", token))
+        isolate_side_effects["notifier"].edit_message_reply_markup.side_effect = (
+            RuntimeError("telegram down")
+        )
+
+        resp = self._post(client, token, message_id=555, reply_markup=kb)
+
+        assert resp.status_code == 200
+        row = db.query(CheckIn).filter(CheckIn.activity_id == a.id).first()
+        assert row is not None and row.rpe == 7

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -160,3 +160,32 @@ def test_answer_callback_raises_when_api_reports_not_ok():
     ):
         with pytest.raises(RuntimeError, match="query is too old"):
             _notifier().answer_callback("cbq-1")
+
+
+def test_edit_message_reply_markup_posts_to_edit_endpoint():
+    kb = {"inline_keyboard": [[{"text": "✓ RPE 7", "callback_data": "t"}]]}
+    with patch(
+        "app.services.notifications.telegram_adapter.httpx.post",
+        return_value=_ok_response(),
+    ) as post:
+        _notifier().edit_message_reply_markup(message_id=555, reply_markup=kb)
+
+    assert post.call_args.args[0] == (
+        "https://api.telegram.org/bot123:ABC/editMessageReplyMarkup"
+    )
+    body = post.call_args.kwargs["json"]
+    assert body == {"chat_id": "42", "message_id": 555, "reply_markup": kb}
+
+
+def test_edit_message_reply_markup_raises_when_api_reports_not_ok():
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"ok": False, "description": "message is not modified"}
+    with patch(
+        "app.services.notifications.telegram_adapter.httpx.post",
+        return_value=response,
+    ):
+        with pytest.raises(RuntimeError, match="message is not modified"):
+            _notifier().edit_message_reply_markup(
+                message_id=555, reply_markup={"inline_keyboard": []}
+            )


### PR DESCRIPTION
Closes #230.

## Problem
A tap's only acknowledgment was the ephemeral `answerCallbackQuery` toast; the owner tapped, the check-in wrote, and there was still no visible trace in the chat that anything was recorded.

## Approach (chosen with the owner)
Edit the opener's inline keyboard in place: the tapped button's label gains a check mark, a re-tap moves it, and `callback_data` is preserved so corrections keep working. The message text is deliberately NOT edited: Telegram's callback payload carries only plain text, so a text edit would strip the opener's bold title and View-in-app link.

- `_mark_tapped_button` in the webhook handler: strips old marks, marks the tapped button, skips the no-change edit Telegram rejects, never raises into the request path, and no-ops for notifiers that cannot edit.
- `TelegramNotifier.edit_message_reply_markup`: the `editMessageReplyMarkup` transport, same error contract as `answer_callback`.
- `_TgMessage` gains `message_id` and `reply_markup` (both already in Telegram's payload).

## Tests
5 new route-seam tests (mark applied with token preserved, re-tap moves mark, same-button no-op skip, missing-keyboard skip with the write intact, marking failure never breaks the request) and 2 adapter wire-shape tests. Marking tests failed before the change. Full suite 949 passed (baseline 942); eval-selftest green.

Residual: no real Telegram edit call exercised (mock-level). The opener with live buttons is still in the owner's chat, so one tap after merge+deploy verifies it end to end.