### PR TITLE
Fix historical Strava import stopping after one page (#239)

### DIFF
--- a/backend/alembic/versions/b4e7c2a9f1d3_strava_import_page_cursor.py
+++ b/backend/alembic/versions/b4e7c2a9f1d3_strava_import_page_cursor.py
@@ -1,0 +1,40 @@
+"""strava import: replace before-epoch cursor with a page cursor
+
+The historical import (#239) paginated with a `before` epoch cursor set to the
+oldest activity in each page. But Strava returns `/athlete/activities`
+oldest-first when `after` is set, so the first page is the oldest 50 activities
+and `before = oldest` excluded everything — the import stopped after one page.
+Switch to page-number pagination (fixed `after`, advancing page), which walks
+the whole window regardless of sort order.
+
+Revision ID: b4e7c2a9f1d3
+Revises: d9f1a2b3c4e5
+Create Date: 2026-06-12 22:40:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'b4e7c2a9f1d3'
+down_revision: Union[str, None] = 'd9f1a2b3c4e5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'strava_imports',
+        sa.Column('cursor_page', sa.Integer(), nullable=False, server_default='1'),
+    )
+    op.drop_column('strava_imports', 'cursor_before')
+
+
+def downgrade() -> None:
+    op.add_column(
+        'strava_imports',
+        sa.Column('cursor_before', sa.BigInteger(), nullable=True),
+    )
+    op.drop_column('strava_imports', 'cursor_page')

--- a/backend/app/jobs/strava_import.py
+++ b/backend/app/jobs/strava_import.py
@@ -1,10 +1,9 @@
 """Historical Strava import: backfill a runner's past activities on demand (#239).
 
 A self-pacing background job (modelled on the stream backfill, #110). Each run
-fetches one page of the runner's Strava history within a moving time window,
-upserts the activity summaries, runs deterministic analysis, and advances a
-resume cursor. It walks backward in time from today to the user-chosen
-`since_date`.
+fetches one page of the runner's Strava history in the window from `since_date`
+to today, upserts the activity summaries, runs deterministic analysis, and
+advances the page cursor.
 
 Crucially it imports *raw data only*: summaries and deterministic analysis
 (distance/time/effort that power trends), never the AI coach report, opener, or
@@ -14,11 +13,15 @@ analyses of runs weeks or years old. Coach analysis stays opt-in (the existing
 per-activity path).
 
 State lives entirely in a `StravaImport` row:
-  - `cursor_before` is the exclusive upper-bound epoch of the next page. It starts
-    NULL (newest) and advances to the oldest activity's start epoch each batch,
-    so a page is never re-walked and an interruption resumes from the cursor.
-  - dedup by `strava_activity_id` (via `upsert_activity`) makes any partial-batch
-    replay idempotent, so the import is safely re-runnable.
+  - `cursor_page` is the next page to fetch (1-based), with a fixed `after` lower
+    bound. Strava returns results oldest-first when `after` is set, so paginating
+    by page number walks the whole window regardless of sort order; the cursor
+    advances by one per full page and an interruption resumes from it. (An
+    earlier `before`-epoch cursor was wrong: with `after` set the first page is
+    the *oldest* 50 activities, so `before = oldest` excluded everything and the
+    import stopped after one page.)
+  - dedup by `strava_activity_id` (via `upsert_activity`) makes any replayed page
+    idempotent, so the import is safely re-runnable.
 
 Pacing: when a full page comes back there is likely more history, so the job
 schedules its own successor via rq-scheduler after `IMPORT_BATCH_PAUSE_SECONDS`,
@@ -57,22 +60,14 @@ class ImportBatchResult:
     done: bool = True
 
 
-def _start_epoch(raw: dict) -> int:
-    dt = datetime.strptime(raw["start_date"], "%Y-%m-%dT%H:%M:%SZ").replace(
-        tzinfo=timezone.utc
-    )
-    return int(dt.timestamp())
-
-
 async def run_import_batch(
     db: Session, import_obj: StravaImport, *, limit: int
 ) -> ImportBatchResult:
-    """Fetch one page within (since_date, cursor_before], upsert + analyze each.
+    """Fetch one page (since_date.., page=cursor_page), upsert + analyze each.
 
-    Advances `cursor_before` to the oldest activity seen so the next batch is the
-    strictly-older page; marks the import complete when a short page signals the
-    window is exhausted. Commits progress as it goes so an interruption resumes.
-    Never notifies.
+    Advances `cursor_page` by one when a full page comes back; marks the import
+    complete when a short page signals the window is exhausted. Commits progress
+    as it goes so an interruption resumes. Never notifies.
     """
     account = (
         db.query(StravaAccount)
@@ -89,13 +84,13 @@ async def run_import_batch(
     port = get_strava_port()
     since = datetime.combine(import_obj.since_date, time.min, tzinfo=timezone.utc)
     after = int(since.timestamp())
-    before = import_obj.cursor_before
+    page = import_obj.cursor_page
 
     try:
         access_token = await ensure_valid_access_token(db, account, port)
         try:
             batch = await port.list_activities_page(
-                access_token, after=after, before=before, per_page=limit
+                access_token, after=after, page=page, per_page=limit
             )
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code != 401:
@@ -105,7 +100,7 @@ async def run_import_batch(
             )
             access_token = await ensure_valid_access_token(db, account, port, force=True)
             batch = await port.list_activities_page(
-                access_token, after=after, before=before, per_page=limit
+                access_token, after=after, page=page, per_page=limit
             )
     except Exception as exc:  # noqa: BLE001 - surface the failure on the row, don't crash the worker
         import_obj.status = "failed"
@@ -116,7 +111,6 @@ async def run_import_batch(
         return ImportBatchResult(imported=0, done=True)
 
     imported = 0
-    oldest_epoch: int | None = None
     for raw in batch:
         try:
             activity = upsert_activity(db, raw, account.user_id)
@@ -137,23 +131,22 @@ async def run_import_batch(
         except Exception as exc:  # noqa: BLE001 - one bad activity must not sink the batch
             db.rollback()
             logger.error("Error importing activity %s: %s", raw.get("id"), exc)
-        epoch = _start_epoch(raw)
-        oldest_epoch = epoch if oldest_epoch is None else min(oldest_epoch, epoch)
 
     import_obj.activities_imported += imported
     # A short page means we have reached the end of the window: done. A full page
-    # means there is likely more, older history to walk; advance the cursor.
+    # means there is likely more history; advance to the next page.
     done = len(batch) < limit
     if done:
         import_obj.status = "completed"
-    elif oldest_epoch is not None:
-        import_obj.cursor_before = oldest_epoch
+    else:
+        import_obj.cursor_page = page + 1
     db.add(import_obj)
     db.commit()
 
     logger.info(
-        "Historical import %s batch: imported %d (total %d), done=%s",
+        "Historical import %s batch: page %d imported %d (total %d), done=%s",
         import_obj.id,
+        page,
         imported,
         import_obj.activities_imported,
         done,
@@ -222,7 +215,7 @@ def enqueue_import(db: Session, account: StravaAccount, since_date) -> StravaImp
         user_id=account.user_id,
         since_date=since_date,
         status="running",
-        cursor_before=None,
+        cursor_page=1,
         activities_imported=0,
     )
     db.add(import_obj)

--- a/backend/app/models/strava_import.py
+++ b/backend/app/models/strava_import.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import date, datetime
 
-from sqlalchemy import BigInteger, Date, DateTime, ForeignKey, Integer, String, Uuid
+from sqlalchemy import Date, DateTime, ForeignKey, Integer, String, Uuid
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
@@ -12,12 +12,12 @@ from app.models.base import generate_uuid
 class StravaImport(Base):
     """State for a resumable historical Strava import (#239).
 
-    A self-pacing background job walks the runner's Strava history backward in
-    time from today to ``since_date``, ingesting activity summaries (no streams,
-    no AI coach analysis, no notifications). State lives entirely in this row so
-    the job is resumable: ``cursor_before`` is the exclusive upper-bound epoch of
-    the next page to fetch and advances to the oldest activity seen each batch,
-    so an interruption resumes without re-walking completed work, and dedup by
+    A self-pacing background job walks the runner's Strava history from
+    ``since_date`` to today, ingesting activity summaries (no streams, no AI
+    coach analysis, no notifications). State lives entirely in this row so the
+    job is resumable: ``cursor_page`` is the next page to fetch (with a fixed
+    ``after`` lower bound), advancing one page per full batch, so an interruption
+    resumes without re-walking completed pages, and dedup by
     ``strava_activity_id`` makes any overlap idempotent.
     """
 
@@ -32,10 +32,10 @@ class StravaImport(Base):
     # "running" | "completed" | "failed".
     status: Mapped[str] = mapped_column(String, default="running")
 
-    # Exclusive upper-bound epoch for the next page's `before` filter. NULL on the
-    # first batch (start from now / newest); advances to the oldest activity's
-    # start epoch after each batch, walking backward in time.
-    cursor_before: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # Next page to fetch (1-based), with a fixed `after` lower bound. Strava
+    # returns oldest-first when `after` is set, so page-number pagination walks
+    # the whole window; the cursor advances by one per full page.
+    cursor_page: Mapped[int] = mapped_column(Integer, default=1)
 
     # How many activities have been upserted so far (progress for the UI).
     activities_imported: Mapped[int] = mapped_column(Integer, default=0)

--- a/backend/tests/test_strava_import_job.py
+++ b/backend/tests/test_strava_import_job.py
@@ -57,12 +57,12 @@ def _raw(strava_id: int, start: datetime, name: str = "Old run") -> dict:
     }
 
 
-def _make_import(db, user, since_date=date(2025, 1, 1), cursor_before=None) -> StravaImport:
+def _make_import(db, user, since_date=date(2025, 1, 1), cursor_page=1) -> StravaImport:
     imp = StravaImport(
         user_id=user.id,
         since_date=since_date,
         status="running",
-        cursor_before=cursor_before,
+        cursor_page=cursor_page,
         activities_imported=0,
     )
     db.add(imp)
@@ -96,7 +96,7 @@ async def test_batch_imports_summaries_and_completes_on_short_page(db, strava_ad
 
 
 @pytest.mark.asyncio
-async def test_full_page_advances_cursor_and_is_not_done(db, strava_adapter):
+async def test_full_page_advances_page_cursor_and_is_not_done(db, strava_adapter):
     from app.jobs.strava_import import run_import_batch
 
     user, _account = _seed_user_and_account(db)
@@ -111,13 +111,18 @@ async def test_full_page_advances_cursor_and_is_not_done(db, strava_adapter):
     assert result.done is False
     db.refresh(imp)
     assert imp.status == "running"
-    # Cursor advanced to the oldest activity's start epoch (exclusive upper bound).
-    assert imp.cursor_before == int(older.timestamp())
+    # Cursor advanced to the next page.
+    assert imp.cursor_page == 2
 
 
 @pytest.mark.asyncio
-async def test_cursor_walks_backward_without_repeating(db, strava_adapter):
-    """A second batch bounded by the cursor returns only strictly-older activities."""
+async def test_page_walk_covers_whole_window_without_repeating(db, strava_adapter):
+    """Walking page by page imports every activity exactly once and completes.
+
+    Regression for the one-page stop: with `after` set, Strava returns
+    oldest-first, so a `before = oldest` cursor would have ended after page 1.
+    Page-number pagination must keep going.
+    """
     from app.jobs.strava_import import run_import_batch
 
     user, _account = _seed_user_and_account(db)
@@ -128,11 +133,13 @@ async def test_cursor_walks_backward_without_repeating(db, strava_adapter):
     imp = _make_import(db, user, since_date=date(2025, 1, 1))
 
     first = await run_import_batch(db, imp, limit=2)
-    assert first.imported == 2  # a, b (newest first)
+    assert first.imported == 2
     assert first.done is False
+    db.refresh(imp)
+    assert imp.cursor_page == 2
 
     second = await run_import_batch(db, imp, limit=2)
-    # Only c remains older than the cursor; a/b are not re-fetched.
+    # Page 2 holds the remaining one activity; the short page completes the import.
     assert second.imported == 1
     assert second.done is True
     db.refresh(imp)


### PR DESCRIPTION
## Problem

The historical Strava import stopped after exactly **50 activities** (one page), regardless of how much history existed — a year of running came back as just 50 runs.

## Root cause

Strava's `GET /athlete/activities` returns results **oldest-first when `after` is set** (a well-known API quirk). The import always sets `after = since_date`, so the first page is the *oldest* 50 activities. The cursor then set `before = oldest-in-page`, which excluded everything older — the second batch came back empty and the import "completed" at 50.

## Fix

Switch to **page-number pagination** with a fixed `after` lower bound — the same approach the existing `list_recent_activities` uses — which walks the whole window regardless of sort order.

- Replace `StravaImport.cursor_before` (epoch) with `cursor_page` (integer), via a follow-up migration (the original table migration already shipped in #252, so this swaps the column).
- Update the job to fetch `page=cursor_page`, advancing one page per full batch and completing on a short page.
- Add a regression test (`test_page_walk_covers_whole_window_without_repeating`) plus update the existing cursor tests.

Full backend suite green (1019 passed). After merge + redeploy, re-running the import will page through the entire history; already-imported runs are de-duplicated by Strava activity ID, so it's safe to just click **Import history** again.

https://claude.ai/code/session_01AjjhvzSc1QCyQGfdSDYByd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjjhvzSc1QCyQGfdSDYByd)_