### PR TITLE
refactor(coach): prompt-feature manifest as single source of truth (#328)

### DIFF
--- a/backend/app/services/coach/prompt_features.py
+++ b/backend/app/services/coach/prompt_features.py
@@ -1,0 +1,82 @@
+"""
+Prompt-feature manifest — the single source of truth for which capabilities each
+coach prompt id carries.
+
+The coach prompt family grew by adding one capability per version: A4 two-stage
+(ADR 0010), then P1.1 voice (ADR 0012/0013), P1.2 corpus (ADR 0014), P1.3 stance
+(ADR 0015), P3 training-load (ADR 0016), and P4 user-materials (ADR 0017). Each
+capability gates one runtime surface: the per-runner voice block
+(``prompts.render_voice_block``), a context-pack section
+(``context._build_*_context``), or the post-activity cadence
+(``service.is_two_stage_prompt``). The static prompt addenda strings
+(``Vn = V(n-1) + addendum``) are baked at module load and are NOT gated here.
+
+This module is the one place that answers "what does prompt vN turn on": read the
+``PROMPT_FEATURES`` row. The ``*_PROMPT_IDS`` frozensets and ``is_*_prompt``
+predicates in ``prompts.py`` (and ``is_two_stage_prompt`` in ``service.py``) are
+thin DERIVED VIEWS over this manifest; their names and semantics are unchanged, so
+call sites and tests are untouched.
+
+A prompt id absent from ``PROMPT_FEATURES`` (every legacy ``coach_report_*`` id,
+``coach_message_v1``, ``None``, and any unknown id) carries no capabilities — exactly
+the inert-under-rollback property each capability relies on, so flipping
+``COACH_PROMPT_ID`` off a capability-bearing id leaves that capability wholly inert
+with zero code change.
+
+Pure data: this module imports nothing from the coach layer, so it sits below
+``prompts.py`` / ``service.py`` with no import cycle.
+"""
+
+from enum import Enum
+from typing import Optional
+
+
+class PromptFeature(Enum):
+    """A capability a coach prompt id can carry. Each gates one runtime surface."""
+
+    TWO_STAGE = "two_stage"            # A4 two-stage Exchange cadence (ADR 0010)
+    VOICE = "voice"                    # P1.1 per-runner voice block (ADR 0012/0013)
+    CORPUS = "corpus"                  # P1.2 coaching-corpus section (ADR 0014)
+    STANCE = "stance"                  # P1.3 emphasis-axes section (ADR 0015)
+    TRAINING_LOAD = "training_load"    # P3 readiness section (ADR 0016)
+    USER_MATERIALS = "user_materials"  # P4 distilled user materials (ADR 0017)
+
+
+# One row per prompt id, listing its FULL capability set. Read a row to know
+# everything that prompt activates. Each coach_message version adds one capability
+# to the prior version's set; the rows are spelled out in full (not chained) so a
+# prompt's capability set is readable without walking the lineage.
+#
+# This is the ONLY place prompt ids and capabilities are paired. Everything else
+# derives. Any prompt id not present here carries no capabilities.
+_F = PromptFeature
+PROMPT_FEATURES: dict[str, frozenset[PromptFeature]] = {
+    "coach_message_v2": frozenset({_F.TWO_STAGE}),
+    "coach_message_v3": frozenset({_F.TWO_STAGE, _F.VOICE}),
+    "coach_message_v4": frozenset({_F.TWO_STAGE, _F.VOICE, _F.CORPUS}),
+    "coach_message_v5": frozenset({_F.TWO_STAGE, _F.VOICE, _F.CORPUS, _F.STANCE}),
+    "coach_message_v6": frozenset(
+        {_F.TWO_STAGE, _F.VOICE, _F.CORPUS, _F.STANCE, _F.TRAINING_LOAD}
+    ),
+    "coach_message_v7": frozenset(
+        {
+            _F.TWO_STAGE,
+            _F.VOICE,
+            _F.CORPUS,
+            _F.STANCE,
+            _F.TRAINING_LOAD,
+            _F.USER_MATERIALS,
+        }
+    ),
+}
+
+
+def has_feature(prompt_id: Optional[str], feature: PromptFeature) -> bool:
+    """True when ``prompt_id`` carries ``feature``. False for any unknown id or None."""
+    return feature in PROMPT_FEATURES.get(prompt_id, frozenset())
+
+
+def ids_with(feature: PromptFeature) -> frozenset[str]:
+    """The frozenset of prompt ids carrying ``feature`` (derives the ``*_PROMPT_IDS``
+    sets in ``prompts.py``)."""
+    return frozenset(pid for pid, feats in PROMPT_FEATURES.items() if feature in feats)

--- a/backend/app/services/coach/prompts.py
+++ b/backend/app/services/coach/prompts.py
@@ -7,6 +7,8 @@ The active prompt_id is set in config (COACH_PROMPT_ID).
 
 from typing import Optional
 
+from app.services.coach.prompt_features import PromptFeature, has_feature, ids_with
+
 SYSTEM_PROMPT_V1 = """You are a running coach assistant. Your job is to translate factual training data into concise, actionable coaching language.
 
 RULES:
@@ -598,11 +600,10 @@ MESSAGE_PROMPT_PREFIX = "coach_message"
 
 # The A4 two-stage prompt ids. Both stages of each share one cache identity / one
 # row; the MODE (opener vs fuller) is chosen by the caller/job, not derived from
-# the id. coach_message_v3 (P1.1) is two-stage exactly like v2.
-TWO_STAGE_PROMPT_IDS = frozenset(
-    {"coach_message_v2", "coach_message_v3", "coach_message_v4", "coach_message_v5",
-     "coach_message_v6", "coach_message_v7"}
-)
+# the id. Derived from the prompt-feature manifest (prompt_features.PROMPT_FEATURES),
+# the single source of truth for which capabilities each prompt id carries — edit the
+# manifest row to change what a prompt activates, never this derived view.
+TWO_STAGE_PROMPT_IDS = ids_with(PromptFeature.TWO_STAGE)
 
 # Retained for back-compat references (the A4 default two-stage id). Membership
 # checks use TWO_STAGE_PROMPT_IDS so coach_message_v3 is covered everywhere.
@@ -620,59 +621,50 @@ _OPENER_PROMPTS = {
     "coach_message_v7": SYSTEM_PROMPT_MESSAGE_V7_OPENER,
 }
 
-# Prompt ids that consume a per-runner VOICE block (P1.1). Only these get the
-# runtime voice block appended; every other prompt stays byte-stable. v4 (P1.2)
-# and v5 (P1.3) build on v3, so they are voice-aware too.
-VOICE_PROMPT_IDS = frozenset(
-    {"coach_message_v3", "coach_message_v4", "coach_message_v5", "coach_message_v6",
-     "coach_message_v7"}
-)
+# The capability-gated prompt-id sets and predicates below are DERIVED VIEWS over
+# the prompt-feature manifest (prompt_features.PROMPT_FEATURES), the single source of
+# truth for which capabilities each prompt id carries. Their names and semantics are
+# unchanged so every call site stays byte-stable; to change what a prompt activates,
+# edit the manifest row, never these views. Each capability is inert under a rollback:
+# flipping COACH_PROMPT_ID off a capability-bearing id drops it from the derived set,
+# so the gated addendum and pack section go silent with zero code change.
+
+# Prompt ids that consume a per-runner VOICE block (P1.1); only these get the runtime
+# voice block appended (render_voice_block), every other prompt stays byte-stable.
+VOICE_PROMPT_IDS = ids_with(PromptFeature.VOICE)
 
 # Prompt ids that carry the P1.2 coaching-corpus addendum AND the `corpus` context-
-# pack section. Membership implies voice-aware and two-stage (v4 builds on v3), and
-# gates BOTH the prompt addendum (above) and _build_corpus_context, so flipping
-# COACH_PROMPT_ID off a corpus-aware id leaves the corpus inert with zero code change.
-# v5 (P1.3) builds on v4, so it is corpus-aware too (it threads the runner's school).
-CORPUS_PROMPT_IDS = frozenset(
-    {"coach_message_v4", "coach_message_v5", "coach_message_v6", "coach_message_v7"}
-)
+# pack section (gates _build_corpus_context).
+CORPUS_PROMPT_IDS = ids_with(PromptFeature.CORPUS)
 
-# Prompt ids that carry the P1.3 emphasis addendum (rule 26) AND the `stance`
-# context-pack section. Membership implies corpus-aware, voice-aware, and two-stage
-# (v5 builds on v4). Gates BOTH the emphasis addendum (above) and
-# _build_stance_context, so flipping COACH_PROMPT_ID off coach_message_v5 leaves the
-# emphasis axes inert with zero code change. (The selected school rides the `corpus`
-# section, gated by CORPUS_PROMPT_IDS; only the emphasis half is stance-gated here.)
-STANCE_PROMPT_IDS = frozenset({"coach_message_v5", "coach_message_v6", "coach_message_v7"})
+# Prompt ids that carry the P1.3 emphasis addendum (rule 26) AND the `stance` context-
+# pack section (gates _build_stance_context). The selected school rides the `corpus`
+# section, gated by CORPUS_PROMPT_IDS; only the emphasis half is stance-gated here.
+STANCE_PROMPT_IDS = ids_with(PromptFeature.STANCE)
 
 # Prompt ids that carry the P3 readiness addendum (rule 27) AND the `training_load`
-# context-pack section. Membership implies stance-, corpus-, voice-aware, and
-# two-stage (v6 builds on v5). Gates BOTH the readiness addendum (above) and
-# _build_training_load_context, so flipping COACH_PROMPT_ID off coach_message_v6
-# leaves the readiness model inert with zero code change.
-TRAINING_LOAD_PROMPT_IDS = frozenset({"coach_message_v6", "coach_message_v7"})
+# context-pack section (gates _build_training_load_context).
+TRAINING_LOAD_PROMPT_IDS = ids_with(PromptFeature.TRAINING_LOAD)
 
 # Prompt ids that carry the P4 user-materials addendum (rule 28) AND the
-# `corpus.user_materials` pack sub-field. Membership implies training-load-, stance-,
-# corpus-, voice-aware, and two-stage (v7 builds on v6). Gates BOTH the addendum
-# (above) and the materials read in _build_corpus_context, so flipping COACH_PROMPT_ID
-# off coach_message_v7 leaves the runner's materials inert with zero code change (the
-# corpus section keeps its P1.2/P1.3 byte-stable shape under v4/v5/v6).
-USER_MATERIALS_PROMPT_IDS = frozenset({"coach_message_v7"})
+# `corpus.user_materials` pack sub-field (gates the materials read in
+# _build_corpus_context; the corpus section keeps its P1.2/P1.3 byte-stable shape
+# under v4/v5/v6).
+USER_MATERIALS_PROMPT_IDS = ids_with(PromptFeature.USER_MATERIALS)
 
 
 def is_corpus_prompt(prompt_id: Optional[str]) -> bool:
     """True when the active prompt is corpus-aware (P1.2+): it carries the corpus
     addendum and its context pack carries the `corpus` section. False for every
     other prompt, so the corpus substrate is wholly inert under a rollback."""
-    return prompt_id in CORPUS_PROMPT_IDS
+    return has_feature(prompt_id, PromptFeature.CORPUS)
 
 
 def is_stance_prompt(prompt_id: Optional[str]) -> bool:
     """True when the active prompt is stance-aware (P1.3): it carries the emphasis
     addendum (rule 26) and its context pack carries the `stance` section. False for
     every other prompt, so the emphasis axes are wholly inert under a rollback."""
-    return prompt_id in STANCE_PROMPT_IDS
+    return has_feature(prompt_id, PromptFeature.STANCE)
 
 
 def is_training_load_prompt(prompt_id: Optional[str]) -> bool:
@@ -680,7 +672,7 @@ def is_training_load_prompt(prompt_id: Optional[str]) -> bool:
     readiness addendum (rule 27) and its context pack carries the `training_load`
     section. False for every other prompt, so the readiness model is wholly inert
     under a rollback."""
-    return prompt_id in TRAINING_LOAD_PROMPT_IDS
+    return has_feature(prompt_id, PromptFeature.TRAINING_LOAD)
 
 
 def is_user_materials_prompt(prompt_id: Optional[str]) -> bool:
@@ -689,7 +681,7 @@ def is_user_materials_prompt(prompt_id: Optional[str]) -> bool:
     the `user_materials` sub-field. False for every other prompt, so the runner's
     distilled materials are wholly inert under a rollback (the corpus section keeps
     its P1.2/P1.3 byte-stable shape under v4/v5/v6)."""
-    return prompt_id in USER_MATERIALS_PROMPT_IDS
+    return has_feature(prompt_id, PromptFeature.USER_MATERIALS)
 
 # ---------------------------------------------------------------------------
 # Activity-type playbooks — appended to the system prompt based on the playbook

--- a/backend/tests/test_prompt_features.py
+++ b/backend/tests/test_prompt_features.py
@@ -1,0 +1,118 @@
+"""Characterization tests for the prompt-feature manifest (#328).
+
+The manifest (`prompt_features.PROMPT_FEATURES`) is the single source of truth for
+which capabilities each coach prompt id carries; the `*_PROMPT_IDS` frozensets and
+`is_*_prompt` predicates in `prompts.py` are derived views over it. These tests pin
+the per-id capability oracle captured from `main` before the refactor, so the
+refactor is provably behaviour-preserving and a future manifest edit that changes a
+prompt's capabilities is caught.
+"""
+
+from app.services.coach import prompts
+from app.services.coach.prompt_features import (
+    PROMPT_FEATURES,
+    PromptFeature,
+    has_feature,
+    ids_with,
+)
+
+F = PromptFeature
+
+# The capability oracle, captured from `main` before the refactor: each coach_message
+# version adds exactly one capability to the prior version's set. Every id NOT listed
+# here (legacy coach_report_*, coach_message_v1, None, unknown) carries no capability.
+EXPECTED_CAPABILITIES = {
+    "coach_message_v2": {F.TWO_STAGE},
+    "coach_message_v3": {F.TWO_STAGE, F.VOICE},
+    "coach_message_v4": {F.TWO_STAGE, F.VOICE, F.CORPUS},
+    "coach_message_v5": {F.TWO_STAGE, F.VOICE, F.CORPUS, F.STANCE},
+    "coach_message_v6": {F.TWO_STAGE, F.VOICE, F.CORPUS, F.STANCE, F.TRAINING_LOAD},
+    "coach_message_v7": {
+        F.TWO_STAGE,
+        F.VOICE,
+        F.CORPUS,
+        F.STANCE,
+        F.TRAINING_LOAD,
+        F.USER_MATERIALS,
+    },
+}
+
+# Ids that must carry NO capabilities (the inert-under-rollback set).
+NON_CAPABILITY_IDS = [
+    "coach_message_v1",
+    "coach_report_v1",
+    "coach_report_v10",
+    None,
+    "unknown_prompt_xyz",
+]
+
+
+def test_manifest_matches_captured_oracle():
+    """Each capability-bearing prompt id carries exactly its captured feature set."""
+    assert {pid: set(feats) for pid, feats in PROMPT_FEATURES.items()} == EXPECTED_CAPABILITIES
+
+
+def test_legacy_and_unknown_ids_carry_no_capabilities():
+    for pid in NON_CAPABILITY_IDS:
+        for feature in PromptFeature:
+            assert not has_feature(pid, feature), (pid, feature)
+
+
+def test_derived_sets_equal_manifest_views():
+    """The `*_PROMPT_IDS` frozensets are exactly the manifest's derived views."""
+    assert prompts.TWO_STAGE_PROMPT_IDS == ids_with(F.TWO_STAGE)
+    assert prompts.VOICE_PROMPT_IDS == ids_with(F.VOICE)
+    assert prompts.CORPUS_PROMPT_IDS == ids_with(F.CORPUS)
+    assert prompts.STANCE_PROMPT_IDS == ids_with(F.STANCE)
+    assert prompts.TRAINING_LOAD_PROMPT_IDS == ids_with(F.TRAINING_LOAD)
+    assert prompts.USER_MATERIALS_PROMPT_IDS == ids_with(F.USER_MATERIALS)
+
+
+def test_derived_sets_match_captured_membership():
+    """Belt-and-suspenders: the derived sets equal the explicit captured membership."""
+    assert prompts.TWO_STAGE_PROMPT_IDS == {
+        "coach_message_v2", "coach_message_v3", "coach_message_v4",
+        "coach_message_v5", "coach_message_v6", "coach_message_v7",
+    }
+    assert prompts.VOICE_PROMPT_IDS == {
+        "coach_message_v3", "coach_message_v4", "coach_message_v5",
+        "coach_message_v6", "coach_message_v7",
+    }
+    assert prompts.CORPUS_PROMPT_IDS == {
+        "coach_message_v4", "coach_message_v5", "coach_message_v6", "coach_message_v7",
+    }
+    assert prompts.STANCE_PROMPT_IDS == {
+        "coach_message_v5", "coach_message_v6", "coach_message_v7",
+    }
+    assert prompts.TRAINING_LOAD_PROMPT_IDS == {"coach_message_v6", "coach_message_v7"}
+    assert prompts.USER_MATERIALS_PROMPT_IDS == {"coach_message_v7"}
+
+
+def test_predicates_agree_with_has_feature():
+    """The is_*_prompt predicates are exactly their has_feature derivation, for every
+    registered prompt id plus the non-capability ids."""
+    for pid in list(prompts.PROMPT_VERSIONS.keys()) + NON_CAPABILITY_IDS:
+        assert prompts.is_corpus_prompt(pid) == has_feature(pid, F.CORPUS)
+        assert prompts.is_stance_prompt(pid) == has_feature(pid, F.STANCE)
+        assert prompts.is_training_load_prompt(pid) == has_feature(pid, F.TRAINING_LOAD)
+        assert prompts.is_user_materials_prompt(pid) == has_feature(pid, F.USER_MATERIALS)
+
+
+def test_opener_prompts_cover_exactly_two_stage_ids():
+    """Every two-stage prompt has a distinct opener form, and nothing else does."""
+    assert set(prompts._OPENER_PROMPTS.keys()) == set(prompts.TWO_STAGE_PROMPT_IDS)
+
+
+def test_manifest_ids_are_registered_prompts():
+    """No capability is declared for a prompt id that does not exist."""
+    assert set(PROMPT_FEATURES.keys()) <= set(prompts.PROMPT_VERSIONS.keys())
+
+
+def test_message_version_capabilities_are_monotonic():
+    """Each coach_message_vN is a superset of vN-1: the family only ever adds."""
+    ordered = [
+        "coach_message_v2", "coach_message_v3", "coach_message_v4",
+        "coach_message_v5", "coach_message_v6", "coach_message_v7",
+    ]
+    for earlier, later in zip(ordered, ordered[1:]):
+        assert PROMPT_FEATURES[earlier] < PROMPT_FEATURES[later], (earlier, later)


### PR DESCRIPTION
Closes #328.

## What

Introduces `app/services/coach/prompt_features.py` — the single source of truth for which capabilities each coach prompt id carries:

- a `PromptFeature` enum (`TWO_STAGE`, `VOICE`, `CORPUS`, `STANCE`, `TRAINING_LOAD`, `USER_MATERIALS`)
- an explicit `PROMPT_FEATURES` manifest, **one row per prompt id listing its full capability set** — so you can read `coach_message_v7`'s row and know everything it activates, without walking the lineage
- `has_feature()` / `ids_with()` accessors

The six `*_PROMPT_IDS` frozensets and the four `is_*_prompt` predicates in `prompts.py` become thin **derived views** over the manifest. Their names and exact semantics are unchanged, so `service.py`, `context.py`, and all existing tests are untouched.

## Why

Before this, "which capabilities does prompt `vN` carry" was reconstructed from six separate declarations across two files (6 frozensets + 4 predicates + the context gates). Adding a feature meant editing a new frozenset + a new predicate + a new context gate, with no single declaration of a prompt's capability set. This is a deepening: the `prompt_id -> capabilities` decision now lives behind one seam (locality), and a prompt's full set is readable in one row.

## Decisions (made autonomously while the owner was away)

- **Explicit rows over incremental lineage.** Each prompt id lists its full feature set rather than only what it adds. Redundant across versions, but it directly delivers the candidate's goal: read one row, know everything. (The lineage alternative is DRY and mirrors `Vn = V(n-1) + addendum`, but reintroduces the very "read the chain" problem being solved.)
- **A dedicated `prompt_features.py` module over keeping it inside `prompts.py`.** The capability concept gets its own home (the deepening), and the existing sets/predicates derive from it with zero call-site / test churn.
- **Scope held tight.** `is_receipt_cadence` still composes `COACH_RECEIPT_CADENCE (config) AND two_stage (capability)` rather than moving into the manifest (that is the separate cadence-seam candidate). The static prompt addenda strings are independent and untouched. The existing irregularities (voice has no predicate; `is_two_stage_prompt` lives in `service.py`) were left as-is — their sets just derive from the manifest now.

## Verification (Refactor modality — behaviour-preserving)

- **Level-6 before/after:** the per-prompt-id capability tuple captured from `main` is byte-identical on the refactored code (triangular matrix; every `coach_report_*` / `None` / unknown id empty).
- **New `tests/test_prompt_features.py`** pins that oracle, the derived-set equality, `predicate ≡ has_feature` for every registered id, and the `opener-keys == two-stage` / `manifest ⊆ PROMPT_VERSIONS` / monotonicity invariants.
- Full backend suite: **1379 passed, 2 skipped** (was 1371/2; +8 new). The unchanged `test_message_prompt_v4/v5/v6/v7` (which assert the actual composed prompt content) and `test_receipt_cadence_gate` remain green — that is the before/after on `build_system_prompt` and the cadence gate.
- `make eval-selftest` green. Policy validation passed. No schema change, no migration (single alembic head unchanged).

**Not verified:** no live LLM coach generation (no API key in env; generation/DB logic is byte-untouched). No DB context-pack byte-diff against a seeded activity — `context.py` is unchanged and consumes proven-equal membership, and the suite's pack tests cover it.

## Context

This is the one refactor taken from the 2026-06-17 `improve-codebase-architecture` scan (report-and-triage mode). The other candidates are filed as separate issues; see the issue tracker.