### PR TITLE
Vendor AI coding workflow (claude/full) via installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,16 +49,19 @@ frontend/tsconfig.tsbuildinfo
 
 # AI workflow and skills (tooling config, not product code)
 .agents/
-.ai-policy/
-.claude/
 .codex/
 .gemini/
-.githooks/
 .github/*
 !.github/workflows/
 .vscode/
 AGENTS.md
-ai-workflow.md
 claude.md
 .vercel
 .env*
+# >>> ai-workflow (vendored, managed by installer) >>>
+ai-workflow.md
+.ai-policy/
+.githooks/
+CLAUDE.md
+.claude/
+# <<< ai-workflow <<<

--- a/backend/alembic/versions/d4e7f2a9c1b3_add_hr_zones_to_user_profile.py
+++ b/backend/alembic/versions/d4e7f2a9c1b3_add_hr_zones_to_user_profile.py
@@ -1,0 +1,38 @@
+"""add hr_zones to user_profiles (Strava-sourced HR zones, #297)
+
+Revision ID: d4e7f2a9c1b3
+Revises: c3f8a1d6e9b2
+Create Date: 2026-06-16 20:30:00.000000
+
+#297: the app's time-in-zone used a generic %-of-max-HR scheme that did not line
+up with the runner's Strava (or watch) zones. We now store the runner's own HR
+zone lower bounds, pulled from their Strava athlete zones, and bin against those.
+
+`hr_zones` is the list of 5 ascending lower bounds (bpm); `hr_zones_source`
+records provenance (currently "strava"). Both are nullable: a profile with no
+synced zones reads null and analysis falls back to the %max scheme, so this is
+backward-safe. Previews share the production DB, so the columns are additive and
+nullable, inert until the new code writes them.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d4e7f2a9c1b3"
+down_revision: Union[str, None] = "c3f8a1d6e9b2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("user_profiles", sa.Column("hr_zones", sa.JSON(), nullable=True))
+    op.add_column(
+        "user_profiles", sa.Column("hr_zones_source", sa.String(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_profiles", "hr_zones_source")
+    op.drop_column("user_profiles", "hr_zones")

--- a/backend/app/models/user_profile.py
+++ b/backend/app/models/user_profile.py
@@ -21,6 +21,11 @@ class UserProfile(Base):
     current_weekly_km: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     max_hr: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     max_hr_source: Mapped[Optional[str]] = mapped_column(String, nullable=True)  # "user_entered", "race_estimate", "lab_test"
+    # The runner's own HR-zone lower bounds (5 ascending bpm values), pulled from
+    # their Strava athlete zones so time-in-zone matches what Strava shows (#297).
+    # Null until first synced; analysis then falls back to the %-of-max-HR scheme.
+    hr_zones: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)  # List[int], len 5
+    hr_zones_source: Mapped[Optional[str]] = mapped_column(String, nullable=True)  # "strava"
     upcoming_races: Mapped[list] = mapped_column(JSON, default=[])  # List[dict]
     injury_notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     # Opt-in medication/physiology flag (N4 confounder stage reads it). Nullable:

--- a/backend/app/services/analysis/_orchestrator.py
+++ b/backend/app/services/analysis/_orchestrator.py
@@ -150,10 +150,18 @@ def analyze(db: Session, activity_id: str) -> Optional[DerivedMetric]:
     if profile and profile.max_hr and profile.max_hr > 100:
         max_hr = profile.max_hr
 
+    # The runner's own Strava HR zones, when synced, drive the time-in-zone
+    # binning so it matches Strava (#297). Absent, binning falls back to %max.
+    zone_boundaries = profile.hr_zones if profile and profile.hr_zones else None
+
     # 5. Compute metrics. Pass the check-in RPE so the training-load primitive
     # (#186) can fall back to session-RPE on a strap-less run.
     metrics_data = compute_derived_metrics_data(
-        activity, streams_dict, max_hr=max_hr, rpe=check_in.rpe if check_in else None
+        activity,
+        streams_dict,
+        max_hr=max_hr,
+        rpe=check_in.rpe if check_in else None,
+        zone_boundaries=zone_boundaries,
     )
 
     # 6. Classify into orthogonal axes (ADR 0007). Probe interval structure so
@@ -195,7 +203,9 @@ def analyze(db: Session, activity_id: str) -> Optional[DerivedMetric]:
 
     # 6.7 Interval-specific KPIs
     if interval_structure:
-        zones_calibrated = bool(profile and profile.max_hr and profile.max_hr > 100)
+        zones_calibrated = bool(
+            profile and (profile.hr_zones or (profile.max_hr and profile.max_hr > 100))
+        )
         interval_kpis = build_interval_kpis(
             interval_structure,
             max_hr=max_hr,

--- a/backend/app/services/analysis/metrics.py
+++ b/backend/app/services/analysis/metrics.py
@@ -3,9 +3,19 @@ from typing import Optional, List, Dict, Any
 from app.models import Activity
 from app.services.analysis.stops import analyze_stops
 
-def calculate_time_in_zones(streams: Dict[str, List[any]], max_hr: int = 190) -> Optional[Dict[str, int]]:
+def calculate_time_in_zones(
+    streams: Dict[str, List[any]],
+    max_hr: int = 190,
+    zone_boundaries: Optional[List[int]] = None,
+) -> Optional[Dict[str, int]]:
     """
     Calculates time spent in 5 heart rate zones.
+
+    When ``zone_boundaries`` is supplied (the runner's own 5 ascending HR-zone
+    lower bounds in bpm, e.g. from their Strava athlete zones), readings are
+    binned against those boundaries so the distribution matches what the runner
+    sees on Strava (#297). Without it, the metric falls back to a generic
+    %-of-max-HR scheme:
     Z1: 50-60%
     Z2: 60-70%
     Z3: 70-80%
@@ -16,37 +26,49 @@ def calculate_time_in_zones(streams: Dict[str, List[any]], max_hr: int = 190) ->
     hr_list = streams.get("heartrate", [])
     if not hr_list:
         return None
-    
+
     # Filter out zeros if any
-    hr_arr = np.array([h for h in hr_list if h > 30]) 
+    hr_arr = np.array([h for h in hr_list if h > 30])
     if len(hr_arr) == 0:
         return None
 
     zones = {
         "Z1": 0, "Z2": 0, "Z3": 0, "Z4": 0, "Z5": 0
     }
-    
-    # Calculate thresholds
+
+    # Preferred path (#297): bin against the runner's own zone boundaries. The 5
+    # lower bounds are ascending; the 4 internal cut points (bounds[1:5]) split
+    # Z1..Z5. Anything below Z2's floor counts as Z1, mirroring Strava, where Z1
+    # is the catch-all low zone. A large finite top edge stands in for "open".
+    if zone_boundaries and len(zone_boundaries) >= 5:
+        cuts = [float(b) for b in zone_boundaries[1:5]]
+        bins = [0.0, *cuts, 10_000.0]
+        hist, _ = np.histogram(hr_arr, bins=bins)
+        for i in range(5):
+            zones[f"Z{i + 1}"] = int(hist[i])
+        return zones
+
+    # Fallback: generic %-of-max-HR thresholds.
     t = [0.5 * max_hr, 0.6 * max_hr, 0.7 * max_hr, 0.8 * max_hr, 0.9 * max_hr]
-    
+
     # Binning
     # Counts of HR readings (assuming 1 reading = 1 second for 'time' stream usually.
     # Ideally should use the 'time' stream deltas, but simple count is close enough for MVP.
-    
+
     # Optimized numpy binning
     # bins: [0, t0, t1, t2, t3, t4, max_possible]
     # invalid (<50%), Z1, Z2, Z3, Z4, Z5
-    bins = [0, t[0], t[1], t[2], t[3], t[4], 250] 
-    
+    bins = [0, t[0], t[1], t[2], t[3], t[4], 250]
+
     hist, _ = np.histogram(hr_arr, bins=bins)
-    
+
     # hist[0] is garbage (<50%), hist[1] is Z1, etc.
     zones["Z1"] = int(hist[1])
     zones["Z2"] = int(hist[2])
     zones["Z3"] = int(hist[3])
     zones["Z4"] = int(hist[4])
     zones["Z5"] = int(hist[5])
-    
+
     return zones
 
 def calculate_pace_variability(streams: Dict[str, List[any]]) -> Optional[float]:
@@ -277,9 +299,14 @@ def compute_derived_metrics_data(
     streams_dict: Dict[str, List[any]] = {},
     max_hr: int = 190,
     rpe: Optional[int] = None,
+    zone_boundaries: Optional[List[int]] = None,
 ) -> Dict[str, Any]:
     """
     Aggregates metrics for the DerivedMetric model.
+
+    ``zone_boundaries`` (the runner's own HR-zone lower bounds, #297) is passed
+    through to the time-in-zone binning so the distribution matches Strava when
+    available; it falls back to the %-of-max-HR scheme when absent.
     """
     drift = None
     pace_var = None
@@ -296,7 +323,9 @@ def compute_derived_metrics_data(
         # Use provided max_hr if reasonable, else default
         effective_max = max_hr if max_hr and max_hr > 150 else 190
 
-        zones = calculate_time_in_zones(streams_dict, effective_max)
+        zones = calculate_time_in_zones(
+            streams_dict, effective_max, zone_boundaries=zone_boundaries
+        )
 
     # Training-load primitive (#186): comparable zone-minutes across HR/no-HR.
     # Tier A uses the zone distribution; Tier B the summary HR against the

--- a/backend/app/services/strava_ingestion/http_adapter.py
+++ b/backend/app/services/strava_ingestion/http_adapter.py
@@ -269,3 +269,20 @@ class HTTPStravaAdapter:
             except httpx.HTTPStatusError as e:
                 logger.error("Strava Stream Error: %s", e.response.status_code)
                 return None
+
+    async def get_athlete_zones(self, access_token: str) -> dict | None:
+        headers = {"Authorization": f"Bearer {access_token}"}
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_S) as client:
+            response = await _send_with_retry(
+                lambda: client.get(f"{_BASE_URL}/athlete/zones", headers=headers),
+                label="get_athlete_zones",
+            )
+            try:
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as e:
+                # Non-fatal: zones are an enhancement to the time-in-zone metric,
+                # not a sync prerequisite. A 403 means the profile:read_all scope
+                # was not granted; we log and fall back to the %max scheme.
+                logger.warning("Strava Zones Error: %s", e.response.status_code)
+                return None

--- a/backend/app/services/strava_ingestion/in_memory_adapter.py
+++ b/backend/app/services/strava_ingestion/in_memory_adapter.py
@@ -16,6 +16,7 @@ class InMemoryStravaAdapter:
     def __init__(self) -> None:
         self.activities: list[dict] = []
         self.streams: dict[int, dict] = {}
+        self.athlete_zones: dict | None = None
         self.next_tokens: Tokens | None = None
         self.exchange_response: Tokens | None = None
         # Call log for assertions.
@@ -33,6 +34,9 @@ class InMemoryStravaAdapter:
 
     def seed_streams(self, activity_id: int, streams: dict) -> None:
         self.streams[activity_id] = streams
+
+    def seed_athlete_zones(self, zones: dict) -> None:
+        self.athlete_zones = zones
 
     def seed_refresh_response(self, tokens: Tokens) -> None:
         self.next_tokens = tokens
@@ -108,3 +112,6 @@ class InMemoryStravaAdapter:
     ) -> dict | None:
         self.stream_calls.append((activity_id, list(stream_types)))
         return self.streams.get(activity_id)
+
+    async def get_athlete_zones(self, access_token: str) -> dict | None:
+        return self.athlete_zones

--- a/backend/app/services/strava_ingestion/ingestion.py
+++ b/backend/app/services/strava_ingestion/ingestion.py
@@ -6,11 +6,75 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.models import Activity, ActivityStream, StravaAccount
+from app.models import Activity, ActivityStream, StravaAccount, UserProfile
 from app.schemas import SyncResponse
 from app.services.strava_ingestion.port import StravaPort, Tokens
 
 logger = logging.getLogger(__name__)
+
+
+def extract_hr_zone_bounds(raw_zones: dict | None) -> list[int] | None:
+    """Pull the 5 ascending HR-zone lower bounds (bpm) from a Strava
+    `/athlete/zones` payload, or None if the shape is not as expected (#297).
+
+    Strava returns ``{"heart_rate": {"custom_zones": bool, "zones": [{"min",
+    "max"}, ...]}}``. We keep each zone's ``min`` as its lower bound; the binning
+    only needs the ordering. A payload that is not exactly 5 ascending integer
+    zones is rejected so analysis falls back to the %-of-max-HR scheme rather
+    than binning against garbage.
+    """
+    if not isinstance(raw_zones, dict):
+        return None
+    hr = raw_zones.get("heart_rate")
+    if not isinstance(hr, dict):
+        return None
+    zones = hr.get("zones")
+    if not isinstance(zones, list) or len(zones) != 5:
+        return None
+    bounds: list[int] = []
+    for zone in zones:
+        if not isinstance(zone, dict):
+            return None
+        low = zone.get("min")
+        if not isinstance(low, (int, float)) or isinstance(low, bool):
+            return None
+        bounds.append(int(low))
+    if bounds != sorted(bounds):
+        return None
+    return bounds
+
+
+async def sync_athlete_zones(
+    db: Session,
+    account: StravaAccount,
+    port: StravaPort,
+    access_token: str,
+) -> list[int] | None:
+    """Fetch the runner's Strava HR zones and store them on their UserProfile
+    (#297). Guarded: a zones failure must never break a sync, since zones only
+    refine the time-in-zone metric and analysis degrades to the %max scheme.
+    Returns the stored bounds, or None when unavailable/unchanged-but-absent.
+    """
+    try:
+        raw_zones = await port.get_athlete_zones(access_token)
+        bounds = extract_hr_zone_bounds(raw_zones)
+        if not bounds:
+            return None
+        profile = (
+            db.query(UserProfile)
+            .filter(UserProfile.user_id == account.user_id)
+            .first()
+        )
+        if profile is None:
+            return None
+        profile.hr_zones = bounds
+        profile.hr_zones_source = "strava"
+        db.commit()
+        return bounds
+    except Exception as exc:  # never break sync over zones
+        db.rollback()
+        logger.warning("strava_zones_sync_failed: %s", exc)
+        return None
 
 # Buffer in seconds before token expiry we'll trigger a refresh.
 _TOKEN_REFRESH_BUFFER_S = 60
@@ -166,6 +230,9 @@ async def ingest_recent_activities(
 
     try:
         access_token = await ensure_valid_access_token(db, account, port)
+        # Refresh the runner's Strava HR zones once per sync so time-in-zone
+        # matches Strava (#297). Guarded internally; never blocks ingestion.
+        await sync_athlete_zones(db, account, port, access_token)
         try:
             raw_activities = await port.list_recent_activities(
                 access_token=access_token, since=since, per_page=50

--- a/backend/app/services/strava_ingestion/port.py
+++ b/backend/app/services/strava_ingestion/port.py
@@ -52,3 +52,11 @@ class StravaPort(Protocol):
         activity_id: int,
         stream_types: list[str],
     ) -> dict | None: ...
+
+    async def get_athlete_zones(self, access_token: str) -> dict | None:
+        """Return the athlete's configured zones (HR/power), or None on failure.
+
+        The raw Strava `/athlete/zones` payload; callers extract what they need.
+        Requires the `profile:read_all` scope (already requested at auth).
+        """
+        ...

--- a/backend/tests/test_strava_ingestion.py
+++ b/backend/tests/test_strava_ingestion.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 
-from app.models import Activity, ActivityStream, StravaAccount, User
+from app.models import Activity, ActivityStream, StravaAccount, User, UserProfile
 from app.services.strava_ingestion import (
     InMemoryStravaAdapter,
     ingest_activity_by_id,
@@ -9,6 +9,32 @@ from app.services.strava_ingestion import (
     refetch_streams,
 )
 from app.services.strava_ingestion.port import Tokens
+
+# Real-shaped Strava /athlete/zones payload (this runner's actual zones, #297).
+_STRAVA_ZONES = {
+    "heart_rate": {
+        "custom_zones": False,
+        "zones": [
+            {"min": 0, "max": 124},
+            {"min": 125, "max": 154},
+            {"min": 155, "max": 169},
+            {"min": 170, "max": 184},
+            {"min": 185, "max": -1},
+        ],
+    },
+}
+
+
+def _make_profile(db, user_id) -> UserProfile:
+    profile = UserProfile(
+        user_id=user_id,
+        goal_type="general",
+        experience_level="intermediate",
+        weekly_days_available=4,
+    )
+    db.add(profile)
+    db.commit()
+    return profile
 
 
 def _make_account(db, athlete_id: int = 12345) -> StravaAccount:
@@ -152,6 +178,42 @@ async def test_refetch_streams_replaces_existing_rows(db):
         .all()
     }
     assert stream_types == {"time", "heartrate"}
+
+
+@pytest.mark.asyncio
+async def test_sync_stores_runner_strava_hr_zones_on_profile(db):
+    """#297: a sync pulls the runner's Strava HR zones and stores their lower
+    bounds on the profile, so analysis can bin time-in-zone against them."""
+    account = _make_account(db, athlete_id=44444)
+    profile = _make_profile(db, account.user_id)
+    adapter = InMemoryStravaAdapter()
+    adapter.seed_activities([_raw_activity(1001, "Run")])
+    adapter.seed_streams(1001, {"time": {"data": [0, 1, 2]}})
+    adapter.seed_athlete_zones(_STRAVA_ZONES)
+
+    await ingest_recent_activities(db, account, adapter)
+
+    db.refresh(profile)
+    assert profile.hr_zones == [0, 125, 155, 170, 185]
+    assert profile.hr_zones_source == "strava"
+
+
+@pytest.mark.asyncio
+async def test_sync_without_zones_leaves_profile_unchanged_and_succeeds(db):
+    """When Strava returns no usable zones, the sync still succeeds and the
+    profile's zones stay null so analysis falls back to the %max scheme."""
+    account = _make_account(db, athlete_id=55555)
+    profile = _make_profile(db, account.user_id)
+    adapter = InMemoryStravaAdapter()  # athlete_zones defaults to None
+    adapter.seed_activities([_raw_activity(1101, "Run")])
+    adapter.seed_streams(1101, {"time": {"data": [0, 1, 2]}})
+
+    ingested, stats = await ingest_recent_activities(db, account, adapter)
+
+    assert stats.upserted == 1
+    db.refresh(profile)
+    assert profile.hr_zones is None
+    assert profile.hr_zones_source is None
 
 
 def _make_401_error(url: str = "https://www.strava.com/api/v3/athlete/activities"):

--- a/backend/tests/test_stream_metrics.py
+++ b/backend/tests/test_stream_metrics.py
@@ -52,7 +52,7 @@ def test_calculate_time_in_zones():
     }
     
     zones = calculate_time_in_zones(streams, max_hr=200)
-    
+
     assert zones is not None
     assert zones["Z1"] == 3
     assert zones["Z2"] == 2
@@ -61,3 +61,83 @@ def test_calculate_time_in_zones():
     assert zones["Z5"] == 1
     # Total sum check
     assert sum(zones.values()) == 6
+
+
+def test_calculate_time_in_zones_uses_runner_boundaries():
+    """#297: when the runner's own Strava zone bounds are supplied, binning
+    follows those boundaries instead of the %-of-max-HR scheme, so the result
+    lines up with Strava. Oracle: the runner's real Strava zones
+    0-124 / 125-154 / 155-169 / 170-184 / 185+ (lower bounds below)."""
+    from app.services.analysis.metrics import calculate_time_in_zones
+
+    bounds = [0, 125, 155, 170, 185]
+    # One reading squarely inside each Strava zone, plus a boundary value (155)
+    # that must land in Z3 (Strava Z3 is 155-169).
+    streams = {"heartrate": [120, 140, 155, 160, 175, 190]}
+
+    zones = calculate_time_in_zones(streams, max_hr=190, zone_boundaries=bounds)
+
+    assert zones is not None
+    assert zones["Z1"] == 1   # 120  -> 0-124
+    assert zones["Z2"] == 1   # 140  -> 125-154
+    assert zones["Z3"] == 2   # 155, 160 -> 155-169
+    assert zones["Z4"] == 1   # 175  -> 170-184
+    assert zones["Z5"] == 1   # 190  -> 185+
+    assert sum(zones.values()) == 6
+
+
+def test_runner_boundaries_reclassify_aerobic_run_below_strava_threshold():
+    """#297 regression: a run sitting at 155-169 bpm read as Z4 under the old
+    %max scheme (Z4 floor 152 at max 190) but is Z3 on Strava. With the runner's
+    bounds it must land in Z3, not Z4."""
+    from app.services.analysis.metrics import calculate_time_in_zones
+
+    bounds = [0, 125, 155, 170, 185]
+    streams = {"heartrate": [160] * 100}  # steady aerobic effort
+
+    with_bounds = calculate_time_in_zones(streams, max_hr=190, zone_boundaries=bounds)
+    fallback = calculate_time_in_zones(streams, max_hr=190)
+
+    assert with_bounds["Z3"] == 100 and with_bounds["Z4"] == 0
+    # The old/fallback scheme misfiles the same effort as Z4.
+    assert fallback["Z4"] == 100
+
+
+def test_extract_hr_zone_bounds_parses_strava_payload():
+    """#297: pull the 5 ascending HR-zone lower bounds from a Strava
+    /athlete/zones payload (real shape: heart_rate.zones with min/max)."""
+    from app.services.strava_ingestion.ingestion import extract_hr_zone_bounds
+
+    payload = {
+        "heart_rate": {
+            "custom_zones": False,
+            "zones": [
+                {"min": 0, "max": 124},
+                {"min": 125, "max": 154},
+                {"min": 155, "max": 169},
+                {"min": 170, "max": 184},
+                {"min": 185, "max": -1},
+            ],
+        },
+        "power": {"zones": [{"min": 0, "max": 100}]},
+    }
+
+    assert extract_hr_zone_bounds(payload) == [0, 125, 155, 170, 185]
+
+
+def test_extract_hr_zone_bounds_rejects_bad_shapes():
+    """Off-shape payloads return None so analysis falls back to the %max scheme
+    rather than binning against garbage."""
+    from app.services.strava_ingestion.ingestion import extract_hr_zone_bounds
+
+    assert extract_hr_zone_bounds(None) is None
+    assert extract_hr_zone_bounds({}) is None
+    assert extract_hr_zone_bounds({"heart_rate": {"zones": []}}) is None
+    # Only 4 zones.
+    assert extract_hr_zone_bounds(
+        {"heart_rate": {"zones": [{"min": 0}, {"min": 1}, {"min": 2}, {"min": 3}]}}
+    ) is None
+    # Non-ascending bounds.
+    assert extract_hr_zone_bounds(
+        {"heart_rate": {"zones": [{"min": 0}, {"min": 9}, {"min": 5}, {"min": 7}, {"min": 8}]}}
+    ) is None

--- a/backend/tests/test_zone_calibration.py
+++ b/backend/tests/test_zone_calibration.py
@@ -1,0 +1,78 @@
+"""#297: end-to-end check that `analyze` bins time-in-zone against the runner's
+own Strava HR zones (stored on the profile) so the result lines up with Strava.
+
+Oracle: this runner's real Strava zones, 0-124 / 125-154 / 155-169 / 170-184 /
+185+. A steady 160 bpm aerobic effort is Z3 on Strava; under the old generic
+%-of-max-HR scheme (Z4 floor 152 at max 190) the same effort read as Z4 — the
+exact mismatch reported in #297.
+"""
+import uuid
+from datetime import datetime, timezone
+
+from app.models import Activity, User, UserProfile
+from app.models.activity_stream import ActivityStream
+from app.services.analysis import analyze
+
+_STRAVA_HR_ZONE_BOUNDS = [0, 125, 155, 170, 185]
+
+
+def _seed_activity(db, *, hr_zones):
+    user = User(email=f"zones_{uuid.uuid4().hex[:8]}@example.com")
+    db.add(user)
+    db.flush()
+    db.add(
+        UserProfile(
+            user_id=user.id,
+            goal_type="general",
+            experience_level="intermediate",
+            weekly_days_available=4,
+            max_hr=190,
+            max_hr_source="user_entered",
+            hr_zones=hr_zones,
+            hr_zones_source="strava" if hr_zones else None,
+        )
+    )
+    activity = Activity(
+        user_id=user.id,
+        strava_activity_id=int(uuid.uuid4().int % (10**12)),
+        name="Steady aerobic run",
+        type="Run",
+        start_date=datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc),
+        distance_m=10000,
+        moving_time_s=300,
+        elapsed_time_s=300,
+        elev_gain_m=20.0,
+        avg_hr=160.0,
+        max_hr=169.0,
+        average_speed_mps=3.3,
+    )
+    db.add(activity)
+    db.flush()
+    n = 300
+    db.add(ActivityStream(activity_id=activity.id, stream_type="heartrate", data=[160] * n))
+    db.add(ActivityStream(activity_id=activity.id, stream_type="velocity_smooth", data=[3.3] * n))
+    db.add(ActivityStream(activity_id=activity.id, stream_type="time", data=list(range(n))))
+    db.commit()
+    return activity
+
+
+def test_analyze_uses_strava_zones_when_present(db):
+    activity = _seed_activity(db, hr_zones=_STRAVA_HR_ZONE_BOUNDS)
+
+    dm = analyze(db, activity.id)
+
+    assert dm is not None
+    # 160 bpm sits in the runner's Strava Z3 (155-169), matching Strava — not Z4.
+    assert dm.time_in_zones["Z3"] == 300
+    assert dm.time_in_zones["Z4"] == 0
+
+
+def test_analyze_falls_back_to_percent_max_without_zones(db):
+    """Without stored zones the generic %max scheme still runs (and misfiles the
+    same 160 bpm effort as Z4 — the behaviour #297 corrects via zone sync)."""
+    activity = _seed_activity(db, hr_zones=None)
+
+    dm = analyze(db, activity.id)
+
+    assert dm is not None
+    assert dm.time_in_zones["Z4"] == 300


### PR DESCRIPTION
Records the installer's vendored-files block in .gitignore. The workflow
files (ai-workflow.md, CLAUDE.md, .claude/, .ai-policy/, .githooks/) are
vendored per the full-profile install and are gitignored, not committed.