### PR TITLE
perf(model): defer Activity.raw_summary, undefer the paths that read it (#359/S9)

### DIFF
--- a/backend/app/models/activity.py
+++ b/backend/app/models/activity.py
@@ -43,7 +43,13 @@ class Activity(Base):
 
     user_intent: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
-    raw_summary: Mapped[dict] = mapped_column(JSON, default={})
+    # Deferred (#359/S9): the full Strava summary blob (5-15 KB) is read by only
+    # a handful of paths (classifier sport_type/trainer, laps projection,
+    # average_temp). Loading it on every ORM materialization wasted bandwidth on
+    # bulk scans that never touch it. Like DerivedMetric.stream_view it is pulled
+    # on demand; queries that DO read it add undefer(Activity.raw_summary) to
+    # avoid a per-row lazy load (see the undefer sites + the query-count tests).
+    raw_summary: Mapped[dict] = mapped_column(JSON, default={}, deferred=True)
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
 
     # The Block this activity belongs to (A1, ADR 0011). Nullable: an activity

--- a/backend/app/services/activity_queries.py
+++ b/backend/app/services/activity_queries.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, joinedload, undefer
 
 from app.models import Activity
 
@@ -8,7 +8,10 @@ from app.models import Activity
 def get_activities(db: Session, skip: int = 0, limit: int = 20) -> list[Activity]:
     return (
         db.query(Activity)
-        .options(joinedload(Activity.metrics))
+        # undefer raw_summary (#359): the list composes a classification headline
+        # per item (compose_headline -> sport_type/trainer reads raw_summary), so
+        # without this the deferred column would lazy-load once per row -> N+1.
+        .options(joinedload(Activity.metrics), undefer(Activity.raw_summary))
         .order_by(Activity.start_date.desc())
         .offset(skip)
         .limit(limit)
@@ -26,6 +29,9 @@ def get_activity(db: Session, activity_id: str | uuid.UUID) -> Activity | None:
             joinedload(Activity.metrics),
             joinedload(Activity.check_in),
             joinedload(Activity.streams),
+            # The detail view reads raw_summary (laps projection + headline);
+            # undefer so it loads with the row, not as a follow-up query (#359).
+            undefer(Activity.raw_summary),
         )
         .filter(Activity.id == activity_id)
         .first()

--- a/backend/app/services/analysis/_orchestrator.py
+++ b/backend/app/services/analysis/_orchestrator.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from typing import Optional
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, undefer
 from sqlalchemy import select
 
 from app.models import Activity, DerivedMetric, CheckIn, ActivityStream, StravaAccount, UserProfile
@@ -165,14 +165,21 @@ def analyze(db: Session, activity_id: str, skip_baseline: bool = False) -> Optio
     """
     activity_uuid = _coerce_uuid(activity_id)
 
-    # 1. Load Activity
-    stmt = select(Activity).where(Activity.id == activity_uuid)
+    # 1. Load Activity. undefer raw_summary (#359): analyze reads it (lap-based
+    # interval detection + average_temp), so load it with the row.
+    stmt = (
+        select(Activity)
+        .where(Activity.id == activity_uuid)
+        .options(undefer(Activity.raw_summary))
+    )
     activity = db.execute(stmt).scalars().first()
     if not activity:
         return None
 
-    # 2. Load History (last 20 activities before this one)
-    history = db.query(Activity).filter(
+    # 2. Load History (last 20 activities before this one). undefer raw_summary
+    # (#359): the classifier calls _is_run(a) (-> sport_type -> raw_summary) on
+    # every history row, so a deferred column would lazy-load per row -> N+1.
+    history = db.query(Activity).options(undefer(Activity.raw_summary)).filter(
         Activity.user_id == activity.user_id,
         Activity.start_date < activity.start_date
     ).order_by(Activity.start_date.desc()).limit(20).all()

--- a/backend/app/services/analysis/baseline.py
+++ b/backend/app/services/analysis/baseline.py
@@ -34,7 +34,7 @@ from typing import Optional
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session, selectinload, undefer
 
 from app.models import Activity, DerivedMetric, RunnerBaseline
 
@@ -332,7 +332,10 @@ def recompute_runner_baseline(db: Session, user_id) -> Optional[RunnerBaseline]:
 
     stmt = (
         select(Activity)
-        .options(selectinload(Activity.metrics))
+        # undefer raw_summary (#359): the per-activity sample loop below reads
+        # average_temp from it, so without this the deferred column lazy-loads
+        # once per windowed activity -> N+1 over the rolling window.
+        .options(selectinload(Activity.metrics), undefer(Activity.raw_summary))
         .where(Activity.user_id == user_id)
         .where(Activity.is_deleted == False)  # noqa: E712
         .where(Activity.start_date >= window_start)

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -21,7 +21,7 @@ from datetime import timedelta
 from typing import Any, Dict, Optional
 
 from sqlalchemy import func
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, joinedload, undefer
 
 from app.models import Activity, Block, DerivedMetric, RunnerBaseline, UserProfile
 from app.models.checkin import CheckIn
@@ -804,7 +804,10 @@ def _comparable_bucket_drifts(db: Session, activity: Activity) -> list[float]:
 
     rows = (
         db.query(Activity)
-        .options(joinedload(Activity.metrics))
+        # undefer raw_summary (#359): the loop below reads average_temp from each
+        # scanned row for bucket matching, so a deferred column would lazy-load
+        # once per row -> N+1 across the calibration scan.
+        .options(joinedload(Activity.metrics), undefer(Activity.raw_summary))
         .filter(
             Activity.user_id == activity.user_id,
             Activity.id != activity.id,

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, undefer
 
 from app.core.config import settings
 from app.models import Activity
@@ -278,8 +278,14 @@ async def get_or_generate_coach_report(
     # mid-regen leaves the prior report intact instead of zero rows. Prior schema-
     # versions are untouched (the in-place update keeps the same cache identity).
 
-    # Load activity
-    activity = db.query(Activity).filter(Activity.id == activity_uuid).first()
+    # Load activity. undefer raw_summary (#359): the context pack reads the
+    # subject's raw_summary (headline, average_temp), so load it with the row.
+    activity = (
+        db.query(Activity)
+        .options(undefer(Activity.raw_summary))
+        .filter(Activity.id == activity_uuid)
+        .first()
+    )
     if not activity or not activity.metrics:
         return None
 
@@ -357,7 +363,12 @@ async def generate_opener(db: Session, activity_id: str) -> Optional[OpenerResul
     has no metrics (nothing to react to).
     """
     activity_uuid = _coerce_uuid(activity_id)
-    activity = db.query(Activity).filter(Activity.id == activity_uuid).first()
+    activity = (
+        db.query(Activity)
+        .options(undefer(Activity.raw_summary))  # #359: context reads subject raw_summary
+        .filter(Activity.id == activity_uuid)
+        .first()
+    )
     if not activity or not activity.metrics:
         return None
 
@@ -459,7 +470,12 @@ async def generate_fuller(
     # complete report intact instead of zero rows. Prior schema-versions are untouched
     # (the in-place update keeps the same cache identity).
 
-    activity = db.query(Activity).filter(Activity.id == activity_uuid).first()
+    activity = (
+        db.query(Activity)
+        .options(undefer(Activity.raw_summary))  # #359: context reads subject raw_summary
+        .filter(Activity.id == activity_uuid)
+        .first()
+    )
     if not activity or not activity.metrics:
         return None
 

--- a/backend/app/services/strava_ingestion/ingestion.py
+++ b/backend/app/services/strava_ingestion/ingestion.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 import httpx
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, undefer
 
 from app.models import Activity, ActivityStream, StravaAccount, UserProfile
 from app.schemas import SyncResponse
@@ -121,7 +121,14 @@ def _apply_tokens(account: StravaAccount, tokens: Tokens) -> None:
 
 def upsert_activity(db: Session, raw: dict, user_id) -> Activity:
     """Parse raw Strava JSON and upsert an Activity row. Caller commits."""
-    stmt = select(Activity).where(Activity.strava_activity_id == raw["id"])
+    # undefer raw_summary (#359): the lap-preservation check below reads
+    # existing.raw_summary["laps"], so load it with the row on this hot
+    # (per-sync) upsert path rather than as a follow-up query.
+    stmt = (
+        select(Activity)
+        .where(Activity.strava_activity_id == raw["id"])
+        .options(undefer(Activity.raw_summary))
+    )
     existing = db.execute(stmt).scalars().first()
 
     # Preserve recorded laps across a lap-less re-sync. The detail endpoint

--- a/backend/tests/test_raw_summary_deferred.py
+++ b/backend/tests/test_raw_summary_deferred.py
@@ -1,0 +1,182 @@
+"""raw_summary deferral + N+1 guards (#359 / S9).
+
+Activity.raw_summary is deferred=True so bulk ORM scans that never read it don't
+drag the 5-15 KB blob along. The risk of deferral is a silent per-row lazy load
+(N+1) on the paths that DO read it. These tests:
+
+  1. prove the column is actually deferred (access triggers a follow-up SELECT),
+  2. prove each undefer'd read path loads it WITHOUT a per-row lazy load and that
+     its query count does NOT scale with the number of activities.
+
+The scaling assertions (count at N=small == count at N=large) are robust to the
+exact absolute count: what matters is that nothing grows per activity.
+"""
+
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.orm import undefer
+
+from app.models import Activity, DerivedMetric, User
+from app.services import activity_queries
+from app.services.analysis import analyze
+from app.services.analysis.baseline import recompute_runner_baseline
+from app.services.analysis.classifier import Classification, compose_headline
+from datetime import datetime, timedelta, timezone
+
+
+class _capture:
+    """Capture SQL statements executed on the test session's bind."""
+
+    def __init__(self, db):
+        self.bind = db.get_bind()
+        self.statements: list[str] = []
+
+    def _on_exec(self, conn, cursor, statement, params, context, executemany):
+        self.statements.append(statement)
+
+    def __enter__(self):
+        sa.event.listen(self.bind, "after_cursor_execute", self._on_exec)
+        return self
+
+    def __exit__(self, *a):
+        sa.event.remove(self.bind, "after_cursor_execute", self._on_exec)
+
+    def containing(self, needle: str) -> list[str]:
+        return [s for s in self.statements if needle in s]
+
+    def activity_selects(self) -> list[str]:
+        return [
+            s for s in self.statements
+            if s.lstrip().upper().startswith("SELECT") and "FROM activities" in s
+        ]
+
+
+def _seed_user(db) -> uuid.UUID:
+    u = User(id=uuid.uuid4(), email=f"rs_{uuid.uuid4()}@example.com")
+    db.add(u)
+    db.flush()
+    return u.id
+
+
+def _seed_activity(db, user_id, *, days_ago: int, temp: float = 18.0) -> Activity:
+    a = Activity(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        strava_activity_id=abs(hash(str(uuid.uuid4()))) % 10**9,
+        name="Run",
+        type="Run",
+        start_date=datetime.now(timezone.utc) - timedelta(days=days_ago),
+        distance_m=8000,
+        moving_time_s=2400,
+        elapsed_time_s=2400,
+        elev_gain_m=20.0,
+        avg_hr=150.0,
+        average_speed_mps=3.3,
+        raw_summary={"sport_type": "Run", "average_temp": temp},
+    )
+    db.add(a)
+    db.flush()
+    db.add(
+        DerivedMetric(
+            id=uuid.uuid4(),
+            activity_id=a.id,
+            effort="moderate",
+            effort_score=40.0,
+            hr_drift=3.0,
+            efficiency_analysis={},
+            confidence="high",
+            flags=[],
+            confidence_reasons=[],
+        )
+    )
+    db.flush()
+    return a
+
+
+# --- 1. the column is actually deferred -------------------------------------
+
+def test_raw_summary_is_deferred_and_lazy_loads_on_access(db):
+    uid = _seed_user(db)
+    a = _seed_activity(db, uid, days_ago=1)
+    db.expire_all()  # drop the just-flushed instance state
+
+    plain = db.query(Activity).filter(Activity.id == a.id).first()
+    with _capture(db) as cap:
+        _ = plain.raw_summary  # deferred -> one follow-up SELECT for the column
+    assert len(cap.containing("raw_summary")) == 1, cap.statements
+
+
+def test_undefer_loads_raw_summary_with_the_row(db):
+    uid = _seed_user(db)
+    a = _seed_activity(db, uid, days_ago=1)
+    db.expire_all()
+
+    eager = (
+        db.query(Activity)
+        .options(undefer(Activity.raw_summary))
+        .filter(Activity.id == a.id)
+        .first()
+    )
+    with _capture(db) as cap:
+        _ = eager.raw_summary  # already loaded -> no follow-up query
+    assert cap.containing("raw_summary") == [], cap.statements
+
+
+# --- 2. no N+1 on the read paths (count does not scale with activity count) --
+
+def _list_query_count(db, n_activities: int) -> int:
+    uid = _seed_user(db)
+    for i in range(n_activities):
+        _seed_activity(db, uid, days_ago=i + 1)
+    db.expire_all()
+    with _capture(db) as cap:
+        activities = activity_queries.get_activities(db, limit=100)
+        # replicate the endpoint's per-item headline composition (reads raw_summary)
+        for act in activities:
+            if act.metrics:
+                compose_headline(act, Classification.from_metrics(act.metrics))
+    return len(cap.activity_selects())
+
+
+def test_list_path_has_no_per_activity_raw_summary_query(db):
+    few = _list_query_count(db, 3)
+    many = _list_query_count(db, 8)
+    # Equal count regardless of N => no per-row lazy load (raw_summary rode the
+    # main query via undefer). Without the fix this would be ~1+N.
+    assert few == many, f"list activity-SELECTs scaled with N: {few} vs {many}"
+
+
+def _baseline_query_count(db, n_activities: int) -> int:
+    uid = _seed_user(db)
+    for i in range(n_activities):
+        _seed_activity(db, uid, days_ago=i + 1)
+    db.expire_all()
+    with _capture(db) as cap:
+        recompute_runner_baseline(db, uid)
+    return len(cap.activity_selects())
+
+
+def test_baseline_recompute_has_no_per_activity_raw_summary_query(db):
+    few = _baseline_query_count(db, 3)
+    many = _baseline_query_count(db, 8)
+    assert few == many, f"baseline activity-SELECTs scaled with N: {few} vs {many}"
+
+
+def _analyze_query_count(db, n_history: int) -> int:
+    uid = _seed_user(db)
+    for i in range(n_history):
+        _seed_activity(db, uid, days_ago=i + 5)  # history, older than the subject
+    subject = _seed_activity(db, uid, days_ago=1)
+    db.expire_all()
+    with _capture(db) as cap:
+        analyze(db, str(subject.id))
+    return len(cap.activity_selects())
+
+
+def test_analyze_has_no_per_history_raw_summary_query(db):
+    # The classifier calls _is_run(a) -> raw_summary on every history row; without
+    # the history undefer this would scale with history size.
+    few = _analyze_query_count(db, 2)
+    many = _analyze_query_count(db, 7)
+    assert few == many, f"analyze activity-SELECTs scaled with history size: {few} vs {many}"


### PR DESCRIPTION
Closes #359 (the remaining S9 item; S8/S12 shipped in #361).

## What
`Activity.raw_summary` (the full Strava summary blob, 5-15 KB) had no deferral, so it loaded on **every** ORM materialization of an `Activity` — including bulk scans that never read it (the reanalyze batch reads only `id`/`strava_id`/`user_id` off its eligible rows; `DerivedMetric.stream_view` is already `deferred=True` for exactly this reason). This marks `raw_summary` **`deferred=True`**.

## The N+1 risk (the whole danger of this change) and how it's handled
Deferral means a per-row **lazy load** on paths that read the column. I audited every `raw_summary` read site and added `undefer(Activity.raw_summary)` to each loop / hot / user-facing query:

| Site | Why it reads raw_summary | Risk without undefer |
|---|---|---|
| `get_activities` (list endpoint) | headline per item (`sport_type`/`trainer`) | **N+1 over the list** |
| `analyze()` **history** load | classifier `_is_run(a)` on every history row | **N+1**, ×100 in reanalyze |
| `recompute_runner_baseline` | `average_temp` per windowed activity | **N+1 over the window** |
| `_comparable_bucket_drifts` (M9 scan) | `average_temp` per scanned row | **N+1** (up to 60 rows) |
| `get_activity` (detail) | laps + headline | single (user-facing) |
| `analyze()` subject load | lap detection + average_temp | single |
| `upsert_activity` | lap preservation on re-sync | single (hot sync path) |
| coach service subject loads (×3) | context pack reads subject raw_summary | single per report |

**Deliberately not undefer'd (documented):** the background notification jobs (`process_new_activity`) keep a single bounded lazy-load of the *primary* activity's `raw_summary` for its headline — **one** query per notification, **not** an N+1. Left out to keep this change focused; trivially tightened later if wanted.

## Verification
- **New `test_raw_summary_deferred.py`** (the guard the issue asks for):
  1. proves the column is genuinely deferred (access → exactly one follow-up SELECT) and that `undefer` loads it with the row (zero follow-up) — so the N+1 tests below are *live*, not vacuous;
  2. proves the **list**, **baseline-recompute**, and **analyze** paths do **not** scale their query count with activity / history count.
- **Full suite: 1445 passed** (1440 + 5 new), 4 deselected. No `DetachedInstanceError`; webhook/pipeline/reply paths green.
- **Real-data differential** (prod-seeded local DB, pre-#359 `main` vs this branch): **byte-identical** across analysis (splits/smoothing), load report, trends (all ranges), weekly stats, and the coach context pack. Deferral changes *when* `raw_summary` loads, never its value.

## Concrete payoff
Bulk ORM scans that don't read `raw_summary` (notably the reanalyze batch, ~100 activities) now skip the blob entirely, with zero N+1.

Ref: `docs/audit/performance-audit-2026-06-18.html` (S9).