### PR TITLE
fix(charts): cadence zero-dropouts gap the PRIMARY line too (#310, supersedes #322)

### DIFF
--- a/frontend/components/StreamCharts.tsx
+++ b/frontend/components/StreamCharts.tsx
@@ -58,20 +58,25 @@ function SimpleChart({ type, data, secondaryData, scrubFraction, onScrub, timeDa
   const areaRef = useRef<HTMLDivElement>(null);
 
   // Compute stats for scaling using only valid data
-  const { pathD, secondaryPathD, min, max, avg, range } = useMemo(() => {
-    // Filter out nulls for stats
-    const validData = data.filter((v): v is number => v !== null);
-    if (!validData.length) return { pathD: '', secondaryPathD: '', min: 0, max: 0, avg: 0, range: 1 };
-
-    // Secondary data with zero-cadence dropouts treated as gaps (null).
-    // Strava sends 0 for cadence when the watch hasn't detected a step yet;
-    // the smoothing pipeline already converts these to null, so the raw
-    // secondary line should do the same. Including raw zeros in the min/max
-    // drives min → 0 and compresses the entire chart to the top ~5%,
-    // leaving a dark empty rectangle in the lower portion of the plot (#310).
+  const { pathD, secondaryPathD, primaryData, min, max, avg, range } = useMemo(() => {
+    // Zero-cadence is a DROPOUT, not a measurement: Strava reports 0 cadence
+    // before the watch detects the first step (and during pauses). Treat those
+    // zeros as gaps (null) for cadence charts, on BOTH the primary and the
+    // secondary series, BEFORE scaling and path generation. Leaving them in
+    // pulls the y-axis min to 0 and draws the line down to the plot floor,
+    // compressing the real ~150-180 spm signal into a sliver and leaving a dark
+    // empty band below it (#310). Cadence-type only: 0 is a legitimate value for
+    // altitude / grade / power, so this must never be a blanket normalisation.
+    const isCadence = type === 'cadence' || type === 'smoothed_cadence';
+    const dropZeros = (arr: (number | null)[]) => arr.map((v) => (v === 0 ? null : v));
+    const primaryData = isCadence ? dropZeros(data) : data;
     const secondaryDataNormalized = secondaryData
-      ? secondaryData.map((v) => (v === 0 ? null : v))
+      ? (isCadence ? dropZeros(secondaryData) : secondaryData)
       : undefined;
+
+    // Filter out nulls for stats
+    const validData = primaryData.filter((v): v is number => v !== null);
+    if (!validData.length) return { pathD: '', secondaryPathD: '', primaryData, min: 0, max: 0, avg: 0, range: 1 };
 
     // Include secondary data in min/max calc so it fits in the chart
     const allValues = [...validData];
@@ -117,18 +122,19 @@ function SimpleChart({ type, data, secondaryData, scrubFraction, onScrub, timeDa
         return commands.join(' ');
     };
 
-    const pathD = generatePath(data);
+    const pathD = generatePath(primaryData);
     const secondaryPathD = secondaryDataNormalized ? generatePath(secondaryDataNormalized) : '';
 
     return {
       pathD,
       secondaryPathD,
+      primaryData,
       min,
       max,
       avg,
       range
     };
-  }, [data, secondaryData]);
+  }, [data, secondaryData, type]);
 
   const validCount = data.filter(x => x !== null).length;
   if (validCount === 0) return null;
@@ -141,7 +147,7 @@ function SimpleChart({ type, data, secondaryData, scrubFraction, onScrub, timeDa
   const scrubIndex = scrubFraction === null
     ? null
     : Math.min(data.length - 1, Math.max(0, Math.round(scrubFraction * (data.length - 1))));
-  const scrubValue = scrubIndex === null ? null : data[scrubIndex];
+  const scrubValue = scrubIndex === null ? null : primaryData[scrubIndex];
   const scrubTime = scrubIndex === null || !timeData ? null : timeData[scrubIndex];
   const scrubX = scrubIndex === null ? null : (scrubIndex / (data.length - 1)) * CHART_WIDTH;
   const scrubY = scrubValue === null || scrubValue === undefined


### PR DESCRIPTION
Closes #310

## Why this exists (and why #322 was not enough)
PR #322 tried to fix #310 by treating zero-cadence as gaps, but it only normalised the SECONDARY (faded raw) overlay line. Verified on the live prod build (commit 5a721a0, which DID include #322) by rendered SVG inspection: the artifact persisted because the PRIMARY (full-opacity, smoothed) cadence line still carried leading zeros. (The earlier prod check that looked OK had hit an intermediate deploy, ae5bf4f / #321, that shipped the favicon but not #322.)

## Root cause (grounded in code + the rendered path)
In `StreamCharts.tsx` `SimpleChart`, `min` is derived from `validData` (the PRIMARY non-nulls) and the primary line is drawn by `generatePath(data)` over the un-normalised primary array. The cadence primary series contains leading zero-cadence samples (dropouts) that are NOT null, so `min` is dragged to 0 and those zeros are drawn down to the plot floor. Observed primary path: `M 0.0,100.0 L 0.2,100.0 L 0.5,57.8 L 0.7,15.6` -- first samples pinned at the floor, real ~150-180 spm compressed into the top sliver, dark empty band below.

## Fix
Treat zero-cadence as a gap (null) for BOTH the primary and secondary series, before scaling AND path generation, gated to cadence-type charts only (`type` is `cadence` or `smoothed_cadence`). Zero is a legitimate value for altitude / grade / power, so this is deliberately NOT a blanket normalisation. The scrub readout now also reads from the normalised primary, so scrubbing a dropout shows a dash rather than "0 spm" and no off-chart dot.

## Testing
- `npm run test` (next lint + build): passes.
- Logic trace: cadence `[0, 0, 150, 160, ...]` -> primary becomes `[null, null, 150, 160, ...]`, `min` from real values (~150, not 0), leading nulls are gapped not drawn to the floor. Altitude `[0, 5, 10]` -> isCadence false -> unchanged (no regression).
- There is no frontend component-test runner (known project gap), so the DEFINITIVE confirmation is a rendered SVG check on the deployed build. I will re-verify on prod after this merges and deploys, checking the GitHub deployment record points at this commit first so I do not read a stale/intermediate build again.

## Out of scope (surfaced, not acted on)
The Power chart shows a similar zero-lead compression (0 power = coasting). Whether to treat power 0 as a dropout is a separate decision; not touched here.