### PR TITLE
fix(intervals): abstain on ambiguous lap-split shapes (#189)

### DIFF
--- a/backend/app/services/analysis/intervals.py
+++ b/backend/app/services/analysis/intervals.py
@@ -25,6 +25,12 @@ import numpy as np
 # Shared by the stream heuristic and the lap-based splitter.
 _MIN_CLUSTER_SEPARATION = 1.3
 
+# When the only rest evidence is a SINGLE standing-stop lap (zero speed), the
+# work cluster must show meaningful pace variation to distinguish interval work
+# from a steady run with a brief pause (#189 shape 2). A CV below this
+# threshold means the runner was simply running at one pace with a stop.
+_STEADY_STATE_CV_THRESHOLD = 10.0
+
 
 def detect_intervals(
     streams_dict: Dict[str, List],
@@ -303,6 +309,10 @@ def _split_laps_work_rest(speeds: List[float]) -> Optional[List[bool]]:
     (>= `_MIN_CLUSTER_SEPARATION`) and there are at least two work laps and one
     slow lap. Returns a per-lap work mask, or None when the laps show no
     work/rest pattern (e.g. uniform auto-distance laps, a steady run).
+
+    Additional guard (#189): a single standing-rest lap (zero-speed) with a
+    tight fast cluster (CV < 10%) is a steady run with a brief stop, not an
+    interval session -- the standing-rest special case must not fire here.
     """
     n = len(speeds)
     if n < _MIN_LAPS_FOR_PATTERN:
@@ -332,6 +342,19 @@ def _split_laps_work_rest(speeds: List[float]) -> Optional[List[bool]]:
     # ratio gate only applies when the slow cluster is itself moving.
     if slow_mean > 0 and fast_mean < slow_mean * _MIN_CLUSTER_SEPARATION:
         return None
+
+    # Guard: a SINGLE standing-rest lap with a uniformly-paced fast cluster is
+    # a steady run with a brief stop, not an interval session. Require meaningful
+    # pace variance in the work cluster when the only rest evidence is one
+    # standing stop (#189 shape 2: easy-run-with-pause mis-segmentation).
+    if (
+        len(slow) == 1
+        and slow[0] == 0.0
+        and len(fast) >= 2
+    ):
+        fast_cv = _cv_percent(fast)
+        if fast_cv is not None and fast_cv < _STEADY_STATE_CV_THRESHOLD:
+            return None
 
     threshold = ordered[split_at]  # first speed in the fast cluster
     return [s >= threshold for s in speeds]
@@ -384,6 +407,21 @@ def detect_intervals_from_laps(raw_summary: Optional[dict]) -> Optional[dict]:
     # progression run, not an interval session -> fall back to stream detection.
     if not any(i not in work_set for i in range(first_work + 1, last_work)):
         return None
+
+    # Guard: an interior consecutive pair of work laps (two adjacent work laps
+    # where neither is at the very start nor the very end of the work window)
+    # indicates a rest lap was promoted into the work cluster by an ambiguous
+    # split -- e.g. heterogeneous recoveries where the largest speed gap falls
+    # BETWEEN two recovery speeds rather than between all recoveries and the
+    # work laps (#189 shape 1). Edge-consecutive pairs (warmup or cooldown
+    # adjacent to the first/last rep) are the documented #188 limitation and
+    # are left to that follow-up.
+    for j in range(len(work_mask) - 1):
+        if work_mask[j] and work_mask[j + 1]:
+            # The pair (j, j+1) is interior when it is not the edge-start
+            # (j == first_work) AND not the edge-end (j + 1 == last_work).
+            if j > first_work and j + 1 < last_work:
+                return None
 
     # Start offset (seconds from activity start) for each lap.
     starts: List[int] = []

--- a/backend/tests/test_intervals_from_laps.py
+++ b/backend/tests/test_intervals_from_laps.py
@@ -477,3 +477,138 @@ class TestLapSpeedAndSeparationGuard:
         # slow cluster is all standing rest (mean 0): accepted on a positive
         # fast cluster alone, the ratio gate does not apply.
         assert _split_laps_work_rest([0.0, 0.0, 5.0, 5.0]) == [False, False, True, True]
+
+
+class TestAmbiguousSplitAbstain:
+    """Guards added by #189: the single-largest-gap split is under-determined
+    for two documented failure shapes. The fix abstains (returns None from
+    detect_intervals_from_laps) rather than asserting a high-confidence
+    mis-segmentation as ground truth.
+
+    The existing TestKnownLimitationBriskWarmup tests (brisk warmup/cooldown
+    adjacent to reps) are UNAFFECTED because those consecutive-work pairs occur
+    only at the edge of the work window, not in the interior (#188 covers that
+    root cause separately).
+    """
+
+    # ------------------------------------------------------------------
+    # Shape 1: heterogeneous recoveries (#189 finding F6)
+    # One walked recovery (~1.2 m/s), one jogged recovery (~3.6 m/s).
+    # The largest gap falls BETWEEN the two recovery speeds rather than
+    # between all recoveries and the work laps, so the jogged recovery is
+    # promoted into the work cluster. The result: rep count off by one,
+    # two adjacent work segments, inflated work-speed CV.
+    # ------------------------------------------------------------------
+
+    def test_heterogeneous_recoveries_abstains(self):
+        """Walk + jog recoveries: the interior jog-rest lap must not be
+        classified as a work rep. The lap split is under-determined and
+        should abstain rather than emit a confident mis-segmentation.
+        """
+        laps = [
+            _lap(1, 400, 5.0, average_heartrate=178.0, max_heartrate=188.0),
+            _lap(2, 200, 1.2, average_heartrate=135.0, max_heartrate=145.0),  # walk recovery
+            _lap(3, 400, 5.0, average_heartrate=180.0, max_heartrate=190.0),
+            _lap(4, 200, 3.6, average_heartrate=155.0, max_heartrate=165.0),  # jog recovery
+            _lap(5, 400, 5.0, average_heartrate=179.0, max_heartrate=189.0),
+        ]
+        result = detect_intervals_from_laps({"laps": laps})
+        assert result is None, (
+            "heterogeneous recoveries (walk 1.2 m/s + jog 3.6 m/s) should abstain; "
+            f"got rep_count={result['summary']['rep_count'] if result else None}"
+        )
+
+    def test_heterogeneous_recoveries_larger_session_abstains(self):
+        """Same shape with more reps: the ambiguous walk-vs-jog recovery
+        classification still causes abstention regardless of total rep count.
+        """
+        # 4 reps: rest0=walk, rest1=jog, rest2=walk, rest3=jog
+        laps = [
+            _lap(1, 400, 5.0, average_heartrate=178.0, max_heartrate=188.0),
+            _lap(2, 200, 1.2, average_heartrate=133.0, max_heartrate=143.0),  # walk
+            _lap(3, 400, 5.0, average_heartrate=180.0, max_heartrate=190.0),
+            _lap(4, 200, 3.6, average_heartrate=155.0, max_heartrate=165.0),  # jog
+            _lap(5, 400, 5.0, average_heartrate=179.0, max_heartrate=189.0),
+            _lap(6, 200, 1.2, average_heartrate=133.0, max_heartrate=143.0),  # walk
+            _lap(7, 400, 5.0, average_heartrate=181.0, max_heartrate=191.0),
+        ]
+        result = detect_intervals_from_laps({"laps": laps})
+        assert result is None, (
+            "heterogeneous recoveries in a larger session should still abstain"
+        )
+
+    # ------------------------------------------------------------------
+    # Shape 2: easy run with one mid-run standing stop (#189, residual from F2)
+    # A steady easy-pace run where the runner pressed the lap button during
+    # a brief standing stop. The standing stop is the sole 'rest' lap;
+    # everything else is the same easy running pace.
+    # ------------------------------------------------------------------
+
+    def test_easy_run_with_single_standing_stop_abstains(self):
+        """A steady easy run with one mid-run standing stop should not be
+        detected as a 4-rep interval session. The standing-rest special case
+        must not fire when the 'work' cluster is just a uniform steady pace.
+        """
+        laps = [
+            _lap(1, 1000, 3.0, average_heartrate=145.0, max_heartrate=155.0),
+            _lap(2, 1000, 3.1, average_heartrate=147.0, max_heartrate=157.0),
+            _standing_rest_lap(3),                                              # brief stop
+            _lap(4, 1000, 3.0, average_heartrate=145.0, max_heartrate=155.0),
+            _lap(5, 1000, 3.1, average_heartrate=147.0, max_heartrate=157.0),
+        ]
+        result = detect_intervals_from_laps({"laps": laps})
+        assert result is None, (
+            "easy run with one standing stop should abstain; "
+            f"got rep_count={result['summary']['rep_count'] if result else None}"
+        )
+
+    def test_standing_stop_mid_faster_easy_run_abstains(self):
+        """Slightly faster easy pace (still easy running, not interval work):
+        the abstain condition must not depend on any absolute-pace threshold.
+        """
+        laps = [
+            _lap(1, 1000, 3.5, average_heartrate=150.0, max_heartrate=160.0),
+            _lap(2, 1000, 3.5, average_heartrate=151.0, max_heartrate=161.0),
+            _standing_rest_lap(3),
+            _lap(4, 1000, 3.5, average_heartrate=150.0, max_heartrate=160.0),
+            _lap(5, 1000, 3.5, average_heartrate=151.0, max_heartrate=161.0),
+        ]
+        result = detect_intervals_from_laps({"laps": laps})
+        assert result is None, (
+            "slightly faster easy run with one standing stop should also abstain"
+        )
+
+    # ------------------------------------------------------------------
+    # Preservation: clean interval sessions must still be detected.
+    # ------------------------------------------------------------------
+
+    def test_homogeneous_recoveries_detected(self):
+        """When ALL recoveries are at the same pace (uniformly jogged), the
+        split is unambiguous and the session must still be detected.
+        """
+        laps = [
+            _lap(1, 400, 5.0, average_heartrate=178.0, max_heartrate=188.0),
+            _lap(2, 200, 2.0, average_heartrate=145.0, max_heartrate=155.0),
+            _lap(3, 400, 5.0, average_heartrate=180.0, max_heartrate=190.0),
+            _lap(4, 200, 2.0, average_heartrate=145.0, max_heartrate=155.0),
+            _lap(5, 400, 5.0, average_heartrate=179.0, max_heartrate=189.0),
+        ]
+        result = detect_intervals_from_laps({"laps": laps})
+        assert result is not None
+        assert result["summary"]["rep_count"] == 3
+
+    def test_standing_rest_clean_interval_still_detected(self):
+        """A genuine track session with standing recoveries AND clear work
+        pace must not be abstained by the standing-rest guard.
+        The work speeds (5.0 m/s) are well above typical easy-running pace.
+        """
+        laps = [
+            _lap(1, 400, 5.0, average_heartrate=178.0, max_heartrate=186.0),
+            _standing_rest_lap(2),
+            _lap(3, 400, 5.0, average_heartrate=179.0, max_heartrate=187.0),
+            _standing_rest_lap(4),
+            _lap(5, 400, 5.0, average_heartrate=180.0, max_heartrate=188.0),
+        ]
+        result = detect_intervals_from_laps({"laps": laps})
+        assert result is not None
+        assert result["summary"]["rep_count"] == 3


### PR DESCRIPTION
## Problem

`_split_laps_work_rest` classifies laps as work/rest by splitting sorted speeds at the single largest gap. Two session shapes cause a mis-segmentation that is then stamped `detection_confidence=high` / `source=recorded_laps` (ground truth), asserted to the runner as fact.

**Shape 1 -- heterogeneous recoveries:** one walked recovery (~1.2 m/s) and one jogged recovery (~3.6 m/s). The largest speed gap falls between the two recovery speeds (2.4) rather than between all recoveries and the work laps (1.4), so the jogged recovery is promoted into the work cluster. Result: rep count off by one, two adjacent work segments, inflated work-speed CV.

**Shape 2 -- easy run with one mid-run standing stop:** speeds ~[3.0, 3.1, 0.0, 3.0, 3.1]. The single standing lap becomes the sole rest; everything else becomes "work", yielding a bogus 4-rep structure for a steady easy run. The downstream classifier `pace_variability >= 20` gate catches this in production, but the lap-sourced structure should not emit confident garbage even if a later gate discards it.

## The conservative abstain approach

Rather than trying to perfectly segment exotic shapes, the fix detects when the split is under-determined and returns None so the pipeline falls back to stream detection (which then abstains itself on easy runs, since `detect_intervals` requires `activity_class == "Intervals"`).

**Guard 1 (shape 1) in `detect_intervals_from_laps`:** after computing `work_mask`, scan for *interior* consecutive work-lap pairs -- two adjacent laps both classified as work, where neither is at the very start nor the very end of the work window. Such a pair means a rest lap was promoted into the wrong cluster by an ambiguous split. Return None.

Edge-consecutive pairs (a brisk warmup adjacent to the first rep, or a brisk cooldown adjacent to the last rep) are the documented #188 known limitation and are deliberately left unchanged by this guard -- those pairs touch the first or last work index so the interior condition does not fire.

**Guard 2 (shape 2) in `_split_laps_work_rest`:** when the slow cluster contains exactly one zero-speed (standing) lap AND the fast cluster has CV < 10% (all laps at the same easy pace), the session is a steady run with a pause, not intervals. Return None. A new constant `_STEADY_STATE_CV_THRESHOLD = 10.0` names the threshold.

## How clean sessions are preserved

- Standard intervals with a slow warmup/cooldown: warmup lands in the slow cluster; no interior consecutive work pairs.
- Standing-rest intervals (2+ standing rests): `len(slow) >= 2`, guard 2 does not fire.
- Mixed standing + jogged recoveries: `all_slow_zero` is False, guard 2 does not fire.
- Cut-down progressions (monotonically rising rep pace): alternating work-rest, no interior consecutive pairs.
- Brisk warmup / brisk cooldown (TestKnownLimitationBriskWarmup): the consecutive work pair is at the edge of the work window (i == first_work or j+1 == last_work), not interior -- those tests remain green and characterise the #188 limitation unchanged.

## Testing

Six new tests in `TestAmbiguousSplitAbstain`:
- `test_heterogeneous_recoveries_abstains` and `_larger_session_abstains` -- shape 1
- `test_easy_run_with_single_standing_stop_abstains` and `_faster_easy_run_abstains` -- shape 2
- `test_homogeneous_recoveries_detected` and `test_standing_rest_clean_interval_still_detected` -- preservation

Full suite: **1352 passed, 4 deselected** (was 1346 before this PR). All 33 pre-existing lap-interval tests pass, including `TestKnownLimitationBriskWarmup`.

## Note on #188

The brisk-warmup root cause (#188) shares the same single-gap limitation. This fix does not touch it -- the `TestKnownLimitationBriskWarmup` characterisation tests remain as-is and #188 is left for a follow-up.

Closes #189