### PR TITLE
fix: stop showing the confidence rating to the runner (in-app + notifications) (#338)

### DIFF
--- a/frontend/components/CoachReportPanel.tsx
+++ b/frontend/components/CoachReportPanel.tsx
@@ -228,7 +228,9 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
   if (!report) return null;
 
   const body = report.report;
-  const { confidence, generated_at } = report.meta;
+  // #338: the internal confidence rating is no longer surfaced to the runner
+  // (it still flows over the API in report.meta.confidence; display-only change).
+  const { generated_at } = report.meta;
 
   // A3 (ADR 0009): the prose-message shape (schema 2.0) renders the message as
   // markdown with tappable-option chips; the legacy structured shape renders the
@@ -486,17 +488,6 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
 
       {/* Meta footer */}
       <div className="flex items-center gap-3 text-xs text-gray-400 dark:text-gray-500 px-1">
-        <span
-          className={`inline-flex items-center rounded-full px-2 py-0.5 font-medium ${
-            confidence === 'high'
-              ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300'
-              : confidence === 'medium'
-              ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300'
-              : 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300'
-          }`}
-        >
-          {confidence} confidence
-        </span>
         <span>
           {new Date(generated_at).toLocaleDateString(undefined, {
             month: 'short',


### PR DESCRIPTION
## Summary
Stop surfacing the internal confidence rating to the runner. Originally scoped to the in-app coach report; widened (owner decision) to also remove it from the notification channel, where the same rating leaked through.

## Decision & rationale
The confidence level is a signal for how a report is produced, not something the runner should interpret; to them it reads as the coach hedging its own advice, which undercuts trust without giving them anything actionable (issue #338). It must therefore not appear on ANY runner-facing surface. The value is retained server-side in `report.meta.confidence` (and in stored report meta) for diagnostics; this is a display-only change everywhere.

Surfaces removed:
- In-app: the confidence badge in `CoachReportPanel.tsx` (the meta footer; generated-at date kept).
- Telegram: the `· {level} confidence` suffix in the notification title.
- Email: the same suffix in the subject and the plain-text header, plus the two `Confidence: {level}` paragraphs in the HTML body (prose and structured shapes).

## Changes
- `frontend/components/CoachReportPanel.tsx`: remove the confidence pill from the meta footer (value still destructured-free; `report.meta.confidence` still arrives over the API).
- `backend/app/services/notifications/telegram_template.py`: title is now `{label} — {dist}km` (or `{label}` when distance is 0).
- `backend/app/services/notifications/email_template.py`: subject/text-header same shape change; drop the HTML `Confidence:` paragraphs; remove the now-unused `confidence` param threading through `_render_html`/`_render_text`.
- Tests: update the email/message subject+title assertions to the new shape; rename the now-misnamed `test_subject_includes_class_distance_confidence`; add regression tests pinning that confidence appears nowhere in the email output (subject/html/text) or the Telegram title.

## Verification
- Frontend (original change): `npm run test` (lint + build) and `npm run smoke` pass; browser-verified on locally-seeded prod data (no confidence badge in the rendered coach panel; generated-at date present; DOM scan finds no "high/medium/low confidence" text).
- Backend: `python -m pytest -q -m "not integration"` -> 1384 passed, 4 deselected. Notification suite (email/telegram/smtp/callback/message/port) green, including the 2 new regression tests.
- Live Telegram send through the real Bot API confirmed the notification wire path works (done during verification of the related notifier PR).

## Residual / human follow-up
- Visual eyeball of a real loaded report in-app remains a human step.
- COORDINATION WITH #351 (refactor/333): that PR's `test_notification_characterization.py` snapshots pin the notification title/subject WITH confidence (they captured pre-#338 output). After this PR lands, those snapshots are stale. Recommended: merge THIS PR (#338) first, then rebase #351 and regenerate its characterization snapshots against the new (no-confidence) output. The refactor stays byte-equivalent relative to its post-#338 base, and `main` stays green throughout. (Flagged on #351 too.)

Closes #338