### PR TITLE
fix(trends): scope activity facts query to owner user (#197)

### DIFF
--- a/backend/app/api/trends.py
+++ b/backend/app/api/trends.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
+from app.api.profile import get_current_user_profile
 from app.db.session import get_db
 from app.schemas.trends import LoadResponse, TrendsResponse, WeeklyStatsResponse
 from app.services.training_load import get_load_report
@@ -22,7 +23,8 @@ router = APIRouter()
 @router.get("/trends/types", response_model=List[str])
 def list_activity_types(db: Session = Depends(get_db)):
     """Return distinct activity types available for filtering."""
-    return get_available_types(db)
+    user_id = get_current_user_profile(db).user_id
+    return get_available_types(db, user_id=user_id)
 
 
 @router.get("/trends", response_model=TrendsResponse)
@@ -31,7 +33,8 @@ def get_trends(
     types: Optional[List[str]] = Query(None, description="Activity types to include (multi-select)"),
     db: Session = Depends(get_db),
 ):
-    return get_trends_report(db, range, types)
+    user_id = get_current_user_profile(db).user_id
+    return get_trends_report(db, range, types, user_id=user_id)
 
 
 @router.get("/trends/load", response_model=LoadResponse)
@@ -43,4 +46,5 @@ def get_training_load(db: Session = Depends(get_db)):
 @router.get("/stats/weekly", response_model=WeeklyStatsResponse)
 def get_dashboard_weekly_stats(db: Session = Depends(get_db)):
     """Rolling 7-day dashboard summary with the prior 7 days for comparison (#246, #248)."""
-    return get_weekly_stats(db)
+    user_id = get_current_user_profile(db).user_id
+    return get_weekly_stats(db, user_id=user_id)

--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -69,7 +69,7 @@ def _build_trends_summary(db: Session, activity: Activity) -> dict:
     end = min(today, activity_date + timedelta(days=1))
     start_30d = end - timedelta(days=30)
 
-    facts = _query_activity_facts(db, start_30d, end)
+    facts = _query_activity_facts(db, start_30d, end, user_id=activity.user_id)
 
     if not facts:
         return {"period": "30d", "activity_count": 0}

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -516,13 +516,16 @@ def build_b_baseline(
     # Recent training summary relative to this activity's date
     activity_date = activity.start_date.date()
     facts_7d = _query_activity_facts(
-        db, activity_date - timedelta(days=7), activity_date
+        db, activity_date - timedelta(days=7), activity_date,
+        user_id=activity.user_id,
     )
     facts_28d = _query_activity_facts(
-        db, activity_date - timedelta(days=28), activity_date
+        db, activity_date - timedelta(days=28), activity_date,
+        user_id=activity.user_id,
     )
     facts_prev_28d = _query_activity_facts(
-        db, activity_date - timedelta(days=56), activity_date - timedelta(days=28)
+        db, activity_date - timedelta(days=56), activity_date - timedelta(days=28),
+        user_id=activity.user_id,
     )
 
     return BBaseline(

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -192,10 +192,11 @@ def _period_window(range_key: str) -> Optional[tuple[date, date]]:
     return current_start, previous_start
 
 
-def get_available_types(db: Session) -> List[str]:
+def get_available_types(db: Session, *, user_id=None) -> List[str]:
     """
     Return the distinct activity types present in the database,
     sorted alphabetically.
+    Pass ``user_id`` to restrict results to a single owner.
     """
     from sqlalchemy import distinct
 
@@ -204,6 +205,8 @@ def get_available_types(db: Session) -> List[str]:
         .where(Activity.is_deleted == False)  # noqa: E712
         .order_by(Activity.type)
     )
+    if user_id is not None:
+        stmt = stmt.where(Activity.user_id == user_id)
     return [row for row in db.execute(stmt).scalars().all()]
 
 
@@ -212,9 +215,17 @@ def _query_activity_facts(
     start_date: Optional[date],
     end_date: Optional[date],
     types: Optional[List[str]] = None,
+    *,
+    user_id=None,
 ) -> List[ActivityFact]:
     """
     Internal helper to query activities by exact date range (start inclusive, end exclusive).
+
+    ``user_id`` scopes the query to a single owner.  Pass it at every call site
+    so that when multi-user lands (Phase 2) there is no accidental cross-user leak.
+    Currently optional so callers that do not yet have a user_id available can
+    continue working; the intent is to make it required once the API auth layer
+    provides a resolved user at every endpoint (ADR 0005 / Phase 2).
     """
     from sqlalchemy.orm import selectinload
 
@@ -224,6 +235,8 @@ def _query_activity_facts(
         .where(Activity.is_deleted == False)  # noqa: E712
         .order_by(Activity.start_date.asc())
     )
+    if user_id is not None:
+        stmt = stmt.where(Activity.user_id == user_id)
     if start_date:
         stmt = stmt.where(Activity.start_date >= datetime.combine(start_date, datetime.min.time()))
     if end_date:
@@ -243,13 +256,16 @@ def build_activity_facts(
     db: Session,
     range_key: str = "30D",
     types: Optional[List[str]] = None,
+    *,
+    user_id=None,
 ) -> List[ActivityFact]:
     """
     Query activities within the given range and project them into ActivityFact rows.
     Optionally filter by activity type (case-insensitive).
+    Pass ``user_id`` to restrict results to a single owner.
     """
     since = _resolve_since(range_key)
-    return _query_activity_facts(db, since, None, types)
+    return _query_activity_facts(db, since, None, types, user_id=user_id)
 
 
 def build_daily_facts(activity_facts: List[ActivityFact]) -> List[DailyFact]:
@@ -519,7 +535,7 @@ def _summarise_window(facts: List[ActivityFact]) -> WeeklyStatsSummary:
     )
 
 
-def get_weekly_stats(db: Session) -> WeeklyStatsResponse:
+def get_weekly_stats(db: Session, *, user_id=None) -> WeeklyStatsResponse:
     """
     Rolling 7-day summary for the dashboard, plus the prior 7 days for comparison.
 
@@ -527,11 +543,12 @@ def get_weekly_stats(db: Session) -> WeeklyStatsResponse:
     ``_period_window``) so the dashboard cards and Trends 7D can never drift
     (#246, #179). "Hard days" is derived from the effort axis rather than an
     HR/name heuristic.
+    Pass ``user_id`` to restrict results to a single owner.
     """
     current_start, prev_start = _period_window("7D")  # type: ignore[misc]
 
-    current = _query_activity_facts(db, current_start, None)
-    previous = _query_activity_facts(db, prev_start, current_start)
+    current = _query_activity_facts(db, current_start, None, user_id=user_id)
+    previous = _query_activity_facts(db, prev_start, current_start, user_id=user_id)
 
     return WeeklyStatsResponse(
         summary=_summarise_window(current),
@@ -543,17 +560,20 @@ def get_trends_report(
     db: Session,
     range_key: str = "30D",
     types: Optional[List[str]] = None,
+    *,
+    user_id=None,
 ) -> TrendsResponse:
     """
     Main entry point for generating the complete trends report.
     Orchestrates data fetching and aggregation.
+    Pass ``user_id`` to restrict results to a single owner.
     """
     range_upper = range_key.upper()
     if range_upper not in ALLOWED_RANGES:
         range_upper = "30D"
 
     # 1. Activity-level facts (filtered by types if provided)
-    activity_facts = build_activity_facts(db, range_upper, types=types)
+    activity_facts = build_activity_facts(db, range_upper, types=types, user_id=user_id)
 
     # 2. Daily facts (sum per local date)
     daily_facts = build_daily_facts(activity_facts)
@@ -571,7 +591,7 @@ def get_trends_report(
     window = _period_window(range_upper)
     if window is not None:
         current_start, prev_start = window
-        prev_facts = _query_activity_facts(db, prev_start, current_start, types=types)
+        prev_facts = _query_activity_facts(db, prev_start, current_start, types=types, user_id=user_id)
         previous_summary = TrendsSummary(
             total_distance_m=sum(f.distance_m for f in prev_facts),
             total_moving_time_s=sum(f.moving_time_s for f in prev_facts),

--- a/backend/tests/test_trends_user_scoping.py
+++ b/backend/tests/test_trends_user_scoping.py
@@ -1,0 +1,138 @@
+"""Cross-user isolation: _query_activity_facts must not leak across users (#197).
+
+When two users each have activities in the same date range, queries for one user
+must return only that user's activities. These tests prove the bug (before the fix,
+they fail because there is no user_id filter) and pin the correct behaviour after.
+"""
+
+import uuid
+from datetime import date, datetime, time, timedelta
+
+import pytest
+
+from app.models import Activity, DerivedMetric, User
+from app.services.trends import (
+    _query_activity_facts,
+    build_activity_facts,
+    get_trends_report,
+    get_weekly_stats,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _user(db) -> uuid.UUID:
+    user = User(email=f"{uuid.uuid4()}@example.com")
+    db.add(user)
+    db.flush()
+    return user.id
+
+
+def _activity_on(db, user_id, on: date, *, distance_m: int = 5000) -> Activity:
+    activity = Activity(
+        user_id=user_id,
+        strava_activity_id=int(uuid.uuid4().int % 1_000_000_000),
+        start_date=datetime.combine(on, time(12, 0)),
+        type="Run",
+        name="Run",
+        distance_m=distance_m,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=0.0,
+        raw_summary={},
+    )
+    db.add(activity)
+    db.flush()
+    db.add(
+        DerivedMetric(
+            id=uuid.uuid4(),
+            activity_id=activity.id,
+            effort_score=1.0,
+            confidence="high",
+            flags=[],
+            confidence_reasons=[],
+        )
+    )
+    db.flush()
+    return activity
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_query_activity_facts_scoped_to_user(db):
+    """_query_activity_facts with a user_id must exclude another user's activities."""
+    today = date.today()
+    user_a = _user(db)
+    user_b = _user(db)
+
+    _activity_on(db, user_a, today - timedelta(days=1), distance_m=1000)
+    _activity_on(db, user_b, today - timedelta(days=1), distance_m=9999)
+
+    facts_a = _query_activity_facts(db, today - timedelta(days=7), None, user_id=user_a)
+    assert len(facts_a) == 1
+    assert facts_a[0].distance_m == 1000, "user_b's 9999m activity must not appear for user_a"
+
+
+def test_query_activity_facts_user_b_sees_only_own(db):
+    """Symmetric: user_b's query must not include user_a's activity."""
+    today = date.today()
+    user_a = _user(db)
+    user_b = _user(db)
+
+    _activity_on(db, user_a, today - timedelta(days=1), distance_m=1000)
+    _activity_on(db, user_b, today - timedelta(days=1), distance_m=9999)
+
+    facts_b = _query_activity_facts(db, today - timedelta(days=7), None, user_id=user_b)
+    assert len(facts_b) == 1
+    assert facts_b[0].distance_m == 9999
+
+
+def test_build_activity_facts_scoped_to_user(db):
+    """build_activity_facts with a user_id must exclude another user's activities."""
+    today = date.today()
+    user_a = _user(db)
+    user_b = _user(db)
+
+    _activity_on(db, user_a, today - timedelta(days=1), distance_m=2000)
+    _activity_on(db, user_b, today - timedelta(days=1), distance_m=8888)
+
+    facts = build_activity_facts(db, "7D", user_id=user_a)
+    assert all(f.distance_m != 8888 for f in facts), "user_b's activity must not appear"
+    assert any(f.distance_m == 2000 for f in facts)
+
+
+def test_get_weekly_stats_scoped_to_user(db):
+    """get_weekly_stats with a user_id must exclude another user's activities."""
+    user_a = _user(db)
+    user_b = _user(db)
+
+    _activity_on(db, user_a, date.today() - timedelta(days=1), distance_m=3000)
+    # user_b has a much larger activity in the same window
+    _activity_on(db, user_b, date.today() - timedelta(days=1), distance_m=50000)
+
+    stats = get_weekly_stats(db, user_id=user_a)
+
+    assert stats.summary.activity_count == 1
+    assert stats.summary.total_distance_m == 3000, (
+        "user_b's 50km must not inflate user_a's stats"
+    )
+
+
+def test_get_trends_report_scoped_to_user(db):
+    """get_trends_report with a user_id must exclude another user's activities."""
+    user_a = _user(db)
+    user_b = _user(db)
+
+    _activity_on(db, user_a, date.today() - timedelta(days=1), distance_m=4000)
+    _activity_on(db, user_b, date.today() - timedelta(days=1), distance_m=60000)
+
+    report = get_trends_report(db, "7D", user_id=user_a)
+
+    assert report.summary.activity_count == 1
+    assert report.summary.total_distance_m == 4000, (
+        "user_b's 60km must not appear in user_a's trends report"
+    )


### PR DESCRIPTION
## Problem

`_query_activity_facts` in `backend/app/services/trends.py` had no `user_id` filter, so it selected across all users in the database. This function backs:

- The `/api/trends` and `/api/stats/weekly` endpoints (trend charts and dashboard summary cards).
- The coach context `build_b_baseline` (the `recent_training_summary` 7d/28d/prev-28d rollups written into every coach report's context pack).
- The coach chat `_build_trends_summary` (the 30-day training context in the chat system prompt).

In the current single-user MVP this is benign, but it is a latent cross-user data leak for Phase 2.

## Approach

Added a keyword-only `user_id=None` parameter to:

- `_query_activity_facts` (the fix: adds `.where(Activity.user_id == user_id)` when provided)
- `build_activity_facts`, `get_weekly_stats`, `get_trends_report`, `get_available_types` (forward `user_id` through to the query)

Threaded `user_id` at every call site:

- `api/trends.py`: resolves via `get_current_user_profile(db).user_id` (the existing canonical MVP pattern used in `coach.py` and `materials.py`) for the trends, weekly-stats, and types endpoints.
- `services/coach/context.py` (`build_b_baseline`): uses `activity.user_id`, already present on the function's `activity` arg.
- `services/coach/chat.py` (`_build_trends_summary`): uses `activity.user_id`.

The parameter is optional (defaults to `None`) to remain backward compatible. With `None` the query behaves exactly as before, so no regression to existing single-user behaviour. Making it required is a Phase 2 task once the ADR-0005 auth layer provides a resolved user at every endpoint.

## Testing

New test file: `backend/tests/test_trends_user_scoping.py` (5 tests):

```
cd backend && .venv/bin/python -m pytest tests/test_trends_user_scoping.py -v
```

All 5 pass after the fix (all 5 fail on the unpatched code, proving the bug).

Full suite:

```
cd backend && .venv/bin/python -m pytest -m "not integration" -q
```

Result: **1331 passed, 4 deselected** (no regressions).

## Assumptions

- `get_current_user_profile(db).user_id` is the correct user-resolution seam for the API layer in the MVP. This matches what `coach.py` and `materials.py` do.
- The `/api/trends/load` endpoint (`get_load_report`) is out of scope: it is in `training_load.py`, a separate service, and the issue explicitly limits the fix to `_query_activity_facts` and its callers.

## Follow-ups

- **`activity_queries.py` audit**: other shared query helpers in `backend/app/services/activity_queries.py` and `backend/app/services/training_load.py` also lack `user_id` scoping. The issue explicitly defers this audit to when multi-user lands (Phase 2 / ADR 0005). A follow-up issue should track it.
- **Make `user_id` required**: once ADR-0005 magic-link sessions provide a resolved user at every request, the `user_id` parameter on these functions should become required (remove the `None` default) so the compiler catches any new unscoped call site.

Closes #197