### PR TITLE
fix(notifications): stop showing the confidence rating in coach notifications (#338)

### DIFF
--- a/backend/app/services/notifications/email_template.py
+++ b/backend/app/services/notifications/email_template.py
@@ -21,26 +21,26 @@ def render_coach_report_email(
     `stage` ("fuller" default, or "opener" for the A4 stage-one email) selects the
     fuller `message` or the opener_message + reply-invite line. Default keeps every
     existing caller byte-stable."""
+    # #338: the internal confidence rating is no longer surfaced to the runner,
+    # including in the email subject and body (it still lives in report.meta).
     distance_km = round((distance_m or 0) / 1000.0, 1)
-    confidence = report.meta.confidence
     activity_label = headline or "Activity"
-    # Subject shape: "{label} — {dist}km · {conf} confidence" for activities
-    # with distance, "{label} — {conf} confidence" for those without (indoor
-    # rides record 0m). The label already includes the noun (e.g. "Easy Run",
-    # "Indoor Ride"), so we don't append it.
+    # Subject shape: "{label} — {dist}km" for activities with distance, "{label}"
+    # for those without (indoor rides record 0m). The label already includes the
+    # noun (e.g. "Easy Run", "Indoor Ride"), so we don't append it.
     if distance_km > 0:
-        subject = f"{activity_label} — {distance_km}km · {confidence} confidence"
+        subject = f"{activity_label} — {distance_km}km"
     else:
-        subject = f"{activity_label} — {confidence} confidence"
+        subject = activity_label
 
     activity_url = f"{app_base_url.rstrip('/')}/activity/{report.activity_id}"
 
-    html = _render_html(report, activity_label, distance_km, confidence, activity_url, stage)
-    text = _render_text(report, activity_label, distance_km, confidence, activity_url, stage)
+    html = _render_html(report, activity_label, distance_km, activity_url, stage)
+    text = _render_text(report, activity_label, distance_km, activity_url, stage)
     return subject, html, text
 
 
-def _render_html(report, activity_label, distance_km, confidence, activity_url, stage="fuller") -> str:
+def _render_html(report, activity_label, distance_km, activity_url, stage="fuller") -> str:
     content = report.report
     heading_distance = f" · {distance_km}km" if distance_km > 0 else ""
 
@@ -55,7 +55,6 @@ def _render_html(report, activity_label, distance_km, confidence, activity_url, 
         return (
             "<!doctype html><html><body style=\"font-family:-apple-system,sans-serif;max-width:600px;margin:0 auto;padding:16px;\">"
             f"<h2>{escape(activity_label)}{heading_distance}</h2>"
-            f"<p style=\"color:#666;\">Confidence: <strong>{escape(confidence)}</strong></p>"
             f"{paragraphs}"
             f"<p><a href=\"{escape(activity_url)}\">View in app</a></p>"
             "</body></html>"
@@ -103,7 +102,6 @@ def _render_html(report, activity_label, distance_km, confidence, activity_url, 
     return (
         "<!doctype html><html><body style=\"font-family:-apple-system,sans-serif;max-width:600px;margin:0 auto;padding:16px;\">"
         f"<h2>{escape(activity_label)}{heading_distance}</h2>"
-        f"<p style=\"color:#666;\">Confidence: <strong>{escape(confidence)}</strong></p>"
         "<h3>Key takeaways</h3>"
         f"<ul>{takeaways_items}</ul>"
         "<h3>Next steps</h3>"
@@ -115,13 +113,13 @@ def _render_html(report, activity_label, distance_km, confidence, activity_url, 
     )
 
 
-def _render_text(report, activity_label, distance_km, confidence, activity_url, stage="fuller") -> str:
+def _render_text(report, activity_label, distance_km, activity_url, stage="fuller") -> str:
     content = report.report
 
     if distance_km > 0:
-        header = f"{activity_label} — {distance_km}km · {confidence} confidence"
+        header = f"{activity_label} — {distance_km}km"
     else:
-        header = f"{activity_label} — {confidence} confidence"
+        header = activity_label
 
     # A3 (ADR 0009): the plain-text body is the prose message. A4: the opener
     # renders its opener_message + the reply-invite line instead.

--- a/backend/app/services/notifications/telegram_template.py
+++ b/backend/app/services/notifications/telegram_template.py
@@ -25,13 +25,14 @@ def render_coach_report_telegram(
     selects which prose to render: the fuller `message` or the opener_message plus
     the reply-invite line. Default keeps every existing caller byte-stable.
     """
+    # #338: the internal confidence rating is no longer surfaced to the runner,
+    # including in the notification title (it still lives in report.meta).
     distance_km = round((distance_m or 0) / 1000.0, 1)
-    confidence = report.meta.confidence
     activity_label = headline or "Activity"
     if distance_km > 0:
-        title = f"{activity_label} — {distance_km}km · {confidence} confidence"
+        title = f"{activity_label} — {distance_km}km"
     else:
-        title = f"{activity_label} — {confidence} confidence"
+        title = activity_label
 
     activity_url = f"{app_base_url.rstrip('/')}/activity/{report.activity_id}"
 

--- a/backend/tests/test_email_template.py
+++ b/backend/tests/test_email_template.py
@@ -57,7 +57,9 @@ def _build_report(*, headline: str = "Easy", confidence: str = "medium") -> Coac
     )
 
 
-def test_subject_includes_class_distance_confidence():
+def test_subject_includes_class_and_distance():
+    # #338: the confidence rating is no longer surfaced to the runner, so the
+    # subject is the label plus distance only (the value still lives in meta).
     report = _build_report(headline="Easy Run", confidence="medium")
     subject, _html, _text = render_coach_report_email(
         report=report,
@@ -65,7 +67,7 @@ def test_subject_includes_class_distance_confidence():
         distance_m=8200,
         app_base_url="http://localhost:3000",
     )
-    assert subject == "Easy Run — 8.2km · medium confidence"
+    assert subject == "Easy Run — 8.2km"
 
 
 def test_subject_does_not_append_literal_run_word():
@@ -91,7 +93,7 @@ def test_subject_drops_distance_when_zero():
         distance_m=0,
         app_base_url="http://localhost:3000",
     )
