### PR TITLE
Add historical Strava import (#239)

### DIFF
--- a/backend/alembic/versions/d9f1a2b3c4e5_add_strava_imports_table.py
+++ b/backend/alembic/versions/d9f1a2b3c4e5_add_strava_imports_table.py
@@ -1,0 +1,45 @@
+"""add strava_imports table
+
+State for a resumable historical Strava import (#239): a self-pacing background
+job walks the runner's Strava history backward in time, ingesting activity
+summaries only (no streams, no AI coach analysis, no notifications). The row
+tracks the resume cursor and progress.
+
+Revision ID: d9f1a2b3c4e5
+Revises: c4d5e6f7a8b9
+Create Date: 2026-06-12 21:50:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'd9f1a2b3c4e5'
+down_revision: Union[str, None] = 'c4d5e6f7a8b9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'strava_imports',
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('user_id', sa.Uuid(), nullable=False),
+        sa.Column('since_date', sa.Date(), nullable=False),
+        sa.Column('status', sa.String(), nullable=False),
+        sa.Column('cursor_before', sa.BigInteger(), nullable=True),
+        sa.Column('activities_imported', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('error', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_strava_imports_user_id', 'strava_imports', ['user_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_strava_imports_user_id', table_name='strava_imports')
+    op.drop_table('strava_imports')

--- a/backend/app/api/strava_import.py
+++ b/backend/app/api/strava_import.py
@@ -1,0 +1,72 @@
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.models import StravaAccount, StravaImport
+from app.schemas import StravaImportCreate, StravaImportRead
+
+router = APIRouter()
+
+
+def _resolve_account(db: Session, strava_athlete_id: Optional[int]) -> StravaAccount:
+    if strava_athlete_id:
+        account = (
+            db.query(StravaAccount)
+            .filter(StravaAccount.strava_athlete_id == strava_athlete_id)
+            .first()
+        )
+    else:
+        # Single-player mode: default to the only connected account.
+        account = db.query(StravaAccount).first()
+    if not account:
+        raise HTTPException(
+            status_code=404,
+            detail="No linked Strava account found. Connect Strava first.",
+        )
+    return account
+
+
+@router.post("/strava/import", response_model=StravaImportRead)
+def start_import(
+    payload: StravaImportCreate,
+    strava_athlete_id: Optional[int] = None,
+    db: Session = Depends(get_db),
+):
+    """Start a resumable historical Strava import from `since_date` to today.
+
+    Imports activity summaries + deterministic analysis only (no streams, no AI
+    coach report, no notifications); the work runs in a self-pacing background
+    job. Idempotent: if an import is already running for this account, that one
+    is returned instead of starting a second walk.
+    """
+    if payload.since_date > date.today():
+        raise HTTPException(status_code=400, detail="since_date cannot be in the future.")
+
+    account = _resolve_account(db, strava_athlete_id)
+
+    from app.jobs.strava_import import enqueue_import
+
+    import_obj = enqueue_import(db, account, payload.since_date)
+    return import_obj
+
+
+@router.get("/strava/import/status", response_model=Optional[StravaImportRead])
+def import_status(
+    strava_athlete_id: Optional[int] = None,
+    db: Session = Depends(get_db),
+):
+    """Return the most recent historical import for the account, or null if none.
+
+    The frontend polls this to show import progress and the final summary.
+    """
+    account = _resolve_account(db, strava_athlete_id)
+    latest = (
+        db.query(StravaImport)
+        .filter(StravaImport.user_id == account.user_id)
+        .order_by(StravaImport.created_at.desc())
+        .first()
+    )
+    return latest

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -79,6 +79,15 @@ class Settings(BaseSettings):
     BACKFILL_BATCH_SIZE: int = 20
     BACKFILL_BATCH_PAUSE_SECONDS: int = 300
 
+    # Historical Strava import (#239). A self-pacing background job walks a
+    # runner's Strava history backward in time, ingesting one page of activity
+    # summaries per batch (no streams, no AI coach analysis, no notifications).
+    # Each batch is a single Strava list call, far below the backfill's
+    # per-activity stream cost; the pause only keeps the worker free for
+    # webhooks/polling between batches. 50 activities per page (Strava's max).
+    IMPORT_PAGE_SIZE: int = 50
+    IMPORT_BATCH_PAUSE_SECONDS: int = 5
+
     # Two-stage Exchange cadence (A4, ADR 0010). The opener fires immediately on a
     # finished activity; the conditional fuller turn fires on the runner's reply or
     # this timer, whichever is first. Only the two-stage prompt (coach_message_v2)

--- a/backend/app/jobs/strava_import.py
+++ b/backend/app/jobs/strava_import.py
@@ -1,0 +1,238 @@
+"""Historical Strava import: backfill a runner's past activities on demand (#239).
+
+A self-pacing background job (modelled on the stream backfill, #110). Each run
+fetches one page of the runner's Strava history within a moving time window,
+upserts the activity summaries, runs deterministic analysis, and advances a
+resume cursor. It walks backward in time from today to the user-chosen
+`since_date`.
+
+Crucially it imports *raw data only*: summaries and deterministic analysis
+(distance/time/effort that power trends), never the AI coach report, opener, or
+any Telegram/email notification. Firing the coach on a bulk historical import
+would generate thousands of LLM calls and flood the runner's channel with
+analyses of runs weeks or years old. Coach analysis stays opt-in (the existing
+per-activity path).
+
+State lives entirely in a `StravaImport` row:
+  - `cursor_before` is the exclusive upper-bound epoch of the next page. It starts
+    NULL (newest) and advances to the oldest activity's start epoch each batch,
+    so a page is never re-walked and an interruption resumes from the cursor.
+  - dedup by `strava_activity_id` (via `upsert_activity`) makes any partial-batch
+    replay idempotent, so the import is safely re-runnable.
+
+Pacing: when a full page comes back there is likely more history, so the job
+schedules its own successor via rq-scheduler after `IMPORT_BATCH_PAUSE_SECONDS`,
+keeping the single worker free for webhooks and polling between batches. Each
+batch is a single Strava list call (no per-activity stream calls), so the call
+rate stays comfortably under the 100-requests/15-min ceiling.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, time, timedelta, timezone
+from uuid import UUID
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.queue import queue
+from app.db.session import SessionLocal
+from app.models import StravaAccount, StravaImport
+from app.services.analysis import analyze
+from app.services.strava_ingestion import (
+    ensure_valid_access_token,
+    get_strava_port,
+    upsert_activity,
+)
+from app.services.strava_ingestion.ingestion import _assign_block
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ImportBatchResult:
+    imported: int = 0
+    done: bool = True
+
+
+def _start_epoch(raw: dict) -> int:
+    dt = datetime.strptime(raw["start_date"], "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
+    return int(dt.timestamp())
+
+
+async def run_import_batch(
+    db: Session, import_obj: StravaImport, *, limit: int
+) -> ImportBatchResult:
+    """Fetch one page within (since_date, cursor_before], upsert + analyze each.
+
+    Advances `cursor_before` to the oldest activity seen so the next batch is the
+    strictly-older page; marks the import complete when a short page signals the
+    window is exhausted. Commits progress as it goes so an interruption resumes.
+    Never notifies.
+    """
+    account = (
+        db.query(StravaAccount)
+        .filter(StravaAccount.user_id == import_obj.user_id)
+        .first()
+    )
+    if account is None:
+        import_obj.status = "failed"
+        import_obj.error = "No linked Strava account found."
+        db.add(import_obj)
+        db.commit()
+        return ImportBatchResult(imported=0, done=True)
+
+    port = get_strava_port()
+    since = datetime.combine(import_obj.since_date, time.min, tzinfo=timezone.utc)
+    after = int(since.timestamp())
+    before = import_obj.cursor_before
+
+    try:
+        access_token = await ensure_valid_access_token(db, account, port)
+        try:
+            batch = await port.list_activities_page(
+                access_token, after=after, before=before, per_page=limit
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 401:
+                raise
+            logger.warning(
+                "strava_401_mid_flight: force-refreshing token and retrying import page"
+            )
+            access_token = await ensure_valid_access_token(db, account, port, force=True)
+            batch = await port.list_activities_page(
+                access_token, after=after, before=before, per_page=limit
+            )
+    except Exception as exc:  # noqa: BLE001 - surface the failure on the row, don't crash the worker
+        import_obj.status = "failed"
+        import_obj.error = f"Strava list failed: {exc}"
+        db.add(import_obj)
+        db.commit()
+        logger.error("Historical import %s failed listing: %s", import_obj.id, exc)
+        return ImportBatchResult(imported=0, done=True)
+
+    imported = 0
+    oldest_epoch: int | None = None
+    for raw in batch:
+        try:
+            activity = upsert_activity(db, raw, account.user_id)
+            db.commit()
+            _assign_block(db, activity)
+            # Deterministic analysis only (no streams, no LLM, no notification);
+            # a failure here must not abort the import of the rest of the page.
+            try:
+                analyze(db, str(activity.id))
+            except Exception as exc:  # noqa: BLE001
+                db.rollback()
+                logger.error(
+                    "Import analysis failed for activity %s: %s",
+                    raw.get("id"),
+                    exc,
+                )
+            imported += 1
+        except Exception as exc:  # noqa: BLE001 - one bad activity must not sink the batch
+            db.rollback()
+            logger.error("Error importing activity %s: %s", raw.get("id"), exc)
+        epoch = _start_epoch(raw)
+        oldest_epoch = epoch if oldest_epoch is None else min(oldest_epoch, epoch)
+
+    import_obj.activities_imported += imported
+    # A short page means we have reached the end of the window: done. A full page
+    # means there is likely more, older history to walk; advance the cursor.
+    done = len(batch) < limit
+    if done:
+        import_obj.status = "completed"
+    elif oldest_epoch is not None:
+        import_obj.cursor_before = oldest_epoch
+    db.add(import_obj)
+    db.commit()
+
+    logger.info(
+        "Historical import %s batch: imported %d (total %d), done=%s",
+        import_obj.id,
+        imported,
+        import_obj.activities_imported,
+        done,
+    )
+    return ImportBatchResult(imported=imported, done=done)
+
+
+def _schedule_next_batch(import_id: str) -> None:
+    """Schedule the next batch after the configured pause via rq-scheduler, so the
+    single worker stays free for webhooks and polling between batches."""
+    from redis import Redis
+    from rq_scheduler import Scheduler
+
+    scheduler = Scheduler(connection=Redis.from_url(settings.REDIS_URL))
+    scheduler.enqueue_in(
+        timedelta(seconds=settings.IMPORT_BATCH_PAUSE_SECONDS),
+        strava_import_job,
+        import_id,
+    )
+
+
+def strava_import_job(import_id: str) -> None:
+    """RQ entrypoint. Runs one batch; if work remains, schedules the next."""
+    db = SessionLocal()
+    try:
+        import_obj = db.get(StravaImport, UUID(str(import_id)))
+        if import_obj is None:
+            logger.warning("Historical import %s not found; skipping", import_id)
+            return
+        if import_obj.status != "running":
+            logger.info(
+                "Historical import %s is %s; not running a batch",
+                import_id,
+                import_obj.status,
+            )
+            return
+        result = asyncio.run(
+            run_import_batch(db, import_obj, limit=settings.IMPORT_PAGE_SIZE)
+        )
+    finally:
+        db.close()
+
+    if not result.done:
+        _schedule_next_batch(str(import_id))
+
+
+def enqueue_import(db: Session, account: StravaAccount, since_date) -> StravaImport:
+    """Create the import-state row and enqueue the first batch.
+
+    Idempotent: if an import is already running for this user, return it rather
+    than starting a second concurrent walk.
+    """
+    existing = (
+        db.query(StravaImport)
+        .filter(
+            StravaImport.user_id == account.user_id,
+            StravaImport.status == "running",
+        )
+        .order_by(StravaImport.created_at.desc())
+        .first()
+    )
+    if existing is not None:
+        return existing
+
+    import_obj = StravaImport(
+        user_id=account.user_id,
+        since_date=since_date,
+        status="running",
+        cursor_before=None,
+        activities_imported=0,
+    )
+    db.add(import_obj)
+    db.commit()
+    db.refresh(import_obj)
+
+    queue.enqueue(
+        strava_import_job,
+        str(import_obj.id),
+        job_id=f"strava_import_{import_obj.id}",
+        result_ttl=3600,
+    )
+    return import_obj

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api import health, auth, activities, blocks, webhooks, profile, trends, coach, debug
+from app.api import health, auth, activities, blocks, webhooks, profile, trends, coach, debug, strava_import
 from app.core.auth import BasicAuthMiddleware
 from app.core.config import settings
 from app.core.observability import init_logging, init_sentry
@@ -41,6 +41,7 @@ app.include_router(health.router, prefix="/api", tags=["System"])
 app.include_router(auth.router, prefix="/api", tags=["Auth"])
 app.include_router(profile.router, prefix="/api", tags=["Profile"])
 app.include_router(activities.router, prefix="/api", tags=["Activities"])
+app.include_router(strava_import.router, prefix="/api", tags=["Strava Import"])
 app.include_router(blocks.router, prefix="/api", tags=["Blocks"])
 app.include_router(webhooks.router, prefix="/api", tags=["Webhooks"])
 app.include_router(trends.router, prefix="/api", tags=["Trends"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -22,6 +22,7 @@ from app.models.coaching_context import CoachingContext  # noqa: F401
 from app.models.block import Block  # noqa: F401
 from app.models.exchange import Exchange  # noqa: F401
 from app.models.coaching_relationship import CoachingRelationship  # noqa: F401
+from app.models.strava_import import StravaImport  # noqa: F401
 
 __all__ = [
     "generate_uuid",
@@ -40,4 +41,5 @@ __all__ = [
     "Block",
     "Exchange",
     "CoachingRelationship",
+    "StravaImport",
 ]

--- a/backend/app/models/strava_import.py
+++ b/backend/app/models/strava_import.py
@@ -1,0 +1,51 @@
+import uuid
+from datetime import date, datetime
+
+from sqlalchemy import BigInteger, Date, DateTime, ForeignKey, Integer, String, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+from app.models.base import generate_uuid
+
+
+class StravaImport(Base):
+    """State for a resumable historical Strava import (#239).
+
+    A self-pacing background job walks the runner's Strava history backward in
+    time from today to ``since_date``, ingesting activity summaries (no streams,
+    no AI coach analysis, no notifications). State lives entirely in this row so
+    the job is resumable: ``cursor_before`` is the exclusive upper-bound epoch of
+    the next page to fetch and advances to the oldest activity seen each batch,
+    so an interruption resumes without re-walking completed work, and dedup by
+    ``strava_activity_id`` makes any overlap idempotent.
+    """
+
+    __tablename__ = "strava_imports"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=generate_uuid)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"))
+
+    # Lower bound the runner chose: import activities on or after this date.
+    since_date: Mapped[date] = mapped_column(Date)
+
+    # "running" | "completed" | "failed".
+    status: Mapped[str] = mapped_column(String, default="running")
+
+    # Exclusive upper-bound epoch for the next page's `before` filter. NULL on the
+    # first batch (start from now / newest); advances to the oldest activity's
+    # start epoch after each batch, walking backward in time.
+    cursor_before: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+    # How many activities have been upserted so far (progress for the UI).
+    activities_imported: Mapped[int] = mapped_column(Integer, default=0)
+
+    # Last error if the import failed; NULL otherwise.
+    error: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), server_default=func.now()
+    )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -30,6 +30,10 @@ from app.schemas.trends import (  # noqa: F401
     WeeklyTimePoint,
     TrendsResponse,
 )
+from app.schemas.strava_import import (  # noqa: F401
+    StravaImportCreate,
+    StravaImportRead,
+)
 from app.schemas.coach import (  # noqa: F401
     CoachTakeaway,
     CoachNextStep,
@@ -55,6 +59,8 @@ __all__ = [
     "CheckInCreate",
     "CheckInRead",
     "SyncResponse",
+    "StravaImportCreate",
+    "StravaImportRead",
     "DerivedMetricRead",
     "ActivityStreamRead",
     "ActivityDetailRead",

--- a/backend/app/schemas/strava_import.py
+++ b/backend/app/schemas/strava_import.py
@@ -1,0 +1,24 @@
+from datetime import date, datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class StravaImportCreate(BaseModel):
+    """Request to start a historical Strava import from `since_date` to today."""
+
+    since_date: date
+
+
+class StravaImportRead(BaseModel):
+    """Progress view of a historical import for the status poll."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    since_date: date
+    status: str
+    activities_imported: int
+    error: str | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/strava_ingestion/http_adapter.py
+++ b/backend/app/services/strava_ingestion/http_adapter.py
@@ -189,6 +189,51 @@ class HTTPStravaAdapter:
                 )
         return activities
 
+    async def list_activities_page(
+        self,
+        access_token: str,
+        *,
+        after: int,
+        before: int | None = None,
+        page: int = 1,
+        per_page: int = 50,
+    ) -> list[dict]:
+        """Fetch one page of `/athlete/activities` in the (after, before) window.
+
+        Strava returns activities newest-first and treats `before`/`after` as
+        exclusive/inclusive epoch bounds. The historical import (#239) walks
+        backward by re-calling with `before` set to the oldest activity's start
+        epoch, so each batch is a bounded, resumable step rather than the full
+        page-walk that `list_recent_activities` does.
+        """
+        headers = {"Authorization": f"Bearer {access_token}"}
+        params: dict[str, int] = {"page": page, "per_page": per_page, "after": after}
+        if before is not None:
+            params["before"] = before
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_S) as client:
+            response = await _send_with_retry(
+                lambda: client.get(
+                    f"{_BASE_URL}/athlete/activities",
+                    headers=headers,
+                    params=params,
+                ),
+                label="list_activities_page",
+            )
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as e:
+                logger.error(
+                    "Strava API Error: %s - %s",
+                    e.response.status_code,
+                    e.response.text,
+                )
+                if e.response.status_code == 403:
+                    logger.error(
+                        "Missing Scopes: Ensure 'activity:read_all' is granted."
+                    )
+                raise
+            return response.json()
+
     async def get_activity(self, access_token: str, activity_id: int) -> dict:
         headers = {"Authorization": f"Bearer {access_token}"}
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_S) as client:

--- a/backend/app/services/strava_ingestion/in_memory_adapter.py
+++ b/backend/app/services/strava_ingestion/in_memory_adapter.py
@@ -1,6 +1,13 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from app.services.strava_ingestion.port import Tokens
+
+
+def _start_epoch(raw: dict) -> int:
+    dt = datetime.strptime(raw["start_date"], "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=timezone.utc
+    )
+    return int(dt.timestamp())
 
 
 class InMemoryStravaAdapter:
@@ -15,6 +22,7 @@ class InMemoryStravaAdapter:
         self.refresh_calls: list[str] = []
         self.exchange_calls: list[str] = []
         self.list_calls: list[tuple[str, datetime, int]] = []
+        self.page_calls: list[tuple[int, int | None, int, int]] = []
         self.stream_calls: list[tuple[int, list[str]]] = []
         self.activity_calls: list[int] = []
 
@@ -61,6 +69,27 @@ class InMemoryStravaAdapter:
     ) -> list[dict]:
         self.list_calls.append((access_token, since, per_page))
         return list(self.activities)
+
+    async def list_activities_page(
+        self,
+        access_token: str,
+        *,
+        after: int,
+        before: int | None = None,
+        page: int = 1,
+        per_page: int = 50,
+    ) -> list[dict]:
+        self.page_calls.append((after, before, page, per_page))
+        # Mirror Strava: inclusive `after`, exclusive `before`, newest first.
+        window = [
+            raw
+            for raw in self.activities
+            if _start_epoch(raw) >= after
+            and (before is None or _start_epoch(raw) < before)
+        ]
+        window.sort(key=_start_epoch, reverse=True)
+        start = (page - 1) * per_page
+        return window[start : start + per_page]
 
     async def get_activity(self, access_token: str, activity_id: int) -> dict:
         self.activity_calls.append(activity_id)

--- a/backend/app/services/strava_ingestion/port.py
+++ b/backend/app/services/strava_ingestion/port.py
@@ -27,6 +27,23 @@ class StravaPort(Protocol):
         per_page: int = 50,
     ) -> list[dict]: ...
 
+    async def list_activities_page(
+        self,
+        access_token: str,
+        *,
+        after: int,
+        before: int | None = None,
+        page: int = 1,
+        per_page: int = 50,
+    ) -> list[dict]:
+        """Return a single page of activities in the (after, before) epoch window.
+
+        Newest first. Used by the historical import (#239) to walk a runner's
+        history backward in time one page at a time, advancing `before` to the
+        oldest activity seen so each batch is bounded and the job is resumable.
+        """
+        ...
+
     async def get_activity(self, access_token: str, activity_id: int) -> dict: ...
 
     async def get_activity_streams(

--- a/backend/tests/test_strava_import_job.py
+++ b/backend/tests/test_strava_import_job.py
@@ -1,0 +1,301 @@
+"""Historical Strava import: resumable, paced, raw-data-only backfill (#239).
+
+Covers the backward time-walk via the `before` cursor, dedup re-runnability,
+deterministic analysis without the coach pipeline, the no-notification
+guarantee, completion on a short page, the self-pacing re-enqueue, and the
+idempotent enqueue.
+"""
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.models import Activity, StravaAccount, StravaImport, User
+from app.services.strava_ingestion import InMemoryStravaAdapter, set_strava_port
+
+
+@pytest.fixture
+def strava_adapter():
+    adapter = InMemoryStravaAdapter()
+    set_strava_port(adapter)
+    yield adapter
+    set_strava_port(None)
+
+
+def _seed_user_and_account(db, athlete_id: int = 555):
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    account = StravaAccount(
+        user_id=user.id,
+        strava_athlete_id=athlete_id,
+        access_token="t",
+        refresh_token="r",
+        expires_at=9999999999,
+        scope="read,activity:read_all",
+    )
+    db.add(account)
+    db.commit()
+    return user, account
+
+
+def _raw(strava_id: int, start: datetime, name: str = "Old run") -> dict:
+    return {
+        "id": strava_id,
+        "name": name,
+        "type": "Run",
+        "start_date": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "distance": 8000,
+        "moving_time": 2400,
+        "elapsed_time": 2400,
+        "total_elevation_gain": 30.0,
+        "average_heartrate": 145,
+        "max_heartrate": 165,
+        "average_speed": 3.3,
+    }
+
+
+def _make_import(db, user, since_date=date(2025, 1, 1), cursor_before=None) -> StravaImport:
+    imp = StravaImport(
+        user_id=user.id,
+        since_date=since_date,
+        status="running",
+        cursor_before=cursor_before,
+        activities_imported=0,
+    )
+    db.add(imp)
+    db.commit()
+    db.refresh(imp)
+    return imp
+
+
+@pytest.mark.asyncio
+async def test_batch_imports_summaries_and_completes_on_short_page(db, strava_adapter):
+    from app.jobs.strava_import import run_import_batch
+
+    user, _account = _seed_user_and_account(db)
+    strava_adapter.seed_activities(
+        [
+            _raw(101, datetime(2025, 3, 1, 9, tzinfo=timezone.utc)),
+            _raw(102, datetime(2025, 2, 1, 9, tzinfo=timezone.utc)),
+        ]
+    )
+    imp = _make_import(db, user)
+
+    result = await run_import_batch(db, imp, limit=50)
+
+    assert result.imported == 2
+    assert result.done is True
+    db.refresh(imp)
+    assert imp.status == "completed"
+    assert imp.activities_imported == 2
+    # Both activities were persisted (summary-only ingest).
+    assert db.query(Activity).filter(Activity.user_id == user.id).count() == 2
+
+
+@pytest.mark.asyncio
+async def test_full_page_advances_cursor_and_is_not_done(db, strava_adapter):
+    from app.jobs.strava_import import run_import_batch
+
+    user, _account = _seed_user_and_account(db)
+    older = datetime(2025, 2, 1, 9, tzinfo=timezone.utc)
+    newer = datetime(2025, 3, 1, 9, tzinfo=timezone.utc)
+    strava_adapter.seed_activities([_raw(201, newer), _raw(202, older)])
+    imp = _make_import(db, user)
+
+    # limit=2 == page size, so the page is "full" -> more history assumed.
+    result = await run_import_batch(db, imp, limit=2)
+
+    assert result.done is False
+    db.refresh(imp)
+    assert imp.status == "running"
+    # Cursor advanced to the oldest activity's start epoch (exclusive upper bound).
+    assert imp.cursor_before == int(older.timestamp())
+
+
+@pytest.mark.asyncio
+async def test_cursor_walks_backward_without_repeating(db, strava_adapter):
+    """A second batch bounded by the cursor returns only strictly-older activities."""
+    from app.jobs.strava_import import run_import_batch
+
+    user, _account = _seed_user_and_account(db)
+    a = datetime(2025, 3, 1, 9, tzinfo=timezone.utc)
+    b = datetime(2025, 2, 1, 9, tzinfo=timezone.utc)
+    c = datetime(2025, 1, 15, 9, tzinfo=timezone.utc)
+    strava_adapter.seed_activities([_raw(301, a), _raw(302, b), _raw(303, c)])
+    imp = _make_import(db, user, since_date=date(2025, 1, 1))
+
+    first = await run_import_batch(db, imp, limit=2)
+    assert first.imported == 2  # a, b (newest first)
+    assert first.done is False
+
+    second = await run_import_batch(db, imp, limit=2)
+    # Only c remains older than the cursor; a/b are not re-fetched.
+    assert second.imported == 1
+    assert second.done is True
+    db.refresh(imp)
+    assert imp.status == "completed"
+    assert imp.activities_imported == 3
+    assert db.query(Activity).filter(Activity.user_id == user.id).count() == 3
+
+
+@pytest.mark.asyncio
+async def test_import_is_rerunnable_via_dedup(db, strava_adapter):
+    """Re-importing the same window upserts rather than duplicating activities."""
+    from app.jobs.strava_import import run_import_batch
+
+    user, _account = _seed_user_and_account(db)
+    strava_adapter.seed_activities(
+        [_raw(401, datetime(2025, 3, 1, 9, tzinfo=timezone.utc), name="First")]
+    )
+
+    imp1 = _make_import(db, user)
+    await run_import_batch(db, imp1, limit=50)
+
+    # Same activity, edited name; a fresh import should update, not duplicate.
+    strava_adapter.seed_activities(
+        [_raw(401, datetime(2025, 3, 1, 9, tzinfo=timezone.utc), name="Renamed")]
+    )
+    imp2 = _make_import(db, user)
+    await run_import_batch(db, imp2, limit=50)
+
+    rows = db.query(Activity).filter(Activity.strava_activity_id == 401).all()
+    assert len(rows) == 1
+    assert rows[0].name == "Renamed"
+
+
+@pytest.mark.asyncio
+async def test_import_never_notifies_and_writes_no_coach_report(db, strava_adapter):
+    from app.jobs.strava_import import run_import_batch
+    from app.services.notifications import InMemoryNotifier, set_notifier
+
+    notifier = InMemoryNotifier()
+    set_notifier(notifier)
+    try:
+        user, _account = _seed_user_and_account(db)
+        strava_adapter.seed_activities(
+            [_raw(501, datetime(2025, 3, 1, 9, tzinfo=timezone.utc))]
+        )
+        imp = _make_import(db, user)
+
+        await run_import_batch(db, imp, limit=50)
+
+        assert notifier.sent == []
+        activity = db.query(Activity).filter(Activity.strava_activity_id == 501).first()
+        assert activity is not None
+        assert activity.coach_notification_sent_at is None
+        assert activity.opener_notification_sent_at is None
+    finally:
+        set_notifier(None)
+
+
+@pytest.mark.asyncio
+async def test_batch_fails_gracefully_without_account(db, strava_adapter):
+    from app.jobs.strava_import import run_import_batch
+
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    imp = _make_import(db, user)
+
+    result = await run_import_batch(db, imp, limit=50)
+
+    assert result.done is True
+    db.refresh(imp)
+    assert imp.status == "failed"
+    assert "No linked Strava account" in (imp.error or "")
+
+
+def test_job_schedules_next_batch_when_not_done():
+    from app.jobs import strava_import as mod
+
+    fake_db = MagicMock()
+    running = MagicMock()
+    running.status = "running"
+    fake_db.get.return_value = running
+    result = mod.ImportBatchResult(imported=50, done=False)
+    with patch.object(mod, "SessionLocal", return_value=fake_db), patch.object(
+        mod, "run_import_batch", new=AsyncMock(return_value=result)
+    ), patch.object(mod, "_schedule_next_batch") as sched:
+        mod.strava_import_job(str(uuid4()))
+
+    sched.assert_called_once()
+
+
+def test_job_does_not_reschedule_when_done():
+    from app.jobs import strava_import as mod
+
+    fake_db = MagicMock()
+    running = MagicMock()
+    running.status = "running"
+    fake_db.get.return_value = running
+    result = mod.ImportBatchResult(imported=3, done=True)
+    with patch.object(mod, "SessionLocal", return_value=fake_db), patch.object(
+        mod, "run_import_batch", new=AsyncMock(return_value=result)
+    ), patch.object(mod, "_schedule_next_batch") as sched:
+        mod.strava_import_job(str(uuid4()))
+
+    sched.assert_not_called()
+
+
+def test_enqueue_import_creates_row_and_enqueues(db):
+    from app.jobs import strava_import as mod
+
+    _user, account = _seed_user_and_account(db)
+    fake_queue = MagicMock()
+    with patch.object(mod, "queue", fake_queue):
+        imp = mod.enqueue_import(db, account, date(2025, 1, 1))
+
+    assert imp.status == "running"
+    assert imp.since_date == date(2025, 1, 1)
+    fake_queue.enqueue.assert_called_once()
+    _args, kwargs = fake_queue.enqueue.call_args
+    assert kwargs["job_id"] == f"strava_import_{imp.id}"
+
+
+def test_enqueue_import_is_idempotent_while_running(db):
+    from app.jobs import strava_import as mod
+
+    _user, account = _seed_user_and_account(db)
+    fake_queue = MagicMock()
+    with patch.object(mod, "queue", fake_queue):
+        first = mod.enqueue_import(db, account, date(2025, 1, 1))
+        second = mod.enqueue_import(db, account, date(2024, 1, 1))
+
+    assert first.id == second.id
+    # Only the first call enqueued a job.
+    fake_queue.enqueue.assert_called_once()
+
+
+def test_endpoint_starts_import_and_status_reports_progress(client, db):
+    from app.jobs import strava_import as mod
+
+    _user, _account = _seed_user_and_account(db)
+    fake_queue = MagicMock()
+    with patch.object(mod, "queue", fake_queue):
+        resp = client.post("/api/strava/import", json={"since_date": "2025-01-01"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "running"
+    assert body["since_date"] == "2025-01-01"
+    fake_queue.enqueue.assert_called_once()
+
+    status = client.get("/api/strava/import/status")
+    assert status.status_code == 200
+    assert status.json()["id"] == body["id"]
+
+
+def test_endpoint_rejects_future_date(client, db):
+    _user, _account = _seed_user_and_account(db)
+    resp = client.post("/api/strava/import", json={"since_date": "2999-01-01"})
+    assert resp.status_code == 400
+
+
+def test_status_is_null_when_no_import(client, db):
+    _seed_user_and_account(db)
+    resp = client.get("/api/strava/import/status")
+    assert resp.status_code == 200
+    assert resp.json() is None

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import ConnectStravaButton from '@/components/ConnectStravaButton';
+import ImportStravaHistory from '@/components/ImportStravaHistory';
 import ThemeToggle from '@/components/ThemeToggle';
 import { fetchFromAPI } from '@/lib/api';
 
@@ -178,6 +179,10 @@ export default function ProfilePage() {
         </button>
 
       </form>
+
+      <div className="mt-6">
+        <ImportStravaHistory />
+      </div>
     </div>
   );
 }

--- a/frontend/components/ImportStravaHistory.tsx
+++ b/frontend/components/ImportStravaHistory.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { History, Loader2, CheckCircle2, AlertTriangle } from 'lucide-react';
+import { fetchFromAPI } from '@/lib/api';
+
+type ImportStatus = {
+  id: string;
+  since_date: string;
+  status: 'running' | 'completed' | 'failed';
+  activities_imported: number;
+  error: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+const POLL_INTERVAL_MS = 3000;
+
+function defaultSinceDate(): string {
+  // Default to one year back — a sensible starting window the user can widen.
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+export default function ImportStravaHistory() {
+  const router = useRouter();
+  const [sinceDate, setSinceDate] = useState<string>(defaultSinceDate());
+  const [importState, setImportState] = useState<ImportStatus | null>(null);
+  const [starting, setStarting] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const today = new Date().toISOString().slice(0, 10);
+  const running = importState?.status === 'running';
+
+  const poll = useCallback(async () => {
+    try {
+      const data: ImportStatus | null = await fetchFromAPI('/api/strava/import/status');
+      setImportState(data);
+      if (data && data.status === 'running') {
+        timer.current = setTimeout(poll, POLL_INTERVAL_MS);
+      } else if (data && data.status === 'completed') {
+        // New activities landed — refresh server components (dashboard/trends).
+        router.refresh();
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }, [router]);
+
+  // On mount, surface any in-flight or recent import and resume polling.
+  useEffect(() => {
+    poll();
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [poll]);
+
+  const handleImport = async () => {
+    if (!sinceDate) return;
+    setStarting(true);
+    try {
+      const data: ImportStatus = await fetchFromAPI('/api/strava/import', {
+        method: 'POST',
+        body: JSON.stringify({ since_date: sinceDate }),
+      });
+      setImportState(data);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(poll, POLL_INTERVAL_MS);
+    } catch (err) {
+      console.error(err);
+      alert('Failed to start Strava history import. Is Strava connected?');
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 p-6 border dark:border-gray-700 rounded-xl shadow-sm space-y-4">
+      <div className="flex items-center gap-2">
+        <History size={18} className="text-blue-600 dark:text-blue-400" />
+        <h2 className="text-lg font-semibold">Import Strava History</h2>
+      </div>
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        Back-fill your past Strava activities so trends and load have history to
+        work with. Imported runs are stored as data only — your coach won&apos;t
+        analyse or message you about old activities.
+      </p>
+
+      <div className="flex flex-wrap items-end gap-3">
+        <div>
+          <label
+            htmlFor="import-since"
+            className="block text-sm font-medium mb-1"
+          >
+            Import from
+          </label>
+          <input
+            id="import-since"
+            type="date"
+            value={sinceDate}
+            max={today}
+            disabled={running}
+            onChange={(e) => setSinceDate(e.target.value)}
+            className="border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2 disabled:opacity-50"
+          />
+        </div>
+        <button
+          onClick={handleImport}
+          disabled={starting || running || !sinceDate}
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          {starting || running ? (
+            <Loader2 size={16} className="animate-spin" />
+          ) : (
+            <History size={16} />
+          )}
+          {running ? 'Importing…' : starting ? 'Starting…' : 'Import history'}
+        </button>
+      </div>
+
+      {importState && (
+        <div className="text-sm">
+          {importState.status === 'running' && (
+            <p className="flex items-center gap-2 text-gray-600 dark:text-gray-300">
+              <Loader2 size={14} className="animate-spin" />
+              Importing… {importState.activities_imported} activities so far.
+            </p>
+          )}
+          {importState.status === 'completed' && (
+            <p className="flex items-center gap-2 text-green-600 dark:text-green-400">
+              <CheckCircle2 size={14} />
+              Imported {importState.activities_imported} activities.
+            </p>
+          )}
+          {importState.status === 'failed' && (
+            <p className="flex items-center gap-2 text-red-600 dark:text-red-400">
+              <AlertTriangle size={14} />
+              Import failed{importState.error ? `: ${importState.error}` : '.'}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds an on-demand "Import Strava history" feature that back-fills a runner's
past activities from a user-chosen start date up to today.

Backend:
- New StravaImport model + migration: per-user job state (since_date, status,
  resume cursor, imported count) so the import is resumable and progress is
  queryable.
- New port method list_activities_page(after, before, page) on the Strava
  protocol + HTTP and in-memory adapters, for a single bounded page.
- Self-pacing background job (app/jobs/strava_import.py) modelled on the stream
  backfill: walks history backward in time one page per batch via a `before`
  cursor, upserts summaries, runs deterministic analysis, advances the cursor,
  and self-schedules the next batch. Imports raw data only — never the AI coach
  report/opener or any Telegram/email notification. Dedup by strava_activity_id
  makes it safely re-runnable; one list call per batch keeps it well under
  Strava's rate limit.
- POST /api/strava/import (idempotent while running) and
  GET /api/strava/import/status endpoints.
- Tests covering the backward walk, dedup re-runnability, completion, the
  no-notification guarantee, graceful failure, self-pacing, and the endpoints.

Frontend:
- ImportStravaHistory component (date picker + progress polling) on the Profile
  page, showing live "importing N activities" progress and a final summary.

https://claude.ai/code/session_01AjjhvzSc1QCyQGfdSDYByd