### PR TITLE
Move Strava history import above the profile form (#239)

### DIFF
--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -86,7 +86,11 @@ export default function ProfilePage() {
             <Link href="/" className="text-blue-600 dark:text-blue-400 hover:underline">Cancel</Link>
         </div>
       </header>
-      
+
+      <div className="mb-6">
+        <ImportStravaHistory />
+      </div>
+
       <form onSubmit={handleSubmit} className="space-y-6 bg-white dark:bg-gray-800 p-6 border dark:border-gray-700 rounded-xl shadow-sm">
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -179,10 +183,6 @@ export default function ProfilePage() {
         </button>
 
       </form>
-
-      <div className="mt-6">
-        <ImportStravaHistory />
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What

Relocates the **Import Strava History** card on the Profile page from the bottom (below the form and the "Save Profile" button) to directly under the "Connected to Strava" block, so it's visible without scrolling.

## Why

The card shipped in #252 but rendered off the bottom of the screen on mobile — below the entire profile form — so it looked like nothing had changed. Moving it up next to the Strava connection status (where it logically belongs, since the import only applies to a connected account) makes it immediately discoverable.

## Change

One-file diff in `frontend/app/profile/page.tsx`: the `<ImportStravaHistory />` block moves from after `</form>` to right after the page header. No behavioural change to the component itself.

https://claude.ai/code/session_01AjjhvzSc1QCyQGfdSDYByd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjjhvzSc1QCyQGfdSDYByd)_