### PR TITLE
fix(ui): NavBar above sticky table headers + consistent activity table headers (#293)

### DIFF
--- a/frontend/components/LapsPanel.tsx
+++ b/frontend/components/LapsPanel.tsx
@@ -142,13 +142,16 @@ export function LapsPanel({ laps }: LapsPanelProps) {
 
       <div className="overflow-x-auto max-h-80 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-700">
         <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-          <thead className="sticky top-0 z-10 bg-gray-100 dark:bg-gray-700 shadow-sm">
+          {/* Header style is kept identical to SplitsPanel's thead/th so the two
+              activity tables read as one UI (#293). The sticky positioning sits
+              below the NavBar (z-30) so the header never paints over it. */}
+          <thead className="sticky top-0 z-10 bg-gray-100 dark:bg-gray-700">
             <tr>
               {['Lap', 'Distance', 'Time', 'Pace', 'Avg HR'].map((label) => (
                 <th
                   key={label}
                   scope="col"
-                  className="px-6 py-3 text-left text-xs font-semibold whitespace-nowrap text-gray-700 dark:text-gray-200 uppercase tracking-wider"
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
                 >
                   {label}
                 </th>

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -16,7 +16,7 @@ export default function NavBar() {
     href === '/' ? pathname === '/' : pathname.startsWith(href);
 
   return (
-    <nav className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900 sticky top-0 z-10 overflow-x-hidden">
+    <nav className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900 sticky top-0 z-30 overflow-x-hidden">
       <div className="max-w-4xl mx-auto px-4 h-16 flex items-center justify-between gap-4">
         <Link
           href="/"

--- a/frontend/components/SplitsPanel.tsx
+++ b/frontend/components/SplitsPanel.tsx
@@ -23,7 +23,9 @@ export function SplitsPanel({ splits }: SplitsPanelProps) {
       </h3>
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-          <thead className="bg-gray-50 dark:bg-gray-700/50">
+          {/* Header style is kept identical to LapsPanel's thead/th so the two
+              activity tables read as one UI (#293). */}
+          <thead className="bg-gray-100 dark:bg-gray-700">
             <tr>
               <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                 {isTimeBased ? '#' : 'Km'}


### PR DESCRIPTION
Closes #293

## Problem
On mobile, the Laps table sticky header painted OVER the top NavBar ("AI Coach" + links), and the Laps and Splits tables used visibly different header styling so they did not read as one UI.

## Root cause
NavBar and the Laps thead were both `sticky top-0 z-10`. With an equal z-index the later-in-DOM Laps header wins the stacking and covers the nav. When laps are few the Laps headers `max-h-80 overflow-y-auto` container does not scroll, so its sticky header escapes to the viewport top and reaches the nav. The two tables also used different thead/th classes (Laps: bg-gray-100/700, font-semibold, gray-700/200, shadow-sm; Splits: bg-gray-50/700-50, font-medium, gray-500/400).

## Fix
- Raise NavBar to `z-30` so the app chrome always sits above any in-content sticky header. The only other content z-indexes are `z-10` and a `z-20` trends dropdown, both now below it. The Laps header tucks UNDER the nav instead of over it.
- Give Laps and Splits one identical header style: opaque `bg-gray-100 dark:bg-gray-700` thead and `text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider` th. The background must be opaque because the Laps header is sticky (a translucent bg would let scrolling rows bleed through). Dropped the Laps-only `shadow-sm`/`font-semibold` to match.

## Testing
- Frontend gate `npm run test` (next lint + build): passes, all routes built, no lint errors.
- No component test runner exists for the frontend, so the VISUAL result is yours to confirm: please open the Vercel preview on your phone and check (a) the Laps header no longer overlaps the NavBar while scrolling, and (b) the Laps and Splits headers now match. The exact gray shade is a one-line tweak if you want it lighter or bolder.

## Not in scope
The Laps/Splits tables still scroll horizontally on narrow screens (many columns + px-6 padding). That clipping is a separate concern from this issue (overlap + header consistency); responsive padding could be a follow-up.