### PR TITLE
fix(charts): exclude zero-cadence dropouts from secondary scale calculation (#310)

### DIFF
--- a/frontend/components/StreamCharts.tsx
+++ b/frontend/components/StreamCharts.tsx
@@ -63,10 +63,20 @@ function SimpleChart({ type, data, secondaryData, scrubFraction, onScrub, timeDa
     const validData = data.filter((v): v is number => v !== null);
     if (!validData.length) return { pathD: '', secondaryPathD: '', min: 0, max: 0, avg: 0, range: 1 };
 
+    // Secondary data with zero-cadence dropouts treated as gaps (null).
+    // Strava sends 0 for cadence when the watch hasn't detected a step yet;
+    // the smoothing pipeline already converts these to null, so the raw
+    // secondary line should do the same. Including raw zeros in the min/max
+    // drives min → 0 and compresses the entire chart to the top ~5%,
+    // leaving a dark empty rectangle in the lower portion of the plot (#310).
+    const secondaryDataNormalized = secondaryData
+      ? secondaryData.map((v) => (v === 0 ? null : v))
+      : undefined;
+
     // Include secondary data in min/max calc so it fits in the chart
     const allValues = [...validData];
-    if (secondaryData) {
-        allValues.push(...secondaryData.filter((v): v is number => v !== null));
+    if (secondaryDataNormalized) {
+        allValues.push(...secondaryDataNormalized.filter((v): v is number => v !== null));
     }
 
     let min = Infinity;
@@ -108,7 +118,7 @@ function SimpleChart({ type, data, secondaryData, scrubFraction, onScrub, timeDa
     };
 
     const pathD = generatePath(data);
-    const secondaryPathD = secondaryData ? generatePath(secondaryData) : '';
+    const secondaryPathD = secondaryDataNormalized ? generatePath(secondaryDataNormalized) : '';
 
     return {
       pathD,


### PR DESCRIPTION
## Root cause

Strava sends `0` for cadence samples taken before the watch detects the first step. The smoothing pipeline (`smooth_cadence`) already treats these as dropouts (zeros while moving become `NaN` → `None`). However, the raw cadence overlay passed as `secondaryData` to `SimpleChart` was not normalised the same way.

`allValues` (used to compute `min`/`max` for the chart's y-axis scale) included all non-null values from both the smoothed and raw cadence arrays. When raw cadence had `0` values, `min` was driven to `0` even though real cadence is ~140-175 spm. This compressed the entire visible cadence line into the top 5% of the chart and left 90-95% of the plot area empty -- showing the card's dark background through the transparent SVG. On the specific activity where cadence detection was delayed for the first third of the run, this appeared as a solid dark rectangle covering the bottom-left portion of the chart.

## Why only the cadence chart

`secondaryData` is set only for the cadence chart (raw cadence when `smoothed_cadence` exists). No other stream chart has a secondary overlay. This is also why it is activity-specific: only activities where a significant fraction of raw cadence samples are `0` (delayed detection) exhibit the scale distortion.

## The fix

In `StreamCharts.tsx`, normalise `secondaryData` before both the min/max calculation and the path generation by replacing `0` with `null`. This treats zero cadence as a gap (no data) rather than a real measurement, consistent with what the backend smoothing pipeline already does.

## Test result

`npm run test` (next lint + next build) passes.

## Visual confirmation

Final confirmation that the artifact is gone on first paint is the maintainer's call on the Vercel preview for the specific activity (`e1a37747-f9ef-4ad1-81bd-677304776d5f`).

Closes #310