### PR TITLE
feat(coach): re-attempt the policy-fix retry once when it truncates (#282)

### DIFF
--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -788,6 +788,50 @@ async def _call_message(
     )
 
 
+async def _reattempt_if_truncated(
+    client: AnthropicClient,
+    system_prompt: str,
+    user_message: str,
+    result,
+    *,
+    escalated: int,
+    context: str,
+):
+    """If a prose-message call stopped on the token ceiling, re-attempt it ONCE at
+    a larger budget and return whichever result is better (#295/#282).
+
+    The same single re-attempt the first generation phase already does, factored out
+    so the policy-fix RETRY can reuse it identically (#282): the corrective retry
+    re-sends the full original context PLUS the fix instructions, so it is a longer
+    prompt than the first call and truncates more readily — without this, a complete
+    first attempt is preferred over a truncated retry (#274) and the fix never lands.
+
+    Truncation is detected uniformly by `stop_reason == "max_tokens"`. The extra
+    call happens ONLY on a truncated result (one re-attempt, at most). The retried
+    result replaces the original unless it refuses (a refusal is worse than a
+    truncated turn — the caller still has prose to fall back on). A turn that is
+    STILL truncated after the escalation is surfaced loudly rather than silently
+    shipped half-written. `context` tags the log line (first / policy retry)."""
+    if result.stop_reason != "max_tokens":
+        return result
+    logger.info(
+        "coach message truncated (max_tokens) on %s; retrying at a larger budget (#295/#282)",
+        context,
+    )
+    retried = await _call_message(
+        client, system_prompt, user_message, max_tokens=escalated
+    )
+    if retried.stop_reason != "refusal":
+        result = retried
+    if result.stop_reason == "max_tokens":
+        logger.warning(
+            "coach message STILL truncated after budget escalation on %s (#295/#282); "
+            "the turn may degrade — investigate the pack size / thinking spend",
+            context,
+        )
+    return result
+
+
 def _opener_fallback_outcome() -> "_GenOutcome":
     """A4 opener fallback: a templated brief reaction in opener_message (message
     empty), a degraded tail, no schedule judgment. The deterministic safety
@@ -875,22 +919,12 @@ async def _generate_message(
             if result.stop_reason == "refusal":
                 logger.warning("coach message refused; storing fallback")
                 return fallback()
-            if result.stop_reason == "max_tokens":
-                logger.info(
-                    "coach message truncated (max_tokens); retrying at a larger budget (#295)"
-                )
-                retried = await _call_message(
-                    client, system_prompt, user_message, max_tokens=escalated
-                )
-                if retried.stop_reason != "refusal":
-                    result = retried
-                if result.stop_reason == "max_tokens":
-                    # The budget escalation did not help: surface it loudly rather
-                    # than silently shipping a half-written turn (#295 AC).
-                    logger.warning(
-                        "coach message STILL truncated after budget escalation (#295); "
-                        "the turn may degrade — investigate the pack size / thinking spend"
-                    )
+            # #295: a truncated first attempt re-attempts ONCE at a larger budget.
+            # Shared with the policy-fix retry's truncation re-attempt (#282).
+            result = await _reattempt_if_truncated(
+                client, system_prompt, user_message, result,
+                escalated=escalated, context="first attempt",
+            )
 
             parsed = parse_blocks(result.content_blocks)
             # Tail-skip corrective retry: the model is allowed to skip the tool under
@@ -984,8 +1018,17 @@ async def _retry_message_with_fixes(
     Returns the retry as a _MsgAttempt (#274), or None when the retry produced
     nothing usable (refusal / empty prose / transport error) — the caller then keeps
     the original attempt. `is_opener` keeps the opener's merge + token budget on the
-    retry too."""
+    retry too.
+
+    #282: the corrective retry re-sends the full original context PLUS the fix
+    instructions, so it is a longer prompt than the first call and truncates more
+    readily. When this retry itself stops on the token ceiling, re-attempt it ONCE at
+    the escalated budget before its result is judged — mirroring the first-generation
+    phase's truncation re-attempt — so the corrective attempt is less likely to come
+    back truncated and discarded by the #274 prefer-complete-over-truncated rule. The
+    extra call happens ONLY on a truncated retry."""
     max_tokens = _OPENER_MAX_TOKENS if is_opener else _MESSAGE_MAX_TOKENS
+    escalated = _OPENER_MAX_TOKENS_ESCALATED if is_opener else _MESSAGE_MAX_TOKENS_ESCALATED
     merge = merge_opener if is_opener else merge_report
     fix_instructions = "\n".join(
         f"- {v.rule}: {v.fix_instruction}" for v in violations
@@ -1001,6 +1044,14 @@ async def _retry_message_with_fixes(
         )
         if result.stop_reason == "refusal":
             return None
+        # #282: a truncated policy-fix retry re-attempts ONCE at a larger budget
+        # before being judged, exactly as the first generation phase does.
+        # _reattempt_if_truncated keeps the original (truncated) result when the
+        # re-attempt refuses, so the refusal check above still covers that case.
+        result = await _reattempt_if_truncated(
+            client, system_prompt, retry_message, result,
+            escalated=escalated, context="policy retry",
+        )
         report = merge(parse_blocks(result.content_blocks))
     except (EmptyMessageError, anthropic.APIError) as e:
         logger.error("Coach message retry error: %s", e)

--- a/backend/tests/test_two_stage_service.py
+++ b/backend/tests/test_two_stage_service.py
@@ -486,6 +486,9 @@ async def test_truncated_retry_does_not_clobber_complete_first_attempt(db, _v2):
     # for a null check-in); the policy retry comes back TRUNCATED (max_tokens, no
     # tail). The stored report must be the COMPLETE first attempt, not the truncated
     # retry — the runner must not get a half-sentence when the model wrote a full one.
+    # #282: a truncated policy retry now re-attempts ONCE at a larger budget before
+    # being judged; when that re-attempt ALSO truncates, the complete first attempt is
+    # still the one stored (the #274 invariant holds). So this case now makes 3 calls.
     activity = _seed(db)
     complete = (
         "At a sustained hard effort, that kind of drift is exactly what we expect, "
@@ -496,13 +499,16 @@ async def test_truncated_retry_does_not_clobber_complete_first_attempt(db, _v2):
         # the retry truncates: a short prefix, no tail
         _result([_text("At a sustained hard effort, that kind of")],
                 stop_reason="max_tokens"),
+        # #282 re-attempt of the truncated retry — also truncates here
+        _result([_text("At a sustained hard")], stop_reason="max_tokens"),
     )
     with patch("app.services.coach.service.AnthropicClient", return_value=fake), \
          patch("app.services.coach.service.write_back_beliefs"), \
          patch("app.services.coach.service.enqueue_consolidation"):
         await generate_fuller(db, str(activity.id))
 
-    assert fake.generate_coach_message.call_count == 2  # first attempt + policy retry
+    # first attempt + policy retry + the #282 re-attempt of the truncated retry
+    assert fake.generate_coach_message.call_count == 3
     row = _stored(db, activity)
     assert row.is_fallback is False
     assert row.report["message"] == complete       # complete prose, not the truncation
@@ -532,3 +538,79 @@ async def test_adopted_retry_keeps_raw_response_in_sync(db, _v2):
     raw = row.raw_llm_response or ""
     assert fixed[:20] in raw                          # raw reflects the stored retry
     assert first[:20] not in raw                      # NOT the discarded first attempt
+
+
+# --- #282: re-attempt the policy-fix retry once when it truncates --------------
+
+
+async def test_truncated_policy_retry_is_reattempted_once_then_adopted(db, _v2):
+    # #282 AC1: a policy-fix retry that stops on the token ceiling is re-attempted
+    # ONCE before being judged. Here the first attempt is COMPLETE but trips rule 1
+    # (no questions for a null check-in); the policy retry TRUNCATES; its re-attempt
+    # comes back COMPLETE and fixes the violation, so it is the one stored. That can
+    # only happen if the truncated retry was re-attempted (without #282 the truncated
+    # retry would be discarded for the first attempt and the fix would never land).
+    activity = _seed(db)
+    first = "First attempt prose that forgot to ask the runner anything at all."
+    fixed = "Re-attempt of the corrective retry, complete and grounded with a question."
+    fake = _client(
+        _result(_no_question_fuller_blocks(first), stop_reason="end_turn"),
+        # the corrective policy retry truncates (max_tokens, a short prefix, no tail)
+        _result([_text("Re-attempt of the")], stop_reason="max_tokens"),
+        # #282 re-attempt of the truncated retry: complete AND fixes rule 1
+        _result(_fuller_blocks(fixed), stop_reason="end_turn"),
+    )
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        await generate_fuller(db, str(activity.id))
+
+    # first attempt + truncated policy retry + the single #282 re-attempt
+    assert fake.generate_coach_message.call_count == 3
+    # the re-attempt's complete, fixed prose is what was stored
+    row = _stored(db, activity)
+    assert row.is_fallback is False
+    assert row.report["message"] == fixed
+    # and the re-attempt ran at the ESCALATED budget, mirroring the first phase
+    calls = fake.generate_coach_message.await_args_list
+    assert calls[2].kwargs["max_tokens"] == 16384
+
+
+async def test_complete_policy_retry_is_not_reattempted(db, _v2):
+    # #282 AC2: a policy-fix retry that completes normally is unchanged — NO extra
+    # call. First attempt trips rule 1; the policy retry completes and fixes it.
+    activity = _seed(db)
+    first = "First attempt prose that forgot to ask anything at all."
+    fixed = "Fixed attempt prose, complete and grounded."
+    fake = _client(
+        _result(_no_question_fuller_blocks(first), stop_reason="end_turn"),
+        # the policy retry completes cleanly (end_turn) and carries a question
+        _result(_fuller_blocks(fixed), stop_reason="end_turn"),
+    )
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        await generate_fuller(db, str(activity.id))
+
+    # first attempt + policy retry only — the completed retry is not re-attempted
+    assert fake.generate_coach_message.call_count == 2
+    row = _stored(db, activity)
+    assert row.is_fallback is False
+    assert row.report["message"] == fixed
+
+
+async def test_no_policy_retry_means_no_reattempt(db, _v2):
+    # #282 AC3: the extra call happens ONLY on a truncated RETRY — never when there is
+    # no policy violation at all. A clean, complete first attempt (carries a question,
+    # so rule 1 does not fire) makes exactly ONE call: no policy retry, no re-attempt.
+    activity = _seed(db)
+    fake = _client(_result(_fuller_blocks("Clean complete first attempt."),
+                           stop_reason="end_turn"))
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        await generate_fuller(db, str(activity.id))
+
+    assert fake.generate_coach_message.call_count == 1
+    row = _stored(db, activity)
+    assert row.is_fallback is False


### PR DESCRIPTION
## Summary

When the A3 coach-message POLICY-FIX RETRY itself stops on the token ceiling, re-attempt that retry ONCE at the escalated budget before its result is judged, mirroring the re-attempt the first generation phase already does. The corrective retry re-sends the full original context PLUS the fix instructions, so it is a longer prompt than the first call and truncates more readily; without this re-attempt a truncated retry is discarded by the #274 prefer-complete-over-truncated rule and the fix never lands. Reduces the chance the corrective attempt comes back truncated.

## Decision & rationale

- **Shared helper vs local mirror:** factored the truncation re-attempt into a shared private helper `_reattempt_if_truncated` used by BOTH the first-generation site (refactored to call it, behaviour-preserving) and the new policy-fix-retry site. The step (detect `max_tokens`, re-call once at the escalated budget, keep the re-attempt unless it refuses, warn if still truncated) is identical at both sites, so a shared helper keeps detection and the single-re-attempt guarantee provably consistent without over-abstracting. This is the "reuse if it reads cleanly" path; the helper is small and self-contained.
- **How truncation is detected:** uniformly via `MessageResult.stop_reason == "max_tokens"` (set in `llm.generate_coach_message`), the same signal the first phase and the #274 `_MsgAttempt.truncated` flag already use.
- **At-most-one-extra-call guarantee + cost:** the helper short-circuits and returns immediately unless `stop_reason == "max_tokens"`, then makes exactly one re-call. So a retry that completes normally makes NO extra call, and a truncated retry makes exactly one. Cost: one extra LLM call only on the rare truncated retry; the escalated budget is the same `_MESSAGE_MAX_TOKENS_ESCALATED` (16384) / `_OPENER_MAX_TOKENS_ESCALATED` (4096) already used by the first phase. The #274 "prefer a complete attempt over a truncated one" behaviour is unchanged: if both the retry and its re-attempt truncate, the complete first attempt is still stored.

## Changes

- `backend/app/services/coach/service.py`
  - New `_reattempt_if_truncated` helper next to `_call_message`.
  - First-generation site in `_generate_message` now calls the helper (replacing the previously inlined #295 re-attempt; behaviour preserved).
  - `_retry_message_with_fixes` now computes the `escalated` budget and calls the helper on its result before merging/judging.
- `backend/tests/test_two_stage_service.py`
  - Updated the existing #274 test `test_truncated_retry_does_not_clobber_complete_first_attempt` to reflect the new behaviour (a truncated retry is re-attempted once; when both truncate, the complete first attempt is still stored — now 3 calls).
  - Added three #282 AC tests.

## Verification

- **AC1 (`test_truncated_policy_retry_is_reattempted_once_then_adopted`):** truncated policy retry is re-attempted exactly once before judging; the complete, fixed re-attempt is the stored report, and the re-attempt runs at the escalated budget (16384). PASS.
- **AC2 (`test_complete_policy_retry_is_not_reattempted`):** a policy retry that completes normally makes NO extra call (2 calls total). PASS.
- **AC3 (`test_no_policy_retry_means_no_reattempt`):** the extra call happens only on a truncated retry; a clean first attempt with no policy violation makes exactly one call. PASS.
- **Mutation check:** removing the #282 re-attempt turns exactly the dependent tests red (AC1 + the updated #274) while AC2/AC3 stay green, confirming the tests have real authority.
- **Full backend suite:** `python -m pytest -q -m "not integration"` -> 1385 passed, 4 deselected, 0 failures (baseline was 1382; +3 new tests). No real network call (LLM client mocked throughout).

## Residual / human follow-up

- No dedicated assertion was added for the OPENER path's truncated policy retry using `_OPENER_MAX_TOKENS_ESCALATED` (4096). The opener shares the same code (`escalated` derived from `is_opener` exactly as the first-phase opener does) and the full opener suite passes, so the risk is low, but a regression that used the wrong (fuller) budget on an opener re-attempt would not be caught by a dedicated test.
- Behaviour is verified deterministically against a mocked client (correct for this control-flow change); real-prod confirmation that retry truncations now recover more often is observable only in live logs over time.

Closes #282
