### PR TITLE
fix(coach): store the best A3 attempt, keep raw_llm_response in sync (#274)

### DIFF
--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -774,6 +774,31 @@ def _opener_fallback_outcome() -> "_GenOutcome":
     )
 
 
+@dataclass
+class _MsgAttempt:
+    """One prose-message generation attempt, carrying the signals storage needs to
+    pick the best of several (#274): its report, the raw serialization that produced
+    it (so raw_llm_response always matches the STORED report, never a discarded
+    attempt), whether the model ran out of tokens (a truncated, half-written message),
+    and its surviving policy violations."""
+    report: CoachMessageReport
+    raw_response: str
+    truncated: bool
+    violations: List[PolicyViolation]
+
+
+def _choose_message_attempt(first: _MsgAttempt, retry: _MsgAttempt) -> _MsgAttempt:
+    """Pick the better of two attempts to store (#274). A complete (non-truncated)
+    attempt beats a truncated one — a runner is better served by a complete message
+    that trips a tolerated non-medical rule than by a half-sentence. Among
+    equally-(non-)truncated attempts, fewer surviving violations wins, and a tie goes
+    to the corrective `retry`. The medical-overreach-forces-fallback rule is applied
+    by the caller to whichever attempt this returns, so the safety floor is unaffected."""
+    if first.truncated != retry.truncated:
+        return retry if first.truncated else first
+    return retry if len(retry.violations) <= len(first.violations) else first
+
+
 async def _generate_message(
     client: AnthropicClient,
     system_prompt: str,
@@ -809,6 +834,7 @@ async def _generate_message(
     # failure; refusal / max_tokens / tail-skip keep their existing one-shot handling.
     report = None
     raw_response = ""
+    truncated = False
     for attempt in range(_EMPTY_PROSE_ATTEMPTS):
         try:
             result = await _call_message(client, system_prompt, user_message, max_tokens=max_tokens)
@@ -837,6 +863,7 @@ async def _generate_message(
                     parsed, result = parsed2, result2
 
             raw_response = _serialize_blocks(result.content_blocks)
+            truncated = result.stop_reason == "max_tokens"  # #274: a half-written msg
             report = merge(parsed)
             break
         except EmptyMessageError:
@@ -853,45 +880,51 @@ async def _generate_message(
             logger.error("coach message transport error: %s", e)
             return fallback()
 
-    violations = validate_message_policy(report, pack)
-    if violations:
+    # #274: track the first attempt with the raw serialization that produced it, so
+    # whichever attempt we store carries ITS OWN raw_llm_response (never a discarded
+    # one). The policy retry is judged against it rather than blindly replacing it.
+    chosen = _MsgAttempt(
+        report=report,
+        raw_response=raw_response,
+        truncated=truncated,
+        violations=validate_message_policy(report, pack),
+    )
+    if chosen.violations:
         logger.info(
             "Message policy violations detected: %s — attempting retry",
-            [v.rule for v in violations],
+            [v.rule for v in chosen.violations],
         )
-        report, remaining = await _retry_message_with_fixes(
-            client, system_prompt, user_message, pack, violations, report,
+        retry_attempt = await _retry_message_with_fixes(
+            client, system_prompt, user_message, pack, chosen.violations,
             is_opener=is_opener,
         )
-        if remaining:
-            # ADR 0009: medical overreach surviving the retry forces a fallback,
-            # because the prose renders verbatim to the runner. Use the
-            # STAGE-CORRECT fallback (the variable bound above), so an opener
-            # overreach yields an opener-shaped fallback (message empty,
-            # opener_message set) that stays opener-only — otherwise the
-            # safety-forced fuller turn would cache-hit a non-opener-only fallback
-            # and never regenerate, silently defeating the safety floor on exactly
-            # the red-flag runs that trip rule 5.
-            if any(v.rule == "medical_overreach" for v in remaining):
-                logger.warning("medical overreach survived retry; forcing fallback")
-                return fallback()
-            logger.warning(
-                "Message policy violations persisted after retry: %s",
-                [v.rule for v in remaining],
-            )
-            return _GenOutcome(
-                report_dump=report.model_dump(),
-                raw_response=raw_response,
-                is_fallback=False,
-                policy_violations=[v.rule for v in remaining],
-                tail_degraded=report.tail_degraded,
-            )
+        if retry_attempt is not None:
+            # #274: store the BETTER attempt — a complete attempt is not clobbered by
+            # a truncated retry, and raw_response follows the report we keep.
+            chosen = _choose_message_attempt(chosen, retry_attempt)
+
+    if any(v.rule == "medical_overreach" for v in chosen.violations):
+        # ADR 0009: medical overreach in the attempt we would store forces a fallback,
+        # because the prose renders verbatim to the runner. Use the STAGE-CORRECT
+        # fallback (the variable bound above), so an opener overreach yields an
+        # opener-shaped fallback (message empty, opener_message set) that stays
+        # opener-only — otherwise the safety-forced fuller turn would cache-hit a
+        # non-opener-only fallback and never regenerate, silently defeating the
+        # safety floor on exactly the red-flag runs that trip rule 5.
+        logger.warning("medical overreach in the stored attempt; forcing fallback")
+        return fallback()
+    if chosen.violations:
+        logger.warning(
+            "Message policy violations persisted: %s",
+            [v.rule for v in chosen.violations],
+        )
 
     return _GenOutcome(
-        report_dump=report.model_dump(),
-        raw_response=raw_response,
+        report_dump=chosen.report.model_dump(),
+        raw_response=chosen.raw_response,
         is_fallback=False,
-        tail_degraded=report.tail_degraded,
+        policy_violations=[v.rule for v in chosen.violations],
+        tail_degraded=chosen.report.tail_degraded,
     )
 
 
@@ -901,15 +934,14 @@ async def _retry_message_with_fixes(
     original_user_message: str,
     pack: CoachContextPack,
     violations: List[PolicyViolation],
-    prior: CoachMessageReport,
     *,
     is_opener: bool = False,
-) -> tuple[CoachMessageReport, List[PolicyViolation]]:
+) -> Optional[_MsgAttempt]:
     """Re-prompt once with fix instructions for the message-policy violations.
-    Returns (report, remaining_violations). If the retry produces nothing usable,
-    the prior report and its violations are kept (so a surviving overreach still
-    forces the fallback upstream). `is_opener` keeps the opener's merge + token
-    budget on the retry too."""
+    Returns the retry as a _MsgAttempt (#274), or None when the retry produced
+    nothing usable (refusal / empty prose / transport error) — the caller then keeps
+    the original attempt. `is_opener` keeps the opener's merge + token budget on the
+    retry too."""
     max_tokens = _OPENER_MAX_TOKENS if is_opener else _MESSAGE_MAX_TOKENS
     merge = merge_opener if is_opener else merge_report
     fix_instructions = "\n".join(
@@ -925,12 +957,17 @@ async def _retry_message_with_fixes(
             client, system_prompt, retry_message, max_tokens=max_tokens
         )
         if result.stop_reason == "refusal":
-            return prior, validate_message_policy(prior, pack)
+            return None
         report = merge(parse_blocks(result.content_blocks))
     except (EmptyMessageError, anthropic.APIError) as e:
         logger.error("Coach message retry error: %s", e)
-        return prior, validate_message_policy(prior, pack)
-    return report, validate_message_policy(report, pack)
+        return None
+    return _MsgAttempt(
+        report=report,
+        raw_response=_serialize_blocks(result.content_blocks),
+        truncated=result.stop_reason == "max_tokens",
+        violations=validate_message_policy(report, pack),
+    )
 
 
 async def _retry_with_fixes(

--- a/backend/tests/test_two_stage_service.py
+++ b/backend/tests/test_two_stage_service.py
@@ -465,3 +465,70 @@ async def test_generate_fuller_noops_under_single_shot_prompt(db, _v2, monkeypat
     assert read is None
     client_cls.assert_not_called()
     assert _stored(db, activity) is None  # nothing written under the rolled-back id
+
+
+# --- #274: the policy retry must not store a degraded attempt over a good one --
+
+
+def _no_question_fuller_blocks(prose):
+    # A COMPLETE fuller message + a valid tail, but NO questions -> trips validator
+    # rule 1 (a null check-in must be prompted) since the seeded activity has no
+    # CheckIn. This is what makes the first attempt provoke the policy retry.
+    return [_text(prose), _tail(
+        headline="Solid aerobic run",
+        next_steps=[{"action": "Easy run", "details": "30 min", "why": "Recovery"}],
+        risks=[], questions=[],
+    )]
+
+
+async def test_truncated_retry_does_not_clobber_complete_first_attempt(db, _v2):
+    # #274: the first attempt is COMPLETE but trips a non-medical rule (no questions
+    # for a null check-in); the policy retry comes back TRUNCATED (max_tokens, no
+    # tail). The stored report must be the COMPLETE first attempt, not the truncated
+    # retry — the runner must not get a half-sentence when the model wrote a full one.
+    activity = _seed(db)
+    complete = (
+        "At a sustained hard effort, that kind of drift is exactly what we expect, "
+        "and the back half held together well. Tomorrow needs to be easy."
+    )
+    fake = _client(
+        _result(_no_question_fuller_blocks(complete), stop_reason="end_turn"),
+        # the retry truncates: a short prefix, no tail
+        _result([_text("At a sustained hard effort, that kind of")],
+                stop_reason="max_tokens"),
+    )
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        await generate_fuller(db, str(activity.id))
+
+    assert fake.generate_coach_message.call_count == 2  # first attempt + policy retry
+    row = _stored(db, activity)
+    assert row.is_fallback is False
+    assert row.report["message"] == complete       # complete prose, not the truncation
+    assert row.report["tail_degraded"] is False     # the complete attempt carried a tail
+
+
+async def test_adopted_retry_keeps_raw_response_in_sync(db, _v2):
+    # #274: when the policy retry IS adopted (it fixes the violation and is complete),
+    # the stored raw_llm_response must reflect the RETRY (the report that was stored),
+    # not the first attempt — the debug column must not disagree with the report.
+    activity = _seed(db)
+    first = "First attempt prose that forgot to ask anything at all."
+    fixed = "Fixed attempt prose, complete and grounded."
+    fake = _client(
+        _result(_no_question_fuller_blocks(first), stop_reason="end_turn"),
+        # the retry is complete AND fixes rule 1 (carries a question)
+        _result(_fuller_blocks(fixed), stop_reason="end_turn"),
+    )
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        await generate_fuller(db, str(activity.id))
+
+    row = _stored(db, activity)
+    assert row.is_fallback is False
+    assert row.report["message"] == fixed           # the fixed retry was adopted
+    raw = row.raw_llm_response or ""
+    assert fixed[:20] in raw                          # raw reflects the stored retry
+    assert first[:20] not in raw                      # NOT the discarded first attempt


### PR DESCRIPTION
## Problem
On a regenerate under a `coach_message_*` prompt, the stored report could be **materially worse** than what the model produced: a **truncated `message` + `tail_degraded=true`** while `raw_llm_response` held a **complete** message and a valid tail (observed on heavy activity `e1a37747` under `coach_message_v5`).

## Root cause
Two coupled defects in the A3 path (`_generate_message`):
1. `raw_response` is set from the **first** attempt, then the policy retry **unconditionally replaces** `report` and never updates `raw_response` — so a stored retry report carries the first attempt's `raw_llm_response` (the debug column disagrees with the report).
2. `_retry_message_with_fixes` did **not** handle `stop_reason == "max_tokens"`. Its retry prompt re-sends the full original context + fix instructions (a longer prompt), so on a heavy activity it truncates → `merge` yields a short `message` with no tail. That degraded retry was then stored over a complete first attempt.

## Fix
Track each attempt as `(report, raw_response, truncated, violations)` and store the **better** one:
- A complete (non-truncated) attempt is never clobbered by a truncated retry.
- Among equally-(non-)truncated attempts, fewer surviving violations wins; ties go to the corrective retry.
- `raw_response` always follows the report that is actually stored.

The medical-overreach-forces-fallback rule and degrade-not-withhold storage of surviving non-medical violations are **preserved** — they now apply to the chosen attempt.

### Selection rule (deliberate)
A retry that *fixes* a non-medical violation but comes back truncated is discarded in favour of the complete-but-still-violating first attempt: a complete message that trips a tolerated non-medical rule serves the runner better than a half-sentence, and the non-medical rules are already stored degrade-not-withhold. Safety is unaffected — medical overreach in the chosen attempt still forces the templated fallback.

## Tests
- Reproducer A: first attempt complete + tail but trips a non-medical rule; retry truncates (`max_tokens`, no tail) → the **complete** first attempt is stored, not the truncation.
- Reproducer B: retry is complete and fixes the violation → it is adopted and `raw_llm_response` reflects the **retry**, not the discarded first attempt.
- Both red on current code, green after. Full suite: 1198 passed, 4 deselected. The medical-overreach, #217 empty-prose, fallback-flag, message-service and fence-recovery suites still pass. eval self-test + policy validation green.

## Follow-ups (filed separately, out of scope)
- A `max_tokens` re-attempt *inside* the policy retry (reduce truncation at the source).
- A frontend signal when a stored report carries surviving `policy_violations`.

Closes #274.