-    assert subject == "Indoor Ride — medium confidence"
+    assert subject == "Indoor Ride"
     assert "0.0km" not in subject
     assert "0.0km" not in html
     assert "0.0km" not in text
@@ -136,4 +138,20 @@ def test_distance_rounded_to_one_decimal():
         distance_m=5347,
         app_base_url="http://localhost:3000",
     )
-    assert subject == "Tempo Run — 5.3km · medium confidence"
+    assert subject == "Tempo Run — 5.3km"
+
+
+def test_confidence_rating_is_not_surfaced_anywhere():
+    """#338 (widened): the internal confidence rating must not reach the runner
+    through the email channel either, in the subject, the HTML body, or the text
+    body. The value still exists in report.meta; it is just never rendered."""
+    report = _build_report(headline="Easy Run", confidence="high")
+    subject, html, text = render_coach_report_email(
+        report=report,
+        headline="Easy Run",
+        distance_m=8200,
+        app_base_url="http://localhost:3000",
+    )
+    assert "confidence" not in subject.lower()
+    assert "confidence" not in html.lower()
+    assert "confidence" not in text.lower()

--- a/backend/tests/test_message_notifications.py
+++ b/backend/tests/test_message_notifications.py
@@ -75,7 +75,8 @@ class TestEmailMessageRender:
             report=read, headline="Easy Run", distance_m=5000,
             app_base_url="https://app.example.com",
         )
-        assert subject == "Easy Run — 5.0km · high confidence"
+        # #338: confidence rating no longer surfaced in the subject (still in meta)
+        assert subject == "Easy Run — 5.0km"
 
 
 class TestTelegramMessageRender:
@@ -88,6 +89,17 @@ class TestTelegramMessageRender:
         assert body == "Great session today. You nailed the easy effort."
         assert "Key takeaways" not in body
         assert url.endswith(f"/activity/{read.activity_id}")
+
+    def test_title_omits_confidence_rating(self):
+        # #338 (widened): the confidence rating must not surface in the Telegram
+        # title either; it reads as the coach hedging its own advice.
+        read = _message_read("Great session.")
+        title, _body, _url = render_coach_report_telegram(
+            report=read, headline="Easy Run", distance_m=5000,
+            app_base_url="https://app.example.com",
+        )
+        assert title == "Easy Run — 5.0km"
+        assert "confidence" not in title.lower()
 
     def test_long_body_truncated_under_4096(self):
         long_message = "\n\n".join(f"Paragraph {i} " + ("w" * 200) for i in range(50))


### PR DESCRIPTION
## Summary
Follow-on to #338. The in-app half merged in #348 (the `CoachReportPanel` badge). The same internal confidence rating still leaked to the runner through the notification channel, so this removes it there too. Owner-requested widening of #338.

## Decision & rationale
The confidence level is a signal for how a report is produced, not something the runner should interpret; to them it reads as the coach hedging its own advice, which undercuts trust without giving them anything actionable (#338). It must not appear on ANY runner-facing surface. The value is retained server-side in `report.meta.confidence`; this is display-only.

Surfaces removed (notification channel):
- Telegram: the `· {level} confidence` suffix in the title -> `{label} — {dist}km` (or `{label}` when distance is 0).
- Email: the same suffix in the subject and the plain-text header; both `Confidence: {level}` paragraphs in the HTML body (prose and structured shapes).

## Changes
- `backend/app/services/notifications/telegram_template.py`: drop confidence from the title.
- `backend/app/services/notifications/email_template.py`: drop confidence from subject, text header, and HTML body; remove the now-unused `confidence` param threading through `_render_html`/`_render_text`.
- Tests: update the email/message subject+title assertions to the new shape; rename the now-misnamed `test_subject_includes_class_distance_confidence`; add regression tests pinning that confidence appears nowhere in the email output (subject/html/text) or the Telegram title.

## Verification
- `python -m pytest -q -m "not integration"` -> 1384 passed, 4 deselected (includes the 2 new regression tests; whole notification suite green).
- Live Telegram send through the real Bot API confirmed the wire path during verification; the render-level removal is pinned by the new regression tests.

## Residual / human follow-up
- COORDINATION WITH #351 (refactor/333): that PR's `test_notification_characterization.py` snapshots pin the notification title/subject WITH confidence. After this PR lands they are stale. Recommended: merge THIS PR first, then rebase #351 and regenerate its characterization snapshots against the new (no-confidence) output. `main` stays green throughout. (Flagged on #351 too.)

Closes #338