### PR TITLE
Fix dashboard/trends mismatch, dark-mode chart tooltips, and load trend

### DIFF
--- a/backend/app/api/trends.py
+++ b/backend/app/api/trends.py
@@ -8,11 +8,12 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
-from app.schemas.trends import LoadResponse, TrendsResponse
+from app.schemas.trends import LoadResponse, TrendsResponse, WeeklyStatsResponse
 from app.services.training_load import get_load_report
 from app.services.trends import (
     get_available_types,
     get_trends_report,
+    get_weekly_stats,
 )
 
 router = APIRouter()
@@ -37,3 +38,9 @@ def get_trends(
 def get_training_load(db: Session = Depends(get_db)):
     """Weekly training-load report: scores, optimal band, contributions (#209)."""
     return get_load_report(db)
+
+
+@router.get("/stats/weekly", response_model=WeeklyStatsResponse)
+def get_dashboard_weekly_stats(db: Session = Depends(get_db)):
+    """Rolling 7-day dashboard summary with the prior 7 days for comparison (#246, #248)."""
+    return get_weekly_stats(db)

--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -94,6 +94,21 @@ class TrendsResponse(BaseModel):
     daily_zone_load: List[DailyZoneLoadPoint]
 
 
+class WeeklyStatsSummary(BaseModel):
+    """Totals for a rolling 7-day window used by the dashboard summary cards."""
+    total_distance_m: int
+    total_moving_time_s: int
+    activity_count: int
+    total_load: float
+    hard_days: int
+
+
+class WeeklyStatsResponse(BaseModel):
+    """Current rolling 7-day window plus the prior 7 days for comparison (#246, #248)."""
+    summary: WeeklyStatsSummary
+    previous_summary: WeeklyStatsSummary
+
+
 class LoadActivityPoint(BaseModel):
     """One activity's contribution to a week's training load (#209)."""
     id: UUID

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -163,11 +163,33 @@ _RANGE_DAYS = {
 
 
 def _resolve_since(range_key: str) -> Optional[date]:
-    """Return the earliest local date to include, or None for ALL."""
+    """Return the earliest local date to include, or None for ALL.
+
+    The window is inclusive on both ends (``since`` .. ``today``), so a range of
+    N days subtracts N-1 to span exactly N calendar days. e.g. 7D with today =
+    Jun 9 covers Jun 3–Jun 9 inclusive, not Jun 2–Jun 9 (#179).
+    """
     days = _RANGE_DAYS.get(range_key.upper())
     if days is None:
         return None
-    return date.today() - timedelta(days=days)
+    return date.today() - timedelta(days=days - 1)
+
+
+def _period_window(range_key: str) -> Optional[tuple[date, date]]:
+    """Return (current_start, previous_start) for a fixed range, or None for ALL.
+
+    The current window is ``[current_start, today]`` (inclusive) and the previous
+    window is ``[previous_start, current_start)``. Both span exactly
+    ``_RANGE_DAYS[range]`` calendar days with no gap or overlap at the boundary,
+    so period-over-period deltas line up with the charts (#179).
+    """
+    days = _RANGE_DAYS.get(range_key.upper())
+    if days is None:
+        return None
+    current_start = _resolve_since(range_key)
+    assert current_start is not None  # days is not None here
+    previous_start = current_start - timedelta(days=days)
+    return current_start, previous_start
 
 
 def get_available_types(db: Session) -> List[str]:
@@ -501,15 +523,12 @@ def get_weekly_stats(db: Session) -> WeeklyStatsResponse:
     """
     Rolling 7-day summary for the dashboard, plus the prior 7 days for comparison.
 
-    Uses exactly the same window as the Trends 7D view — current window is
-    ``[today-7d, now)`` and the previous window is ``[today-14d, today-7d)`` —
-    so the dashboard cards and Trends 7D can never drift (#246). "Hard days" is
-    derived from the effort axis rather than an HR/name heuristic.
+    Uses exactly the same 7-day window as the Trends 7D view (via
+    ``_period_window``) so the dashboard cards and Trends 7D can never drift
+    (#246, #179). "Hard days" is derived from the effort axis rather than an
+    HR/name heuristic.
     """
-    days = _RANGE_DAYS["7D"]
-    today = date.today()
-    current_start = today - timedelta(days=days)
-    prev_start = current_start - timedelta(days=days)
+    current_start, prev_start = _period_window("7D")  # type: ignore[misc]
 
     current = _query_activity_facts(db, current_start, None)
     previous = _query_activity_facts(db, prev_start, current_start)
@@ -549,12 +568,9 @@ def get_trends_report(
 
     # Previous period summary
     previous_summary = None
-    days = _RANGE_DAYS.get(range_upper)
-    if days is not None:
-        today = date.today()
-        current_start = today - timedelta(days=days)
-        prev_start = current_start - timedelta(days=days)
-
+    window = _period_window(range_upper)
+    if window is not None:
+        current_start, prev_start = window
         prev_facts = _query_activity_facts(db, prev_start, current_start, types=types)
         previous_summary = TrendsSummary(
             total_distance_m=sum(f.distance_m for f in prev_facts),

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -25,7 +25,12 @@ from app.schemas.trends import (
     EfficiencyPoint,
     ZoneLoadWeekPoint,
     DailyZoneLoadPoint,
+    WeeklyStatsSummary,
+    WeeklyStatsResponse,
 )
+
+# Effort-axis labels that count a day as "hard" for the dashboard summary.
+_HARD_EFFORTS = {"tempo", "hard"}
 
 ALLOWED_RANGES = {"7D", "30D", "3M", "6M", "1Y", "ALL"}
 
@@ -41,7 +46,7 @@ class ActivityFact:
         "activity_id", "local_date", "activity_type", "user_intent",
         "distance_m", "moving_time_s", "elapsed_time_s",
         "elev_gain_m", "avg_hr", "avg_cadence", "average_speed_mps",
-        "effort_score", "time_in_zones",
+        "effort_score", "effort", "time_in_zones",
     )
 
     def __init__(self, activity: Activity):
@@ -59,6 +64,11 @@ class ActivityFact:
         self.average_speed_mps = activity.average_speed_mps
         self.effort_score: Optional[float] = (
             activity.metrics.effort_score if activity.metrics else None
+        )
+        # Effort axis (ADR 0007): recovery|easy|moderate|tempo|hard. Used to
+        # count "hard days" on the dashboard without an HR/name heuristic.
+        self.effort: Optional[str] = (
+            activity.metrics.effort if activity.metrics else None
         )
         self.time_in_zones: Optional[dict] = (
             activity.metrics.time_in_zones if activity.metrics else None
@@ -473,6 +483,41 @@ def build_zone_load_daily(
             "hard_min": round(hard_s / 60, 1),
         })
     return result
+
+
+def _summarise_window(facts: List[ActivityFact]) -> WeeklyStatsSummary:
+    """Collapse activity facts for one window into the dashboard summary card totals."""
+    hard_days = len({f.local_date for f in facts if f.effort in _HARD_EFFORTS})
+    return WeeklyStatsSummary(
+        total_distance_m=sum(f.distance_m for f in facts),
+        total_moving_time_s=sum(f.moving_time_s for f in facts),
+        activity_count=len(facts),
+        total_load=round(sum(f.effort_score or 0.0 for f in facts), 1),
+        hard_days=hard_days,
+    )
+
+
+def get_weekly_stats(db: Session) -> WeeklyStatsResponse:
+    """
+    Rolling 7-day summary for the dashboard, plus the prior 7 days for comparison.
+
+    Uses exactly the same window as the Trends 7D view — current window is
+    ``[today-7d, now)`` and the previous window is ``[today-14d, today-7d)`` —
+    so the dashboard cards and Trends 7D can never drift (#246). "Hard days" is
+    derived from the effort axis rather than an HR/name heuristic.
+    """
+    days = _RANGE_DAYS["7D"]
+    today = date.today()
+    current_start = today - timedelta(days=days)
+    prev_start = current_start - timedelta(days=days)
+
+    current = _query_activity_facts(db, current_start, None)
+    previous = _query_activity_facts(db, prev_start, current_start)
+
+    return WeeklyStatsResponse(
+        summary=_summarise_window(current),
+        previous_summary=_summarise_window(previous),
+    )
 
 
 def get_trends_report(

--- a/backend/tests/test_trends_window.py
+++ b/backend/tests/test_trends_window.py
@@ -1,0 +1,95 @@
+"""Fixed-range windows span exactly N days, not N+1 (#179).
+
+`7D` must cover 7 calendar days (today-6 .. today inclusive), and the
+previous-period window must abut it with no gap or overlap so deltas line up.
+"""
+
+import uuid
+from datetime import date, datetime, time, timedelta
+
+from app.models import Activity, DerivedMetric, User
+from app.services.trends import get_trends_report, get_weekly_stats
+
+
+def _user(db) -> uuid.UUID:
+    user = User(email=f"{uuid.uuid4()}@example.com")
+    db.add(user)
+    db.flush()
+    return user.id
+
+
+def _activity_on(db, user_id, on: date, *, distance_m: int = 5000) -> Activity:
+    activity = Activity(
+        user_id=user_id,
+        strava_activity_id=int(uuid.uuid4().int % 1_000_000_000),
+        # Midday so the local date is unambiguous regardless of run time.
+        start_date=datetime.combine(on, time(12, 0)),
+        type="Run",
+        name="Run",
+        distance_m=distance_m,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=0.0,
+        raw_summary={},
+    )
+    db.add(activity)
+    db.flush()
+    db.add(
+        DerivedMetric(
+            id=uuid.uuid4(),
+            activity_id=activity.id,
+            effort_score=1.0,
+            confidence="high",
+            flags=[],
+            confidence_reasons=[],
+        )
+    )
+    db.flush()
+    return activity
+
+
+def test_7d_continuous_charts_span_exactly_7_days(db):
+    report = get_trends_report(db, "7D")
+    assert len(report.daily_distance) == 7
+    assert len(report.daily_time) == 7
+    assert len(report.daily_suffer_score) == 7
+
+    today = date.today()
+    assert report.daily_distance[0].date == today - timedelta(days=6)
+    assert report.daily_distance[-1].date == today
+
+
+def test_30d_continuous_charts_span_exactly_30_days(db):
+    report = get_trends_report(db, "30D")
+    assert len(report.daily_distance) == 30
+    assert report.daily_distance[0].date == date.today() - timedelta(days=29)
+    assert report.daily_distance[-1].date == date.today()
+
+
+def test_7d_window_boundary_is_inclusive_of_6_days_ago_only(db):
+    user_id = _user(db)
+    today = date.today()
+    # The 7-day window is [today-6, today]. today-7 falls in the PREVIOUS window.
+    _activity_on(db, user_id, today - timedelta(days=6), distance_m=1000)  # current edge
+    _activity_on(db, user_id, today - timedelta(days=7), distance_m=2000)  # previous edge
+
+    stats = get_weekly_stats(db)
+
+    assert stats.summary.activity_count == 1
+    assert stats.summary.total_distance_m == 1000
+    assert stats.previous_summary.activity_count == 1
+    assert stats.previous_summary.total_distance_m == 2000
+
+
+def test_previous_window_abuts_current_with_no_gap(db):
+    user_id = _user(db)
+    today = date.today()
+    # Previous window is [today-13, today-7]. today-13 is its earliest day;
+    # today-14 must fall outside both windows.
+    _activity_on(db, user_id, today - timedelta(days=13), distance_m=3000)
+    _activity_on(db, user_id, today - timedelta(days=14), distance_m=9999)
+
+    stats = get_weekly_stats(db)
+
+    assert stats.previous_summary.activity_count == 1
+    assert stats.previous_summary.total_distance_m == 3000

--- a/backend/tests/test_weekly_stats.py
+++ b/backend/tests/test_weekly_stats.py
@@ -1,0 +1,131 @@
+"""Rolling 7-day dashboard summary, with the prior 7 days for comparison (#246, #248).
+
+These totals must agree with the Trends 7D view, so the windows mirror it:
+current = [today-7d, now), previous = [today-14d, today-7d). "Hard days" comes
+from the effort axis, not an HR/name heuristic.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+
+from app.models import Activity, DerivedMetric, User
+from app.services.trends import get_weekly_stats
+
+
+def _user(db) -> uuid.UUID:
+    user = User(email=f"{uuid.uuid4()}@example.com")
+    db.add(user)
+    db.flush()
+    return user.id
+
+
+def _activity(
+    db,
+    user_id,
+    *,
+    days_ago: float,
+    distance_m: int = 5000,
+    moving_time_s: int = 1500,
+    effort: str | None = None,
+    effort_score: float = 0.0,
+    type: str = "Run",
+) -> Activity:
+    activity = Activity(
+        user_id=user_id,
+        strava_activity_id=int(uuid.uuid4().int % 1_000_000_000),
+        start_date=datetime.now() - timedelta(days=days_ago),
+        type=type,
+        name="Run",
+        distance_m=distance_m,
+        moving_time_s=moving_time_s,
+        elapsed_time_s=moving_time_s,
+        elev_gain_m=0.0,
+        raw_summary={},
+    )
+    db.add(activity)
+    db.flush()
+    db.add(
+        DerivedMetric(
+            id=uuid.uuid4(),
+            activity_id=activity.id,
+            effort=effort,
+            effort_score=effort_score,
+            confidence="high",
+            flags=[],
+            confidence_reasons=[],
+        )
+    )
+    db.flush()
+    return activity
+
+
+def test_current_window_sums_distance_time_count_and_load(db):
+    user_id = _user(db)
+    _activity(db, user_id, days_ago=1, distance_m=5000, moving_time_s=1500, effort_score=10.0)
+    _activity(db, user_id, days_ago=3, distance_m=8000, moving_time_s=2400, effort_score=20.0)
+
+    stats = get_weekly_stats(db)
+
+    assert stats.summary.total_distance_m == 13000
+    assert stats.summary.total_moving_time_s == 3900
+    assert stats.summary.activity_count == 2
+    assert stats.summary.total_load == 30.0
+
+
+def test_previous_window_is_separate_from_current(db):
+    user_id = _user(db)
+    # current
+    _activity(db, user_id, days_ago=2, distance_m=4000, effort_score=5.0)
+    # previous 7 days
+    _activity(db, user_id, days_ago=9, distance_m=6000, effort_score=15.0)
+    _activity(db, user_id, days_ago=11, distance_m=1000, effort_score=2.0)
+
+    stats = get_weekly_stats(db)
+
+    assert stats.summary.activity_count == 1
+    assert stats.summary.total_distance_m == 4000
+    assert stats.previous_summary.activity_count == 2
+    assert stats.previous_summary.total_distance_m == 7000
+    assert stats.previous_summary.total_load == 17.0
+
+
+def test_activities_outside_both_windows_are_excluded(db):
+    user_id = _user(db)
+    _activity(db, user_id, days_ago=3, distance_m=5000)
+    _activity(db, user_id, days_ago=20, distance_m=9999)  # older than previous window
+
+    stats = get_weekly_stats(db)
+
+    assert stats.summary.activity_count == 1
+    assert stats.previous_summary.activity_count == 0
+    assert stats.previous_summary.total_distance_m == 0
+
+
+def test_hard_days_counts_distinct_days_with_tempo_or_hard_effort(db):
+    user_id = _user(db)
+    # Two hard activities on the same day count once.
+    _activity(db, user_id, days_ago=2.0, effort="hard")
+    _activity(db, user_id, days_ago=2.1, effort="hard")
+    # A tempo day on a different day.
+    _activity(db, user_id, days_ago=4, effort="tempo")
+    # Easy / unclassified days don't count.
+    _activity(db, user_id, days_ago=1, effort="easy")
+    _activity(db, user_id, days_ago=5, effort=None)
+
+    stats = get_weekly_stats(db)
+
+    assert stats.summary.hard_days == 2
+
+
+def test_deleted_activities_are_ignored(db):
+    user_id = _user(db)
+    keep = _activity(db, user_id, days_ago=2, distance_m=5000)
+    gone = _activity(db, user_id, days_ago=3, distance_m=5000)
+    gone.is_deleted = True
+    db.flush()
+
+    stats = get_weekly_stats(db)
+
+    assert stats.summary.activity_count == 1
+    assert stats.summary.total_distance_m == 5000
+    assert keep.is_deleted is False

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,30 +1,46 @@
 import { fetchFromAPI } from '@/lib/api';
+import { WeeklyStatsData } from '@/lib/types';
+import { formatDistanceKm, formatDuration } from '@/lib/format';
 import ActivityList from '@/components/ActivityList';
 import SyncButton from '@/components/SyncButton';
+import StatDiff from '@/components/StatDiff';
 
 // Force dynamic since we fetch user data (no static cache for dashboard)
 export const dynamic = 'force-dynamic';
 
+/**
+ * Percentage change in load vs the previous 7 days, e.g. "+12%".
+ * Returns null when there's no prior load to compare against (can't divide by 0).
+ */
+function formatLoadTrend(current: number, previous: number): string | null {
+  if (previous <= 0) return null;
+  const pct = Math.round(((current - previous) / previous) * 100);
+  const sign = pct > 0 ? '+' : '';
+  return `${sign}${pct}%`;
+}
+
 export default async function Dashboard() {
+  // Recent activity list (for the feed) and the weekly summary stats are
+  // separate concerns. The summary aggregates over a true rolling 7-day window
+  // server-side (matching Trends 7D) instead of summing a capped recent list,
+  // so the two surfaces report identical numbers (#246).
   let activities = [];
+  let stats: WeeklyStatsData | null = null;
   try {
-    activities = await fetchFromAPI('/api/activities?limit=10') || [];
+    [activities, stats] = await Promise.all([
+      fetchFromAPI('/api/activities?limit=10').then((a) => a || []),
+      fetchFromAPI('/api/stats/weekly') as Promise<WeeklyStatsData | null>,
+    ]);
   } catch (e) {
-    console.error("Failed to fetch activities", e);
+    console.error('Failed to fetch dashboard data', e);
   }
 
-  // Calculate stats from fetched activities
-  // In a real app, this should come from a dedicated /api/stats endpoint
-  // to aggregate correctly over date ranges (e.g. this week vs last week).
-  // For MVP Step 9/11, we aggregate locally on the clientside from recent list.
-  
-  const totalDistance = activities.reduce((sum: number, act: any) => sum + (act.distance_m || 0), 0);
-  const totalTime = activities.reduce((sum: number, act: any) => sum + (act.moving_time_s || 0), 0);
-  const hardDays = activities.filter((act: any) => {
-      // Very crude "hard day" check if HR > 150 or label contains Hard/Tempo
-      // Ideally use the derived effort axis once the list endpoint exposes it.
-      return (act.avg_hr && act.avg_hr > 155) || (act.name && act.name.match(/Tempo|Interval|Race/i));
-  }).length;
+  const summary = stats?.summary;
+  const previous = stats?.previous_summary;
+  const loadTrend =
+    summary && previous
+      ? formatLoadTrend(summary.total_load, previous.total_load)
+      : null;
 
   return (
     <div className="space-y-8">
@@ -38,23 +54,55 @@ export default async function Dashboard() {
         </div>
       </header>
 
-      {/* Week Stats Placeholder */}
+      {/* Week stats — rolling 7-day window vs the previous 7 days (#246, #248). */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border dark:border-gray-700 shadow-sm">
             <div className="text-sm text-gray-500 dark:text-gray-400">Distance</div>
-            <div className="text-2xl font-bold">{(totalDistance / 1000).toFixed(1)} km</div>
+            <div className="text-2xl font-bold">
+              {summary ? formatDistanceKm(summary.total_distance_m) : '—'}
+            </div>
+            {summary && previous && (
+              <StatDiff
+                current={summary.total_distance_m}
+                previous={previous.total_distance_m}
+                format={formatDistanceKm}
+              />
+            )}
         </div>
         <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border dark:border-gray-700 shadow-sm">
             <div className="text-sm text-gray-500 dark:text-gray-400">Time</div>
-            <div className="text-2xl font-bold">{(totalTime / 3600).toFixed(1)} h</div>
+            <div className="text-2xl font-bold">
+              {summary ? formatDuration(summary.total_moving_time_s) : '—'}
+            </div>
+            {summary && previous && (
+              <StatDiff
+                current={summary.total_moving_time_s}
+                previous={previous.total_moving_time_s}
+                format={formatDuration}
+              />
+            )}
         </div>
         <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border dark:border-gray-700 shadow-sm">
             <div className="text-sm text-gray-500 dark:text-gray-400">Hard Days</div>
-            <div className="text-2xl font-bold">{hardDays}</div>
+            <div className="text-2xl font-bold">{summary ? summary.hard_days : '—'}</div>
+            {summary && previous && (
+              <StatDiff
+                current={summary.hard_days}
+                previous={previous.hard_days}
+                format={(v) => v.toString()}
+              />
+            )}
         </div>
         <div className="bg-white dark:bg-gray-800 p-4 rounded-lg border dark:border-gray-700 shadow-sm">
             <div className="text-sm text-gray-500 dark:text-gray-400">Load Trend</div>
-            <div className="text-2xl font-bold">--%</div>
+            <div className="text-2xl font-bold">{loadTrend ?? '--%'}</div>
+            {summary && previous && (
+              <StatDiff
+                current={summary.total_load}
+                previous={previous.total_load}
+                format={(v) => Math.round(v).toLocaleString()}
+              />
+            )}
         </div>
       </div>
 

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -11,35 +11,7 @@ import TrendBarChart from "@/components/trends/TrendBarChart";
 import SufferScoreChart from "@/components/trends/SufferScoreChart";
 import EfficiencyTrendChart from "@/components/trends/EfficiencyTrendChart";
 import ZoneLoadChart from "@/components/trends/ZoneLoadChart";
-
-const DiffStat = ({
-  current,
-  previous,
-  format,
-}: {
-  current: number;
-  previous?: number | null;
-  format: (val: number) => string;
-}) => {
-  if (previous === undefined || previous === null) return null;
-  const diff = current - previous;
-  // Use a small epsilon for float comparison, or checking if effectively 0
-  if (Math.abs(diff) < 0.001) {
-    return <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">No change</div>;
-  }
-
-  const isPositive = diff > 0;
-  // For these metrics (distance, time, count, score), more is generally "active" (green).
-  // If we had "pace" where lower is better, we'd need a prop logic.
-  const color = isPositive ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400";
-  const arrow = isPositive ? "↑" : "↓";
-
-  return (
-    <div className={`text-xs ${color} mt-1 font-medium`}>
-      {arrow} {format(Math.abs(diff))}
-    </div>
-  );
-};
+import StatDiff from "@/components/StatDiff";
 
 export default function TrendsPage() {
   const [range, setRange] = useState<TrendsRange>("30D");
@@ -125,7 +97,7 @@ export default function TrendsPage() {
               <div className="text-2xl font-bold">
                 {formatDistanceKm(data.summary.total_distance_m)}
               </div>
-              <DiffStat
+              <StatDiff
                 current={data.summary.total_distance_m}
                 previous={data.previous_summary?.total_distance_m}
                 format={formatDistanceKm}
@@ -136,7 +108,7 @@ export default function TrendsPage() {
               <div className="text-2xl font-bold">
                 {formatDuration(data.summary.total_moving_time_s)}
               </div>
-              <DiffStat
+              <StatDiff
                 current={data.summary.total_moving_time_s}
                 previous={data.previous_summary?.total_moving_time_s}
                 format={formatDuration}
@@ -147,7 +119,7 @@ export default function TrendsPage() {
               <div className="text-2xl font-bold">
                 {data.summary.activity_count}
               </div>
-              <DiffStat
+              <StatDiff
                 current={data.summary.activity_count}
                 previous={data.previous_summary?.activity_count}
                 format={(v) => v.toString()}
@@ -158,7 +130,7 @@ export default function TrendsPage() {
               <div className="text-2xl font-bold">
                 {Math.round(data.summary.total_suffer_score).toLocaleString()}
               </div>
-              <DiffStat
+              <StatDiff
                 current={data.summary.total_suffer_score}
                 previous={data.previous_summary?.total_suffer_score}
                 format={(v) => Math.round(v).toLocaleString()}

--- a/frontend/components/StatDiff.tsx
+++ b/frontend/components/StatDiff.tsx
@@ -1,0 +1,46 @@
+/**
+ * Week-over-week (or period-over-period) delta shown under a summary card.
+ *
+ * Shared by the Trends summary cards and the Dashboard weekly-summary cards so
+ * the two surfaces render the comparison identically (#248). Renders nothing
+ * when there is no previous value to compare against.
+ */
+
+interface StatDiffProps {
+  current: number;
+  previous?: number | null;
+  format: (val: number) => string;
+  /**
+   * When true, a decrease is "good" (green) and an increase is "bad" (red).
+   * Defaults to false — for distance/time/count/load, more is treated as active.
+   */
+  lowerIsBetter?: boolean;
+}
+
+export default function StatDiff({
+  current,
+  previous,
+  format,
+  lowerIsBetter = false,
+}: StatDiffProps) {
+  if (previous === undefined || previous === null) return null;
+
+  const diff = current - previous;
+  // Small epsilon so float noise doesn't render as a spurious change.
+  if (Math.abs(diff) < 0.001) {
+    return <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">No change</div>;
+  }
+
+  const isIncrease = diff > 0;
+  const isGood = lowerIsBetter ? !isIncrease : isIncrease;
+  const color = isGood
+    ? "text-green-600 dark:text-green-400"
+    : "text-red-600 dark:text-red-400";
+  const arrow = isIncrease ? "↑" : "↓";
+
+  return (
+    <div className={`text-xs ${color} mt-1 font-medium`}>
+      {arrow} {format(Math.abs(diff))}
+    </div>
+  );
+}

--- a/frontend/components/charts/ChartTooltip.tsx
+++ b/frontend/components/charts/ChartTooltip.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { ReactNode } from "react";
+
+/**
+ * Dark-mode-aware tooltip for the Recharts charts (#247).
+ *
+ * Recharts' default `<Tooltip>` renders a hard-coded white box with low-contrast
+ * text, which is unreadable in dark mode. Passing this as `content` gives every
+ * chart the same themed surface. Because `content` replaces the default render,
+ * the per-chart `formatter` / `labelFormatter` are passed in here instead of on
+ * `<Tooltip>` (where they'd be ignored).
+ */
+
+interface TooltipPayloadItem {
+  name?: string | number;
+  value?: unknown;
+  color?: string;
+  dataKey?: string | number;
+  payload?: Record<string, unknown>;
+}
+
+interface ChartTooltipProps {
+  // Injected by Recharts when used as `content`.
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+  label?: string | number;
+  /** Mirrors Recharts' formatter: returns [displayValue, displayName]. */
+  formatter?: (
+    value: unknown,
+    name: unknown,
+    entry: TooltipPayloadItem
+  ) => [ReactNode, ReactNode];
+  labelFormatter?: (label: unknown) => ReactNode;
+  /** Drop rows whose value is null/undefined (e.g. an empty band series). */
+  hideNullRows?: boolean;
+  /** Colour each row's name with its series colour (default true). */
+  colorNames?: boolean;
+}
+
+export default function ChartTooltip({
+  active,
+  payload,
+  label,
+  formatter,
+  labelFormatter,
+  hideNullRows = true,
+  colorNames = true,
+}: ChartTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  const rows = payload
+    .filter((p) => !hideNullRows || (p.value !== null && p.value !== undefined))
+    .map((p, i) => {
+      let displayName: ReactNode = p.name as ReactNode;
+      let displayValue: ReactNode = p.value as ReactNode;
+      if (formatter) {
+        const [v, n] = formatter(p.value, p.name, p);
+        displayValue = v;
+        displayName = n;
+      }
+      return {
+        key: `${p.dataKey ?? p.name ?? i}`,
+        color: p.color,
+        displayName,
+        displayValue,
+      };
+    });
+
+  if (rows.length === 0) return null;
+
+  const displayLabel = labelFormatter ? labelFormatter(label) : label;
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 text-sm">
+      {displayLabel !== undefined && displayLabel !== null && displayLabel !== "" && (
+        <p className="font-semibold text-gray-700 dark:text-gray-300 mb-1">
+          {displayLabel}
+        </p>
+      )}
+      {rows.map((r) => (
+        <div key={r.key} className="flex items-center justify-between gap-6">
+          <span
+            className="text-gray-600 dark:text-gray-300"
+            style={colorNames && r.color ? { color: r.color } : undefined}
+          >
+            {r.displayName}
+          </span>
+          <span className="font-medium text-gray-900 dark:text-gray-100">
+            {r.displayValue}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/load/LoadTrendChart.tsx
+++ b/frontend/components/load/LoadTrendChart.tsx
@@ -12,6 +12,7 @@ import {
 } from "recharts";
 import { LoadWeek } from "@/lib/types";
 import { formatDateLabel } from "@/lib/format";
+import ChartTooltip from "@/components/charts/ChartTooltip";
 
 interface Props {
   weeks: LoadWeek[];
@@ -48,12 +49,16 @@ export default function LoadTrendChart({ weeks }: Props) {
             <XAxis dataKey="label" tick={{ fontSize: 12 }} tickLine={false} axisLine={false} />
             <YAxis tick={{ fontSize: 12 }} tickLine={false} axisLine={false} width={40} />
             <Tooltip
-              formatter={(value: any, name: string | undefined) => {
-                if (name === "band" && Array.isArray(value)) {
-                  return [`${value[0]} – ${value[1]}`, "Optimal range"];
-                }
-                return [value ?? 0, "Weekly load"];
-              }}
+              content={
+                <ChartTooltip
+                  formatter={(value, name) => {
+                    if (name === "band" && Array.isArray(value)) {
+                      return [`${value[0]} – ${value[1]}`, "Optimal range"];
+                    }
+                    return [(value as number) ?? 0, "Weekly load"];
+                  }}
+                />
+              }
             />
             <Area
               dataKey="band"

--- a/frontend/components/trends/EfficiencyTrendChart.tsx
+++ b/frontend/components/trends/EfficiencyTrendChart.tsx
@@ -15,6 +15,7 @@ import { EfficiencyPoint } from "@/lib/types";
 import { formatDateLabel } from "@/lib/format";
 import { useMemo, useState } from "react";
 import ActivityTypeFilter from "./ActivityTypeFilter";
+import ChartTooltip from "@/components/charts/ChartTooltip";
 
 interface Props {
   data: EfficiencyPoint[];
@@ -125,11 +126,14 @@ export default function EfficiencyTrendChart({ data, granularity }: Props) {
                 unit=""
               />
               <Tooltip
-                formatter={(value: any, name: any) => [
-                  typeof value === "number" ? `${value.toFixed(2)} m/beat` : value,
-                  name === "trend" ? "Trend (5-act avg)" : name,
-                ]}
-                labelFormatter={(label) => label}
+                content={
+                  <ChartTooltip
+                    formatter={(value, name) => [
+                      typeof value === "number" ? `${value.toFixed(2)} m/beat` : (value as any),
+                      name === "trend" ? "Trend (5-act avg)" : (name as any),
+                    ]}
+                  />
+                }
               />
               <Legend />
               

--- a/frontend/components/trends/SufferScoreChart.tsx
+++ b/frontend/components/trends/SufferScoreChart.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 import { SufferScorePoint, DailySufferScorePoint, WeeklySufferScorePoint } from "@/lib/types";
 import { formatDateLabel } from "@/lib/format";
+import ChartTooltip from "@/components/charts/ChartTooltip";
 
 interface Props {
   data: SufferScorePoint[] | DailySufferScorePoint[] | WeeklySufferScorePoint[];
@@ -54,8 +55,12 @@ export default function SufferScoreChart({ data, granularity }: Props) {
               width={40}
             />
             <Tooltip
-              formatter={(value: number | undefined) => [value ?? 0, "Accumulated Load"]}
-              labelFormatter={(label) => label}
+              content={
+                <ChartTooltip
+                  formatter={(value) => [(value as number) ?? 0, "Accumulated Load"]}
+                />
+              }
+              cursor={{ fill: "rgba(0,0,0,0.05)" }}
             />
             <Bar
               dataKey="effort_score"

--- a/frontend/components/trends/TrendBarChart.tsx
+++ b/frontend/components/trends/TrendBarChart.tsx
@@ -10,6 +10,7 @@ import {
   CartesianGrid,
 } from "recharts";
 import { formatDateLabel } from "@/lib/format";
+import ChartTooltip from "@/components/charts/ChartTooltip";
 
 interface TrendBarChartProps {
   data: any[];
@@ -61,16 +62,6 @@ export default function TrendBarChart({
 
   const tooltipPrefix = granularity === "daily" ? "" : "Week of ";
 
-  const formatTooltipValue = (val: number, entry: any) => {
-    // entry.payload contains the full data object
-    const raw = entry.payload.rawValue;
-    if (isDistance) {
-      return [`${(raw / 1000).toFixed(2)} km`, "Distance"];
-    } else {
-      return [formatMinutes(raw), "Moving Time"];
-    }
-  };
-
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 shadow-sm p-5">
       <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-4">{title}</h3>
@@ -95,25 +86,17 @@ export default function TrendBarChart({
               unit={unitLabel}
               width={60}
             />
-            {/* 
-              Recharts Tooltip formatter signature can vary.
-              We want to format the 'value' but specifically look at rawValue.
-              However, the simplest approach for Recharts is to just format the value we plotted
-              OR pass a custom content.
-              Actually, the formatter callback receives (value, name, props).
-              Props.payload is the data item.
-            */}
             <Tooltip
-              formatter={(value, name, props) => {
-                if (props && props.payload) {
-                   // When hovering, props.payload is the data object
-                   const raw = props.payload.rawValue;
-                   if (isDistance) return [`${(raw / 1000).toFixed(2)} km`, "Distance"];
-                   return [formatMinutes(raw), "Moving Time"];
-                }
-                return [value, name];
-              }}
-              labelFormatter={(label) => `${tooltipPrefix}${label}`}
+              content={
+                <ChartTooltip
+                  formatter={(_value, _name, entry) => {
+                    const raw = (entry.payload?.rawValue as number) ?? 0;
+                    if (isDistance) return [`${(raw / 1000).toFixed(2)} km`, "Distance"];
+                    return [formatMinutes(raw), "Moving Time"];
+                  }}
+                  labelFormatter={(label) => `${tooltipPrefix}${label}`}
+                />
+              }
               cursor={{ fill: "rgba(0,0,0,0.05)" }}
             />
             <Bar

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -21,6 +21,8 @@ export type {
   TrendsSummary,
   TrendsData,
   TrendsRange,
+  WeeklyStatsSummary,
+  WeeklyStatsData,
   LoadActivityPoint,
   LoadStatus,
   LoadWeek,

--- a/frontend/lib/types/trends.ts
+++ b/frontend/lib/types/trends.ts
@@ -83,6 +83,19 @@ export interface TrendsData {
 
 export type TrendsRange = "7D" | "30D" | "3M" | "6M" | "1Y" | "ALL";
 
+export interface WeeklyStatsSummary {
+  total_distance_m: number;
+  total_moving_time_s: number;
+  activity_count: number;
+  total_load: number;
+  hard_days: number;
+}
+
+export interface WeeklyStatsData {
+  summary: WeeklyStatsSummary;
+  previous_summary: WeeklyStatsSummary;
+}
+
 export interface LoadActivityPoint {
   id: string;
   name: string;


### PR DESCRIPTION
The dashboard "Weekly Summary" summed only the 10 most recent activities
(/api/activities?limit=10) regardless of date, so it disagreed with the
Trends 7D view whenever a week had more than 10 activities (#246).

Backend
- Add /api/stats/weekly: a rolling 7-day summary plus the prior 7 days,
  using exactly the same window as Trends 7D so the two can never drift.
  Returns distance, time, activity count, total load, and hard-day count.
- Derive "hard days" from the effort axis (tempo|hard) instead of an
  HR/name heuristic. Project the effort label onto ActivityFact.
- Tests for the windowing, hard-day counting, and deleted-activity exclusion.

Frontend
- Dashboard now consumes /api/stats/weekly: real numbers that match Trends,
  a computed Load Trend % (was hard-coded "--%"), and a week-over-week diff
  under every card (#248).
- Extract the Trends diff indicator into a shared <StatDiff> used by both
  the dashboard and trends cards.
- Add a dark-mode-aware <ChartTooltip> and use it across the bar/line charts
  whose default Recharts tooltip rendered an unreadable white box in dark
  mode (#247).