### PR TITLE
perf(reanalyze): recompute runner baseline once per batch, not per activity (#366)

### DIFF
--- a/backend/app/jobs/reanalyze_history.py
+++ b/backend/app/jobs/reanalyze_history.py
@@ -38,6 +38,7 @@ from app.core.queue import queue
 from app.db.session import SessionLocal
 from app.models import Activity, ActivityStream
 from app.services.analysis import analyze
+from app.services.analysis.baseline import recompute_runner_baseline
 
 logger = logging.getLogger(__name__)
 
@@ -91,14 +92,23 @@ def reanalyze_history_batch(
     batch = db.execute(_eligible_stmt(cursor=cursor).limit(limit)).scalars().all()
     # Snapshot identity up front: a per-activity failure rolls the session back,
     # which expires the ORM instances in `batch`, so re-reading their attributes
-    # afterwards would re-query (or raise on a now-absent row). The id and strava
-    # id are all we need downstream.
-    items = [(activity.id, activity.strava_activity_id) for activity in batch]
+    # afterwards would re-query (or raise on a now-absent row). The id, strava
+    # id, and user id are all we need downstream.
+    items = [
+        (activity.id, activity.strava_activity_id, activity.user_id)
+        for activity in batch
+    ]
     result = ReanalyzeBatchResult()
 
-    for activity_id, strava_id in items:
+    # Defer the runner-baseline recompute to once per touched user after the
+    # batch (#366): analyze() recomputes it per call by default, which redid the
+    # 182-day windowed scan up to REANALYZE_BATCH_SIZE times per batch. We pass
+    # skip_baseline=True here and recompute once per user below; the recompute
+    # is a full idempotent pass, so the final baseline is identical.
+    recompute_user_ids: list = []
+    for activity_id, strava_id, user_id in items:
         try:
-            analyze(db, str(activity_id))
+            analyze(db, str(activity_id), skip_baseline=True)
         except Exception as exc:  # noqa: BLE001 - convergence over completeness
             db.rollback()
             logger.error(
@@ -107,7 +117,21 @@ def reanalyze_history_batch(
                 strava_id,
                 exc,
             )
+        else:
+            if user_id not in recompute_user_ids:
+                recompute_user_ids.append(user_id)
         result.processed.append(strava_id)
+
+    # One baseline recompute per user that had at least one activity succeed.
+    # Best-effort, mirroring analyze()'s _post_commit_baseline: a failure is
+    # logged and the session rolled back so the next user starts clean, never
+    # aborting the chain.
+    for user_id in recompute_user_ids:
+        try:
+            recompute_runner_baseline(db, user_id)
+        except Exception:  # noqa: BLE001 - baseline is best-effort
+            logger.exception("runner baseline recompute failed for user %s", user_id)
+            db.rollback()
 
     # A full batch means there may be more; a short batch means we drained the
     # set. Advance the cursor to the last id seen so the next batch continues

--- a/backend/app/services/analysis/_orchestrator.py
+++ b/backend/app/services/analysis/_orchestrator.py
@@ -138,7 +138,7 @@ def _post_commit_baseline(db: Session, user_id) -> None:
         logger.exception("runner baseline recompute failed for user %s", user_id)
 
 
-def analyze(db: Session, activity_id: str) -> Optional[DerivedMetric]:
+def analyze(db: Session, activity_id: str, skip_baseline: bool = False) -> Optional[DerivedMetric]:
     """
     Main entry point.
     Loads activity, history, computes all metrics, saves DerivedMetric.
@@ -345,6 +345,13 @@ def analyze(db: Session, activity_id: str) -> Optional[DerivedMetric]:
     # runner-baseline recompute must follow the commit above so the
     # just-analysed activity is included in its rolling window. See
     # `_post_commit_baseline`.
-    _post_commit_baseline(db, activity.user_id)
+    #
+    # `skip_baseline` lets a bulk caller (the reanalyze job, #366) defer the
+    # recompute to once-per-user after its whole batch instead of paying it on
+    # every activity. recompute_runner_baseline is a full idempotent pass over
+    # the rolling window, so the deferred result is identical. The per-activity
+    # ingest path leaves it False and recomputes per activity as before.
+    if not skip_baseline:
+        _post_commit_baseline(db, activity.user_id)
 
     return dm

--- a/backend/tests/test_reanalyze_history_job.py
+++ b/backend/tests/test_reanalyze_history_job.py
@@ -152,7 +152,7 @@ def test_failure_on_one_activity_does_not_halt_the_batch(db):
 
     calls = {"n": 0}
 
-    def flaky_analyze(db_, activity_id):
+    def flaky_analyze(db_, activity_id, skip_baseline=False):
         calls["n"] += 1
         if calls["n"] == 1:  # newest (7002) blows up
             raise RuntimeError("boom")
@@ -164,6 +164,36 @@ def test_failure_on_one_activity_does_not_halt_the_batch(db):
     # Both activities were attempted and reported despite the first failing.
     assert calls["n"] == 2
     assert sorted(result.processed) == [7001, 7002]
+
+
+def test_baseline_recomputed_once_per_user_after_the_batch(db):
+    """#366: the runner baseline is recomputed once per touched user after the
+    batch, not once per activity. analyze() is invoked with skip_baseline=True,
+    so the only recompute is the job's single end-of-batch pass."""
+    from app.jobs import reanalyze_history as mod
+
+    user = _seed_user(db)
+    _seed_activity(db, user, 8001)
+    _seed_activity(db, user, 8002)
+    _seed_activity(db, user, 8003)
+
+    seen_skip = []
+
+    def tracking_analyze(db_, activity_id, skip_baseline=False):
+        seen_skip.append(skip_baseline)
+        return MagicMock()
+
+    with patch.object(mod, "analyze", side_effect=tracking_analyze), patch.object(
+        mod, "recompute_runner_baseline", wraps=mod.recompute_runner_baseline
+    ) as spy:
+        result = mod.reanalyze_history_batch(db, limit=100)
+
+    assert sorted(result.processed) == [8001, 8002, 8003]
+    # analyze deferred the baseline on every activity...
+    assert seen_skip == [True, True, True]
+    # ...and the job recomputed it exactly once, for that one user.
+    assert spy.call_count == 1
+    assert spy.call_args.args[1] == user.id
 
 
 def test_reanalysis_never_notifies(db):


### PR DESCRIPTION
Closes #366.

## What
`reanalyze_history_batch` calls `analyze()` per activity (up to `REANALYZE_BATCH_SIZE`=100), and `analyze()` unconditionally ran `_post_commit_baseline` — a 182-day windowed `selectinload` scan — at the end. So a 100-activity batch recomputed the runner baseline **100 times** when only the final state matters.

- `analyze()` gains `skip_baseline` (default `False`): when `True` it still commits the `DerivedMetric` but skips the post-commit recompute.
- The reanalyze batch passes `skip_baseline=True` and recomputes the baseline **once per touched user** after the loop.
- The per-activity **ingest** path is unchanged (default `False`, recomputes per activity — audit finding D4 says leave it).

## Why this is behavior-preserving
`recompute_runner_baseline` is a **full idempotent recompute** over the rolling window (not incremental). The old per-activity flow left each user's baseline reflecting the *last* activity's recompute; running that same full recompute once after the batch produces the identical final state.

## Decisions
- **Recompute once per distinct user that had ≥1 successful `analyze`** (not blindly once). The batch query is not user-scoped, so a batch can span users (relevant as multi-user lands). I snapshot `user_id` up front because a per-activity rollback expires the ORM instances (same reason the existing code snapshots `id`/`strava_id`).
- A failed activity (rolled back) does **not** trigger its user's baseline recompute, matching the old behavior where a failing `analyze` never reached `_post_commit_baseline`.
- End-of-batch recompute is best-effort (log + rollback on failure, mirroring `_post_commit_baseline`), so a baseline error never aborts the self-pacing chain.

## Verification
- Updated the `flaky_analyze` test double to mirror `analyze()`'s new signature (a positional-only mock would have raised `TypeError` on the new kwarg). Assertions unchanged — this keeps the double faithful, not a test weakening.
- New `test_baseline_recomputed_once_per_user_after_the_batch`: asserts `skip_baseline=True` on every `analyze` call and exactly **one** recompute for the single user across a 3-activity batch.
- `make backend-test`: **1432 passed**, 4 deselected.

Ref: `docs/audit/performance-audit-2026-06-18.html` (S7).