### PR TITLE
perf(analysis): vectorize median filter and split-boundary scan (#363, #364)

### DIFF
--- a/backend/app/services/analysis/smoothing.py
+++ b/backend/app/services/analysis/smoothing.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import List, Optional
 import numpy as np
 
@@ -55,31 +56,28 @@ def smooth_cadence(
     # Unrealistic spikes
     cad_arr[cad_arr > MAX_VALID_CADENCE] = np.nan
     
-    # 2. Median Filter
-    # Rolling median ignores NaNs if possible, but standard rolling median might not.
-    # We can skip NaNs or treat them. 
-    # Better approach: 
-    # For the median filter, we usually want to operate on valid data. 
-    # However, preserving the gaps is important.
-    # Let's run a window over the data.
-    
-    # To use a moving median robustly with NaNs, we can use a loop or scipy.ndimage.generic_filter
-    # Since we only have numpy, let's implement a simple sliding window median that ignores NaNs.
-    
-    smoothed = np.full(n, np.nan)
+    # 2. Median Filter (NaN-aware rolling median, vectorized — #363)
+    # The prior implementation was a per-sample Python loop that sliced a
+    # MEDIAN_FILTER_WINDOW-wide window, stripped NaNs, and called np.median —
+    # ~n iterations dominated by dispatch overhead. The vectorized form is
+    # exactly equivalent: NaN-pad the series by half_window on each side so
+    # every output index has a full window, build all windows in one C call
+    # with sliding_window_view, then take the NaN-ignoring median per row.
+    #  - Interior dropout NaNs are stripped by nanmedian just as the loop's
+    #    valid_window stripped them.
+    #  - The NaN edge padding reproduces the loop's shrinking edge window (the
+    #    out-of-range samples the loop omitted are NaN here, and nanmedian
+    #    ignores them), so edge outputs are identical.
+    #  - An all-NaN window yields NaN (a preserved gap), matching the loop's
+    #    len(valid_window) == 0 branch; nanmedian's expected All-NaN
+    #    RuntimeWarning for that case is suppressed.
     half_window = MEDIAN_FILTER_WINDOW // 2
-    
-    for i in range(n):
-        start = max(0, i - half_window)
-        end = min(n, i + half_window + 1)
-        window = cad_arr[start:end]
-        valid_window = window[~np.isnan(window)]
-        
-        if len(valid_window) > 0:
-            smoothed[i] = np.median(valid_window)
-        else:
-            smoothed[i] = np.nan
-            
+    padded = np.pad(cad_arr, half_window, mode="constant", constant_values=np.nan)
+    windows = np.lib.stride_tricks.sliding_window_view(padded, MEDIAN_FILTER_WINDOW)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        smoothed = np.nanmedian(windows, axis=1)
+
     # 3. Fill short gaps (Linear Interpolation)
     # logic: identify gaps (sequences of NaNs). If gap duration <= MAX_GAP_INTERPOLATE_S, interpolate.
     

--- a/backend/app/services/analysis/splits.py
+++ b/backend/app/services/analysis/splits.py
@@ -61,75 +61,58 @@ def calculate_splits(
     n_points = len(distance)
     if len(time) != n_points:
         return [] # Mismatch
-    
+
+    # Boundary detection, vectorized (#364). The split boundary for each km
+    # target is the first sample whose cumulative distance reaches that target.
+    # For a monotonic cumulative-distance stream np.searchsorted(side="left")
+    # returns exactly the index the prior per-sample scan stopped at (the first
+    # i with distance[i] >= target), in one C call instead of ~n_points Python
+    # iterations. Per-split metrics are still computed by the unchanged
+    # _compute_split_metrics over the same [start, end) index pairs, so the
+    # split boundaries and every per-split metric are identical.
+    distance_arr = np.asarray(distance, dtype=float)
+    total_dist = distance[-1]
+    n_full = int(total_dist // split_distance_m)  # full km splits crossed
+
     splits = []
-    
     current_split_start_idx = 0
-    current_split_target_dist = split_distance_m
-    
     split_number = 1
-    
-    # We iterate through points. When distance exceeds current target, we verify the split.
-    # Note: Optimization could be done with numpy searchsorted if data was guaranteed numpy arrays.
-    
-    for i in range(1, n_points):
-        d_curr = distance[i]
-        
-        # Check if we crossed a split boundary
-        # We handle multiple splits in one step if gaps are huge (unlikely in streams, but possible)
-        while d_curr >= current_split_target_dist:
-            # Found a split boundary at index i (inclusive or exclusive? let's say up to i)
-            # Actually, the point i is AFTER the boundary.
-            # Interpolation would be precise, but nearest point is usually fine for dense streams.
-            # Let's use index i as the end of the split.
-            
-            # Slice range: [current_split_start_idx, i+1) involves points that might be past the mark.
-            # Using 'i' as end index means data[current_split_start_idx : i]
-            
-            # Refine: if distance[i] is 1005 and distance[i-1] is 998, the cut is between i-1 and i.
-            # Including i in the average might bias slightly, but effectively standard for app-level analysis.
-            
-            end_idx = i
-            
-            # Calculate metrics for this range
-            split_data = _compute_split_metrics(
-                split_number,
-                current_split_start_idx, 
-                end_idx, 
-                distance, 
-                time, 
-                heartrate, 
-                grade, 
-                cadence,
-                watts,
-                altitude,
+
+    if n_full > 0:
+        targets = np.arange(1, n_full + 1) * split_distance_m
+        boundaries = np.searchsorted(distance_arr, targets, side="left")
+        for boundary in boundaries:
+            end_idx = int(boundary)
+            splits.append(
+                _compute_split_metrics(
+                    split_number,
+                    current_split_start_idx,
+                    end_idx,
+                    distance,
+                    time,
+                    heartrate,
+                    grade,
+                    cadence,
+                    watts,
+                    altitude,
+                )
             )
-            splits.append(split_data)
-            
-            # Next split setup
-            prev_split_dist = current_split_target_dist
-            current_split_target_dist += split_distance_m
             current_split_start_idx = end_idx
             split_number += 1
-            
-            # If we reached the end of data inside the loop (perfect finish), break
-            if current_split_start_idx >= n_points:
-                break
-                
+
     # Handle partial last split if there is remaining distance meaningful
     # e.g. if > 100m left
     if current_split_start_idx < n_points - 1:
-        total_dist = distance[-1]
         last_split_dist_start = (split_number - 1) * split_distance_m
         if total_dist - last_split_dist_start > 100: # Show partial if > 100m
              split_data = _compute_split_metrics(
                 split_number,
-                current_split_start_idx, 
-                n_points, 
-                distance, 
-                time, 
-                heartrate, 
-                grade, 
+                current_split_start_idx,
+                n_points,
+                distance,
+                time,
+                heartrate,
+                grade,
                 cadence,
                 watts,
                 altitude,
@@ -274,30 +257,34 @@ def _calculate_time_splits(
     if n_points < 2:
         return []
 
+    # Boundary detection, vectorized (#364) — same searchsorted equivalence as
+    # the distance path, over the (monotonic) time stream.
+    time_arr = np.asarray(time, dtype=float)
+    total_time = time[-1]
+    n_full = int(total_time // split_time_s)
+
     splits: List[Dict[str, Any]] = []
     split_number = 1
     start_idx = 0
-    target_time = split_time_s
 
-    for i in range(1, n_points):
-        t_curr = time[i]
-        while t_curr >= target_time:
-            end_idx = i
-            split_data = _compute_time_split_metrics(
-                split_number,
-                start_idx,
-                end_idx,
-                time,
-                heartrate,
-                cadence,
-                watts,
+    if n_full > 0:
+        targets = np.arange(1, n_full + 1) * split_time_s
+        boundaries = np.searchsorted(time_arr, targets, side="left")
+        for boundary in boundaries:
+            end_idx = int(boundary)
+            splits.append(
+                _compute_time_split_metrics(
+                    split_number,
+                    start_idx,
+                    end_idx,
+                    time,
+                    heartrate,
+                    cadence,
+                    watts,
+                )
             )
-            splits.append(split_data)
-            target_time += split_time_s
             start_idx = end_idx
             split_number += 1
-            if start_idx >= n_points:
-                break
 
     # Partial last split – include if > 30 s remain
     if start_idx < n_points - 1:

--- a/backend/tests/test_distance_splits.py
+++ b/backend/tests/test_distance_splits.py
@@ -1,0 +1,76 @@
+"""Distance-based split boundary and metric correctness (#364).
+
+`calculate_splits` builds one split per `split_distance_m` (default 1000 m)
+when a cumulative `distance` stream is present. The boundary detection was
+vectorized with `np.searchsorted` (#364); these tests pin the boundaries, the
+partial-last-split rule, and the per-split metrics so the vectorized form
+cannot drift from the documented behavior.
+
+Ground truth: a synthetic constant-pace run (2.5 m/s, 1 Hz). Expected values
+are hand-derived from the split formula in `_compute_split_metrics`, which uses
+`distance[end_idx - 1]` as a split's end distance and `time[end_idx]`-style
+indexing — so a full 1 km split spans samples [start, boundary) and reports the
+distance covered up to the sample just before the boundary (997.5 m here), not
+a rounded 1000 m. That quirk is existing behavior and is pinned deliberately.
+"""
+
+from types import SimpleNamespace
+
+from app.services.analysis.splits import calculate_splits
+
+
+def _stream(stream_type, data):
+    return SimpleNamespace(stream_type=stream_type, data=data)
+
+
+def _constant_pace_streams(total_s, mps=2.5, hr=150):
+    """1 Hz run at a constant pace, with a flat HR stream for metric pinning."""
+    time = list(range(total_s + 1))
+    distance = [mps * i for i in time]
+    heartrate = [hr] * len(time)
+    return [
+        _stream("time", time),
+        _stream("distance", distance),
+        _stream("heartrate", heartrate),
+    ]
+
+
+def test_distance_splits_boundaries_and_metrics():
+    # 1000 s @ 2.5 m/s = 2500 m -> two full 1 km splits + a 500 m partial.
+    splits = calculate_splits(_constant_pace_streams(1000))
+
+    assert [s["split"] for s in splits] == [1, 2, 3]
+    assert all(s["split_type"] == "distance" for s in splits)
+
+    # Two full splits: boundary at the first sample reaching the km mark
+    # (index 400 and 800), so each spans 399 samples of elapsed time and the
+    # distance up to the sample before the boundary (997.5 m).
+    for full in splits[:2]:
+        assert full["elapsed_time"] == 399
+        assert abs(full["distance"] - 997.5) < 1e-6
+        assert abs(full["speed"] - 2.5) < 1e-6
+        assert abs(full["pace"] - 400.0) < 1e-6  # 400 s/km = 6:40/km
+        assert abs(full["avg_hr"] - 150.0) < 1e-6
+
+    # Partial last split: samples [800, 1001) -> 2000..2500 m over 200 s.
+    partial = splits[2]
+    assert partial["elapsed_time"] == 200
+    assert abs(partial["distance"] - 500.0) < 1e-6
+    assert abs(partial["speed"] - 2.5) < 1e-6
+
+
+def test_no_partial_split_when_remainder_under_100m():
+    # 820 s @ 2.5 m/s = 2050 m: 50 m past the 2 km mark, under the 100 m floor.
+    splits = calculate_splits(_constant_pace_streams(820))
+
+    assert [s["split"] for s in splits] == [1, 2]
+    assert all(s["split_type"] == "distance" for s in splits)
+
+
+def test_exact_km_finish_emits_no_partial():
+    # 800 s @ 2.5 m/s = exactly 2000 m: the final km boundary lands on the last
+    # sample, so there is no remainder and no partial split.
+    splits = calculate_splits(_constant_pace_streams(800))
+
+    assert [s["split"] for s in splits] == [1, 2]
+    assert all(s["split_type"] == "distance" for s in splits)


### PR DESCRIPTION
Closes #363, closes #364.

## What
Replaces two per-sample Python loops on the hot ingest / bulk-reanalyze path with single vectorized numpy calls. **Output is unchanged** in both cases.

### #363 — `smooth_cadence` NaN-aware rolling median
Was a `for i in range(n)` loop slicing a 7-wide window, stripping NaNs, and calling `np.median` per sample. Now: NaN-pad by `half_window`, build all windows with `sliding_window_view`, then `np.nanmedian(axis=1)`.
- The NaN edge padding reproduces the loop's shrinking edge window (nanmedian strips it), and interior dropout NaNs are stripped identically, so every output value is the same.
- An all-NaN window yields a preserved gap (NaN), matching the loop's `len(valid_window) == 0` branch; the expected All-NaN RuntimeWarning is suppressed.

### #364 — split-boundary detection
`calculate_splits` (and `_calculate_time_splits`) walked every stream sample to find km/time boundaries. Now `np.searchsorted(side="left")` over the monotonic cumulative distance/time stream returns the same boundary indices in one C call. `_compute_split_metrics` is **unchanged**, so the `[start, end)` index pairs and every per-split metric are identical by construction.

## Verification
- **Behavior-preservation harness**: loaded the original implementations from `HEAD` and compared against the new ones over **5000 randomized synthetic streams** (empty, dropouts, spikes, time gaps, exact-km finishes, sub-100m partials, missing aux streams). Result: **byte-identical, 5000/5000**.
- Added `test_distance_splits.py` — the distance-split path had **no direct unit test**; pins boundaries, the partial-last-split rule, and per-split metrics (expected values hand-derived from the split formula).
- `make backend-test`: **1434 passed**, 4 deselected.

## Decisions
- **Scoped #364 to boundary detection only**, leaving `_compute_split_metrics` untouched. The issue's hot-loop complaint is the per-sample boundary scan; the metrics function is per-split (not per-sample) and already O(n) total. Keeping it byte-identical guarantees identical metrics and minimizes risk.
- The existing `end_idx - 1` end-distance quirk (a full 1 km split reports ~997.5 m, not a rounded 1000 m) is **preserved and pinned by the new test** — this is a behavior-preserving refactor, not a correction.

## Risk / notes
- `searchsorted` assumes a sorted (monotonic) input. Cumulative distance/time streams are monotonic non-decreasing; the harness confirms equivalence on monotonic data. Not changed: behavior on a (non-physical) non-monotonic stream, which the original sequential scan also handled idiosyncratically.
- Not benchmarked for absolute speedup; correctness (the only thing that could regress) is proven.

Ref: `docs/audit/performance-audit-2026-06-18.html` (S4, S5).