### PR TITLE
Fix Chat with Coach "Load failed" error (#223)

### DIFF
--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -1,3 +1,5 @@
+import json
+import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -15,7 +17,23 @@ from app.services.coach.service import (
     _to_read,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+
+def _sse_data(text: str) -> str:
+    """Frame one chunk as an SSE `data:` event.
+
+    The payload is JSON-encoded so it survives the SSE line protocol intact: a
+    coach reply is multi-paragraph markdown, and a raw newline inside `data: …`
+    would split the value across lines (everything after the first newline is
+    silently dropped by an SSE parser) or, on a blank line, dispatch a truncated
+    event. JSON escaping collapses every chunk to a single line with no blank
+    lines, so the client reconstructs the exact text. The `[DONE]` sentinel is
+    sent unencoded and checked for before any JSON parse on the client.
+    """
+    return f"data: {json.dumps(text)}\n\n"
 
 
 @router.get(
@@ -59,7 +77,7 @@ def delete_chat(activity_id: UUID, db: Session = Depends(get_db)):
     from app.models.coach_chat_message import CoachChatMessage
 
     db.query(CoachChatMessage).filter(
-        CoachChatMessage.activity_id == str(activity_id)
+        CoachChatMessage.activity_id == activity_id
     ).delete()
     db.commit()
 
@@ -74,7 +92,7 @@ async def post_chat(
     # Validate that a coach report exists
     existing = (
         db.query(CoachReport)
-        .filter(CoachReport.activity_id == str(activity_id))
+        .filter(CoachReport.activity_id == activity_id)
         .first()
     )
     if not existing:
@@ -84,10 +102,26 @@ async def post_chat(
         )
 
     async def event_stream():
-        async for chunk in stream_chat_response(db, str(activity_id), body.message):
-            # SSE format: data lines followed by blank line
-            yield f"data: {chunk}\n\n"
-        yield "data: [DONE]\n\n"
+        # Flush a comment frame immediately so the connection (and its 200) is
+        # established before the slow first token, rather than going silent
+        # through proxies that would otherwise time the request out (#223).
+        yield ": ok\n\n"
+        try:
+            async for chunk in stream_chat_response(db, activity_id, body.message):
+                yield _sse_data(chunk)
+        except Exception:
+            # The stream is already open (status + headers sent), so a raised
+            # exception here would just sever the connection — the browser
+            # surfaces that as a bare "Load failed". Stream a readable message
+            # instead so the user sees what happened and can retry (#223).
+            logger.exception(
+                "coach chat stream failed for activity %s", activity_id
+            )
+            yield _sse_data(
+                "Sorry, I hit an error answering that. Please try again."
+            )
+        finally:
+            yield "data: [DONE]\n\n"
 
     return StreamingResponse(
         event_stream(),

--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -111,9 +111,11 @@ def _build_chat_system_prompt(
 
 def get_chat_history(db: Session, activity_id: str) -> List[ChatMessageRead]:
     """Return all chat messages for an activity, ordered chronologically."""
+    from app.services.coach.service import _coerce_uuid
+
     messages = (
         db.query(CoachChatMessage)
-        .filter(CoachChatMessage.activity_id == activity_id)
+        .filter(CoachChatMessage.activity_id == _coerce_uuid(activity_id))
         .order_by(CoachChatMessage.created_at.asc())
         .all()
     )
@@ -133,7 +135,11 @@ async def stream_chat_response(
     # Load the coach report (must exist before chatting). Prefer the active
     # version; fall back to the most recent report of any version so chat still
     # works against an activity whose only report predates a version bump.
-    from app.services.coach.service import get_active_report_row
+    from app.services.coach.service import _coerce_uuid, get_active_report_row
+
+    # Coerce once: Postgres tolerates the string form via implicit cast, but the
+    # Uuid column type does not bind a str under SQLite (used in tests).
+    activity_id = _coerce_uuid(activity_id)
 
     report_row = get_active_report_row(db, activity_id) or (
         db.query(CoachReport)

--- a/backend/tests/test_coach_chat_stream.py
+++ b/backend/tests/test_coach_chat_stream.py
@@ -1,0 +1,116 @@
+"""Repro for #223: 'Chat with Coach' streaming.
+
+Exercises the POST /api/activities/{id}/coach-chat SSE endpoint end to end with
+a mocked LLM, then reconstructs the client-visible text from the SSE frames the
+way the frontend does. The coach prompt explicitly asks for multi-paragraph
+markdown, so the LLM emits text deltas containing newlines; the wire format must
+survive them.
+"""
+
+import json
+from datetime import datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+from app.models import Activity, DerivedMetric, StravaAccount, User, UserProfile
+from app.models.coach_report import CoachReport
+
+
+def _seed_activity_with_report(db) -> Activity:
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    db.add(UserProfile(user_id=user.id, goal_type="general", experience_level="intermediate", weekly_days_available=4, max_hr=190))
+    db.add(StravaAccount(user_id=user.id, strava_athlete_id=1, access_token="t", refresh_token="r", expires_at=9999999999, scope="read"))
+    activity = Activity(
+        user_id=user.id, strava_activity_id=42,
+        start_date=datetime(2026, 5, 27, 10, 0, 0), type="Run", name="Test run",
+        distance_m=5000, moving_time_s=1500, elapsed_time_s=1500, elev_gain_m=10.0,
+        avg_hr=140, raw_summary={},
+    )
+    db.add(activity)
+    db.commit()
+    db.add(DerivedMetric(
+        activity_id=activity.id, effort="easy", structure="continuous",
+        duration_class="standard", effort_score=50.0, flags=[],
+        confidence="medium", confidence_reasons=[],
+    ))
+    db.add(CoachReport(
+        activity_id=activity.id, report={"key_takeaways": [{"text": "ok"}]},
+        meta={}, context_pack={}, prompt_id="x", schema_version=1, is_fallback=False,
+    ))
+    db.commit()
+    db.refresh(activity)
+    return activity
+
+
+def _reconstruct_from_sse(raw: str) -> str:
+    """Reconstruct the assistant text from the SSE stream the frontend's way:
+    split on the blank-line event delimiter, then JSON-decode each data frame."""
+    out = []
+    for event in raw.split("\n\n"):
+        for line in event.split("\n"):
+            if not line.startswith("data: "):
+                continue
+            data = line[len("data: "):]
+            if data == "[DONE]":
+                continue
+            out.append(json.loads(data))
+    return "".join(out)
+
+
+def test_chat_stream_preserves_multiline_markdown(client, db):
+    activity = _seed_activity_with_report(db)
+
+    # A realistic coach reply: markdown with blank lines and a bullet list,
+    # streamed as deltas that straddle newlines (as the SDK actually does).
+    reply = "Great run!\n\nHere's what stood out:\n\n- Steady pace\n- Strong finish"
+
+    async def fake_stream(self, system, messages, max_tokens=1024):
+        # The Anthropic SDK yields text deltas of arbitrary size, including ones
+        # that contain newlines.
+        for delta in ["Great run!\n\nHere's ", "what stood out:\n\n- Steady pace\n", "- Strong finish"]:
+            yield delta
+
+    with patch("app.services.coach.llm.AnthropicClient.stream_chat", new=fake_stream):
+        resp = client.post(
+            f"/api/activities/{activity.id}/coach-chat",
+            json={"message": "How did I do?"},
+        )
+
+    assert resp.status_code == 200
+    reconstructed = _reconstruct_from_sse(resp.text)
+    assert reconstructed == reply, f"got {reconstructed!r}"
+    # The user turn and the assembled assistant turn are both persisted.
+    from app.models.coach_chat_message import CoachChatMessage
+
+    saved = (
+        db.query(CoachChatMessage)
+        .filter(CoachChatMessage.activity_id == activity.id)
+        .order_by(CoachChatMessage.created_at.asc())
+        .all()
+    )
+    assert [m.role for m in saved] == ["user", "assistant"]
+    assert saved[1].content == reply
+
+
+def test_chat_stream_reports_error_without_breaking_connection(client, db):
+    """A failure mid-stream must not sever the connection (which the browser
+    shows as a bare "Load failed") — it streams a readable message and closes
+    cleanly with the [DONE] sentinel (#223)."""
+    activity = _seed_activity_with_report(db)
+
+    async def boom(self, system, messages, max_tokens=1024):
+        raise RuntimeError("upstream exploded")
+        yield  # pragma: no cover — makes this an async generator
+
+    with patch("app.services.coach.llm.AnthropicClient.stream_chat", new=boom):
+        resp = client.post(
+            f"/api/activities/{activity.id}/coach-chat",
+            json={"message": "How did I do?"},
+        )
+
+    assert resp.status_code == 200
+    assert "data: [DONE]" in resp.text
+    reconstructed = _reconstruct_from_sse(resp.text)
+    assert reconstructed  # a human-readable message, not an empty/severed stream

--- a/frontend/components/CoachChat.tsx
+++ b/frontend/components/CoachChat.tsx
@@ -79,23 +79,36 @@ export default function CoachChat({ activityId }: Props) {
 
       const decoder = new TextDecoder();
       let fullResponse = '';
+      // SSE events are delimited by a blank line. Buffer across reads so an
+      // event split over two network chunks is reassembled before parsing.
+      let buffer = '';
+
+      const handleEvent = (event: string) => {
+        for (const line of event.split('\n')) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6);
+          if (data === '[DONE]') continue;
+          try {
+            // The backend JSON-encodes each chunk so multi-line markdown
+            // survives the SSE protocol intact.
+            fullResponse += JSON.parse(data) as string;
+            setStreamingText(fullResponse);
+          } catch {
+            // Ignore a malformed frame rather than aborting the whole stream.
+          }
+        }
+      };
 
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
 
-        const chunk = decoder.decode(value, { stream: true });
-        // Parse SSE data lines
-        const lines = chunk.split('\n');
-        for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            const data = line.slice(6);
-            if (data === '[DONE]') continue;
-            fullResponse += data;
-            setStreamingText(fullResponse);
-          }
-        }
+        buffer += decoder.decode(value, { stream: true });
+        const events = buffer.split('\n\n');
+        buffer = events.pop() ?? ''; // keep the trailing partial event
+        for (const event of events) handleEvent(event);
       }
+      if (buffer.trim()) handleEvent(buffer);
 
       // Finalize: replace streaming text with a proper message
       const assistantMsg: ChatMessage = {
@@ -108,11 +121,13 @@ export default function CoachChat({ activityId }: Props) {
       setMessages(prev => [...prev, assistantMsg]);
       setStreamingText('');
     } catch (err) {
+      // Surface a friendly, actionable message rather than the raw fetch error
+      // (Safari reports a dropped connection as the opaque "Load failed") (#223).
       const errorMsg: ChatMessage = {
         id: crypto.randomUUID(),
         activity_id: activityId,
         role: 'assistant',
-        content: err instanceof Error ? err.message : 'Something went wrong. Please try again.',
+        content: "Sorry, I couldn't reach your coach just now. Please try again.",
         created_at: new Date().toISOString(),
       };
       setMessages(prev => [...prev, errorMsg]);


### PR DESCRIPTION
The chat endpoint streamed each LLM text delta as `data: {chunk}\n\n`. Coach
replies are multi-paragraph markdown (the prompt asks for it), so chunks
contain newlines, which broke the SSE line protocol: a parser drops everything
after the first newline and a blank line dispatches a truncated event. Frames
split across network reads were also mis-parsed. Separately, any failure once
the stream was open severed the connection, which the browser surfaces as the
opaque "Load failed".

- Backend: JSON-encode each chunk so multi-line text survives the SSE protocol;
  wrap the generator so a mid-stream failure streams a readable message and
  closes cleanly with [DONE] instead of dropping the connection; flush an
  initial comment frame so slow first-token latency does not trip proxy
  timeouts.
- Frontend: buffer across reads and split on the blank-line event delimiter,
  JSON-decode each data frame, and show a friendly retry message instead of the
  raw fetch error.
- Coerce the activity id to a UUID on the chat queries/inserts so they are
  dialect-agnostic (Postgres tolerated the string form; SQLite did not), which
  also unblocks an end-to-end endpoint test.
- Add tests covering multi-line reconstruction and error resilience.

https://claude.ai/code/session_01Awt66UfcC8zTHcfPTKPNv4