### PR TITLE
docs(readme): refresh to reflect the shipped AI coaching relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,55 @@
-# Running Coach (Strava): Single-user MVP
+# Running Coach — an AI coach for your Strava runs (single-user MVP)
 
-App that connects to Strava, ingests running activities, computes training signals, and displays actionable analysis. Runs locally via `docker compose` or as a deployed single-user instance on Railway and Vercel (see [Production deployment](#production-deployment)).
+Running Coach connects to Strava, deeply processes each run into deterministic training signals, and turns those signals into an ongoing relationship with an LLM coach: short, human, opinionated coaching that arrives after you run and remembers you over time. It runs locally via `docker compose`, or as a deployed single-user instance on Railway (backend) and Vercel (frontend) — see [Production deployment](#production-deployment).
 
-Most Strava-based tools surface raw stats but offer little actionable insight — they tell you what happened, not what to do next. This project is an experiment in using computed training signals and an LLM coaching layer to bridge that gap, producing short and opinionated post-run analysis from the data you already have.
+Most Strava-based tools surface raw stats but little actionable insight — they tell you what happened, not what to do next. This project bridges that gap: a correct, auditable deterministic substrate (metrics, blocks, training load) under an LLM coaching layer that has a voice, a point of view, and durable memory — while never letting personality override the measured data or a safety floor.
+
+## What it does
+
+- **Deep run analysis.** Pulls activity streams from Strava and computes effort, pace variability, HR drift, time-in-zones (binned against your own Strava HR zones), interval structure (from your recorded laps), stops, efficiency, risk flags, and a confidence read.
+- **An AI coach, not a report.** After a run you get an immediate, input-free message, then a fuller coaching turn once you have had a moment (or once you reply) — delivered over Telegram with one-tap RPE/pain buttons so it never blocks on input. The coach writes human prose first and emits structure only as a thin tail.
+- **Personalization you control.** Declare the coach's **Voice** (warmth / humor / directness / energy, plus presets), its **Coaching stance** (a training school of thought + two emphasis dials), and upload your own coaching **materials**. These flex how the coach talks and what it foregrounds — never the facts, your goal, or the safety floor.
+- **Memory that compounds.** A durable, split memory (auditable deterministic facts + an LLM-written relationship narrative) plus a learning loop that tracks which advice you actually act on, so the coach advances the conversation instead of repeating itself.
+- **Training load.** A deterministic acute / chronic / form readiness model (fitness, fatigue, form) built from your own per-activity load, shown on the activity page and read by the coach.
+- **Multi-activity sessions.** Temporally-contiguous activities (a walk, then a run, then a row) are grouped into one **Block**, so the coach reasons about the whole session, not each fragment.
+- **A web app.** An activity list and detail view (stream charts, splits, laps, a training-load card, the coach report and a follow-up chat), a trends dashboard, a training-load view, and a profile editor for voice / stance / materials. Light / dark / system theming.
+
+A deterministic policy validator gates every coach message (medical scope, HR-zone language, interval claims), and an offline eval harness scores reports against a rubric so quality regressions are caught before they ship.
+
+## How it's built (deeper docs)
+
+- [`project-context.md`](project-context.md) — the current implementation reference (product, scope, architecture, structure).
+- [`CONTEXT.md`](CONTEXT.md) — the domain glossary.
+- [`docs/vision/coach-north-star.md`](docs/vision/coach-north-star.md) — the vision and roadmap behind the coaching-relationship design (now built).
+- [`docs/adr/`](docs/adr/) — architecture decision records.
 
 ## Stack
-- Backend: FastAPI + SQLAlchemy + Alembic + Postgres
-- Jobs: Redis + RQ
-- Frontend: Next.js (App Router)
+- **Backend:** FastAPI, SQLAlchemy, Alembic, Postgres
+- **Jobs:** Redis + RQ (with `rq-scheduler` for polling)
+- **Coach:** Anthropic Claude (prose message + structured tail), a deterministic policy validator, and an offline eval gate
+- **Notifications:** Telegram Bot API (the deployed channel) or SMTP email (optional)
+- **Frontend:** Next.js (App Router), React, Recharts, Tailwind
 
 ## Production deployment
 
-The app also runs in production on Railway (backend — web, worker, and scheduler — plus Postgres and Redis) and Vercel (frontend). It is single-user and gated by HTTP basic auth; multi-user readiness is tracked under Phase 2 (see [ADR 0005](docs/adr/0005-magic-link-is-identity-strava-is-an-integration.md) and [ADR 0006](docs/adr/0006-multi-user-drops-polling-for-user-triggered-self-healing.md)). The earlier Fly/Neon/Upstash deployment plan in [`docs/deployment/phase-1-plan.md`](docs/deployment/phase-1-plan.md) is retained as historical context; the migration to Railway is tracked in issue #97.
+The app runs in production on **Railway** (backend as three services off one image — `web`, `worker`, `scheduler` — plus managed Postgres and Redis) and **Vercel** (frontend). It is single-user and gated by HTTP basic auth; the deployed coach-notification channel is **Telegram** (Railway blocks outbound SMTP from the worker). Multi-user readiness is tracked under Phase 2 (see [ADR 0005](docs/adr/0005-magic-link-is-identity-strava-is-an-integration.md) and [ADR 0006](docs/adr/0006-multi-user-drops-polling-for-user-triggered-self-healing.md)). The full production and local-dev topology, the connection seam, and per-service env var ownership are documented in [`docs/deployment/topology.md`](docs/deployment/topology.md).
 
 ## Repo structure
 ```
 /
-  backend/             # FastAPI app, models, schemas, services, jobs
+  backend/             # FastAPI app, models, schemas, services (analysis + coach), jobs
   frontend/            # Next.js app, components, types, utilities
+  docs/                # ADRs, vision/north-star, deployment topology, testing notes
   docker-compose.yml
   project-context.md   # Current product, scope, architecture, and structure reference
+  CONTEXT.md           # Domain glossary
   README.md
 ```
 
 ## Prerequisites
 - Docker + Docker Compose
-- Python 3.11+
-- Node 18+
+- Python 3.11+ (CI runs 3.12)
+- Node 20+
 
 ## Quick start (local)
 
@@ -58,17 +81,18 @@ In a second terminal (from `backend/`, venv activated):
 ```bash
 rq worker --with-scheduler --url $REDIS_URL
 ```
+The worker runs the background pipeline for each new activity: ingest → analyze → assign block → generate the coach exchange → notify.
 
-### 4b) Run the polling scheduler (optional, enables ASAP coach-report emails)
+### 4b) Run the polling scheduler (optional, catches activities the webhook missed)
 In a third terminal (from `backend/`, venv activated):
 ```bash
 python -m app.jobs.scheduler   # registers the recurring polling schedule once
 rqscheduler --url $REDIS_URL   # long-running process that actually fires jobs
 ```
-The polling fallback periodically asks Strava for new activities and runs the
-ingest → analyze → coach report → email pipeline for each new one, in case
-your local backend can't receive Strava webhooks directly. Email delivery is
-off until `SMTP_HOST` and `NOTIFY_TO` are set in `backend/.env`.
+The polling fallback periodically asks Strava for new activities and converges on the
+same pipeline, in case your local backend cannot receive Strava webhooks directly.
+Coach notifications are off until a channel is configured: Telegram (`TELEGRAM_BOT_TOKEN`
++ `TELEGRAM_CHAT_ID`) or email (`SMTP_HOST` + `NOTIFY_TO`) in `backend/.env`.
 
 ### 5) Run frontend
 ```bash
@@ -78,6 +102,11 @@ npm run dev
 ```
 
 Open: http://localhost:3000
+
+### Coaching (optional, local)
+The coach layer needs `ANTHROPIC_API_KEY` in `backend/.env`; the model and active prompt
+are set via `COACH_MODEL_ID` and `COACH_PROMPT_ID`. Without a key the rest of the app
+(sync, analysis, charts) still works; only the LLM coach output is skipped.
 
 ## Automated validation
 
@@ -101,6 +130,13 @@ This currently runs:
 - backend stable automated tests via `python -m pytest -m "not integration"`
 - frontend automated regression checks via `npm run test`, which runs lint and production build validation
 
+The offline coach-report eval harness (the quality gate for the coaching layer) runs via:
+
+```bash
+make eval            # score stored reports against the rubric (needs a local DB)
+make eval-selftest   # validate the harness against its synthetic fixtures (no DB/key needed)
+```
+
 ### Install backend test dependencies
 If you want to run the backend suite in a fresh environment, install the test extras:
 
@@ -113,12 +149,11 @@ pip install -e ".[test]"
 - `make smoke` is the fast readiness layer for basic startup and core route availability.
 - `make test` is the main repo-wide regression routine.
 - The backend global baseline excludes tests marked `integration`, which currently rely on local services or deeper cross-layer behavior that is not yet dependable as a routine regression check.
-- Smoke checks are now standardized as a separate repository-level command.
-- Frontend unit and route-level automated coverage are also tracked separately from this baseline.
+- Frontend unit and route-level automated coverage are tracked separately from this baseline.
 
 ## Strava setup
 1. Create a Strava API application and copy Client ID + Client Secret.
-2. Set backend env vars in `backend/.env`: STRAVA_CLIENT_ID, STRAVA_CLIENT_SECRET, STRAVA_REDIRECT_URI.
+2. Set backend env vars in `backend/.env`: `STRAVA_CLIENT_ID`, `STRAVA_CLIENT_SECRET`, `STRAVA_REDIRECT_URI`.
 3. Start the backend and click "Connect Strava" in the UI.
 
 ## Common ports


### PR DESCRIPTION
The README predated the entire coach build. It described the product as "computes training signals and displays actionable analysis" and stated the Railway migration was still tracked under #97, when in fact prod is live on Railway and the whole north-star coaching-relationship reframe shipped (epic #177).

## Changes
- **Framing rewrite:** the product is now described as an AI coaching relationship over a deterministic substrate, not a stats display.
- **New "What it does" section:** deep run analysis, the two-stage coach exchange (Telegram, one-tap RPE/pain, never blocks on input), Voice / Coaching stance / user materials, split durable memory + learning loop, training load, Blocks (multi-activity sessions), and the web app — plus the policy validator + offline eval gate.
- **"How it's built" pointers** to `project-context.md`, `CONTEXT.md`, `docs/vision/coach-north-star.md`, `docs/adr/`.
- **Stack** updated (Anthropic Claude coach, Telegram, Recharts/Tailwind).
- **Production deployment** corrected: it IS on Railway (web/worker/scheduler + managed PG/Redis) and Vercel; Telegram is the deployed channel (Railway blocks SMTP); dropped the stale #97 "migration tracked" line; points at `docs/deployment/topology.md`.
- **Worker note** fixed from email-only to the real pipeline (ingest → analyze → block → coach exchange → notify) and Telegram-or-email.
- Added the `make eval` / `make eval-selftest` commands and a coaching-setup note; aligned prerequisites (Node 20, Python 3.11+/CI 3.12).
- Preserved the still-accurate quick-start, ports, validation, Strava-setup, and dev-notes sections. All referenced doc links verified to exist.

Companion to this PR: the GitHub About description + topics were refreshed directly (repo settings, not a file change).