### PR TITLE
fix: pace variability empty state, RPE typo, favicon

### DIFF
--- a/frontend/app/icon.svg
+++ b/frontend/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#2563EB"/>
+  <text x="16" y="22" font-family="sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">AI</text>
+</svg>

--- a/frontend/components/AdvancedMetrics.tsx
+++ b/frontend/components/AdvancedMetrics.tsx
@@ -46,17 +46,17 @@ export default function AdvancedMetrics({ metrics }: Props) {
                 <div className="text-xs text-gray-400 dark:text-gray-500 italic">Not enough data for Cardiac Drift.</div>
             )}
 
-            {metrics.pace_variability !== undefined && (
-                <div className="bg-slate-50 dark:bg-gray-700/50 p-4 rounded-lg">
-                    <div className="flex justify-between items-center mb-1">
-                        <span className="text-sm text-gray-600 dark:text-gray-400">Pace Variability</span>
-                        <span className="font-bold text-slate-700 dark:text-gray-300">{metrics.pace_variability}%</span>
-                    </div>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
-                        Coefficient of Variation. Lower means a steadier, more consistent effort.
-                    </p>
+            <div className="bg-slate-50 dark:bg-gray-700/50 p-4 rounded-lg">
+                <div className="flex justify-between items-center mb-1">
+                    <span className="text-sm text-gray-600 dark:text-gray-400">Pace Variability</span>
+                    <span className="font-bold text-slate-700 dark:text-gray-300">
+                        {metrics.pace_variability != null ? `${metrics.pace_variability}%` : '—'}
+                    </span>
                 </div>
-            )}
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Coefficient of Variation. Lower means a steadier, more consistent effort.
+                </p>
+            </div>
         </div>
 
         {/* Right Col: Zones */}

--- a/frontend/components/CheckInForm.tsx
+++ b/frontend/components/CheckInForm.tsx
@@ -185,7 +185,7 @@ export default function CheckInForm({ activityId, existingCheckIn, currentType, 
             value={effort}
             onChange={(e) => setEffort(e.target.value === '' ? '' : Number(e.target.value))}
             className="w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all"
-            placeholder="Difficuty"
+            placeholder="Difficulty"
             required
             />
         </div>


### PR DESCRIPTION
## Summary

Three small cosmetic/UX fixes discovered during a live smoke on 2026-06-16.

### #311 - Pace Variability bare "%" (AdvancedMetrics.tsx)

The card was conditionally rendered only when `pace_variability !== undefined`, but the backend returns `null` for activities with no pace stream (e.g. indoor rides). Since `null !== undefined` is true, the condition passed and `{null}%` rendered as a bare `%`. Fix: always render the card and use `!= null` (covers both null and undefined) to show the value with `%` when present, or `—` when absent.

### #312 - RPE placeholder typo (CheckInForm.tsx)

`placeholder="Difficuty"` corrected to `placeholder="Difficulty"`.

### #313 - Favicon 404 (app/icon.svg)

Added `frontend/app/icon.svg` (a blue rounded square with "AI" text). Next.js 14 App Router automatically serves a file named `icon.svg` in the `app/` directory as the page icon, emitting a `<link rel="icon">` tag. The build output confirms `/icon.svg` as a static route. Note: the browser's default probe for `/favicon.ico` (a binary ICO file) may still 404 if no binary `favicon.ico` is present in `public/`; a binary favicon could be added later to silence that probe entirely. The SVG icon is served and the browser tab icon is populated in browsers that respect `<link rel="icon">`.

## Test result

`npm run test` (next lint + next build) passed clean: no ESLint errors, TypeScript clean, all 8 pages built.

Closes #311
Closes #312
Closes #313