### PR TITLE
perf(trends): bound get_load_report to MAX_WEEKS + project columns (#362)

### DIFF
--- a/backend/app/services/training_load.py
+++ b/backend/app/services/training_load.py
@@ -14,12 +14,13 @@ without HR, so summing it across a mixed history is valid.
 
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
+from types import SimpleNamespace
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
-from app.models import Activity
+from app.models import Activity, DerivedMetric
 from app.schemas.trends import LoadActivityPoint, LoadResponse, LoadWeek
 from app.services.analysis.classifier import Classification, compose_headline
 
@@ -57,15 +58,28 @@ def _status(score: float, target_min: Optional[float], target_max: Optional[floa
     return "optimal"
 
 
-def build_load_report(facts: list[LoadFact], today: date) -> LoadResponse:
-    """Pure aggregation: facts -> chronological weekly report ending this week."""
+def build_load_report(
+    facts: list[LoadFact],
+    today: date,
+    series_start: Optional[date] = None,
+) -> LoadResponse:
+    """Pure aggregation: facts -> chronological weekly report ending this week.
+
+    ``series_start`` lets the caller pin the first week of the series when it
+    has bounded ``facts`` to a window but still knows older history exists (so
+    the series length matches an unbounded build). When None, the first week is
+    derived from ``facts`` as before. Either way it is clamped to the
+    MAX_WEEKS floor.
+    """
     current_week = week_start(today)
-    if facts:
+    # Bound the series so per-request cost stays flat as history grows.
+    earliest_served = current_week - timedelta(weeks=MAX_WEEKS - 1)
+    if series_start is not None:
+        first_week = series_start
+    elif facts:
         first_week = min(week_start(f.day) for f in facts)
     else:
         first_week = current_week
-    # Bound the series so per-request cost stays flat as history grows.
-    earliest_served = current_week - timedelta(weeks=MAX_WEEKS - 1)
     first_week = max(first_week, earliest_served)
 
     by_week: dict[date, list[LoadFact]] = {}
@@ -115,24 +129,82 @@ def build_load_report(facts: list[LoadFact], today: date) -> LoadResponse:
 
 
 def get_load_report(db: Session, today: Optional[date] = None) -> LoadResponse:
-    activities = (
-        db.query(Activity)
-        .options(joinedload(Activity.metrics))
+    # Bound the scan to the served window (#362). build_load_report only keeps
+    # weeks from `earliest_served` onward, so an activity older than that Monday
+    # is discarded anyway — fetching it was wasted work on an unbounded
+    # full-history scan. We compute `today` once and reuse it for both the SQL
+    # bound and the pure report build so a midnight rollover can't disagree.
+    resolved_today = today or date.today()
+    earliest_served = week_start(resolved_today) - timedelta(weeks=MAX_WEEKS - 1)
+
+    # Project only the columns the report needs instead of materializing full
+    # Activity + DerivedMetric ORM objects. This avoids loading the per-row
+    # DerivedMetric JSON blobs (time_in_zones, interval_structure,
+    # discount_signals, ...) the report never reads. raw_summary is still
+    # loaded because the headline depends on its sport_type/trainer keys
+    # (see classifier.compose_headline); see PR notes for why it cannot be
+    # dropped without changing output. The inner join + skip mirrors the prior
+    # joinedload + `metrics is None` filter exactly.
+    rows = (
+        db.query(
+            Activity.id,
+            Activity.name,
+            Activity.start_date,
+            Activity.type,
+            Activity.distance_m,
+            Activity.raw_summary,
+            DerivedMetric.effort_score,
+            DerivedMetric.effort,
+            DerivedMetric.duration_class,
+            DerivedMetric.structure,
+            DerivedMetric.is_hilly,
+            DerivedMetric.is_race,
+        )
+        .join(DerivedMetric, DerivedMetric.activity_id == Activity.id)
         .filter(Activity.is_deleted.is_(False))
+        .filter(Activity.start_date >= earliest_served)
         .all()
     )
+
+    # Preserve the series length exactly. The unbounded build clamped the
+    # first week to `earliest_served` whenever any contributing activity was
+    # older than the window; we reproduce that with one cheap existence probe
+    # instead of materializing the old rows. No older activity -> the series
+    # starts at the first in-window activity, as before.
+    older_exists = (
+        db.query(Activity.id)
+        .join(DerivedMetric, DerivedMetric.activity_id == Activity.id)
+        .filter(Activity.is_deleted.is_(False))
+        .filter(Activity.start_date < earliest_served)
+        .first()
+    ) is not None
+    series_start = earliest_served if older_exists else None
+
     facts = []
-    for a in activities:
-        if a.metrics is None or a.metrics.effort_score is None:
+    for r in rows:
+        if r.effort_score is None:
             continue
-        start = a.start_date.date() if isinstance(a.start_date, datetime) else a.start_date
+        start = r.start_date.date() if isinstance(r.start_date, datetime) else r.start_date
+        metrics = SimpleNamespace(
+            effort_score=r.effort_score,
+            effort=r.effort,
+            duration_class=r.duration_class,
+            structure=r.structure,
+            is_hilly=r.is_hilly,
+            is_race=r.is_race,
+        )
+        activity = SimpleNamespace(
+            type=r.type,
+            distance_m=r.distance_m,
+            raw_summary=r.raw_summary,
+        )
         facts.append(
             LoadFact(
-                activity_id=a.id,
-                name=a.name,
+                activity_id=r.id,
+                name=r.name,
                 day=start,
-                effort_score=float(a.metrics.effort_score),
-                headline=compose_headline(a, Classification.from_metrics(a.metrics)),
+                effort_score=float(r.effort_score),
+                headline=compose_headline(activity, Classification.from_metrics(metrics)),
             )
         )
-    return build_load_report(facts, today or date.today())
+    return build_load_report(facts, resolved_today, series_start=series_start)

--- a/backend/tests/test_training_load.py
+++ b/backend/tests/test_training_load.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import date, datetime, timezone, timedelta
 
 from app.models import Activity, DerivedMetric, User
-from app.services.training_load import LoadFact, build_load_report, week_start
+from app.services.training_load import MAX_WEEKS, LoadFact, build_load_report, week_start
 
 
 TODAY = date(2026, 6, 12)  # a Friday; week starts Mon 2026-06-08
@@ -107,3 +107,89 @@ def test_endpoint_returns_load_report(client, db):
     weeks = resp.json()["weeks"]
     assert weeks[-1]["score"] == 72.0
     assert weeks[-1]["activities"][0]["name"] == "Morning Run"
+
+
+def test_endpoint_composes_headline_through_projection(client, db):
+    """The headline depends on raw_summary (sport_type/trainer) plus the
+    classification axes; the column projection (#362) must still produce the
+    same headline the full ORM load did. A hilly long run exercises both the
+    metric axes and the run-noun composition."""
+    user_id = uuid.uuid4()
+    db.add(User(id=user_id, email=f"hl_{user_id}@example.com"))
+    db.flush()
+    a = Activity(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        strava_activity_id=abs(hash("hl" + str(uuid.uuid4()))) % 10**9,
+        name="Big Sunday Long Run",
+        type="Run",
+        start_date=datetime.now(timezone.utc),
+        distance_m=25000,
+        moving_time_s=9000,
+        elapsed_time_s=9200,
+        elev_gain_m=400.0,
+        raw_summary={"sport_type": "Run"},
+    )
+    db.add(a)
+    db.flush()
+    db.add(
+        DerivedMetric(
+            activity_id=a.id,
+            effort_score=180.0,
+            confidence="high",
+            effort="moderate",
+            duration_class="long",
+            structure="continuous",
+            is_hilly=True,
+            is_race=False,
+        )
+    )
+    db.commit()
+
+    resp = client.get("/api/trends/load")
+    assert resp.status_code == 200, resp.text
+    point = resp.json()["weeks"][-1]["activities"][0]
+    assert point["name"] == "Big Sunday Long Run"
+    assert point["headline"] == "Hilly long run (moderate)"
+
+
+def test_endpoint_excludes_old_activity_but_preserves_series_length(client, db):
+    """An activity older than MAX_WEEKS is dropped from the served weeks, yet
+    its existence still anchors the series to the full MAX_WEEKS window — the
+    series-start probe (#362) reproduces the prior unbounded build's length."""
+    user_id = uuid.uuid4()
+    db.add(User(id=user_id, email=f"old_{user_id}@example.com"))
+    db.flush()
+    now = datetime.now(timezone.utc)
+
+    def _run(name, when):
+        return Activity(
+            id=uuid.uuid4(),
+            user_id=user_id,
+            strava_activity_id=abs(hash(name + str(uuid.uuid4()))) % 10**9,
+            name=name,
+            type="Run",
+            start_date=when,
+            distance_m=8000,
+            moving_time_s=2400,
+            elapsed_time_s=2500,
+            elev_gain_m=20.0,
+        )
+
+    recent = _run("Recent Run", now)
+    old = _run("Ancient Run", now - timedelta(weeks=60))
+    db.add_all([recent, old])
+    db.flush()
+    db.add_all(
+        [
+            DerivedMetric(activity_id=recent.id, effort_score=60.0, confidence="high"),
+            DerivedMetric(activity_id=old.id, effort_score=99.0, confidence="high"),
+        ]
+    )
+    db.commit()
+
+    weeks = client.get("/api/trends/load").json()["weeks"]
+    assert len(weeks) == MAX_WEEKS  # old history anchors the full window
+    names = [p["name"] for w in weeks for p in w["activities"]]
+    assert "Recent Run" in names
+    assert "Ancient Run" not in names  # older than the window -> not served


### PR DESCRIPTION
Closes #362.

## What
`get_load_report` (`GET /api/trends/load`) queried **every** non-deleted activity with `joinedload(Activity.metrics)` and **no date window**, materialized full ORM objects (including `raw_summary` and the DerivedMetric JSON blobs), then threw away anything older than 52 weeks. This change:

1. **Bounds the scan in SQL** — `Activity.start_date >= earliest_served` (the `MAX_WEEKS` floor). Out-of-window history is never fetched.
2. **Projects only needed columns** over an inner join, so the per-row DerivedMetric JSON blobs (`time_in_zones`, `interval_structure`, `discount_signals`, ...) the report never reads are not loaded. Full ORM objects are replaced with row tuples + tiny shims for `compose_headline`/`from_metrics`.
3. **Preserves the series length exactly** via a cheap `EXISTS` probe (one indexed `LIMIT 1`) for any contributing activity older than the window, threaded into `build_load_report` as a new optional `series_start`.

## Why the series-start probe (the subtle part)
`build_load_report` sets `first_week = max(min(week of all facts), earliest_served)`. The old unbounded build saw *all* activities, so a single very old activity clamped the series to the full 52 weeks. If I simply drop out-of-window rows, that clamp disappears and a gappy history (old activity, long gap, recent activity) would return a **shorter** series — an output change. The `EXISTS` probe restores the exact clamp without materializing the old rows.

## Decisions
- **`raw_summary` is still loaded**, deviating from the issue's "no `raw_summary`" criterion. The headline (`LoadActivityPoint.headline`) is composed by `classifier.compose_headline`, which reads `raw_summary["sport_type"]` and `raw_summary["trainer"]`. Dropping it would change output. Extracting just those two keys via a JSON-path projection was rejected as too risky for an output-unchanged guarantee: the test dialect (SQLite) and prod dialect (Postgres) differ on JSON operators, which is exactly the "green on SQLite, wrong on Postgres" trap. The projection still drops the larger DerivedMetric JSON blobs, and the date bound is the dominant win.
- Kept `build_load_report`'s `series_start` parameter optional (default None = prior behavior), so the pure-function tests are unaffected.

## Verification
- New: `test_endpoint_composes_headline_through_projection` (a hilly long run → `"Hilly long run (moderate)"`, proving the `raw_summary`+classification headline survives the projection) and `test_endpoint_excludes_old_activity_but_preserves_series_length` (60-week-old activity dropped from served weeks, series still 52 weeks long).
- `make backend-test`: **1433 passed**, 4 deselected.

Ref: `docs/audit/performance-audit-2026-06-18.html` (S3).