### PR TITLE
refactor(analysis): one home for the elevated-HR-drift threshold (#331)

### DIFF
--- a/backend/app/services/analysis/discount_signals.py
+++ b/backend/app/services/analysis/discount_signals.py
@@ -8,15 +8,17 @@ the coach must honor the annotation but never invent confounders not listed here
 
 from typing import Optional
 
+from app.services.analysis.thresholds import ELEVATED_HR_DRIFT_PCT
+
 HEAT_TEMP_C = 25.0
 
 # A confounder only warrants discounting the HR drift when the drift is actually
 # elevated. Below this, there is nothing to discount, so the stage abstains rather
 # than handing the coach a contradictory "discount this drift as fatigue"
-# instruction on a run whose drift is negligible (#176). Mirrors the fatigue
-# threshold in flags.py (drift > 5% -> fatigue_possible) and the M9 population
-# guideline (calibration.POPULATION_DRIFT_THRESHOLD_PCT).
-ELEVATED_DRIFT_THRESHOLD_PCT = 5.0
+# instruction on a run whose drift is negligible (#176). The threshold is the one
+# shared invariant in thresholds.py, aliased here under the name this module's
+# callers (eval/rubric.py) already import.
+ELEVATED_DRIFT_THRESHOLD_PCT = ELEVATED_HR_DRIFT_PCT
 
 
 def compute_discount_signals(

--- a/backend/app/services/analysis/flags.py
+++ b/backend/app/services/analysis/flags.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Any, Optional
 from app.models import Activity, CheckIn, DerivedMetric
+from app.services.analysis.thresholds import ELEVATED_HR_DRIFT_PCT
 
 
 def generate_flags(
@@ -32,7 +33,7 @@ def generate_flags(
 
     # --- Fatigue Possible (was cardiac_drift_high) ---
     drift = metric_data.get("hr_drift")
-    if drift is not None and drift > 5.0:
+    if drift is not None and drift > ELEVATED_HR_DRIFT_PCT:
         flags.append("fatigue_possible")
 
     # --- Pace Unstable ---

--- a/backend/app/services/analysis/thresholds.py
+++ b/backend/app/services/analysis/thresholds.py
@@ -1,0 +1,17 @@
+"""Shared numeric invariants for the analysis pipeline.
+
+One home for thresholds that several stages must agree on. Coupling them by a
+constant (an explicit import) rather than by duplicated literals and a comment
+keeps the invariant in one place, so changing it cannot silently desync the
+stages that read it.
+"""
+
+# The elevated-HR-drift threshold (percent). One invariant shared by:
+#   - flags.py:           drift > ELEVATED_HR_DRIFT_PCT -> fatigue_possible
+#   - discount_signals.py: a confounder only discounts drift above this (#176)
+#   - calibration.py:     the LABELED population guideline ("~5.0%") fallback
+# These three must agree: if flags fired fatigue at one threshold while
+# discount_signals explained it at another, the coach would receive
+# contradictory signals about the same run. Kept as a float so the user-facing
+# f-strings in calibration.py render "~5.0%".
+ELEVATED_HR_DRIFT_PCT = 5.0

--- a/backend/app/services/coach/calibration.py
+++ b/backend/app/services/coach/calibration.py
@@ -26,13 +26,17 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from app.services.analysis.thresholds import ELEVATED_HR_DRIFT_PCT
+
 # Enough like-for-like comparable runs before a personal expected drift is
 # trusted; mirrors the M2 baseline abstention threshold.
 MIN_SAMPLES_FOR_CALIBRATION = 4
 
 # The legacy population heuristic (flags.py: drift > 5% -> fatigue_possible),
-# surfaced as a LABELED fallback when personal history is too thin.
-POPULATION_DRIFT_THRESHOLD_PCT = 5.0
+# surfaced as a LABELED fallback when personal history is too thin. Aliases the
+# shared invariant in thresholds.py under the name kept for this module's
+# readable user-facing f-strings (which render "~5.0%").
+POPULATION_DRIFT_THRESHOLD_PCT = ELEVATED_HR_DRIFT_PCT
 
 # How far this run's drift must sit from the personal norm to read as notable
 # (rather than within run-to-run noise).


### PR DESCRIPTION
## Summary

The elevated-HR-drift threshold `5.0` (percent) was duplicated across three sites, coupled only by a comment. Changing one would silently desync the others (flags firing fatigue at one threshold while discount_signals explained it at another). This extracts one shared constant and makes the coupling an explicit import. Behaviour-preserving (Refactor modality).

## Decision & rationale

New module `backend/app/services/analysis/thresholds.py` holds the single invariant `ELEVATED_HR_DRIFT_PCT = 5.0` (with a docstring naming the three readers).

I chose the **alias** option for both `discount_signals.py` and `calibration.py` rather than importing the shared name directly at every use site:

- `discount_signals.ELEVATED_DRIFT_THRESHOLD_PCT` is imported elsewhere (`coach/eval/rubric.py`), so keeping the name as an alias avoids changing that import site.
- `calibration.POPULATION_DRIFT_THRESHOLD_PCT` is imported by `tests/test_calibration.py` and threaded through this module's user-facing guideline f-strings; aliasing keeps both the test import and the f-strings readable.

`flags.py` had only a bare literal (no public name), so it imports and uses `ELEVATED_HR_DRIFT_PCT` directly.

All three literals were confirmed exactly `5.0` before the change, so the extraction is behaviour-preserving. The constant is kept a **float** (`5.0`, not `5`), so calibration.py's `f"~{POPULATION_DRIFT_THRESHOLD_PCT}%"` still renders the byte-identical user-facing string `~5.0%`.

## Changes

- `backend/app/services/analysis/thresholds.py` (new): `ELEVATED_HR_DRIFT_PCT = 5.0` + invariant docstring.
- `backend/app/services/analysis/flags.py`: import the constant; `drift > 5.0` -> `drift > ELEVATED_HR_DRIFT_PCT`.
- `backend/app/services/analysis/discount_signals.py`: `ELEVATED_DRIFT_THRESHOLD_PCT = ELEVATED_HR_DRIFT_PCT` (alias); comment updated.
- `backend/app/services/coach/calibration.py`: `POPULATION_DRIFT_THRESHOLD_PCT = ELEVATED_HR_DRIFT_PCT` (alias); comment updated. No f-string text changed.

## Verification

- `cd backend && python -m pytest -q -m "not integration"` -> **1382 passed, 4 deselected** (identical to the pre-change baseline). Includes `tests/test_calibration.py` (asserts `heuristic_threshold_pct == POPULATION_DRIFT_THRESHOLD_PCT` and the "above 5% guideline" path) and `tests/test_discount_signals.py` (the 5.0% boundary test).
- Grep confirms no uncoupled `5.0` drift literal remains at the three sites; each now references the shared constant (the only `5.0` left at a site is the literal `~5.0%` inside calibration.py's explanatory comment).
- Ran `calibrate_drift` directly on both code paths and asserted the user-facing strings still contain `~5.0% drift guideline as a heuristic` and `~5.0% guideline` (byte-identical).

## Residual / human follow-up

- A fourth reader, `coach/eval/rubric.py`, imports `ELEVATED_DRIFT_THRESHOLD_PCT` from `discount_signals`; preserved via the alias, so it now transitively reads the shared invariant with no edit. Optional future tidy: point it at `thresholds.ELEVATED_HR_DRIFT_PCT` directly. Left out of scope.
- The two aliases keep the legacy names stable; a later pass could rename call sites to the shared name everywhere, but that would touch the test and rubric import surfaces and is not behaviour-preserving in the same trivial way, so deferred.

Closes #331
