### PR TITLE
Add period-over-period deltas to trends graph cards

### DIFF
--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -76,6 +76,11 @@ class TrendsSummary(BaseModel):
     total_moving_time_s: int
     activity_count: int
     total_suffer_score: float
+    # Period aggregates backing the graph-card deltas (#385). Efficiency is an
+    # average (a rate, not a sum) and is None when no activity in the window has
+    # usable HR/distance. Zone minutes is the total across all three HR zones.
+    avg_efficiency_mps_per_bpm: Optional[float] = None
+    total_zone_minutes: float = 0.0
 
 
 class TrendsResponse(BaseModel):

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -569,6 +569,27 @@ def build_zone_load_daily(
     return result
 
 
+def _avg_efficiency(facts: List[ActivityFact]) -> Optional[float]:
+    """Mean HR-efficiency (m/s per bpm) over the window, or None when no
+    activity qualifies. Reuses build_efficiency_trend so the average is taken
+    over exactly the activities the efficiency chart plots (#385)."""
+    points = build_efficiency_trend(facts)
+    if not points:
+        return None
+    return round(sum(p["efficiency_mps_per_bpm"] for p in points) / len(points), 4)
+
+
+def _total_zone_minutes(facts: List[ActivityFact]) -> float:
+    """Total minutes across all three HR zones over the window (#385)."""
+    total_s = 0
+    for af in facts:
+        if not af.time_in_zones:
+            continue
+        easy_s, mod_s, hard_s = _collapse_to_3_zones(af.time_in_zones)
+        total_s += easy_s + mod_s + hard_s
+    return round(total_s / 60, 1)
+
+
 def _summarise_window(facts: List[ActivityFact]) -> WeeklyStatsSummary:
     """Collapse activity facts for one window into the dashboard summary card totals."""
     hard_days = len({f.local_date for f in facts if f.effort in _HARD_EFFORTS})
@@ -630,6 +651,8 @@ def get_trends_report(
         total_moving_time_s=sum(d.total_moving_time_s for d in daily_facts),
         activity_count=sum(d.activity_count for d in daily_facts),
         total_suffer_score=sum(d.total_effort_score for d in daily_facts),
+        avg_efficiency_mps_per_bpm=_avg_efficiency(activity_facts),
+        total_zone_minutes=_total_zone_minutes(activity_facts),
     )
 
     # Previous period summary
@@ -643,6 +666,8 @@ def get_trends_report(
             total_moving_time_s=sum(f.moving_time_s for f in prev_facts),
             activity_count=len(prev_facts),
             total_suffer_score=sum(f.effort_score or 0.0 for f in prev_facts),
+            avg_efficiency_mps_per_bpm=_avg_efficiency(prev_facts),
+            total_zone_minutes=_total_zone_minutes(prev_facts),
         )
 
     # 3. Continuous daily facts (every day filled)

--- a/backend/tests/test_trends_summary_aggregates.py
+++ b/backend/tests/test_trends_summary_aggregates.py
@@ -1,0 +1,95 @@
+"""Trends summary carries period aggregates for the graph-card deltas (#385).
+
+`avg_efficiency_mps_per_bpm` and `total_zone_minutes` must be computed over the
+current window for ``summary`` and the prior window for ``previous_summary`` so
+the Efficiency and Zone-Load graph cards can show a period-over-period delta.
+"""
+
+import uuid
+from datetime import date, datetime, time, timedelta
+
+from app.models import Activity, DerivedMetric, User
+from app.services.trends import get_trends_report
+
+
+def _user(db) -> uuid.UUID:
+    user = User(email=f"{uuid.uuid4()}@example.com")
+    db.add(user)
+    db.flush()
+    return user.id
+
+
+def _activity(db, user_id, on, *, distance_m, moving_time_s, avg_hr, time_in_zones):
+    activity = Activity(
+        user_id=user_id,
+        strava_activity_id=int(uuid.uuid4().int % 1_000_000_000),
+        start_date=datetime.combine(on, time(12, 0)),
+        type="Run",
+        name="Run",
+        distance_m=distance_m,
+        moving_time_s=moving_time_s,
+        elapsed_time_s=moving_time_s,
+        elev_gain_m=0.0,
+        avg_hr=avg_hr,
+        raw_summary={},
+    )
+    db.add(activity)
+    db.flush()
+    db.add(
+        DerivedMetric(
+            id=uuid.uuid4(),
+            activity_id=activity.id,
+            effort_score=1.0,
+            confidence="high",
+            flags=[],
+            confidence_reasons=[],
+            time_in_zones=time_in_zones,
+        )
+    )
+    db.flush()
+    return activity
+
+
+def test_summary_carries_efficiency_and_zone_minutes_per_window(db):
+    user_id = _user(db)
+    today = date.today()
+
+    # Current 7D window: speed = 3000/1000 = 3.0 m/s, hr = 150
+    #   efficiency = 3.0 / 150 = 0.02 mps/bpm
+    #   zones = (300+300) easy + 300 mod + (60+40) hard = 1000 s = 16.7 min
+    _activity(
+        db, user_id, today - timedelta(days=1),
+        distance_m=3000, moving_time_s=1000, avg_hr=150,
+        time_in_zones={"Z1": 300, "Z2": 300, "Z3": 300, "Z4": 60, "Z5": 40},
+    )
+    # Previous 7D window: speed = 2000/1000 = 2.0 m/s, hr = 200
+    #   efficiency = 2.0 / 200 = 0.01 mps/bpm
+    #   zones = (200+100) easy + 100 mod + (50+50) hard = 500 s = 8.3 min
+    _activity(
+        db, user_id, today - timedelta(days=8),
+        distance_m=2000, moving_time_s=1000, avg_hr=200,
+        time_in_zones={"Z1": 200, "Z2": 100, "Z3": 100, "Z4": 50, "Z5": 50},
+    )
+
+    report = get_trends_report(db, "7D", user_id=user_id)
+
+    assert report.summary.avg_efficiency_mps_per_bpm == 0.02
+    assert report.previous_summary.avg_efficiency_mps_per_bpm == 0.01
+    assert report.summary.total_zone_minutes == 16.7
+    assert report.previous_summary.total_zone_minutes == 8.3
+
+
+def test_efficiency_is_none_when_no_activity_has_usable_hr(db):
+    user_id = _user(db)
+    today = date.today()
+    # Distance qualifies but no HR → efficiency cannot be computed.
+    _activity(
+        db, user_id, today - timedelta(days=1),
+        distance_m=3000, moving_time_s=1000, avg_hr=None,
+        time_in_zones=None,
+    )
+
+    report = get_trends_report(db, "7D", user_id=user_id)
+
+    assert report.summary.avg_efficiency_mps_per_bpm is None
+    assert report.summary.total_zone_minutes == 0.0

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -142,26 +142,68 @@ export default function TrendsPage() {
             type="distance"
             data={isDaily ? data.daily_distance : data.weekly_distance}
             granularity={granularity}
+            delta={
+              <StatDiff
+                current={data.summary.total_distance_m}
+                previous={data.previous_summary?.total_distance_m}
+                format={formatDistanceKm}
+              />
+            }
           />
           <TrendBarChart
             type="time"
             data={isDaily ? data.daily_time : data.weekly_time}
             granularity={granularity}
+            delta={
+              <StatDiff
+                current={data.summary.total_moving_time_s}
+                previous={data.previous_summary?.total_moving_time_s}
+                format={formatDuration}
+              />
+            }
           />
 
           <SufferScoreChart
             data={isDaily ? data.daily_suffer_score : data.weekly_suffer_score}
             granularity={granularity}
+            delta={
+              <StatDiff
+                current={data.summary.total_suffer_score}
+                previous={data.previous_summary?.total_suffer_score}
+                format={(v) => Math.round(v).toLocaleString()}
+              />
+            }
           />
           {data.efficiency_trend && (
             <EfficiencyTrendChart
               data={data.efficiency_trend}
               granularity={granularity}
+              delta={
+                data.summary.avg_efficiency_mps_per_bpm != null ? (
+                  <StatDiff
+                    // Display in meters-per-heartbeat (×60), matching the chart.
+                    current={data.summary.avg_efficiency_mps_per_bpm * 60}
+                    previous={
+                      data.previous_summary?.avg_efficiency_mps_per_bpm != null
+                        ? data.previous_summary.avg_efficiency_mps_per_bpm * 60
+                        : undefined
+                    }
+                    format={(v) => `${v.toFixed(2)} m/beat`}
+                  />
+                ) : undefined
+              }
             />
           )}
           <ZoneLoadChart
             data={isDaily ? data.daily_zone_load : data.weekly_zone_load}
             granularity={granularity}
+            delta={
+              <StatDiff
+                current={data.summary.total_zone_minutes ?? 0}
+                previous={data.previous_summary?.total_zone_minutes}
+                format={(v) => formatDuration(v * 60)}
+              />
+            }
           />
         </div>
       )}

