### PR TITLE
Break the Zone-Load card delta out per HR band (Easy / Moderate / Hard)

### DIFF
--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -78,9 +78,12 @@ class TrendsSummary(BaseModel):
     total_suffer_score: float
     # Period aggregates backing the graph-card deltas (#385). Efficiency is an
     # average (a rate, not a sum) and is None when no activity in the window has
-    # usable HR/distance. Zone minutes is the total across all three HR zones.
+    # usable HR/distance. Zone minutes are split per HR band so the Zone-Load
+    # card can show an Easy / Moderate / Hard delta.
     avg_efficiency_mps_per_bpm: Optional[float] = None
-    total_zone_minutes: float = 0.0
+    zone_easy_minutes: float = 0.0
+    zone_moderate_minutes: float = 0.0
+    zone_hard_minutes: float = 0.0
 
 
 class TrendsResponse(BaseModel):

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -579,15 +579,17 @@ def _avg_efficiency(facts: List[ActivityFact]) -> Optional[float]:
     return round(sum(p["efficiency_mps_per_bpm"] for p in points) / len(points), 4)
 
 
-def _total_zone_minutes(facts: List[ActivityFact]) -> float:
-    """Total minutes across all three HR zones over the window (#385)."""
-    total_s = 0
+def _zone_minutes(facts: List[ActivityFact]) -> tuple[float, float, float]:
+    """Minutes in each HR band (easy, moderate, hard) over the window (#385)."""
+    easy_s = mod_s = hard_s = 0
     for af in facts:
         if not af.time_in_zones:
             continue
-        easy_s, mod_s, hard_s = _collapse_to_3_zones(af.time_in_zones)
-        total_s += easy_s + mod_s + hard_s
-    return round(total_s / 60, 1)
+        e, m, h = _collapse_to_3_zones(af.time_in_zones)
+        easy_s += e
+        mod_s += m
+        hard_s += h
+    return round(easy_s / 60, 1), round(mod_s / 60, 1), round(hard_s / 60, 1)
 
 
 def _summarise_window(facts: List[ActivityFact]) -> WeeklyStatsSummary:
