### PR TITLE
fix(trends): deterministic chronological order for get_load_report

### DIFF
--- a/backend/app/services/training_load.py
+++ b/backend/app/services/training_load.py
@@ -163,6 +163,14 @@ def get_load_report(db: Session, today: Optional[date] = None) -> LoadResponse:
         .join(DerivedMetric, DerivedMetric.activity_id == Activity.id)
         .filter(Activity.is_deleted.is_(False))
         .filter(Activity.start_date >= earliest_served)
+        # Deterministic chronological order. build_load_report sorts members
+        # by date only (a LoadFact carries no time), so a stable sort preserves
+        # this query order WITHIN a day — without an explicit ORDER BY the
+        # same-day activity order is whatever physical order the scan yields
+        # (it was unordered before too; the #362 join just perturbed it). Order
+        # by start_date so same-day activities read chronologically, with id as
+        # a total-order tiebreaker.
+        .order_by(Activity.start_date.asc(), Activity.id.asc())
         .all()
     )
 

--- a/backend/tests/test_training_load.py
+++ b/backend/tests/test_training_load.py
@@ -4,7 +4,13 @@ import uuid
 from datetime import date, datetime, timezone, timedelta
 
 from app.models import Activity, DerivedMetric, User
-from app.services.training_load import MAX_WEEKS, LoadFact, build_load_report, week_start
+from app.services.training_load import (
+    MAX_WEEKS,
+    LoadFact,
+    build_load_report,
+    get_load_report,
+    week_start,
+)
 
 
 TODAY = date(2026, 6, 12)  # a Friday; week starts Mon 2026-06-08
@@ -193,3 +199,41 @@ def test_endpoint_excludes_old_activity_but_preserves_series_length(client, db):
     names = [p["name"] for w in weeks for p in w["activities"]]
     assert "Recent Run" in names
     assert "Ancient Run" not in names  # older than the window -> not served
+
+
+def test_same_day_activities_are_ordered_chronologically(db):
+    """build_load_report sorts a week's members by date only, so the query's
+    order breaks same-day ties. An explicit chronological ORDER BY makes that
+    deterministic — without it the order was whatever physical scan order the
+    DB returned (which the #362 join silently perturbed)."""
+    user_id = uuid.uuid4()
+    db.add(User(id=user_id, email=f"ord_{user_id}@example.com"))
+    db.flush()
+    day = datetime(2026, 3, 1, 0, 0, tzinfo=timezone.utc)
+
+    def _run(name, hour):
+        a = Activity(
+            id=uuid.uuid4(),
+            user_id=user_id,
+            strava_activity_id=abs(hash(name + str(uuid.uuid4()))) % 10**9,
+            name=name,
+            type="Run",
+            start_date=day.replace(hour=hour),
+            distance_m=5000,
+            moving_time_s=1500,
+            elapsed_time_s=1600,
+            elev_gain_m=10.0,
+        )
+        db.add(a)
+        db.flush()
+        db.add(DerivedMetric(activity_id=a.id, effort_score=10.0, confidence="high"))
+
+    # Same calendar day, inserted out of chronological order.
+    _run("OrdTest-Late", 18)
+    _run("OrdTest-Early", 6)
+    _run("OrdTest-Mid", 12)
+    db.commit()
+
+    resp = get_load_report(db, today=day.date())
+    names = [a.name for w in resp.weeks for a in w.activities if a.name.startswith("OrdTest")]
+    assert names == ["OrdTest-Early", "OrdTest-Mid", "OrdTest-Late"]


### PR DESCRIPTION
Follow-up to #379/#362, found by a **real-data differential verification run**.

## How it was found
I ran a read-only snapshot of every merged perf path (analysis splits/smoothing, `get_load_report`, trends + weekly stats, coach context pack) over the prod-seeded local DB at the **pre-batch commit vs current main**, and diffed.

Four of five sections were **byte-identical** (proving #378, #382, #383 preserved behavior on real data). One differed: **`get_load_report`** — same weeks, same scores, same headlines, same weekly totals, but the **order of activities within a week** changed.

## Root cause
`get_load_report`'s query has **no `ORDER BY`** (it never did). `build_load_report` sorts a week's members **by date only** (a `LoadFact` has no time), so a stable sort leaves same-day activities in whatever physical order the scan returned. #362 swapped the query to a projection + join, which perturbed that incidental order. **Values were never affected** — only array ordering, and it was latently non-deterministic before too.

## Fix
Add `ORDER BY start_date, id` so same-day activities read chronologically and the response is deterministic. Mirrors the `ORDER BY` already on `trends._query_activity_facts`.

## Verification (the differential, three-way)
| section | pre-#362 | current main | this fix |
|---|---|---|---|
| analysis (splits/smoothing) | = | = | = |
| trends (all ranges) | = | = | = |
| weekly stats | = | = | = |
| coach context pack | = | = | = |
| **load_report aggregates+multiset** | = | = | = |
| **load_report ordering** | (nondeterministic) | (nondeterministic, perturbed) | **deterministic, chronological** |

- Weekly aggregates (score/status/targets) and the per-week activity **multiset** are identical across pre-#362 / current / fix — **no value change**.
- The fix's `load_report` is **stable across re-runs** (same hash twice).
- New regression test `test_same_day_activities_are_ordered_chronologically` pins it.
- `make backend-test`: **1440 passed**, 4 deselected.

## Note
This makes the ordering deterministic; it does **not** reproduce the exact pre-#362 byte order, because that order was itself unspecified (no `ORDER BY`). Chronological is the correct, stable choice.