--- a/frontend/components/StatDiff.tsx
+++ b/frontend/components/StatDiff.tsx
@@ -38,9 +38,15 @@ export default function StatDiff({
     : "text-red-600 dark:text-red-400";
   const arrow = isIncrease ? "↑" : "↓";
 
+  // Percentage change alongside the absolute amount. The arrow already conveys
+  // direction, so the percentage is shown as a magnitude. Omitted when there is
+  // no positive baseline to divide by (a 0 → N jump has no finite percentage).
+  const pct = previous > 0 ? Math.round((Math.abs(diff) / previous) * 100) : null;
+
   return (
     <div className={`text-xs ${color} mt-1 font-medium`}>
       {arrow} {format(Math.abs(diff))}
+      {pct !== null && <span className="opacity-75"> · {pct}%</span>}
     </div>
   );
 }

--- a/frontend/components/trends/EfficiencyTrendChart.tsx
+++ b/frontend/components/trends/EfficiencyTrendChart.tsx
@@ -13,13 +13,15 @@ import {
 } from "recharts";
 import { EfficiencyPoint } from "@/lib/types";
 import { formatDateLabel } from "@/lib/format";
-import { useMemo, useState } from "react";
+import { ReactNode, useMemo, useState } from "react";
 import ActivityTypeFilter from "./ActivityTypeFilter";
 import ChartTooltip from "@/components/charts/ChartTooltip";
 
 interface Props {
   data: EfficiencyPoint[];
   granularity: "daily" | "weekly";
+  /** Period-over-period delta shown under the title (e.g. a <StatDiff>). */
+  delta?: ReactNode;
 }
 
 function calculateSMA(data: EfficiencyPoint[], window: number = 5): (number | null)[] {
@@ -33,7 +35,7 @@ function calculateSMA(data: EfficiencyPoint[], window: number = 5): (number | nu
   return result;
 }
 
-export default function EfficiencyTrendChart({ data, granularity }: Props) {
+export default function EfficiencyTrendChart({ data, granularity, delta }: Props) {
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
 
   // Derive available types from the dataset
@@ -91,6 +93,7 @@ export default function EfficiencyTrendChart({ data, granularity }: Props) {
           <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
             Meters per heartbeat. Higher is better.
           </p>
+          {delta}
         </div>
         <div>
           <ActivityTypeFilter

--- a/frontend/components/trends/SufferScoreChart.tsx
+++ b/frontend/components/trends/SufferScoreChart.tsx
@@ -9,6 +9,7 @@ import {
   ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
+import { ReactNode } from "react";
 import { SufferScorePoint, DailySufferScorePoint, WeeklySufferScorePoint } from "@/lib/types";
 import { formatDateLabel } from "@/lib/format";
 import ChartTooltip from "@/components/charts/ChartTooltip";
@@ -16,9 +17,11 @@ import ChartTooltip from "@/components/charts/ChartTooltip";
 interface Props {
   data: SufferScorePoint[] | DailySufferScorePoint[] | WeeklySufferScorePoint[];
   granularity: "daily" | "weekly";
+  /** Period-over-period delta shown under the title (e.g. a <StatDiff>). */
+  delta?: ReactNode;
 }
 
-export default function SufferScoreChart({ data, granularity }: Props) {
+export default function SufferScoreChart({ data, granularity, delta }: Props) {
   const chartData = data.map((d: any) => ({
     ...d,
     label: formatDateLabel(d.date ?? d.week_start),
@@ -31,6 +34,7 @@ export default function SufferScoreChart({ data, granularity }: Props) {
       <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
         {title}
       </h3>
+      {delta && <div className="mb-1">{delta}</div>}
       <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">
         Accumulates with both duration and intensity. Not a measure of how hard you ran.
       </p>

--- a/frontend/components/trends/TrendBarChart.tsx
+++ b/frontend/components/trends/TrendBarChart.tsx
@@ -9,6 +9,7 @@ import {
   ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
+import { ReactNode } from "react";
 import { formatDateLabel } from "@/lib/format";
 import ChartTooltip from "@/components/charts/ChartTooltip";
 
@@ -16,6 +17,8 @@ interface TrendBarChartProps {
   data: any[];
   type: "distance" | "time";
   granularity: "daily" | "weekly";
+  /** Period-over-period delta shown under the title (e.g. a <StatDiff>). */
+  delta?: ReactNode;
 }
 
 function formatMinutes(seconds: number): string {
@@ -29,6 +32,7 @@ export default function TrendBarChart({
   data,
   type,
   granularity,
+  delta,
 }: TrendBarChartProps) {
   // Configuration based on type
   const isDistance = type === "distance";
@@ -64,7 +68,10 @@ export default function TrendBarChart({
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 shadow-sm p-5">
-      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-4">{title}</h3>
+      <div className="mb-4">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">{title}</h3>
+        {delta}
+      </div>
       {chartData.length === 0 ? (
         <p className="text-gray-400 dark:text-gray-500 text-sm py-8 text-center">
           No data for this range.

--- a/frontend/components/trends/ZoneLoadChart.tsx
+++ b/frontend/components/trends/ZoneLoadChart.tsx
@@ -10,12 +10,15 @@ import {
   ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
+import { ReactNode } from "react";
 import { ZoneLoadWeekPoint, DailyZoneLoadPoint } from "@/lib/types";
 import { formatDateLabel } from "@/lib/format";
 
 interface ZoneLoadChartProps {
   data: ZoneLoadWeekPoint[] | DailyZoneLoadPoint[];
   granularity: "daily" | "weekly";
+  /** Period-over-period delta shown under the title (e.g. a <StatDiff>). */
+  delta?: ReactNode;
 }
 
 const ZONE_COLORS = {
@@ -61,7 +64,7 @@ function CustomTooltip({
   );
 }
 
-export default function ZoneLoadChart({ data, granularity }: ZoneLoadChartProps) {
+export default function ZoneLoadChart({ data, granularity, delta }: ZoneLoadChartProps) {
   const title =
     granularity === "daily"
       ? "Training Load by Zone per Day"
@@ -99,6 +102,7 @@ export default function ZoneLoadChart({ data, granularity }: ZoneLoadChartProps)
         <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
           Easy (&lt;70% HR) · Moderate (70-80%) · Hard (&gt;80%)
         </p>
+        {delta}
       </div>
       <ResponsiveContainer width="100%" height={260}>
         <BarChart data={chartData} barCategoryGap="20%">

--- a/frontend/lib/types/trends.ts
+++ b/frontend/lib/types/trends.ts
@@ -63,6 +63,10 @@ export interface TrendsSummary {
   total_moving_time_s: number;
   activity_count: number;
   total_suffer_score: number;
+  // Period aggregates backing the graph-card deltas (#385). Efficiency is null
+  // when no activity in the window has usable HR/distance.
+  avg_efficiency_mps_per_bpm?: number | null;
+  total_zone_minutes?: number;
 }
 
 export interface TrendsData {


### PR DESCRIPTION
## Summary
This PR adds period-over-period delta indicators to the trends dashboard graph cards, allowing users to see how their metrics have changed compared to the previous period. The deltas are displayed as absolute changes with percentage changes, helping users quickly assess performance trends.

## Key Changes

**Backend:**
- Added two new aggregation functions to compute period-level metrics:
  - `_avg_efficiency()`: Calculates mean HR-efficiency (m/s per bpm) over a window, reusing the efficiency trend logic to ensure consistency
  - `_total_zone_minutes()`: Computes total minutes across all three HR zones (easy, moderate, hard) for the period
- Extended `TrendsSummary` schema with `avg_efficiency_mps_per_bpm` and `total_zone_minutes` fields
- Updated `get_trends_report()` to populate these aggregates for both current and previous period summaries
- Added comprehensive test coverage (`test_trends_summary_aggregates.py`) validating efficiency and zone minute calculations across windows

**Frontend:**
- Enhanced `StatDiff` component to display percentage change alongside absolute delta (e.g., "↑ 2.5 km · 15%")
- Added optional `delta` prop to all trend chart components:
  - `TrendBarChart` (distance/time)
  - `SufferScoreChart`
  - `EfficiencyTrendChart`
  - `ZoneLoadChart`
- Integrated `StatDiff` components into each chart's header to show period-over-period comparisons
- Special handling for efficiency delta: displayed in meters-per-heartbeat (×60) to match chart units
- Updated TypeScript types to include new summary fields

## Notable Implementation Details

- Efficiency aggregates are computed using the same `build_efficiency_trend()` logic as the chart itself, ensuring the average is taken over exactly the activities plotted
- Zone minutes aggregation collapses the 5-zone model (Z1-Z5) into 3 zones (easy/moderate/hard) for consistency with the zone load chart
- Efficiency can be `None` when no activities in the window have usable HR data; zone minutes defaults to 0.0
- Percentage change is omitted when the previous value is zero or missing (no meaningful baseline for comparison)

https://claude.ai/code/session_018xecMbmY6Nm7pNiXwXES89