### PR TITLE
fix(coach): a failed force-regen keeps the prior good report (#279)

### DIFF
--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -517,6 +517,27 @@ def _persist_report(
     """
     activity_uuid = activity.id
 
+    # #279: never replace a prior GOOD report with a fallback. A fallback may only
+    # land where there is nothing good to protect — a first generation (existing is
+    # None) or a fuller fallback over an opener-only row (the #217 recovery; an
+    # opener-only row is not a complete report). A force-regenerate whose generation
+    # failed therefore keeps the runner's prior complete, non-fallback report instead
+    # of overwriting it with "analysis unavailable" (paired with the #273 generate-
+    # then-swap: the prior row is held, so it is here to preserve).
+    if (
+        outcome.is_fallback
+        and existing is not None
+        and not existing.is_fallback
+        and not is_opener_only(existing.report)
+    ):
+        logger.warning(
+            "coach_regen_fallback_preserved_prior: a regeneration yielded a fallback; "
+            "kept the prior good report (activity=%s, prompt=%s)",
+            activity_uuid,
+            prompt_id,
+        )
+        return _to_read(existing)
+
     if outcome.tail_degraded:
         # Monitoring (A3): one greppable WARNING per stored degraded tail.
         logger.warning(

--- a/backend/tests/test_coach_report_versioning.py
+++ b/backend/tests/test_coach_report_versioning.py
@@ -209,3 +209,27 @@ async def test_force_regen_worker_death_preserves_prior_report(db):
     assert survived is not None, \
         "single-shot force-regen interruption lost the report entirely (#273)"
     assert survived.report["key_takeaways"][0]["text"] == "Cached takeaway one."
+
+
+# --- #279: a failed force-regen must not clobber a prior good report ------
+
+
+@pytest.mark.asyncio
+async def test_force_regen_fallback_preserves_prior_good_report(db):
+    # #279: a force-regenerate whose generation fails (unparseable -> fallback) must
+    # KEEP the prior complete, non-fallback report rather than overwrite it.
+    activity = _seed_activity(db)
+    good = _insert_report(db, activity.id, ACTIVE_PROMPT_ID, SCHEMA_VERSION)
+    good_id = good.id
+
+    # generate_json returns unparseable content -> _generate_structured falls back.
+    fake = AsyncMock()
+    fake.generate_json = AsyncMock(return_value="not valid json")
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake):
+        result = await get_or_generate_coach_report(db, str(activity.id), force=True)
+
+    survived = db.query(CoachReport).filter(CoachReport.id == good_id).first()
+    assert survived is not None
+    assert survived.is_fallback is False  # NOT downgraded to a fallback
+    assert survived.report["key_takeaways"][0]["text"] == "Cached takeaway one."
+    assert result is not None  # returns the preserved good report

--- a/backend/tests/test_two_stage_service.py
+++ b/backend/tests/test_two_stage_service.py
@@ -419,6 +419,41 @@ async def test_force_regen_worker_death_preserves_prior_report(db, _v2):
     assert survived.is_fallback is False
 
 
+# --- #279: a failed force-regen must not clobber a prior good report ----------
+
+
+async def test_force_regen_fallback_preserves_prior_good_report(db, _v2):
+    # #279: a force-regenerate whose fuller generation fails (both attempts yield no
+    # prose -> a fallback) must KEEP the runner's prior complete, non-fallback report
+    # rather than overwrite it with "analysis unavailable".
+    activity = _seed(db)
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_fuller_blocks("Good report.")))), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        await generate_fuller(db, str(activity.id))
+    good = _stored(db, activity)
+    assert good.report["message"] == "Good report." and good.is_fallback is False
+    good_id = good.id
+
+    # Force-regenerate, but BOTH fuller attempts return no prose -> a fallback.
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_empty_prose_blocks()),
+                                     _result(_empty_prose_blocks()))), \
+         patch("app.services.coach.service.write_back_beliefs") as wb, \
+         patch("app.services.coach.service.enqueue_consolidation") as ec:
+        read = await generate_fuller(db, str(activity.id), force=True)
+
+    row = _stored(db, activity)
+    assert row.id == good_id                       # same row, untouched
+    assert row.is_fallback is False                # NOT downgraded to a fallback
+    assert row.report["message"] == "Good report."  # prior good prose preserved
+    assert read is not None                        # returns the preserved good report
+    # nothing new was stored, so the learning loop never fires
+    wb.assert_not_called()
+    ec.assert_not_called()
+
+
 async def test_generate_fuller_noops_under_single_shot_prompt(db, _v2, monkeypatch):
     # #216: generate_fuller is meaningful only under the two-stage prompt. After a
     # rollback to a single-shot id it must refuse to run — no LLM call, nothing


### PR DESCRIPTION
## Problem
Builds on #273 (merged in #278). Once force-regenerate holds the prior row and swaps content in place, a regeneration that **fails** (the LLM/parse path yields a fallback) still overwrote the held good report with the fallback in place. A runner could turn a successful report into "analysis temporarily unavailable" just by hitting **regenerate** when one retry failed.

## Fix
Guard the shared persist seam (`_persist_report`): when the new outcome is a fallback **and** the existing row is a complete, non-fallback report, keep the prior report instead of swapping. Covers both the single-shot and two-stage paths.

Scoped so a fallback still lands where there is nothing good to protect:
- **First generation** (`existing is None`) — the activity is not left report-less.
- **The #217 fuller-fallback-over-opener recovery** — an opener-only row is not a complete report (`is_opener_only` excludes it), so that recovery path is untouched.

## UX
On a failed regen the prior report is preserved (its `generated_at` is unchanged), so the regenerate button's poll times out to the existing graceful "still being written… reload in a few minutes" state rather than showing a fallback. The runner keeps their good report. A clearer "regeneration failed, kept your prior report" signal is a frontend follow-up, out of scope here.

## Tests
- Two reproducers (single-shot + two-stage) that force-regenerate over a good report with a failing generation: they **clobber** the good report (`is_fallback` flips true) with the guard disabled and **preserve** it with the guard in place.
- Full backend suite: 1196 passed, 4 deselected. The #217 recovery tests and the fallback-flag tests still pass. eval self-test + policy validation green.

## Base
Was stacked on the #273 branch (merged in #278 as `d55041d`). Rebased onto `main`; base is now `main` and the diff is exactly the #279 change.

Closes #279.