### PR TITLE
perf(api): trim unused payload (raw_summary off list response; gate detail debug dump)

### DIFF
--- a/backend/app/schemas/activity.py
+++ b/backend/app/schemas/activity.py
@@ -18,11 +18,13 @@ class ActivityBase(BaseModel):
     elev_gain_m: float
     avg_hr: Optional[float] = None
     max_hr: Optional[float] = None
-    raw_summary: Dict[str, Any] = {}
 
 
 class ActivityCreate(ActivityBase):
-    pass
+    # The full Strava summary JSON, persisted on create. Deliberately NOT on the
+    # list read model (ActivityRead): that payload ships per item on the home page
+    # and never reads raw_summary (#359). The detail read model re-adds it.
+    raw_summary: Dict[str, Any] = {}
 
 
 class ActivityRead(ActivityBase):

--- a/backend/app/schemas/detail.py
+++ b/backend/app/schemas/detail.py
@@ -87,6 +87,10 @@ class TrainingLoadRead(BaseModel):
 
 
 class ActivityDetailRead(ActivityRead):
+    # The full Strava summary JSON, carried only on the per-activity detail view
+    # (the home list omits it, #359). The detail page renders elapsed_time,
+    # max_heartrate, suffer_score, power, and device fields from here.
+    raw_summary: Dict[str, Any] = {}
     metrics: Optional[DerivedMetricRead] = None
     check_in: Optional[CheckInRead] = None
     streams: List[ActivityStreamRead] = []

--- a/frontend/app/activity/[id]/page.tsx
+++ b/frontend/app/activity/[id]/page.tsx
@@ -16,6 +16,13 @@ import TrainingLoadCard from '@/components/TrainingLoadCard';
 
 export const dynamic = 'force-dynamic';
 
+// Dev-only raw-data/streams dump. Inlined at build time; set
+// NEXT_PUBLIC_SHOW_DEBUG_PANEL=true (or "1") to expose it. Off in production so
+// the full stream arrays do not ship in every activity page's SSR HTML (#359).
+const SHOW_DEBUG_PANEL =
+  process.env.NEXT_PUBLIC_SHOW_DEBUG_PANEL === 'true' ||
+  process.env.NEXT_PUBLIC_SHOW_DEBUG_PANEL === '1';
+
 export default async function ActivityDetail({ params }: { params: { id: string } }) {
   const activity: Activity | null = await fetchFromAPI(`/api/activities/${params.id}`);
   
@@ -199,7 +206,8 @@ export default async function ActivityDetail({ params }: { params: { id: string 
         </div>
       </div>
 
-      {/* Debug Section */}
+      {/* Debug Section (dev only; gated by NEXT_PUBLIC_SHOW_DEBUG_PANEL, #359) */}
+      {SHOW_DEBUG_PANEL && (
       <details className="mt-8 text-xs text-slate-400 dark:text-gray-500">
         <summary className="cursor-pointer mb-2">Debug: Raw Strava Data & Streams</summary>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -223,6 +231,7 @@ export default async function ActivityDetail({ params }: { params: { id: string 
             </div>
         </div>
       </details>
+      )}
 
     </div>
   );


### PR DESCRIPTION
Addresses #359 (the S8 and S12 parts; S9 deferred, see below).

## What

- **S8 — `raw_summary` off the activity list response.** It lived on the shared `ActivityBase`, so `GET /api/activities` shipped the full Strava JSON blob (~5-15 KB) per list item, though the home list renders none of it. Moved it onto `ActivityCreate` (persist) and `ActivityDetailRead` (per-activity view); `ActivityRead` (list) no longer carries it. Verified the frontend list/home path never reads `raw_summary` (only the detail page does), and the frontend type marks it optional.
- **S12 — gate the detail-page debug dump.** `frontend/app/activity/[id]/page.tsx` rendered an always-on `<details>` that `JSON.stringify`d `raw_summary` + all stream arrays (~200-400 KB) into the SSR HTML. Now gated behind `NEXT_PUBLIC_SHOW_DEBUG_PANEL`, matching the existing `CoachReportPanel` pattern.

## Verification

- `make backend-test`: **1404 passed**, 4 deselected. `test_training_load_detail` passing confirms `ActivityDetailRead.raw_summary` still serializes.
- Frontend `npm run test` (next lint + next build): clean, all 8 routes built, no type errors.
- Not verified (human/runtime): a visual check that the detail page still renders the raw_summary-derived fields and the list omits the blob.

## S9 deferred on purpose

The third part of #359 (mark `Activity.raw_summary` `deferred=True` at the ORM layer) is **not** in this PR. Doing it safely requires an `undefer` audit across every `raw_summary` access site plus a query-count assertion, otherwise a missed site silently becomes a lazy-load N+1 (the exact perf footgun the profiling discipline warns against). It also overlaps with audit finding S10 (trends column projection). Worth its own focused PR.

Ref: `docs/audit/performance-audit-2026-06-18.html` (findings S8, S9, S12).