### PR TITLE
fix: recorded_laps detection confidence stays high when plan present (#190)

### DIFF
--- a/backend/app/services/analysis/workout_matching.py
+++ b/backend/app/services/analysis/workout_matching.py
@@ -83,28 +83,34 @@ def match_planned_to_detected(
     if detected["rep_duration_cv"] is not None and detected["rep_duration_cv"] > 30:
         result["confidence_reasons"].append("high_rep_duration_variability")
 
-    # Without a planned workout, confidence depends on detection quality alone
-    if not planned_workout:
-        result["confidence_reasons"].append("no_planned_workout")
-        if interval_structure.get("source") == "recorded_laps":
-            # The runner's own lap marks are ground-truth structure: detection
-            # is certain even when the reps varied. Rep-to-rep consistency is
-            # reported separately via consistency_score and does not lower this.
-            # Variability across reps (a ladder/pyramid/fartlek) is the runner's
-            # actual workout, not detection uncertainty, so those reasons must not
-            # propagate to lower the activity-level confidence downstream.
-            result["confidence_reasons"] = [
-                r
-                for r in result["confidence_reasons"]
-                if "variability" not in r and "outlier" not in r
-            ]
-            # The recorded laps are a perfect de-facto plan, so match_score is 1.0
-            # -- this keeps the prompt's "high AND match_score >= 0.8" gate and
+    # Recorded-laps ground-truth treatment: applies regardless of whether a
+    # planned workout is present. The runner's own lap marks settle the detection
+    # question -- confidence is always "high". Rep-to-rep spread is the runner's
+    # actual workout (a ladder, pyramid, fartlek), not detection uncertainty, so
+    # variability/outlier reasons are stripped here before they can leak downstream.
+    # When no plan is present the laps are also a perfect de-facto plan (match_score
+    # 1.0). When a plan IS present, match_score is left to the plan-scoring block
+    # below so it can reflect plan adherence -- detection certainty is still "high"
+    # because the detection question is already settled by the lap marks.
+    if interval_structure.get("source") == "recorded_laps":
+        result["confidence_reasons"] = [
+            r
+            for r in result["confidence_reasons"]
+            if "variability" not in r and "outlier" not in r
+        ]
+        result["detection_confidence"] = "high"
+        if not planned_workout:
+            result["confidence_reasons"].append("no_planned_workout")
+            # The recorded laps are a perfect de-facto plan, so match_score is
+            # 1.0 -- keeps the prompt's "high AND match_score >= 0.8" gate and
             # the deterministic validator consistent for the lap-sourced case.
             result["match_score"] = 1.0
-            result["detection_confidence"] = "high"
             return result
-        # Stream-derived structure: base detection confidence on consistency.
+        # Fall through to plan scoring so match_score can reflect adherence.
+
+    elif not planned_workout:
+        # Stream-derived, no plan: base detection confidence on consistency.
+        result["confidence_reasons"].append("no_planned_workout")
         consistency = summary.get("consistency_score", "unknown")
         if consistency == "high" and not any(
             "outlier" in r for r in result["confidence_reasons"]
@@ -167,19 +173,23 @@ def match_planned_to_detected(
 
     result["match_score"] = match_score
 
-    # Derive detection confidence from match score and reasons
-    critical_reasons = [
-        r
-        for r in reasons
-        if r
-        not in ("no_planned_workout",)
-    ]
-    if match_score >= 0.8 and len(critical_reasons) <= 1:
-        result["detection_confidence"] = "high"
-    elif match_score >= 0.5:
-        result["detection_confidence"] = "medium"
-    else:
-        result["detection_confidence"] = "low"
+    # For recorded_laps the detection confidence was already locked to "high"
+    # above -- plan adherence (match_score) is a separate axis and must not
+    # downgrade detection certainty that the lap marks have already settled.
+    if interval_structure.get("source") != "recorded_laps":
+        # Derive detection confidence from match score and reasons
+        critical_reasons = [
+            r
+            for r in reasons
+            if r
+            not in ("no_planned_workout",)
+        ]
+        if match_score >= 0.8 and len(critical_reasons) <= 1:
+            result["detection_confidence"] = "high"
+        elif match_score >= 0.5:
+            result["detection_confidence"] = "medium"
+        else:
+            result["detection_confidence"] = "low"
 
     return result
 

--- a/backend/tests/test_workout_matching.py
+++ b/backend/tests/test_workout_matching.py
@@ -180,6 +180,39 @@ class TestMatchPlannedToDetected:
         assert result["match_score"] == 1.0
         assert result["detection_confidence"] == "high"
 
+    def test_recorded_laps_confidence_high_even_with_plan_deviation(self):
+        """When a planned workout is present AND source is recorded_laps, detection
+        confidence must stay 'high' and variability/outlier reasons must not appear
+        (#190). The runner's own lap marks are ground-truth detection regardless of
+        how far the run deviated from the plan. match_score reflecting plan adherence
+        (plan deviation → low adherence) is acceptable."""
+        # Build a ladder: reps vary a lot so variability reasons would fire
+        structure = _make_interval_structure(reps=4, distance_per_rep=400)
+        structure["source"] = "recorded_laps"
+        # Force high distance variability by injecting extreme rep distances
+        structure["work_segments"][0]["distance_m"] = 200.0
+        structure["work_segments"][1]["distance_m"] = 400.0
+        structure["work_segments"][2]["distance_m"] = 800.0
+        structure["work_segments"][3]["distance_m"] = 1200.0
+        # Planned workout that differs from the execution (e.g. 8x400 planned, 4 reps done)
+        planned = {"reps_planned": 8, "rep_distance_m": 400, "rest_s": 60}
+        result = match_planned_to_detected(structure, planned)
+        # Detection certainty: the laps are ground truth, must be high
+        assert result["detection_confidence"] == "high", (
+            f"Expected 'high' but got {result['detection_confidence']!r}; "
+            f"reasons: {result['confidence_reasons']}"
+        )
+        # Variability and outlier reasons must not appear (they are plan-adherence noise)
+        reasons = result["confidence_reasons"]
+        assert not any("variability" in r for r in reasons), (
+            f"Variability reason leaked: {reasons}"
+        )
+        assert not any("outlier" in r for r in reasons), (
+            f"Outlier reason leaked: {reasons}"
+        )
+        # match_score may reflect plan deviation (low adherence is fine here)
+        assert result["match_score"] is not None
+
 
 class TestBuildIntervalKPIs:
     def test_basic_kpis(self):


### PR DESCRIPTION
## Problem (latent)

In `workout_matching.py`, the `recorded_laps` special case (detection_confidence="high", variability/outlier reason stripping) is nested inside the `if not planned_workout:` branch. When a planned workout is present, a `source="recorded_laps"` structure falls through to the ordinary plan-scoring path, where detection_confidence can drop and reasons are not stripped. This conflates plan adherence with detection certainty.

## Why latent

`_extract_planned_workout` in `_orchestrator.py` returns None unconditionally (planned-workout capture is not yet implemented), so the plan-present branch is unreachable in production. The four existing recorded_laps tests all pass planned=None.

## Approach

Hoist the recorded_laps ground-truth treatment so it applies before (or independently of) plan scoring. When source is "recorded_laps", detection_confidence is always "high" and variability/outlier detection reasons are stripped, regardless of plan deviation. Plan adherence (match_score vs plan) is a separate axis and can still reflect deviation.

A guard at the end of the plan-scoring block prevents the match_score-derived confidence derivation from overwriting the "high" already set for recorded_laps.

## Testing

Added one regression test: a recorded_laps structure with highly variable reps and a deviating planned workout (8 reps planned, 4 run, distances spread 200-1200m). Asserts detection_confidence stays "high" and detection reasons are stripped; match_score reflecting plan deviation is accepted. All five recorded_laps tests pass. Full backend suite: 1327 passed, 0 failed.

Note: the planned + recorded_laps path is exercised only by the new direct-call test since `_extract_planned_workout` still returns None in production.

## Assumptions

No planned-workout schema changes needed. The fix is purely in `workout_matching.py` and the test file.

Closes #190