### PR TITLE
Add 4-week view toggle to Weekly Load Trend chart

### DIFF
--- a/frontend/components/load/LoadTrendChart.tsx
+++ b/frontend/components/load/LoadTrendChart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   ComposedChart,
   Area,
@@ -19,7 +20,11 @@ interface Props {
   selectedWeekStart?: string;
 }
 
+type TrendView = "all" | "4w";
+
 export default function LoadTrendChart({ weeks }: Props) {
+  const [view, setView] = useState<TrendView>("all");
+
   // Per-week optimal range; null for early weeks that lack a trailing baseline.
   const rawBands = weeks.map((w) =>
     w.target_min != null && w.target_max != null
@@ -41,11 +46,41 @@ export default function LoadTrendChart({ weeks }: Props) {
     band: filledBands[i],
   }));
 
+  // Slice after the band fill so the carried-forward optimal range stays correct
+  // in the zoomed-in 4-week view.
+  const visibleData = view === "4w" ? chartData.slice(-4) : chartData;
+
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 shadow-sm p-5">
-      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
-        Weekly Load Trend
-      </h3>
+      <div className="flex items-start justify-between gap-3 mb-1">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+          Weekly Load Trend
+        </h3>
+        {chartData.length > 0 && (
+          <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-1 gap-0.5">
+            {(
+              [
+                { key: "all", label: "All" },
+                { key: "4w", label: "4 weeks" },
+              ] as { key: TrendView; label: string }[]
+            ).map(({ key, label }) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setView(key)}
+                aria-pressed={view === key}
+                className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                  view === key
+                    ? "bg-blue-600 text-white shadow-sm"
+                    : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
       <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">
         Weekly load against your optimal range (0.8–1.3× your trailing 4-week average).
       </p>
@@ -55,7 +90,7 @@ export default function LoadTrendChart({ weeks }: Props) {
         </p>
       ) : (
         <ResponsiveContainer width="100%" height={260}>
-          <ComposedChart data={chartData}>
+          <ComposedChart data={visibleData}>
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
             <XAxis dataKey="label" tick={{ fontSize: 12 }} tickLine={false} axisLine={false} />
             <YAxis tick={{ fontSize: 12 }} tickLine={false} axisLine={false} width={40} />


### PR DESCRIPTION
## What
Adds an **"All" / "4 weeks"** segmented toggle to the Weekly Load Trend chart (`frontend/components/load/LoadTrendChart.tsx`). The full-history view remains the default; selecting "4 weeks" zooms into the most recent 4 weekly-load points, rescaled to that window.

## Why
Closes #355. The chart plots ~a year of weekly load, so recent weeks are compressed on the right and week-to-week movement is hard to read. A 4-week view lets the runner focus on what's happening now.

## How
- Added `view` state (`"all" | "4w"`) and a button group matching the existing `RangeSelector` styling.
- The 4-week slice (`chartData.slice(-4)`) is applied **after** the optimal-range band fill, so the carried-forward band renders correctly in the zoomed-in view.
- Toggle is hidden when there is no load history.

## Acceptance criteria
- [x] Toggle switches between full history and the last 4 weeks.
- [x] 4-week view plots only the most recent 4 weeks, scaled to that window.
- [x] Optimal-range band renders correctly in both views.
- [x] Full-history view preserved and default; view choice is clear.

## Verification
- `npm run test` (ESLint + `next build` with strict TypeScript) passes; the `/load` route builds.
- Runtime/visual confirmation (toggle interaction, band rendering in both views, light/dark appearance) is left to human review — no component test framework exists in `frontend/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPerP7eKDXdLAzZLfYq77M)_