### PR TITLE
fix(#302): handle streaming disconnect as transient transport failure

### DIFF
--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -198,14 +198,20 @@ def regenerate_coach_report(activity_id: UUID, db: Session = Depends(get_db)):
     # the read endpoints (and out of test collection that does not touch Redis).
     from app.core.config import settings
     from app.core.queue import queue
-    from app.jobs.process_new_activity import regenerate_report_job
+    from app.jobs.process_new_activity import PIPELINE_RETRY, regenerate_report_job
 
     # job_timeout (#264): the two-stage regeneration runs ~120-360s, past RQ's 180s
     # default; without this the worker's death penalty kills it before it stores the
     # report. (The queue default_timeout also covers it; explicit here documents it.)
+    #
+    # retry (#302): give the regeneration the same bounded PIPELINE_RETRY policy
+    # (3 attempts, 60/300/900s backoffs) used by the create/poll paths, so a
+    # transient streaming disconnect (httpx.RemoteProtocolError) retries at the
+    # RQ level rather than silently leaving the runner with a stale fallback report.
     queue.enqueue(
         regenerate_report_job, str(activity_id),
         job_timeout=settings.RQ_JOB_TIMEOUT_SECONDS,
+        retry=PIPELINE_RETRY,
     )
     return {"status": "regenerating"}
 

--- a/backend/app/services/coach/llm.py
+++ b/backend/app/services/coach/llm.py
@@ -7,6 +7,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any, AsyncIterator, Dict, List, Optional, Protocol
 
+import httpx
+
 logger = logging.getLogger(__name__)
 
 # Cap any single Anthropic call. The SDK default is 600s; the RQ worker
@@ -228,7 +230,19 @@ class AnthropicClient:
                     content_blocks=list(final.content),
                     stop_reason=final.stop_reason,
                 )
