### PR TITLE
Merge forked alembic heads so the web service can deploy (#305)

### DIFF
--- a/backend/alembic/versions/b7e9d2c4a1f8_merge_receipt_cadence_and_hr_zones_heads.py
+++ b/backend/alembic/versions/b7e9d2c4a1f8_merge_receipt_cadence_and_hr_zones_heads.py
@@ -1,0 +1,33 @@
+"""merge receipt-cadence and hr-zones heads
+
+#305: two migrations were authored off the same parent (c3f8a1d6e9b2) and merged
+to main in parallel — `f1a2b3c4d5e6` (receipt cadence, #299) and `d4e7f2a9c1b3`
+(HR zones, #297 via #298) — leaving two alembic heads, which makes
+`alembic upgrade head` fail at deploy ("Multiple head revisions are present") and
+blocks the web service. This is a no-op merge revision that unifies the two heads
+into one so `alembic upgrade head` works again; it adds no schema of its own.
+
+Revision ID: b7e9d2c4a1f8
+Revises: d4e7f2a9c1b3, f1a2b3c4d5e6
+Create Date: 2026-06-16 22:29:11.962092
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7e9d2c4a1f8'
+down_revision: Union[str, None] = ('d4e7f2a9c1b3', 'f1a2b3c4d5e6')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Closes #305. **Hotfix — currently blocking all web deploys.**

## What happened
The receipt-cadence migration (#299, `f1a2b3c4d5e6`) and the HR-zones migration (#297 via #298, `d4e7f2a9c1b3`) were authored off the same parent and merged to `main` in parallel, leaving **two alembic heads**. `alembic upgrade head` then fails with "Multiple head revisions are present". Prod runs migrations on deploy, so the **web service deploy crashes** and stays on old code (the worker boots because its entrypoint does not run the migration). The test suite builds schema from the ORM models via `create_all`, not alembic, so the fork passed CI.

## Fix
A no-op alembic merge revision (`b7e9d2c4a1f8`) unifying the two heads. It adds no schema of its own; `alembic upgrade head` works again and applies whichever parallel migration a given database has not yet seen (on prod, which is at `d4e7f2a9c1b3`: the receipt-cadence columns + the merge).

## Verification
- `alembic upgrade head` against real local Postgres → single head `b7e9d2c4a1f8` (mergepoint), both column sets present.
- `alembic heads` → single head (re-checked after rebasing onto current main).
- Full backend suite green (1326).

## Note
This unblocks **all** web deploys (the HR-zones feature's web side has also not been able to deploy), and it is the prerequisite for activating the receipt cadence. Recommend merging promptly. AC also asks for a CI single-head guard to prevent recurrence — left as the follow-up named in #305 rather than bundled here.