### PR TITLE
fix(charts): robust cadence scale ignores dropout + ramp artifacts (#310, supersedes #322/#323)

### DIFF
--- a/frontend/components/StreamCharts.tsx
+++ b/frontend/components/StreamCharts.tsx
@@ -59,19 +59,27 @@ function SimpleChart({ type, data, secondaryData, scrubFraction, onScrub, timeDa
 
   // Compute stats for scaling using only valid data
   const { pathD, secondaryPathD, primaryData, min, max, avg, range } = useMemo(() => {
-    // Zero-cadence is a DROPOUT, not a measurement: Strava reports 0 cadence
-    // before the watch detects the first step (and during pauses). Treat those
-    // zeros as gaps (null) for cadence charts, on BOTH the primary and the
-    // secondary series, BEFORE scaling and path generation. Leaving them in
-    // pulls the y-axis min to 0 and draws the line down to the plot floor,
-    // compressing the real ~150-180 spm signal into a sliver and leaving a dark
-    // empty band below it (#310). Cadence-type only: 0 is a legitimate value for
-    // altitude / grade / power, so this must never be a blanket normalisation.
+    // Cadence dropouts/ramps must not set the chart scale (#310). Strava reports
+    // 0 cadence before the first detected step (and during pauses), and the
+    // smoothing of that region emits LOW NON-ZERO ramp values (real data observed:
+    // smoothed_cadence = [0, 0, 76, 152, ...]). Dropping only exact zeros leaves
+    // the ramp (76) as the scale minimum, compressing the real ~150-180 spm signal
+    // into a sliver with a dark empty band below. So gap any cadence sample below
+    // half the median of real (>0) cadence: this catches both the zeros and the
+    // ramp while keeping genuine low cadence. Cadence-type ONLY: 0 is a legitimate
+    // value for altitude / grade / power, so this is never a blanket normalisation.
     const isCadence = type === 'cadence' || type === 'smoothed_cadence';
-    const dropZeros = (arr: (number | null)[]) => arr.map((v) => (v === 0 ? null : v));
-    const primaryData = isCadence ? dropZeros(data) : data;
+    const dropCadenceDropouts = (arr: (number | null)[]) => {
+      const positives = arr.filter((v): v is number => v !== null && v > 0);
+      if (!positives.length) return arr;
+      const sorted = [...positives].sort((a, b) => a - b);
+      const median = sorted[Math.floor(sorted.length / 2)];
+      const floor = median * 0.5;
+      return arr.map((v) => (v !== null && v < floor ? null : v));
+    };
+    const primaryData = isCadence ? dropCadenceDropouts(data) : data;
     const secondaryDataNormalized = secondaryData
-      ? (isCadence ? dropZeros(secondaryData) : secondaryData)
+      ? (isCadence ? dropCadenceDropouts(secondaryData) : secondaryData)
       : undefined;
 
     // Filter out nulls for stats


### PR DESCRIPTION
Closes #310

## Why a third attempt
#322 and #323 both tried "drop exact zeros". Verified against the prod API for the affected activity, the real data is:
- raw cadence: [0, 0, 0, 0, 0, 152, ...]
- smoothed_cadence: [0, 0, 76, 152, ...]

The smoothed series has a low NON-ZERO ramp (76) from smoothing the leading zeros into the first real samples. Dropping only exact zeros leaves the 76 as the scale minimum, so the real 150-180 spm signal stays compressed into the top ~27 percent with a dark band below. The exact-zero approach could never fix this.

## Fix
For cadence-type charts only, gap any sample below HALF the median of real (>0) cadence, before scaling and path generation. This catches both the dropout zeros and the smoothing ramp while keeping genuine low cadence. Applied to both the primary and secondary series. Zero is legitimate for altitude / grade / power, so this is deliberately NOT a blanket normalisation.

## Verification (done before shipping this time)
Replicated the exact `dropCadenceDropouts` logic over the real observed arrays:
- smoothed [0,0,76,152,...] -> [null,null,null,152,...], scale min 0 -> 152
- raw [0,0,0,0,0,152,...] -> [null x5, 152,...], scale min 0 -> 152
So the leading dropout+ramp is gapped and the chart scales from real cadence (~152) to max, using the full vertical range. `npm run test` (next lint + build) passes.

There is no frontend component-test runner (known project gap), so I will still re-confirm on the deployed render after merge, checking the prod deployment SHA matches this commit first (the trap that masked the earlier checks).

## Follow-up filed
The underlying data defect (smoothed_cadence emitting a 0,0,76 ramp instead of nulling the dropout region) is filed separately as a backend issue; this PR is the display-layer fix that also repairs already-stored activities without re-analysis.