-            except (anthropic.APITimeoutError, anthropic.APIConnectionError) as exc:
+            except (
+                anthropic.APITimeoutError,
+                anthropic.APIConnectionError,
+                # httpx.RemoteProtocolError is raised mid-stream when the peer
+                # closes the connection before the chunked response body is
+                # complete ("incomplete chunked read"). The SDK wraps httpx
+                # errors that occur during the *initial* HTTP call into
+                # APIConnectionError, but errors that surface during SSE
+                # stream iteration (inside stream.get_final_message()) escape
+                # unwrapped. Treat them as the same transient transport class
+                # so they follow the same retry-then-propagate path (#302).
+                httpx.RemoteProtocolError,
+            ) as exc:
                 last_exc = exc
                 logger.warning(
                     "anthropic_message_transient_failure",

--- a/backend/tests/test_coach_llm_timeout_retry.py
+++ b/backend/tests/test_coach_llm_timeout_retry.py
@@ -1,4 +1,5 @@
-"""Tests for AnthropicClient.generate_json's explicit timeout + bounded retry.
+"""Tests for AnthropicClient.generate_json's explicit timeout + bounded retry,
+and for generate_coach_message's streaming disconnect handling (#302).
 
 The SDK's default timeout is 600 seconds, so a single hung call would lock
 an RQ worker for ten minutes. Acceptance:
@@ -7,10 +8,15 @@ an RQ worker for ten minutes. Acceptance:
 - Non-retriable errors (4xx other than 429) propagate immediately.
 - After the retry is exhausted, the underlying error propagates so the
   caller's fallback path (services/coach/service.py is_fallback=True) fires.
+- A mid-stream httpx.RemoteProtocolError (peer closed connection) is treated
+  as a transient transport failure in generate_coach_message — retried once,
+  and propagates after retry exhaustion so the service fallback path fires.
+  It must NOT crash the job with an uncaught raw exception.
 """
 
-from unittest.mock import AsyncMock, patch
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import anthropic
 import httpx
@@ -148,3 +154,108 @@ async def test_propagates_5xx_after_retry_exhausted():
             await client.generate_json("sys", "user")
 
     assert fake_create.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# generate_coach_message — streaming disconnect (#302)
+#
+# httpx.RemoteProtocolError (peer closed connection without completing the
+# chunked stream) is raised from stream.get_final_message() inside the async
+# context manager. It is NOT a subclass of anthropic.APIConnectionError, so
+# the existing except clause does not catch it. The fix must treat it as a
+# transient transport failure: retry once, then propagate so the service
+# fallback path (is_fallback=True) fires — exactly like APIConnectionError.
+# ---------------------------------------------------------------------------
+
+def _make_remote_protocol_error() -> httpx.RemoteProtocolError:
+    """Build a real httpx.RemoteProtocolError as the peer-disconnect case."""
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    return httpx.RemoteProtocolError(
+        "peer closed connection without sending complete message body"
+        " (incomplete chunked read)",
+        request=request,
+    )
+
+
+def _make_ok_message_result():
+    """Minimal stand-in for anthropic.types.Message returned by get_final_message."""
+    block = SimpleNamespace(type="text", text="Well run today.")
+    return SimpleNamespace(content=[block], stop_reason="end_turn")
+
+
+def _make_streaming_ctx(side_effect):
+    """Return a factory that produces an async context manager whose
+    get_final_message() raises or returns according to *side_effect*
+    (a list, consumed one item per call — same semantics as AsyncMock
+    side_effect)."""
+    calls = iter(side_effect)
+
+    @asynccontextmanager
+    async def _ctx(*args, **kwargs):
+        outcome = next(calls)
+        stream = MagicMock()
+        if isinstance(outcome, BaseException):
+            stream.get_final_message = AsyncMock(side_effect=outcome)
+        else:
+            stream.get_final_message = AsyncMock(return_value=outcome)
+        yield stream
+
+    return _ctx
+
+
+@pytest.mark.asyncio
+async def test_generate_coach_message_retries_on_remote_protocol_error_then_succeeds():
+    """A mid-stream RemoteProtocolError on the first attempt triggers one retry
+    and the successful second attempt is returned."""
+    client = AnthropicClient(api_key="k", model="m")
+    ok = _make_ok_message_result()
+    err = _make_remote_protocol_error()
+
+    client.client.messages.stream = _make_streaming_ctx([err, ok])
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        result = await client.generate_coach_message(
+            system="sys", user="user", tools=[]
+        )
+
+    assert result.stop_reason == "end_turn"
+    assert len(result.content_blocks) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_coach_message_propagates_remote_protocol_error_after_retry_exhausted():
+    """After the single retry is also a RemoteProtocolError, the exception
+    propagates so the caller's fallback path (is_fallback=True) fires.
+    It must NOT be swallowed and silently dropped."""
+    client = AnthropicClient(api_key="k", model="m")
+    err1 = _make_remote_protocol_error()
+    err2 = _make_remote_protocol_error()
+
+    client.client.messages.stream = _make_streaming_ctx([err1, err2])
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(httpx.RemoteProtocolError):
+            await client.generate_coach_message(
+                system="sys", user="user", tools=[]
+            )
+
+
+@pytest.mark.asyncio
+async def test_generate_coach_message_logs_warning_on_remote_protocol_error(caplog):
+    """A RemoteProtocolError is logged at WARNING with the transient-failure key,
+    not silently dropped or re-raised as an unknown error."""
+    import logging
+
+    client = AnthropicClient(api_key="k", model="m")
+    ok = _make_ok_message_result()
+    err = _make_remote_protocol_error()
+
+    client.client.messages.stream = _make_streaming_ctx([err, ok])
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        with caplog.at_level(logging.WARNING, logger="app.services.coach.llm"):
+            await client.generate_coach_message(
+                system="sys", user="user", tools=[]
+            )
+
+    assert any("transient" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## Failure mode

When the Anthropic streaming call for a coach report loses the connection mid-response, `httpx.RemoteProtocolError` is raised inside `stream.get_final_message()`. This is distinct from errors during the initial HTTP handshake, which the SDK wraps into `anthropic.APIConnectionError`. Errors raised during SSE body iteration escape unwrapped — and because `httpx.RemoteProtocolError` is not a subclass of `anthropic.APIConnectionError`, the existing except clause in `generate_coach_message` did not catch it. The raw exception propagated and crashed the RQ job without triggering `service.py`'s `is_fallback=True` graceful path.

Second issue: `regenerate_report_job` (the UI "Re-run" path) had no RQ-level retry policy. A transient streaming drop during re-generation was permanent: the job failed, the frontend polled indefinitely, and the runner remained on the prior fallback report.

## Root cause

`generate_coach_message` in `llm.py` caught `(anthropic.APITimeoutError, anthropic.APIConnectionError)` but not `httpx.RemoteProtocolError`. The SDK wraps connection errors at the HTTP send layer, not during SSE stream body reads.

## Approach

1. `backend/app/services/coach/llm.py`: add `httpx.RemoteProtocolError` to the caught exception tuple in `generate_coach_message`. It receives the same retry-once-then-propagate treatment as `APITimeoutError`/`APIConnectionError`. After retries exhausted the exception propagates to `service.py`, which sets `is_fallback=True` — the same graceful fallback path that applies to all other transient transport failures.

2. `backend/app/api/coach.py`: add `retry=PIPELINE_RETRY` to the `regenerate_report_job` enqueue call. This reuses the existing bounded policy (3 attempts, backoffs 60/300/900s) already used by the create/poll paths. A transient drop during re-generation now retries at the RQ level rather than failing permanently.

## Testing

Three new tests in `tests/test_coach_llm_timeout_retry.py`:
- `test_generate_coach_message_retries_on_remote_protocol_error_then_succeeds` — retry fires, second attempt succeeds, result returned
- `test_generate_coach_message_propagates_remote_protocol_error_after_retry_exhausted` — after both attempts fail, `httpx.RemoteProtocolError` propagates (so the service's fallback path fires)
- `test_generate_coach_message_logs_warning_on_remote_protocol_error` — WARNING log with "transient" key is emitted (for observability)

Full suite: `1329 passed, 4 deselected` (baseline unchanged).

## Assumptions

- No other streaming path (`stream_chat`, used for coach chat) needs this change: it is a UI streaming response and its caller handles disconnects at the HTTP/SSE level, not inside the LLM client.
- The `generate_json` and `generate_structured` non-streaming paths do not need `httpx.RemoteProtocolError` added: they use the non-streaming `messages.create`, where the SDK's own wrapping already converts httpx transport errors into `APIConnectionError`.
- The `PIPELINE_RETRY` policy (3 attempts) on the regeneration job is appropriate. A 3-attempt retry with increasing backoffs is more than enough to outlast a transient peer disconnect, without risking runaway retries on a genuine configuration error.

Closes #302