@@ -646,13 +648,16 @@ def get_trends_report(
     daily_facts = build_daily_facts(activity_facts)
 
     # Summary totals across the entire range
+    cur_easy, cur_mod, cur_hard = _zone_minutes(activity_facts)
     summary = TrendsSummary(
         total_distance_m=sum(d.total_distance_m for d in daily_facts),
         total_moving_time_s=sum(d.total_moving_time_s for d in daily_facts),
         activity_count=sum(d.activity_count for d in daily_facts),
         total_suffer_score=sum(d.total_effort_score for d in daily_facts),
         avg_efficiency_mps_per_bpm=_avg_efficiency(activity_facts),
-        total_zone_minutes=_total_zone_minutes(activity_facts),
+        zone_easy_minutes=cur_easy,
+        zone_moderate_minutes=cur_mod,
+        zone_hard_minutes=cur_hard,
     )
 
     # Previous period summary
@@ -661,13 +666,16 @@ def get_trends_report(
     if window is not None:
         current_start, prev_start = window
         prev_facts = _query_activity_facts(db, prev_start, current_start, types=types, user_id=user_id)
+        prev_easy, prev_mod, prev_hard = _zone_minutes(prev_facts)
         previous_summary = TrendsSummary(
             total_distance_m=sum(f.distance_m for f in prev_facts),
             total_moving_time_s=sum(f.moving_time_s for f in prev_facts),
             activity_count=len(prev_facts),
             total_suffer_score=sum(f.effort_score or 0.0 for f in prev_facts),
             avg_efficiency_mps_per_bpm=_avg_efficiency(prev_facts),
-            total_zone_minutes=_total_zone_minutes(prev_facts),
+            zone_easy_minutes=prev_easy,
+            zone_moderate_minutes=prev_mod,
+            zone_hard_minutes=prev_hard,
         )
 
     # 3. Continuous daily facts (every day filled)

--- a/backend/tests/test_trends_summary_aggregates.py
+++ b/backend/tests/test_trends_summary_aggregates.py
@@ -56,7 +56,8 @@ def test_summary_carries_efficiency_and_zone_minutes_per_window(db):
 
     # Current 7D window: speed = 3000/1000 = 3.0 m/s, hr = 150
     #   efficiency = 3.0 / 150 = 0.02 mps/bpm
-    #   zones = (300+300) easy + 300 mod + (60+40) hard = 1000 s = 16.7 min
+    #   zones: easy = (300+300) = 600 s = 10.0 min; moderate = 300 s = 5.0 min;
+    #          hard = (60+40) = 100 s = 1.7 min
     _activity(
         db, user_id, today - timedelta(days=1),
         distance_m=3000, moving_time_s=1000, avg_hr=150,
@@ -64,7 +65,8 @@ def test_summary_carries_efficiency_and_zone_minutes_per_window(db):
     )
     # Previous 7D window: speed = 2000/1000 = 2.0 m/s, hr = 200
     #   efficiency = 2.0 / 200 = 0.01 mps/bpm
-    #   zones = (200+100) easy + 100 mod + (50+50) hard = 500 s = 8.3 min
+    #   zones: easy = (200+100) = 300 s = 5.0 min; moderate = 100 s = 1.7 min;
+    #          hard = (50+50) = 100 s = 1.7 min
     _activity(
         db, user_id, today - timedelta(days=8),
         distance_m=2000, moving_time_s=1000, avg_hr=200,
@@ -75,8 +77,14 @@ def test_summary_carries_efficiency_and_zone_minutes_per_window(db):
 
     assert report.summary.avg_efficiency_mps_per_bpm == 0.02
     assert report.previous_summary.avg_efficiency_mps_per_bpm == 0.01
-    assert report.summary.total_zone_minutes == 16.7
-    assert report.previous_summary.total_zone_minutes == 8.3
+
+    assert report.summary.zone_easy_minutes == 10.0
+    assert report.summary.zone_moderate_minutes == 5.0
+    assert report.summary.zone_hard_minutes == 1.7
+
+    assert report.previous_summary.zone_easy_minutes == 5.0
+    assert report.previous_summary.zone_moderate_minutes == 1.7
+    assert report.previous_summary.zone_hard_minutes == 1.7
 
 
 def test_efficiency_is_none_when_no_activity_has_usable_hr(db):
@@ -92,4 +100,6 @@ def test_efficiency_is_none_when_no_activity_has_usable_hr(db):
     report = get_trends_report(db, "7D", user_id=user_id)
 
     assert report.summary.avg_efficiency_mps_per_bpm is None
-    assert report.summary.total_zone_minutes == 0.0
+    assert report.summary.zone_easy_minutes == 0.0
+    assert report.summary.zone_moderate_minutes == 0.0
+    assert report.summary.zone_hard_minutes == 0.0

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -198,11 +198,26 @@ export default function TrendsPage() {
             data={isDaily ? data.daily_zone_load : data.weekly_zone_load}
             granularity={granularity}
             delta={
-              <StatDiff
-                current={data.summary.total_zone_minutes ?? 0}
-                previous={data.previous_summary?.total_zone_minutes}
-                format={(v) => formatDuration(v * 60)}
-              />
+              <div>
+                <StatDiff
+                  label="Easy"
+                  current={data.summary.zone_easy_minutes ?? 0}
+                  previous={data.previous_summary?.zone_easy_minutes}
+                  format={(v) => formatDuration(v * 60)}
+                />
+                <StatDiff
+                  label="Moderate"
+                  current={data.summary.zone_moderate_minutes ?? 0}
+                  previous={data.previous_summary?.zone_moderate_minutes}
+                  format={(v) => formatDuration(v * 60)}
+                />
+                <StatDiff
+                  label="Hard"
+                  current={data.summary.zone_hard_minutes ?? 0}
+                  previous={data.previous_summary?.zone_hard_minutes}
+                  format={(v) => formatDuration(v * 60)}
+                />
+              </div>
             }
           />
         </div>

--- a/frontend/components/StatDiff.tsx
+++ b/frontend/components/StatDiff.tsx
@@ -15,6 +15,11 @@ interface StatDiffProps {
    * Defaults to false — for distance/time/count/load, more is treated as active.
    */
   lowerIsBetter?: boolean;
+  /**
+   * Optional neutral-coloured prefix (e.g. a zone name) so several deltas can be
+   * told apart when stacked, as on the Zone-Load card.
+   */
+  label?: string;
 }
 
 export default function StatDiff({
@@ -22,13 +27,22 @@ export default function StatDiff({
   previous,
   format,
   lowerIsBetter = false,
+  label,
 }: StatDiffProps) {
   if (previous === undefined || previous === null) return null;
+
+  const prefix = label ? (
+    <span className="text-gray-500 dark:text-gray-400 font-normal">{label} </span>
+  ) : null;
 
   const diff = current - previous;
   // Small epsilon so float noise doesn't render as a spurious change.
   if (Math.abs(diff) < 0.001) {
-    return <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">No change</div>;
+    return (
+      <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+        {prefix}No change
+      </div>
+    );
   }
 
   const isIncrease = diff > 0;
@@ -45,7 +59,7 @@ export default function StatDiff({
 
   return (
     <div className={`text-xs ${color} mt-1 font-medium`}>
-      {arrow} {format(Math.abs(diff))}
+      {prefix}{arrow} {format(Math.abs(diff))}
       {pct !== null && <span className="opacity-75"> · {pct}%</span>}
     </div>
   );

--- a/frontend/lib/types/trends.ts
+++ b/frontend/lib/types/trends.ts
@@ -64,9 +64,12 @@ export interface TrendsSummary {
   activity_count: number;
   total_suffer_score: number;
   // Period aggregates backing the graph-card deltas (#385). Efficiency is null
-  // when no activity in the window has usable HR/distance.
+  // when no activity in the window has usable HR/distance. Zone minutes are
+  // split per HR band for the Zone-Load card's Easy / Moderate / Hard deltas.
   avg_efficiency_mps_per_bpm?: number | null;
-  total_zone_minutes?: number;
+  zone_easy_minutes?: number;
+  zone_moderate_minutes?: number;
+  zone_hard_minutes?: number;
 }
 
 export interface TrendsData {


### PR DESCRIPTION
## Summary
Follow-up to #386. The Training Load by Zone card showed a single combined period-over-period delta; this splits it into one delta per HR band — **Easy**, **Moderate**, **Hard** — each with its own absolute change and percentage vs the previous period.

## Changes
**Backend**
- `TrendsSummary` now carries `zone_easy_minutes` / `zone_moderate_minutes` / `zone_hard_minutes` (current and previous windows) instead of the single `total_zone_minutes`.
- `_zone_minutes()` replaces `_total_zone_minutes()`, returning per-band minutes from the same 3-zone collapse the chart uses.
- `test_trends_summary_aggregates.py` updated to assert per-band minutes for both windows plus the zero case.

**Frontend**
- `StatDiff` gains an optional neutral `label` prefix so several deltas can be told apart when stacked.
- The Zone-Load card renders three labeled `StatDiff` deltas (Easy / Moderate / Hard) instead of one.

## Verification
- Backend: full suite green (1447 passed, 4 integration deselected).
- Frontend: `next lint` + `next build` clean; smoke passed.
- Not covered: visual confirmation of the populated three-line render and the per-band up/down colouring — the smoke fixture has the zone fields null, so that path was type-checked but not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xecMbmY6Nm7pNiXwXES89

---
_Generated by [Claude Code](https://claude.ai/code/session_018xecMbmY6Nm7pNiXwXES89)_