### PR TITLE
fix(strava): add request timeout and retry on mid-flight 401

### DIFF
--- a/backend/app/services/strava_ingestion/http_adapter.py
+++ b/backend/app/services/strava_ingestion/http_adapter.py
@@ -26,6 +26,11 @@ _MAX_RETRY_AFTER_S = 60.0
 # silent truncation never masquerades as "fetched everything". See #109.
 _MAX_PAGES = 40
 
+# Hard cap on how long we wait for a single Strava response. 30 s is well
+# above typical latency but short enough to free a worker within one polling
+# interval. Without this, a slow Strava response hangs the job queue forever.
+_HTTP_TIMEOUT_S = 30.0
+
 
 def _parse_retry_after(response: httpx.Response, default: float) -> float:
     raw = response.headers.get("Retry-After")
@@ -92,7 +97,7 @@ class HTTPStravaAdapter:
         return f"https://www.strava.com/oauth/authorize?{query}"
 
     async def exchange_code(self, code: str) -> Tokens:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_S) as client:
             response = await client.post(
                 _OAUTH_URL,
                 data={
@@ -112,7 +117,7 @@ class HTTPStravaAdapter:
         )
 
     async def refresh_token(self, refresh_token: str) -> Tokens:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_S) as client:
             response = await client.post(
                 _OAUTH_URL,
                 data={
@@ -146,7 +151,7 @@ class HTTPStravaAdapter:
         headers = {"Authorization": f"Bearer {access_token}"}
         after = int(since.timestamp())
         activities: list[dict] = []
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_S) as client:
             for page in range(1, _MAX_PAGES + 1):
                 params = {"page": page, "per_page": per_page, "after": after}
                 response = await _send_with_retry(
@@ -186,7 +191,7 @@ class HTTPStravaAdapter:
 
     async def get_activity(self, access_token: str, activity_id: int) -> dict:
         headers = {"Authorization": f"Bearer {access_token}"}
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_S) as client:
             response = await _send_with_retry(
                 lambda: client.get(
                     f"{_BASE_URL}/activities/{activity_id}",
@@ -205,7 +210,7 @@ class HTTPStravaAdapter:
     ) -> dict | None:
         keys = ",".join(stream_types)
         headers = {"Authorization": f"Bearer {access_token}"}
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_S) as client:
             response = await _send_with_retry(
                 lambda: client.get(
                     f"{_BASE_URL}/activities/{activity_id}/streams/{keys}?key_by_type=true",

--- a/backend/app/services/strava_ingestion/ingestion.py
+++ b/backend/app/services/strava_ingestion/ingestion.py
@@ -2,6 +2,7 @@ import logging
 import time
 from datetime import datetime, timedelta
 
+import httpx
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -31,10 +32,13 @@ _STREAM_TYPES = [
 
 
 async def ensure_valid_access_token(
-    db: Session, account: StravaAccount, port: StravaPort
+    db: Session, account: StravaAccount, port: StravaPort, *, force: bool = False
 ) -> str:
-    """Return a valid access token, refreshing and persisting if needed."""
-    if account.expires_at > time.time() + _TOKEN_REFRESH_BUFFER_S:
+    """Return a valid access token, refreshing and persisting if needed.
+
+    Pass force=True to unconditionally refresh (e.g. after a mid-flight 401).
+    """
+    if not force and account.expires_at > time.time() + _TOKEN_REFRESH_BUFFER_S:
         return account.access_token
 
     tokens = await port.refresh_token(account.refresh_token)
@@ -162,9 +166,18 @@ async def ingest_recent_activities(
 
     try:
         access_token = await ensure_valid_access_token(db, account, port)
-        raw_activities = await port.list_recent_activities(
-            access_token=access_token, since=since, per_page=50
-        )
+        try:
+            raw_activities = await port.list_recent_activities(
+                access_token=access_token, since=since, per_page=50
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 401:
+                raise
+            logger.warning("strava_401_mid_flight: force-refreshing token and retrying list")
+            access_token = await ensure_valid_access_token(db, account, port, force=True)
+            raw_activities = await port.list_recent_activities(
+                access_token=access_token, since=since, per_page=50
+            )
         stats.fetched = len(raw_activities)
 
         for raw in raw_activities:
@@ -200,7 +213,14 @@ async def ingest_activity_by_id(
 ) -> Activity:
     """Fetch a single activity summary and upsert it. No streams, no analysis."""
     access_token = await ensure_valid_access_token(db, account, port)
-    raw = await port.get_activity(access_token, strava_activity_id)
+    try:
+        raw = await port.get_activity(access_token, strava_activity_id)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code != 401:
+            raise
+        logger.warning("strava_401_mid_flight: force-refreshing token and retrying get_activity")
+        access_token = await ensure_valid_access_token(db, account, port, force=True)
+        raw = await port.get_activity(access_token, strava_activity_id)
     activity = upsert_activity(db, raw, account.user_id)
     db.commit()
     db.refresh(activity)

--- a/backend/tests/test_strava_http_adapter_retries.py
+++ b/backend/tests/test_strava_http_adapter_retries.py
@@ -231,3 +231,46 @@ class TestGetActivityStreamsRetries:
         )
 
         assert result is None
+
+
+class TestHttpTimeout:
+    """ReadTimeout must propagate so the job-level handler can log and react."""
+
+    @pytest.mark.asyncio
+    async def test_read_timeout_propagates_from_list_activities(
+        self, monkeypatch, _no_real_sleep
+    ):
+        original_init = httpx.AsyncClient.__init__
+
+        async def _timeout_handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ReadTimeout("timed out", request=request)
+
+        def patched_init(self, *args, **kwargs):
+            kwargs["transport"] = httpx.MockTransport(_timeout_handler)
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+
+        with pytest.raises(httpx.ReadTimeout):
+            await HTTPStravaAdapter().list_recent_activities(
+                access_token="abc",
+                since=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+
+    @pytest.mark.asyncio
+    async def test_read_timeout_propagates_from_get_activity(
+        self, monkeypatch, _no_real_sleep
+    ):
+        original_init = httpx.AsyncClient.__init__
+
+        async def _timeout_handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ReadTimeout("timed out", request=request)
+
+        def patched_init(self, *args, **kwargs):
+            kwargs["transport"] = httpx.MockTransport(_timeout_handler)
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+
+        with pytest.raises(httpx.ReadTimeout):
+            await HTTPStravaAdapter().get_activity(access_token="abc", activity_id=42)

--- a/backend/tests/test_strava_ingestion.py
+++ b/backend/tests/test_strava_ingestion.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 
 from app.models import Activity, ActivityStream, StravaAccount, User
@@ -7,6 +8,7 @@ from app.services.strava_ingestion import (
     ingest_recent_activities,
     refetch_streams,
 )
+from app.services.strava_ingestion.port import Tokens
 
 
 def _make_account(db, athlete_id: int = 12345) -> StravaAccount:
@@ -150,3 +152,68 @@ async def test_refetch_streams_replaces_existing_rows(db):
         .all()
     }
     assert stream_types == {"time", "heartrate"}
+
+
+def _make_401_error(url: str = "https://www.strava.com/api/v3/athlete/activities"):
+    request = httpx.Request("GET", url)
+    response = httpx.Response(401, request=request)
+    return httpx.HTTPStatusError("401 Unauthorized", request=request, response=response)
+
+
+class TestIngestRetryOn401:
+    """A mid-flight 401 triggers a forced token refresh and a single retry."""
+
+    @pytest.mark.asyncio
+    async def test_list_activities_retries_after_401(self, db):
+        account = _make_account(db, athlete_id=60001)
+
+        class _Once401Adapter(InMemoryStravaAdapter):
+            _calls = 0
+
+            async def list_recent_activities(self, access_token, since, per_page=50):
+                self._calls += 1
+                if self._calls == 1:
+                    raise _make_401_error()
+                return await super().list_recent_activities(access_token, since, per_page)
+
+        adapter = _Once401Adapter()
+        adapter.seed_activities([_raw_activity(600, "Post-401 Run")])
+        adapter.seed_refresh_response(
+            Tokens(access_token="fresh_token", refresh_token="new_refresh", expires_at=9999999999)
+        )
+
+        ingested, stats = await ingest_recent_activities(
+            db, account, adapter, fetch_streams=False
+        )
+
+        assert stats.upserted == 1
+        assert ingested[0].strava_activity_id == 600
+        assert adapter.refresh_calls == ["fake_refresh"]
+        assert adapter._calls == 2
+
+    @pytest.mark.asyncio
+    async def test_get_activity_retries_after_401(self, db):
+        account = _make_account(db, athlete_id=60002)
+
+        class _Once401Adapter(InMemoryStravaAdapter):
+            _calls = 0
+
+            async def get_activity(self, access_token, activity_id):
+                self._calls += 1
+                if self._calls == 1:
+                    raise _make_401_error(
+                        f"https://www.strava.com/api/v3/activities/{activity_id}"
+                    )
+                return await super().get_activity(access_token, activity_id)
+
+        adapter = _Once401Adapter()
+        adapter.seed_activities([_raw_activity(700, "Post-401 Single")])
+        adapter.seed_refresh_response(
+            Tokens(access_token="fresh_token", refresh_token="new_refresh", expires_at=9999999999)
+        )
+
+        activity = await ingest_activity_by_id(db, account, adapter, 700)
+
+        assert activity.strava_activity_id == 700
+        assert adapter.refresh_calls == ["fake_refresh"]
+        assert adapter._calls == 2

--- a/frontend/components/ConnectStravaButton.tsx
+++ b/frontend/components/ConnectStravaButton.tsx
@@ -42,7 +42,7 @@ export default function ConnectStravaButton() {
 
   if (status?.connected) {
     return (
-      <div className="flex items-center gap-3 whitespace-nowrap">
+      <div className="flex flex-col gap-1">
         <span className="inline-flex items-center gap-2 text-sm text-green-700 dark:text-green-300">
           <CheckCircle2 size={16} />
           <span>
@@ -54,10 +54,10 @@ export default function ConnectStravaButton() {
         </span>
         <a
           href={STRAVA_LOGIN_HREF}
-          className="inline-flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline ml-6"
           title="Re-run the Strava OAuth flow to refresh tokens or switch athletes"
         >
-          <RefreshCw size={14} />
+          <RefreshCw size={12} />
           Reconnect
         </a>
       </div>


### PR DESCRIPTION
Two gaps in the Strava HTTP layer caused context builds to hang or fail
silently:

1. Every httpx.AsyncClient() was created without a timeout, so a slow or
   unresponsive Strava endpoint could block a worker indefinitely. Added
   _HTTP_TIMEOUT_S = 30.0 and wired it into all five call sites.

2. ensure_valid_access_token proactively refreshes tokens that are near
   expiry, but a token revoked by Strava between the check and a later
   API call raised an unhandled 401 and crashed the whole ingestion run.
   Added force=True to ensure_valid_access_token and wrapped the port
   calls in ingest_recent_activities and ingest_activity_by_id to catch
   a 401, force-refresh the token, and retry exactly once.

Closes #244