### PR TITLE
perf(coach): collapse build_b_baseline's three recent-summary queries into one (#365)

### DIFF
--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -513,20 +513,24 @@ def build_b_baseline(
     if profile is None:
         profile = _load_profile(db, activity.user_id)
 
-    # Recent training summary relative to this activity's date
+    # Recent training summary relative to this activity's date. The three
+    # windows (7d, 28d, prev_28d) all fall within [activity_date-56d,
+    # activity_date), so fetch that span once and partition in Python (#365)
+    # instead of issuing three queries (each was a select + selectinload = 6 SQL
+    # statements). The window edges are date midnights and a fact's local_date
+    # is start_date.date(), so partitioning by local_date reproduces the prior
+    # per-window start_date bounds exactly — and _summarize_period is unchanged,
+    # so every summary value is byte-identical.
     activity_date = activity.start_date.date()
-    facts_7d = _query_activity_facts(
-        db, activity_date - timedelta(days=7), activity_date,
+    facts_56d = _query_activity_facts(
+        db, activity_date - timedelta(days=56), activity_date,
         user_id=activity.user_id,
     )
-    facts_28d = _query_activity_facts(
-        db, activity_date - timedelta(days=28), activity_date,
-        user_id=activity.user_id,
-    )
-    facts_prev_28d = _query_activity_facts(
-        db, activity_date - timedelta(days=56), activity_date - timedelta(days=28),
-        user_id=activity.user_id,
-    )
+    since_7d = activity_date - timedelta(days=7)
+    since_28d = activity_date - timedelta(days=28)
+    facts_7d = [f for f in facts_56d if f.local_date >= since_7d]
+    facts_28d = [f for f in facts_56d if f.local_date >= since_28d]
+    facts_prev_28d = [f for f in facts_56d if f.local_date < since_28d]
 
     return BBaseline(
         profile=ProfileContext(

--- a/backend/tests/test_b_baseline_windows.py
+++ b/backend/tests/test_b_baseline_windows.py
@@ -1,0 +1,87 @@
+"""build_b_baseline recent-training-summary windowing (#365).
+
+The 7d / 28d / previous_28d summaries are now derived by partitioning a single
+56-day fetch in Python instead of three separate queries. These tests pin the
+partition boundaries (inclusive start, exclusive end at the activity's own date,
+the prev-28d band, and the 56-day lower bound) so the collapse cannot drift from
+the prior per-window behavior. Expected values are hand-derived from the window
+definitions in build_b_baseline.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from app.models import Activity, DerivedMetric, User
+from app.services.coach.context import build_b_baseline
+
+
+def _seed_activity(db, user_id, start_dt, *, distance_m, effort_score):
+    activity = Activity(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        strava_activity_id=int(uuid.uuid4().int % 1_000_000_000),
+        name="Run",
+        type="Run",
+        start_date=start_dt,
+        distance_m=distance_m,
+        moving_time_s=distance_m // 3,
+        elapsed_time_s=distance_m // 3,
+        elev_gain_m=0.0,
+        average_speed_mps=3.0,
+        raw_summary={},
+    )
+    db.add(activity)
+    db.flush()
+    db.add(
+        DerivedMetric(
+            id=uuid.uuid4(),
+            activity_id=activity.id,
+            effort_score=effort_score,
+            confidence="high",
+            flags=[],
+            confidence_reasons=[],
+        )
+    )
+    db.flush()
+    return activity
+
+
+def test_recent_training_summary_partitions_the_56_day_window(db):
+    user_id = uuid.uuid4()
+    db.add(User(id=user_id, email=f"bw_{user_id}@example.com"))
+    db.flush()
+
+    anchor_dt = datetime(2026, 3, 1, 10, 0, tzinfo=timezone.utc)
+    D = anchor_dt.date()
+
+    # In the 7d window [D-7, D):
+    _seed_activity(db, user_id, anchor_dt - timedelta(days=3), distance_m=5000, effort_score=10.0)
+    _seed_activity(db, user_id, anchor_dt - timedelta(days=5), distance_m=3000, effort_score=5.0)
+    # In 28d but not 7d:
+    _seed_activity(db, user_id, anchor_dt - timedelta(days=15), distance_m=8000, effort_score=20.0)
+    # In previous_28d [D-56, D-28):
+    _seed_activity(db, user_id, anchor_dt - timedelta(days=40), distance_m=6000, effort_score=12.0)
+    # Boundary exclude: an activity older than the 56-day span.
+    _seed_activity(db, user_id, anchor_dt - timedelta(days=60), distance_m=9000, effort_score=42.0)
+
+    # The anchor itself sits on D; the windows end exclusive at D, so it must
+    # not appear in any summary (tests the exclusive upper bound).
+    anchor = _seed_activity(db, user_id, anchor_dt, distance_m=10000, effort_score=99.0)
+    db.refresh(anchor)
+
+    summary = build_b_baseline(db, anchor).recent_training_summary
+
+    # last_7d: the D-3 and D-5 runs only.
+    assert summary.last_7d.activity_count == 2
+    assert summary.last_7d.total_distance_m == 8000
+    assert summary.last_7d.total_effort == 15.0
+
+    # last_28d: adds the D-15 run.
+    assert summary.last_28d.activity_count == 3
+    assert summary.last_28d.total_distance_m == 16000
+    assert summary.last_28d.total_effort == 35.0
+
+    # previous_28d: only the D-40 run (D-60 is outside the 56-day span).
+    assert summary.previous_28d.activity_count == 1
+    assert summary.previous_28d.total_distance_m == 6000
+    assert summary.previous_28d.total_effort == 12.0


### PR DESCRIPTION
Closes #365.

## What
`build_b_baseline` (run synchronously on every coach-report build) issued **three** `_query_activity_facts` calls — 7d, 28d, prev_28d — each a `select(Activity).options(selectinload(Activity.metrics))` = **6 SQL statements**. `_summarize_period` uses only four aggregates per window (count, sum distance, sum moving time, sum effort). The three windows all fall within a fixed 56-day span, so this fetches one 56-day window once and partitions it in Python.

## Why it's byte-stable
- The three windows are `[D-7, D)`, `[D-28, D)`, `[D-56, D-28)` where `D = activity_date`. Their union is `[D-56, D)`.
- The original per-window filter is `start_date >= combine(window_start, 00:00)` and `< combine(window_end, 00:00)`. Because the bounds are **date midnights** and a fact's `local_date` is `start_date.date()`, `start_date >= window_start 00:00 ⟺ local_date >= window_start` and `start_date < window_end 00:00 ⟺ local_date < window_end`. So partitioning the single fetch by `local_date` selects exactly the same rows each window query did.
- `_summarize_period` is untouched, and its aggregates are order-independent, so every summary value is identical and the context pack stays byte-stable.

## Verification
- New `test_b_baseline_windows.py`: seeds activities across the 56-day span and asserts the 7d / 28d / prev_28d counts, distances, and effort totals, including the boundary cases — the **exclusive upper bound** (the anchor activity on day `D` appears in no window) and the **56-day lower bound** (a `D-60` activity is excluded). Expected values hand-derived from the window definitions.
- Existing `test_coach_context_pack.py` roundtrip + fingerprint tests confirm pack byte-stability.
- `make backend-test`: **1432 passed**, 4 deselected.

## Note
This composes with #367 (which projects columns in `_query_activity_facts`): after both merge, `build_b_baseline` makes one call to the projected query. No conflict (separate files).

Ref: `docs/audit/performance-audit-2026-06-18.html` (S6).