### PR TITLE
fix(intervals): detect lap-marked intervals despite a fast finisher (#389)

### DIFF
--- a/backend/app/services/analysis/intervals.py
+++ b/backend/app/services/analysis/intervals.py
@@ -301,6 +301,19 @@ def _lap_speed(lap: dict) -> Optional[float]:
     return None
 
 
+def _largest_speed_gap_split(ordered: List[float], upper: int) -> Optional[int]:
+    """Index of the largest consecutive gap in sorted ``ordered`` speeds over the
+    candidate splits ``range(1, upper)``. None when no positive gap exists."""
+    best_gap = 0.0
+    at: Optional[int] = None
+    for i in range(1, upper):
+        gap = ordered[i] - ordered[i - 1]
+        if gap > best_gap:
+            best_gap = gap
+            at = i
+    return at
+
+
 def _split_laps_work_rest(speeds: List[float]) -> Optional[List[bool]]:
     """Classify each lap as work (fast) or rest (slow) by speed.
 
@@ -309,6 +322,14 @@ def _split_laps_work_rest(speeds: List[float]) -> Optional[List[bool]]:
     (>= `_MIN_CLUSTER_SEPARATION`) and there are at least two work laps and one
     slow lap. Returns a per-lap work mask, or None when the laps show no
     work/rest pattern (e.g. uniform auto-distance laps, a steady run).
+
+    Fast-finisher fallback (#389): when the largest gap isolates a single very
+    fast lap (a sprint finish far quicker than the reps), the session would
+    otherwise abstain. Instead it falls back to the largest gap that leaves at
+    least two work laps, merging the outlier into the work cluster -- but only
+    when the clusters are genuinely separated (the slowest work lap is clearly
+    faster than the fastest rest lap), so a steady run with one fast surge is not
+    manufactured into an interval session. The normal split path is unchanged.
 
     Additional guard (#189): a single standing-rest lap (zero-speed) with a
     tight fast cluster (CV < 10%) is a steady run with a brief stop, not an
@@ -319,15 +340,19 @@ def _split_laps_work_rest(speeds: List[float]) -> Optional[List[bool]]:
         return None
 
     ordered = sorted(speeds)
-    best_gap = 0.0
-    split_at: Optional[int] = None
-    for i in range(1, n):
-        gap = ordered[i] - ordered[i - 1]
-        if gap > best_gap:
-            best_gap = gap
-            split_at = i
+    split_at = _largest_speed_gap_split(ordered, n)
     if split_at is None:
         return None
+
+    fallback = False
+    if n - split_at < 2:
+        # The largest gap isolates a single very fast lap (a sprint finisher).
+        # Rather than abstain, fall back to the largest gap that leaves >= 2 work
+        # laps, so the outlier joins the work cluster above the boundary (#389).
+        split_at = _largest_speed_gap_split(ordered, n - 1)
+        if split_at is None:
+            return None
+        fallback = True
 
     slow, fast = ordered[:split_at], ordered[split_at:]
     if len(fast) < 2 or len(slow) < 1:
@@ -341,6 +366,14 @@ def _split_laps_work_rest(speeds: List[float]) -> Optional[List[bool]]:
     # work/rest signal, so it is accepted on a positive fast cluster alone; the
     # ratio gate only applies when the slow cluster is itself moving.
     if slow_mean > 0 and fast_mean < slow_mean * _MIN_CLUSTER_SEPARATION:
+        return None
+
+    # On the fallback path only, require a genuinely separated boundary so a
+    # steady run with a lone fast surge is not manufactured into an interval
+    # session: the slowest work lap must be clearly faster than the fastest rest
+    # lap (#389). The mean gate above can be fooled by one outlier inflating the
+    # fast-cluster mean; the normal split path keeps its long-standing behaviour.
+    if fallback and max(slow) > 0 and min(fast) < max(slow) * _MIN_CLUSTER_SEPARATION:
         return None
 
     # Guard: a SINGLE standing-rest lap with a uniformly-paced fast cluster is

--- a/backend/tests/test_intervals_from_laps.py
+++ b/backend/tests/test_intervals_from_laps.py
@@ -612,3 +612,73 @@ class TestAmbiguousSplitAbstain:
         result = detect_intervals_from_laps({"laps": laps})
         assert result is not None
         assert result["summary"]["rep_count"] == 3
+
+
+# Real recorded laps from production activity strava_activity_id 18865186150
+# ("Afternoon Run", 2026-06-10; trust level 1: actual captured lap data, with
+# the rep count human-confirmed against the planned Garmin workout: warmup
+# 1.5 km easy, 6x200 m @ 4:30/km, a fast 100 m finisher, cooldown -> 7 reps).
+# The 100 m finisher was run at 6.25 m/s, far above the ~4.5 m/s 200 m reps; the
+# single-largest-gap split isolated it as the only "work" lap and abstained,
+# discarding the runner's lap marks and undercounting to 6 via the stream
+# heuristic (#389).
+def _lap_rs(idx, dist, mps, ahr, mhr, sec):
+    return {
+        "lap_index": idx, "split": idx, "name": f"Lap {idx}",
+        "distance": float(dist), "average_speed": float(mps),
+        "elapsed_time": int(sec), "moving_time": int(sec),
+        "average_heartrate": float(ahr), "max_heartrate": float(mhr),
+        "resource_state": 2,
+    }
+
+
+_REAL_FAST_FINISHER_LAPS = [
+    _lap_rs(1, 1000, 2.95, 154.8, 172.0, 539),  # warmup
+    _lap_rs(2, 500, 2.99, 168.1, 171.0, 167),   # warmup
+    _lap_rs(3, 99, 2.20, 162.5, 167.0, 44),     # short recovery/transition
+    _lap_rs(4, 200, 4.55, 169.5, 182.0, 44),    # rep 1
+    _lap_rs(5, 92, 2.05, 174.1, 184.0, 44),
+    _lap_rs(6, 200, 4.76, 168.9, 177.0, 42),    # rep 2
+    _lap_rs(7, 86, 1.90, 177.0, 184.0, 44),
+    _lap_rs(8, 200, 4.65, 177.2, 186.0, 43),    # rep 3
+    _lap_rs(9, 79, 1.76, 176.1, 185.0, 44),
+    _lap_rs(10, 200, 4.35, 168.1, 174.0, 46),   # rep 4
+    _lap_rs(11, 80, 1.78, 175.4, 181.0, 44),
+    _lap_rs(12, 200, 4.65, 165.9, 175.0, 43),   # rep 5
+    _lap_rs(13, 89, 1.98, 174.9, 179.0, 44),
+    _lap_rs(14, 200, 4.26, 174.3, 188.0, 47),   # rep 6
+    _lap_rs(15, 65, 1.44, 182.8, 191.0, 44),
+    _lap_rs(16, 100, 6.25, 182.7, 184.0, 16),   # rep 7 (fast 100 m finisher)
+    _lap_rs(17, 152, 2.53, 179.4, 189.0, 59),   # cooldown
+    _lap_rs(18, 11, 2.81, 167.3, 168.0, 4),     # cooldown fragment
+]
+
+
+class TestFastFinisherSplitRobustness:
+    """A lap-recorded interval session whose finisher is much faster than the
+    main reps must still be detected from the laps, not abstained to the stream
+    heuristic because the fast outlier isolates itself in the speed split (#389).
+    """
+
+    def test_real_session_with_fast_finisher_detected_from_laps(self):
+        result = detect_intervals_from_laps({"laps": _REAL_FAST_FINISHER_LAPS})
+
+        assert result is not None, "fast finisher must not abstain the lap path"
+        assert result["source"] == "recorded_laps"
+        # 6x200 m + the 100 m finisher = 7 reps (human-confirmed).
+        assert result["summary"]["rep_count"] == 7
+        # The easy 1.5 km warmup is correctly separated, not counted as a rep.
+        assert result["warmup_duration_s"] is not None
+
+    def test_steady_run_with_fast_finish_still_abstains(self):
+        # A continuous easy run with one fast finishing surge and NO recovery
+        # laps between fast efforts is not an interval session: the next-best
+        # split must not manufacture one (issue AC).
+        laps = [
+            _lap(1, 1000, 3.00, average_heartrate=150.0, max_heartrate=160.0),
+            _lap(2, 1000, 3.05, average_heartrate=152.0, max_heartrate=162.0),
+            _lap(3, 1000, 2.98, average_heartrate=151.0, max_heartrate=161.0),
+            _lap(4, 1000, 3.02, average_heartrate=153.0, max_heartrate=163.0),
+            _lap(5, 200, 5.50, average_heartrate=175.0, max_heartrate=185.0),  # fast finish
+        ]
+        assert detect_intervals_from_laps({"laps": laps}) is None


### PR DESCRIPTION
Closes #389.

## Problem
The lap-based interval detector (`_split_laps_work_rest`) splits the recorded laps at the single largest gap in their sorted speeds. When a session ends with a finisher run much faster than the main reps (e.g. a 100 m strideout at 6.25 m/s among 200 m reps at ~4.5 m/s), that one lap creates the largest gap at the very top and isolates itself as the only work lap, failing the `>=2 work laps` check, so the detector **abstains entirely**. The runner's own lap marks are then discarded and the stream heuristic undercounts (the short finisher falls below its 30 s work-segment floor).

Real example: activity strava `18865186150` (the runner's standard `warmup + 6x200m + 100m finisher + cooldown` = 7 reps, confirmed against the planned Garmin workout) reported **6 reps from the stream fallback** instead of 7 from the laps.

## Fix
When the top gap isolates a lone fast lap, fall back to the largest gap that still leaves `>=2` work laps, so the outlier joins the work cluster. The fallback is guarded by a boundary check (the slowest work lap must be clearly faster than the fastest rest lap) so a steady run with one fast surge is **not** manufactured into an interval session. **The normal split path is unchanged** — sessions whose largest gap already leaves `>=2` work laps take the exact prior code path.

## Validation
Validated end-to-end against all three real lap-sourced sessions of this workout in production:

| activity | before | after |
|---|---|---|
| e1abf436 (06-10, fast 6.25 m/s finisher) | abstain -> stream 6 reps | **7 reps, recorded_laps** |
| 6bafef6f (06-02) | 7 reps | 7 reps (preserved) |
| d4159086 (05-27) | 7 reps | 7 reps (preserved) |

The regression test (`TestFastFinisherSplitRobustness`) uses the **real production lap data** with the human-confirmed rep count, plus a steady-run-with-fast-finish abstain guard. Full backend suite green (1449 passed); all existing lap-detection guards (abstention cases, the four legitimate shapes, standing-rest, #189) unchanged.

## Notes
- The bug was surfaced while investigating #188 (closed won't-fix: brisk-warmup-vs-slow-rep disambiguation is under-determined and had 0 real occurrences for this runner; an HR-band attempt clipped a real rep on 100% of real lap-sourced sessions).
- e1abf436's **stored** metric still says 6; it will pick up the fix on the next `reanalyze` (#300) after deploy.