### PR TITLE
perf(frontend): memoize SimpleChart to skip unrelated re-renders (#368)

### DIFF
--- a/frontend/components/StreamCharts.tsx
+++ b/frontend/components/StreamCharts.tsx
@@ -52,7 +52,15 @@ interface SimpleChartProps {
   timeData?: (number | null)[];
 }
 
-function SimpleChart({ type, data, secondaryData, scrubFraction, onScrub, timeData }: SimpleChartProps) {
+// Memoized so a parent re-render that does not change this chart's props is a
+// no-op (#368). The activity-detail page re-renders on unrelated state — most
+// often the coach-report poll (#260) — and without memo every such tick re-ran
+// all 4-6 charts. The data/secondaryData/timeData props are referentially
+// stable (the same stream `.data` references) and onScrub is the stable
+// useState setter, so only scrubFraction changes during a scrub; that fraction
+// is shared, so all charts still update their synced indicator together (#207),
+// which is intended.
+const SimpleChart = React.memo(function SimpleChart({ type, data, secondaryData, scrubFraction, onScrub, timeData }: SimpleChartProps) {
   const preset = PRESETS[type] || { label: type, color: 'text-gray-500', icon: Activity };
   const Icon = preset.icon;
   const areaRef = useRef<HTMLDivElement>(null);
@@ -252,7 +260,7 @@ function SimpleChart({ type, data, secondaryData, scrubFraction, onScrub, timeDa
       </div>
     </div>
   );
-}
+});
 
 export default function StreamCharts({ streams }: StreamChartsProps) {
   // One scrub position shared by every chart, as a fraction of the run.


### PR DESCRIPTION
Closes #368.

## What
`SimpleChart` was a plain function component. Because the `scrubFraction` state lives in the `StreamCharts` parent (and the parent itself lives under the activity-detail page), any re-render of that subtree re-ran all 4-6 charts. Wrapping `SimpleChart` in `React.memo` lets a chart skip re-rendering when its own props are unchanged.

## Honest scope of the win (please read)
I dug into the prop flow before claiming the issue's stated benefit:

- `onScrub={setScrubFraction}` is React's **stable** `useState` setter, and `data` / `secondaryData` / `timeData` resolve to the **same** stream `.data` references across renders. So the only prop that changes during a scrub is `scrubFraction`.
- `scrubFraction` is **shared** — the same value is passed to every chart (synced scrubbing, #207). So when it changes, it changes for *all* charts, and they all re-render to move their synced indicator. `React.memo` does **not** (and should not) prevent that — it's the intended behavior.

So the real, frequent win is different from "only the active chart updates": it's that the charts now **skip re-rendering when the parent/page re-renders for reasons unrelated to the charts** — most notably the activity-detail page's coach-report polling (#260), which updates state on an interval. Before, every poll tick re-ran all charts; now they're skipped because their props are referentially stable.

Achieving literal "only the active chart's indicator updates during scrub" would require giving each chart its own scrub state (or an imperative/portal indicator) so non-active charts' props don't change — a larger architectural change I've flagged as a follow-up rather than silently expanding scope.

## Verification
- `npm run test` (`next lint` + `next build`): **green**.
- `React.memo` is behavior-preserving by construction (skips re-renders only on shallow-equal props; identical output). The live scrub interaction is a UX/real-device judgment for the owner, but no behavior changes.

Ref: `docs/audit/performance-audit-2026-06-18.html` (S11).