### PR TITLE
perf(trends): project columns instead of full Activity ORM on the trends range query (#367)

### DIFF
--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 from sqlalchemy import select, and_
 from sqlalchemy.orm import Session
 
-from app.models import Activity
+from app.models import Activity, DerivedMetric
 from app.schemas.trends import (
     TrendsResponse,
     TrendsSummary,
@@ -73,6 +73,33 @@ class ActivityFact:
         self.time_in_zones: Optional[dict] = (
             activity.metrics.time_in_zones if activity.metrics else None
         )
+
+    @classmethod
+    def from_row(cls, row) -> "ActivityFact":
+        """Build from a column-projection Row instead of a full Activity ORM
+        object (#367). The trends queries only read the ~14 scalar fields below,
+        so projecting them (mirroring readiness.py) avoids materializing the
+        Activity/DerivedMetric JSON blobs (raw_summary, interval_structure,
+        discount_signals, ...) the trend charts never touch. The LEFT join makes
+        the three metric columns NULL for an activity without a DerivedMetric,
+        reproducing the prior `activity.metrics ... else None`.
+        """
+        self = cls.__new__(cls)
+        self.activity_id = row.id
+        self.local_date = row.start_date.date()
+        self.activity_type = row.type
+        self.user_intent = row.user_intent
+        self.distance_m = row.distance_m or 0
+        self.moving_time_s = row.moving_time_s or 0
+        self.elapsed_time_s = row.elapsed_time_s or 0
+        self.elev_gain_m = row.elev_gain_m or 0.0
+        self.avg_hr = row.avg_hr
+        self.avg_cadence = row.avg_cadence
+        self.average_speed_mps = row.average_speed_mps
+        self.effort_score = row.effort_score
+        self.effort = row.effort
+        self.time_in_zones = row.time_in_zones
+        return self
 
     @property
     def effective_type(self) -> str:
@@ -227,11 +254,30 @@ def _query_activity_facts(
     continue working; the intent is to make it required once the API auth layer
     provides a resolved user at every endpoint (ADR 0005 / Phase 2).
     """
-    from sqlalchemy.orm import selectinload
-
+    # Project only the columns ActivityFact reads instead of materializing full
+    # Activity ORM objects + a selectinload of DerivedMetric (#367). The LEFT
+    # outer join keeps activities without a DerivedMetric (their metric columns
+    # come back NULL); DerivedMetric.activity_id is unique, so the join never
+    # duplicates a row. This avoids loading the Activity/DerivedMetric JSON
+    # blobs the trend charts never touch — the worst over-fetch on the ALL range.
     stmt = (
-        select(Activity)
-        .options(selectinload(Activity.metrics))
+        select(
+            Activity.id,
+            Activity.start_date,
+            Activity.type,
+            Activity.user_intent,
+            Activity.distance_m,
+            Activity.moving_time_s,
+            Activity.elapsed_time_s,
+            Activity.elev_gain_m,
+            Activity.avg_hr,
+            Activity.avg_cadence,
+            Activity.average_speed_mps,
+            DerivedMetric.effort_score,
+            DerivedMetric.effort,
+            DerivedMetric.time_in_zones,
+        )
+        .outerjoin(DerivedMetric, DerivedMetric.activity_id == Activity.id)
         .where(Activity.is_deleted == False)  # noqa: E712
         .order_by(Activity.start_date.asc())
     )
@@ -242,8 +288,8 @@ def _query_activity_facts(
     if end_date:
         stmt = stmt.where(Activity.start_date < datetime.combine(end_date, datetime.min.time()))
 
-    activities = db.execute(stmt).scalars().all()
-    facts = [ActivityFact(a) for a in activities]
+    rows = db.execute(stmt).all()
+    facts = [ActivityFact.from_row(r) for r in rows]
 
     if types:
         type_set = {t.lower() for t in types}

--- a/backend/tests/test_weekly_stats.py
+++ b/backend/tests/test_weekly_stats.py
@@ -129,3 +129,36 @@ def test_deleted_activities_are_ignored(db):
     assert stats.summary.activity_count == 1
     assert stats.summary.total_distance_m == 5000
     assert keep.is_deleted is False
+
+
+def test_activity_without_metrics_is_still_counted(db):
+    """An activity with no DerivedMetric row (e.g. summary-only, not yet
+    analyzed) must still appear in the totals with a null effort_score. The
+    column projection's LEFT join (#367) reproduces the prior ORM behavior
+    where activity.metrics was None."""
+    user_id = _user(db)
+    _activity(db, user_id, days_ago=1, distance_m=5000, moving_time_s=1500, effort_score=10.0)
+
+    bare = Activity(
+        user_id=user_id,
+        strava_activity_id=int(uuid.uuid4().int % 1_000_000_000),
+        start_date=datetime.now() - timedelta(days=2),
+        type="Run",
+        name="Unanalyzed run",
+        distance_m=6000,
+        moving_time_s=1800,
+        elapsed_time_s=1800,
+        elev_gain_m=0.0,
+        raw_summary={},
+    )
+    db.add(bare)
+    db.flush()
+
+    stats = get_weekly_stats(db)
+
+    # Both counted, distance summed across both.
+    assert stats.summary.activity_count == 2
+    assert stats.summary.total_distance_m == 11000
+    # The metrics-less activity contributes no load and is not a hard day.
+    assert stats.summary.total_load == 10.0
+    assert stats.summary.hard_days == 0


### PR DESCRIPTION
Closes #367.

## What
`_query_activity_facts` (the single helper behind every trends range, including ALL) ran `select(Activity).options(selectinload(Activity.metrics))` with **no date bound** for the ALL range — materializing every non-deleted `Activity` ORM object (with the `raw_summary` blob) plus a `selectinload` of `DerivedMetric`. `ActivityFact` reads only ~14 scalar fields.

- Replaced the ORM load with a **column projection over a LEFT outer join** (mirroring the existing `readiness.py` pattern): the 11 `Activity` scalar columns + `DerivedMetric.effort_score`/`effort`/`time_in_zones`. The JSON blobs the trend charts never read (`raw_summary`, `interval_structure`, `discount_signals`, `flags`, ...) are no longer loaded.
- Added `ActivityFact.from_row(row)` to build a fact from a projection `Row`.

## Why it's behavior-preserving
- **LEFT outer join** keeps activities with no `DerivedMetric`; their three metric columns come back `NULL`, exactly reproducing the prior `activity.metrics.X if activity.metrics else None`.
- `DerivedMetric.activity_id` is **unique** (one-to-one), so the join never duplicates a row.
- The `is_deleted` filter, `user_id` scoping, `start_date`/`end_date` bounds, `order_by(start_date asc)`, and the post-query `types` filter are all unchanged.

## Verification
- Existing trends suite covers the metric columns flowing through (`effort_score` → load, `effort` → hard-days), the `types` filter, deleted-exclusion, user scoping, and window bounds — all green.
- New `test_activity_without_metrics_is_still_counted`: an activity with no `DerivedMetric` row is still counted in distance/count with a null `effort_score` (and contributes no load / hard-day) — exercises the LEFT-join NULL path the change introduces.
- `make backend-test`: **1432 passed**, 4 deselected.

## Note
Overlaps with #359(b) (`Activity.raw_summary` `deferred=True` at the ORM layer). This PR removes `raw_summary` from *this* query directly via projection; #359(b) is the complementary model-level deferral across the remaining ORM call sites and is left as a separate change (it touches many `undefer()` sites and is higher-risk).

Ref: `docs/audit/performance-audit-2026-06-18.html` (S10).