### PR TITLE
Fix header overflow, disable zoom, remove web-only browser behaviors

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2,6 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
+html,
+body {
+  /* Native-app feel: kill browser-only gestures and chrome that don't belong
+     in the app shell. */
+  overscroll-behavior: none; /* no pull-to-refresh / scroll-chaining bounce */
+  -webkit-tap-highlight-color: transparent; /* no blue flash on tap (Android) */
+  -webkit-touch-callout: none; /* no long-press callout menu on links/images */
+  touch-action: manipulation; /* no 300ms double-tap-to-zoom delay */
+  user-select: none; /* no accidental text selection on UI chrome */
+}
+
 body {
   background: #fdfbf7;
   color: #171717;
@@ -10,4 +21,15 @@ body {
 .dark body {
   background: #0f172a;
   color: #e5e7eb;
+}
+
+/* Re-enable selection where reading/copying real content is expected. */
+p,
+pre,
+code,
+article,
+input,
+textarea,
+.selectable {
+  user-select: text;
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,5 @@
 import './globals.css';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import NavBar from '@/components/NavBar';
 import ThemeProvider from '@/components/ThemeProvider';
@@ -9,6 +9,15 @@ const inter = Inter({ subsets: ['latin'] });
 export const metadata: Metadata = {
   title: 'AI Running Coach',
   description: 'Local-first running advice',
+};
+
+// Lock the viewport so the app behaves like a native screen: no pinch-to-zoom
+// and no double-tap zoom on mobile.
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
 };
 
 export default function RootLayout({

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import ConnectStravaButton from '@/components/ConnectStravaButton';
+import ThemeToggle from '@/components/ThemeToggle';
 import { fetchFromAPI } from '@/lib/api';
 
 export default function ProfilePage() {
@@ -79,6 +80,7 @@ export default function ProfilePage() {
       <header className="mb-6 flex flex-wrap justify-between items-center gap-4">
         <h1 className="text-2xl font-bold whitespace-nowrap">Athlete Profile</h1>
         <div className="flex items-center gap-4 flex-wrap">
+            <ThemeToggle />
             <ConnectStravaButton />
             <Link href="/" className="text-blue-600 dark:text-blue-400 hover:underline">Cancel</Link>
         </div>

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import ThemeToggle from '@/components/ThemeToggle';
 
 const LINKS = [
   { href: '/load', label: 'Load' },
@@ -17,7 +16,7 @@ export default function NavBar() {
     href === '/' ? pathname === '/' : pathname.startsWith(href);
 
   return (
-    <nav className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900 sticky top-0 z-10">
+    <nav className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900 sticky top-0 z-10 overflow-x-hidden">
       <div className="max-w-4xl mx-auto px-4 h-16 flex items-center justify-between gap-4">
         <Link
           href="/"
@@ -39,7 +38,6 @@ export default function NavBar() {
               {label}
             </Link>
           ))}
-          <ThemeToggle />
         </div>
       </div>
     </nav>


### PR DESCRIPTION
- Move ThemeToggle from NavBar to the Profile page so the header no
  longer overflows on narrow screens; add overflow-x-hidden as a guard.
- Add a locked viewport export (maximumScale 1, userScalable false) plus
  touch-action: manipulation to disable pinch and double-tap zoom.
- Strip browser-only behaviors that feel wrong in a native app:
  pull-to-refresh, tap-highlight flash, long-press callout, and
  accidental text selection; re-enable selection on real content.

Closes #242