### PR TITLE
fix(trends): remove recharts width(-1)/height(-1) warning on /trends (#314)

### DIFF
--- a/frontend/components/trends/EfficiencyTrendChart.tsx
+++ b/frontend/components/trends/EfficiencyTrendChart.tsx
@@ -106,8 +106,7 @@ export default function EfficiencyTrendChart({ data, granularity }: Props) {
           No sufficient heart rate data for this range.
         </p>
       ) : (
-        <div className="h-[300px] w-full">
-          <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height={300}>
             <ComposedChart data={chartData}>
               <CartesianGrid strokeDasharray="3 3" vertical={false} />
               <XAxis
@@ -163,8 +162,7 @@ export default function EfficiencyTrendChart({ data, granularity }: Props) {
               ))}
 
             </ComposedChart>
-          </ResponsiveContainer>
-        </div>
+        </ResponsiveContainer>
       )}
       
       <div className="mt-3 text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-700/50 p-2 rounded">


### PR DESCRIPTION
## Root cause

`EfficiencyTrendChart` was the only trends chart using `<ResponsiveContainer height="100%">`. A percentage height on `ResponsiveContainer` requires the parent element to have a resolved height before recharts can measure it. On initial render the measurement returns -1, triggering the recharts console warning: `The width(-1) and height(-1) of chart should be greater than 0`.

Every other chart on the page (`TrendBarChart`, `SufferScoreChart`, `ZoneLoadChart`) already uses an explicit pixel height (`height={260}`), avoiding this entirely.

## The minimal fix

Replace `height="100%"` with `height={300}` on the `ResponsiveContainer` in `EfficiencyTrendChart.tsx`, matching the intent of the removed `h-[300px]` wrapper div (which is now redundant and also removed). One component, two lines changed.

## Why appearance is unchanged

The chart was already constrained to 300px by the Tailwind wrapper div. The explicit `height={300}` prop produces the same 300px chart height without needing a parent div to propagate that size.

## Runtime confirmation

The recharts warning is a runtime console message; `next build` cannot capture it. Final confirmation that the warning is gone is a visual check on the Vercel preview deployment.

Closes #314