### PR TITLE
fix(analysis): treat cadence dropout (raw 0) as missing in smoothing (#325)

### DIFF
--- a/backend/app/services/analysis/smoothing.py
+++ b/backend/app/services/analysis/smoothing.py
@@ -29,21 +29,27 @@ def smooth_cadence(
     # If partial data, min length is used or we assume aligned.
     # Strava streams are typically consistently length-aligned.
     
-    # Convert to numpy for easier handling
+    # Convert to numpy for easier handling. velocity_data / moving_data are part
+    # of the contract but no longer consulted for the dropout rule (#325): a raw
+    # cadence of 0 is a dropout regardless of moving state.
     cad_arr = np.array(cadence_data, dtype=float)
-    vel_arr = np.array(velocity_data, dtype=float) if velocity_data else np.zeros(n)
-    mov_arr = np.array(moving_data, dtype=bool) if moving_data else np.ones(n, dtype=bool) # Assume moving if no stream
     time_arr = np.array(time_data, dtype=float)
     
     # 1. Clean dropouts & Spikes
-    # Rule: If cadence == 0 AND (moving == true OR velocity > 0.3), set to NaN
+    # Rule: If cadence == 0, set to NaN (a dropout, never a measurement)
     # Rule: If cadence > 220, set to NaN
-    
-    # Create a mask for "physically moving"
-    is_moving_physically = (mov_arr) | (vel_arr > MIN_VELOCITY_MOVING)
-    
+    #
+    # A raw cadence of 0 is always a dropout, not a reading: Strava reports 0
+    # before the first detected step and while not running / paused, and you
+    # cannot run at 0 spm. Treating it as missing (NaN -> None downstream) keeps
+    # the rolling median from averaging dropout zeros together with the first
+    # real cadence, which previously bled a physiologically meaningless low ramp
+    # value into smoothed_cadence at the dropout/real boundary (#325). The
+    # earlier guard only NaN'd zeros while "physically moving", so a leading
+    # not-yet-moving dropout survived as 0.0 and corrupted the boundary window.
+
     # Zero dropouts
-    dropout_mask = (cad_arr == 0) & is_moving_physically
+    dropout_mask = cad_arr == 0
     cad_arr[dropout_mask] = np.nan
     
     # Unrealistic spikes

--- a/backend/tests/test_smoothing_cadence.py
+++ b/backend/tests/test_smoothing_cadence.py
@@ -1,0 +1,99 @@
+"""Regression tests for cadence smoothing dropout handling (#325).
+
+A raw cadence sample of 0 is a DROPOUT (Strava reports 0 before the first
+detected step and while not running / paused), not a measurement. The smoother
+must not average dropout zeros together with real cadence, because a window
+straddling the dropout/real boundary produces a physiologically meaningless low
+ramp value (the observed 76 spm in the issue).
+
+The reported case ([0,0,0,0,0,152,152,...] -> 76 ramp) is sourced from a real
+prod API capture quoted in issue #325 (ground-truth trust level 4: a
+hand-constructed minimal example confirmed by the reporter from real data). The
+mid-run-dropout and all-nonzero cases are synthetic shapes exercising the
+function's branches (test setup, built inline).
+"""
+
+from app.services.analysis.smoothing import smooth_cadence
+
+
+def test_leading_dropout_does_not_emit_low_ramp():
+    """The reported case: leading zero dropout must not bleed a ~76 ramp.
+
+    Raw [0,0,0,0,0,152,152,...] previously smoothed to [0,0,76,152,...]. The
+    leading dropout samples must be missing (None), never a low non-zero ramp.
+    """
+    n = 12
+    cadence = [0, 0, 0, 0, 0] + [152] * (n - 5)
+    velocity = [0.0] * 5 + [3.0] * (n - 5)
+    moving = [False] * 5 + [True] * (n - 5)
+    time = list(range(n))
+
+    result = smooth_cadence(cadence, velocity, moving, time)
+
+    # No sample may be a physiologically-meaningless low ramp value: every value
+    # the smoother emits is either a real cadence reading or missing, never a
+    # blend of dropout zeros and real cadence (the old [..,76,..] / [..,0,..]).
+    real_values = [v for v in result if v is not None]
+    assert all(
+        v >= 100 for v in real_values
+    ), f"smoothed cadence leaked a sub-physiological ramp value: {result}"
+
+    # The start of the dropout region must be represented as missing, never 0.
+    assert result[0] is None, f"leading dropout must be missing, got {result[0]}"
+    assert 0.0 not in result, f"a dropout sample leaked as a literal 0, got {result}"
+
+    # The real cadence must survive unchanged.
+    assert result[-1] == 152.0
+
+
+def test_midrun_stop_dropout_is_missing_not_zero():
+    """A mid-run stop (cadence 0 while not moving) must read as missing, not 0.
+
+    This is the broader bug class behind #325: the old guard only NaN'd zeros
+    while moving, so a mid-run STOP (moving False, velocity 0) leaked a block of
+    literal 0.0 values right next to real cadence. The dropout must be missing.
+    """
+    # 8 real, 24 dropout (a stop: not moving, zero velocity), 8 real. Long
+    # enough that, after the rolling median spreads real cadence a few samples
+    # into each edge, the central gap still exceeds the 10s interpolation
+    # ceiling, so the core of the dropout must stay missing rather than bridged.
+    cadence = [170] * 8 + [0] * 24 + [170] * 8
+    n = len(cadence)
+    velocity = [3.0] * 8 + [0.0] * 24 + [3.0] * 8  # stopped through the dropout
+    moving = [True] * 8 + [False] * 24 + [True] * 8
+    time = list(range(n))
+
+    result = smooth_cadence(cadence, velocity, moving, time)
+
+    real_values = [v for v in result if v is not None]
+    assert all(
+        v >= 100 for v in real_values
+    ), f"mid-run dropout leaked a sub-physiological value: {result}"
+    assert 0.0 not in result, f"a dropout sample leaked as a literal 0, got {result}"
+
+    # The core of the dropout must be missing, not a low blend of zeros and the
+    # surrounding real cadence. Index 20 sits in the centre of the dropout.
+    assert result[20] is None, f"expected mid-dropout sample to be None, got {result[20]}"
+    # Real cadence on both sides survives.
+    assert result[0] == 170.0
+    assert result[-1] == 170.0
+
+
+def test_normal_cadence_is_unchanged():
+    """A normal all-nonzero cadence series must smooth exactly as before.
+
+    This is the only intended behaviour change boundary: legitimate cadence
+    smoothing must be untouched.
+    """
+    cadence = [168, 170, 169, 171, 172, 170, 169, 171, 170]
+    n = len(cadence)
+    velocity = [3.2] * n
+    moving = [True] * n
+    time = list(range(n))
+
+    result = smooth_cadence(cadence, velocity, moving, time)
+
+    # No nulls: every sample is a real measurement.
+    assert all(v is not None for v in result), f"normal series produced gaps: {result}"
+    # Median-filtered values stay in the real cadence band.
+    assert all(168 <= v <= 172 for v in result), f"normal series shifted out of band: {result}"


### PR DESCRIPTION
## Summary

`smoothed_cadence` emitted a physiologically meaningless low value across cadence-dropout regions instead of treating them as missing. A raw cadence of 0 is a dropout (Strava reports 0 before the first detected step and while not running / paused), not a measurement. The rolling-median smoother let leading dropout zeros bleed into the boundary window, producing the reported `[0, 0, 76, 152, ...]`-style ramp (and, for a mid-run stop, a block of literal `0.0`). This fixes the root data defect at the source. (#310 fixed the symptom at the display layer; this fixes the cause.)

## Decision & rationale

**Representation chosen: a dropout sample becomes `null` (not `0`).**

`smooth_cadence` already returns `List[Optional[float]]` and already emits `None` for unfillable gaps, so `None` IS the established missing-sample representation in this function, and it matches the domain's gap convention (pace is null when stopped). The single consumer, the read-time projection in `app/schemas/detail.py`, already tolerates `None` (it filters nulls when recomputing `avg_cadence`), and the frontend cadence chart (`StreamCharts.tsx`, the #310 fix) already treats `null` as a gap (skips it in the SVG path and excludes it from the chart scale). Choosing `0` would reintroduce the sub-physiological floor the display layer has to keep working around; `null` is the honest, consistent representation and every downstream consumer already handles it. The consolidated `stream_view` (stored on `DerivedMetric`) is unaffected because it derives from the RAW `cadence` stream, not `smoothed_cadence`.

**Intended behaviour change (the only one):** raw `cadence == 0` is now masked as a dropout regardless of moving state, so the smoother never averages dropout zeros with real cadence. Legitimate non-zero cadence smoothing (median filter + short-gap interpolation) is unchanged.

## Changes

- `backend/app/services/analysis/smoothing.py`: the dropout mask now matches every `cadence == 0` sample (was gated by `& is_moving_physically`, which left a leading not-yet-moving dropout as `0.0`). Removed the now-dead `velocity`/`moving` array conversions; the function signature is unchanged so the `detail.py` call site is untouched.
- `backend/tests/test_smoothing_cadence.py` (new): the first regression tests for `smooth_cadence`.

## Verification

- Test-first (Fix modality): wrote the failing tests first, confirmed red, then fixed to green.
  - Red-without-fix / green-with-fix confirmed by stashing the source change: both dropout tests fail on the original code (leading dropout leaks the sub-physiological / `0.0` value; mid-run stop leaks a block of `0.0`) and pass after the fix. The normal all-nonzero-cadence test stays green in both states (scope guard).
  - The reported reproducer `[0,0,0,0,0,152,152,...]` no longer yields any sub-physiological value; the dropout reads as `null` and the real `152` survives.
- Full backend suite (`python -m pytest -q -m \"not integration\"`): **1385 passed, 4 deselected, 0 failures** (baseline was ~1382; +3 from the new tests). No pre-existing test changed its expected output, confirming none was asserting the buggy behaviour.
- Coverage gap that allowed the bug to ship: `smooth_cadence` had zero tests. The new file closes that gap and pins the broader bug class (dropout while not moving), not just the single reported reproducer.

## Residual / human follow-up

- `smoothed_cadence` is generated at READ time (in `app/schemas/detail.py`), not stored, so already-stored activities self-correct on next read with no backfill required. This differs slightly from the issue's framing, which assumed the stream was stored and would need a #300 re-analysis. If any stored artifact derived from smoothed cadence ever needs correcting, a #300-style re-analysis would be the path, but no stored field is affected by this change (the stored `DerivedMetric.stream_view` uses raw cadence).
- Frontend was verified by code trace only (no local Strava OAuth for an end-to-end UI run); the chart already handles arbitrary `null` gaps by construction and `null` was already a possible value in this stream, so the change introduces no new value type for the UI.

Closes #325