### PR TITLE
fix(coach): hold the prior report until force-regen commits the new one (#273)

### DIFF
--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -244,10 +244,11 @@ async def get_or_generate_coach_report(
     existing = get_active_report_row(db, activity_uuid)
     if existing and not force:
         return _to_read(existing)
-    if force and existing:
-        # Replace only the active-version row; prior versions are untouched.
-        db.delete(existing)
-        db.commit()
+    # #273: a force regenerate does NOT delete the active row up front. The LLM call
+    # runs first and _persist_report updates the existing row in place (generate-
+    # then-swap), so the single content-swapping commit is atomic — a worker death
+    # mid-regen leaves the prior report intact instead of zero rows. Prior schema-
+    # versions are untouched (the in-place update keeps the same cache identity).
 
     # Load activity
     activity = db.query(Activity).filter(Activity.id == activity_uuid).first()
@@ -295,7 +296,7 @@ async def get_or_generate_coach_report(
         pack_dict=pack_dict,
         input_hash=input_hash,
         outcome=outcome,
-        existing=None,
+        existing=existing,  # #273: in-place swap on force; None -> insert (first gen)
         fire_learning_loop=True,
     )
     return read
@@ -417,19 +418,18 @@ async def generate_fuller(
     activity_uuid = _coerce_uuid(activity_id)
 
     existing = get_active_report_row(db, activity_uuid)
-    # Capture the opener prose BEFORE any force-delete, so a force-regenerate of a
-    # complete two-line row still preserves the opener half of the thread (the
-    # brief's "preserving both halves" survives force too).
+    # Capture the opener prose up front, so a force-regenerate of a complete two-line
+    # row still preserves the opener half of the thread (the brief's "preserving both
+    # halves" survives force too) — the in-place swap below overwrites the report dict.
     opener_prose = (existing.report or {}).get("opener_message") if existing else None
-    if force and existing is not None:
-        # A manual regenerate produces a fresh complete report; prior versions are
-        # untouched (force replaces only the active-version row).
-        db.delete(existing)
-        db.commit()
-        existing = None
-    if existing is not None and not is_opener_only(existing.report):
+    if existing is not None and not is_opener_only(existing.report) and not force:
         # A complete fuller turn is already cached for this version.
         return _to_read(existing)
+    # #273: a force regenerate does NOT delete the active row up front. The fuller
+    # call runs first and _persist_report (existing=existing below) updates the SAME
+    # row in place (generate-then-swap), so a worker death mid-regen leaves the prior
+    # complete report intact instead of zero rows. Prior schema-versions are untouched
+    # (the in-place update keeps the same cache identity).
 
     activity = db.query(Activity).filter(Activity.id == activity_uuid).first()
     if not activity or not activity.metrics:

--- a/backend/tests/test_coach_report_versioning.py
+++ b/backend/tests/test_coach_report_versioning.py
@@ -161,13 +161,15 @@ async def test_force_regenerates_active_and_retains_prior_versions(db):
     fake.generate_json.assert_called_once()
     # Prior (1.0) version survives the force.
     assert db.query(CoachReport).filter(CoachReport.id == old.id).first() is not None
-    # Exactly one active-version row, and it is a fresh one (old active row replaced).
+    # Exactly one active-version row, regenerated IN PLACE (#273 generate-then-swap:
+    # the active row is held and its content swapped atomically, so the row id is
+    # stable and a crash mid-regen can never leave zero rows). Content is refreshed.
     active_rows = db.query(CoachReport).filter(
         CoachReport.activity_id == activity.id,
         CoachReport.schema_version == SCHEMA_VERSION,
     ).all()
     assert len(active_rows) == 1
-    assert active_rows[0].id != active_id
+    assert active_rows[0].id == active_id  # same physical row, swapped in place
     assert result.report.key_takeaways[0].text == "Freshly generated one."
 
 
@@ -181,3 +183,29 @@ def test_force_via_api_does_not_destroy_prior_versions(client, db):
     assert resp.status_code == 200
     # The destructive old behaviour wiped the only report; versioning must retain 1.0.
     assert db.query(CoachReport).filter(CoachReport.id == old.id).first() is not None
+
+
+# --- #273: force-regen crash safety (no delete-then-die window) -----------
+
+
+@pytest.mark.asyncio
+async def test_force_regen_worker_death_preserves_prior_report(db):
+    # #273: an interrupted force-regen on the single-shot path must NOT lose the
+    # report. The old path deleted+committed the active row before the LLM call,
+    # so a worker death between the committed delete and the write left zero rows.
+    activity = _seed_activity(db)
+    active = _insert_report(db, activity.id, ACTIVE_PROMPT_ID, SCHEMA_VERSION)
+    active_id = active.id
+
+    # The worker is killed during the regeneration LLM step: _generate_structured
+    # never returns (an uncaught interruption, not a handled fallback).
+    with patch("app.services.coach.service.AnthropicClient"), \
+         patch("app.services.coach.service._generate_structured",
+               side_effect=RuntimeError("worker killed mid-regen")):
+        with pytest.raises(RuntimeError):
+            await get_or_generate_coach_report(db, str(activity.id), force=True)
+
+    survived = db.query(CoachReport).filter(CoachReport.id == active_id).first()
+    assert survived is not None, \
+        "single-shot force-regen interruption lost the report entirely (#273)"
+    assert survived.report["key_takeaways"][0]["text"] == "Cached takeaway one."

--- a/backend/tests/test_two_stage_service.py
+++ b/backend/tests/test_two_stage_service.py
@@ -383,6 +383,42 @@ async def test_fuller_persistent_fallback_stays_opener_only_and_recovers(db, _v2
     assert row2.report["opener_message"].startswith("Nice work")
 
 
+# --- #273: force-regen crash safety (no delete-then-die window) ---------------
+
+
+async def test_force_regen_worker_death_preserves_prior_report(db, _v2):
+    # #273: a worker death mid-force-regen must NOT lose the report. The old path
+    # deleted+committed the active-version row BEFORE the LLM call, so an
+    # interruption between the committed delete and the write left ZERO rows (the
+    # observed prod incident: a 404 on the activity). With generate-then-swap the
+    # prior row is held until the new content commits, so an interrupted
+    # regeneration leaves the prior report fully intact.
+    activity = _seed(db)
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_fuller_blocks("Original report.")))), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        await generate_fuller(db, str(activity.id))
+    original = _stored(db, activity)
+    assert original.report["message"] == "Original report."
+    original_id = original.id
+
+    # The worker is killed during the regeneration LLM step: _generate_message
+    # never returns (an uncaught interruption, not a handled fallback).
+    with patch("app.services.coach.service.AnthropicClient"), \
+         patch("app.services.coach.service._generate_message",
+               side_effect=RuntimeError("worker killed mid-regen")):
+        with pytest.raises(RuntimeError):
+            await generate_fuller(db, str(activity.id), force=True)
+
+    survived = _stored(db, activity)
+    assert survived is not None, \
+        "force-regen interruption lost the report entirely (#273)"
+    assert survived.id == original_id
+    assert survived.report["message"] == "Original report."
+    assert survived.is_fallback is False
+
+
 async def test_generate_fuller_noops_under_single_shot_prompt(db, _v2, monkeypatch):
     # #216: generate_fuller is meaningful only under the two-stage prompt. After a
     # rollback to a single-shot id it must refuse to run — no LLM call, nothing


### PR DESCRIPTION
## Problem
Force-regenerate (`get_or_generate_coach_report(force=True)` → `generate_fuller` under a two-stage prompt) **deleted and committed** the active `CoachReport` row *before* the LLM call. A worker death between the committed delete and the write left the activity with **zero report rows** — a 404 on the activity page, falling to the slow synchronous on-demand path. This was the observed one-activity data-loss incident during **both** the P1.3 and P3 prod activations (a redeploy killed the old worker mid-regen).

## Fix
Generate-then-swap on both force paths: the LLM call runs first, and `_persist_report` updates the **existing row in place**, so the single content-swapping commit is atomic. An interrupted regeneration now leaves the prior report fully intact.

- `get_or_generate_coach_report` (single-shot / rollback path): no upfront delete; `existing` routed into the in-place swap.
- `generate_fuller` (two-stage path, what prod hits on `coach_message_v6`): no upfront delete; the cache-hit gate now also checks `not force` so force still regenerates.

The `(activity_id, prompt_id, schema_version)` UNIQUE constraint plus SQLAlchemy flush ordering made a literal delete+insert-in-one-transaction fragile; in-place update achieves the issue's stated "keep the old row until the new one is committed" more simply. Side effect: the active row id is now **stable** across a force regen (content swapped in place); prior schema-versions are still retained, and `meta.generated_at` still refreshes so the frontend poll contract holds.

## Tests
- Two reproducers (one per path) that inject an interruption during the regen LLM step: **RED** before (the prior row is gone), **GREEN** after.
- Re-characterised `test_force_regenerates_active_and_retains_prior_versions` to pin the in-place behaviour (same row id, fresh content, prior version retained).
- Full backend suite: 1194 passed, 4 deselected. Policy validation 22/22.

Closes #273.