### PR TITLE
refactor(reanalyze): reconcile the two bulk re-analysis paths (#326)

### DIFF
--- a/backend/scripts/reanalyze_all.py
+++ b/backend/scripts/reanalyze_all.py
@@ -1,48 +1,68 @@
-"""Re-run the analysis pipeline over every stored activity.
+"""Re-run the analysis pipeline over all stored history, run-to-completion.
 
-Used after the classification-axes migration (ADR 0007): existing DerivedMetric
-rows lose `activity_class` and have NULL axes until re-analyzed. This repopulates
-them from the streams already in the database — no Strava calls are made.
+Synchronous, local equivalent of the async re-analysis job (#300): it reuses the
+SAME batch function, `reanalyze_history_batch`, so both paths share one
+re-analysis contract (eligibility, ordering, baseline-once) and cannot drift
+apart (#326). Used by the coach-report eval real-data rebuild
+(`docs/testing/coach-report-eval.md`): it rebuilds historical `DerivedMetric`
+rows from the streams already in the database — no Strava calls — and blocks
+until the whole eligible set is drained (no queue, no pacing), which is exactly
+what the offline eval workflow needs.
 
-    python -m scripts.reanalyze_all            # all activities
-    python -m scripts.reanalyze_all --limit 50 # bound the run
+    python -m scripts.reanalyze_all            # all eligible activities
+    python -m scripts.reanalyze_all --limit 50 # bound the run (newest first)
 
-Idempotent: analyze() upserts the DerivedMetric, so re-running is safe.
+Eligible = non-deleted activities that have stored streams (the only rows that
+can be re-derived offline). Idempotent: `analyze` upserts the `DerivedMetric`, so
+re-running — or resuming after an interruption — is always safe.
 """
 import argparse
+from typing import Optional
 
+from app.core.config import settings
 from app.db.session import SessionLocal
-from app.models import Activity
-from app.services.analysis import analyze
+from app.jobs.reanalyze_history import reanalyze_history_batch
+
+
+def reanalyze_all(
+    db, *, limit: Optional[int] = None, batch_size: Optional[int] = None
+) -> int:
+    """Re-analyze eligible stored history to completion; return the count processed.
+
+    Walks the same eligible set as the async job (non-deleted, stream-bearing),
+    newest first, by looping `reanalyze_history_batch` until the cursor drains —
+    so the re-analysis contract lives in one place. `limit` bounds the TOTAL
+    number of activities processed (None means all); `batch_size` defaults to the
+    configured `REANALYZE_BATCH_SIZE`.
+    """
+    batch_size = batch_size or settings.REANALYZE_BATCH_SIZE
+    processed = 0
+    cursor: Optional[int] = None
+    while limit is None or processed < limit:
+        this_limit = (
+            batch_size if limit is None else min(batch_size, limit - processed)
+        )
+        result = reanalyze_history_batch(db, limit=this_limit, cursor=cursor)
+        processed += len(result.processed)
+        if result.next_cursor is None:  # set drained
+            break
+        cursor = result.next_cursor
+    return processed
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Re-analyze stored activities.")
-    parser.add_argument("--limit", type=int, default=None, help="max activities to process")
+    parser = argparse.ArgumentParser(
+        description="Re-analyze stored activities from their stored streams (run to completion)."
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="max activities to process (newest first)"
+    )
     args = parser.parse_args()
 
     db = SessionLocal()
     try:
-        q = db.query(Activity.id).order_by(Activity.start_date.desc())
-        if args.limit:
-            q = q.limit(args.limit)
-        ids = [row[0] for row in q.all()]
-
-        ok = 0
-        failed = 0
-        for activity_id in ids:
-            try:
-                if analyze(db, str(activity_id)) is not None:
-                    ok += 1
-                else:
-                    failed += 1
-                    print(f"  skipped (no result): {activity_id}")
-            except Exception as exc:  # keep going; report at the end
-                failed += 1
-                db.rollback()
-                print(f"  error on {activity_id}: {exc}")
-
-        print(f"Re-analyzed {ok}/{len(ids)} activities ({failed} skipped/failed).")
+        count = reanalyze_all(db, limit=args.limit)
+        print(f"Re-analyzed {count} activities.")
     finally:
         db.close()
 

--- a/backend/tests/test_reanalyze_history_job.py
+++ b/backend/tests/test_reanalyze_history_job.py
@@ -283,3 +283,60 @@ def test_endpoint_triggers_reanalyze_and_reports_eligible(client, db):
     assert resp.json()["eligible"] == 2
     assert resp.json()["status"] == "scheduled"
     fake_queue.enqueue.assert_called_once()
+
+
+# --- The synchronous run-to-completion CLI (#326) -------------------------------
+# `scripts.reanalyze_all` is the offline eval-rebuild path. It reuses the job's
+# `reanalyze_history_batch`, so the two re-analysis paths share one contract and
+# cannot drift. These tests pin the run-to-completion loop and that the shared
+# eligibility/limit semantics carry through.
+
+
+def test_cli_reanalyzes_whole_set_across_batch_boundaries(db):
+    """The CLI drains every eligible activity even when the eligible set spans
+    several batches, reusing the job's cursor-paged batch function."""
+    from scripts.reanalyze_all import reanalyze_all
+
+    user = _seed_user(db)
+    activities = [_seed_activity(db, user, sid) for sid in (9201, 9202, 9203)]
+
+    # batch_size=2 forces two batches (2 + 1) over the 3 eligible activities.
+    processed = reanalyze_all(db, batch_size=2)
+
+    assert processed == 3
+    assert all(_has_metric(db, a) for a in activities)
+
+
+def test_cli_limit_bounds_the_total_processed(db):
+    """`--limit N` stops after N activities (newest first), leaving the rest
+    untouched, even when a single batch could hold more."""
+    from scripts.reanalyze_all import reanalyze_all
+
+    user = _seed_user(db)
+    a1 = _seed_activity(db, user, 9301)  # oldest by strava id
+    a2 = _seed_activity(db, user, 9302)
+    a3 = _seed_activity(db, user, 9303)  # newest by strava id
+
+    processed = reanalyze_all(db, limit=2, batch_size=10)
+
+    assert processed == 2
+    # Newest two re-analyzed; the oldest left untouched.
+    assert _has_metric(db, a3)
+    assert _has_metric(db, a2)
+    assert not _has_metric(db, a1)
+
+
+def test_cli_inherits_eligibility_excludes_streamless(db):
+    """Eligibility is the job's: streamless activities are not processed, so the
+    CLI cannot drift from the operational path on which rows it touches."""
+    from scripts.reanalyze_all import reanalyze_all
+
+    user = _seed_user(db)
+    streamed = _seed_activity(db, user, 9401, with_streams=True)
+    streamless = _seed_activity(db, user, 9402, with_streams=False)
+
+    processed = reanalyze_all(db)
+
+    assert processed == 1
+    assert _has_metric(db, streamed)
+    assert not _has_metric(db, streamless)


### PR DESCRIPTION
Closes #326.

## What
The two ways to re-run analysis over stored history had drifted apart. The async operational job (`reanalyze_history_job`, #300) and the synchronous eval-rebuild CLI (`scripts/reanalyze_all.py`) both re-derive `DerivedMetric` rows from already-stored streams (no Strava calls), but with different shapes:

| | old CLI | async job |
|---|---|---|
| eligible set | **all** activities | non-deleted **stream-bearing** only |
| ordering | `start_date desc` | `strava_activity_id desc` |
| baseline recompute | **per activity** | **once per user** (the #366 fix) |

Two implementations of one operation invites drift: a future change to the re-analysis contract had to be remembered in both.

## Change
Rewrite `scripts/reanalyze_all.py` so it delegates to the job's already-tested `reanalyze_history_batch`, looping cursor-paged batches to completion. There is now one re-analysis contract; the CLI is a thin synchronous run-to-completion wrapper around it.

The `python -m scripts.reanalyze_all` entrypoint (and its `--limit`) is unchanged, so the 4 references in `docs/testing/coach-report-eval.md` and the eval real-data rebuild workflow keep working with no doc churn.

## Decisions made (you were away — flagging for review)
- **Reconcile without deleting the CLI.** The issue floated retiring `reanalyze_all.py`, but the eval workflow needs a blocking, local, run-to-completion entrypoint and four docs invoke it by name. Deleting/renaming would mean doc churn plus a delete approval, for no functional gain. Keeping the entrypoint and routing it through the shared batch function removes the drift (the actual concern) at minimum risk. Full retirement/rename is left as a deferred option.
- **Left the historical migration docstring untouched.** `a1b2c3d4e5f6_...` names the `reanalyze_all` command, which still exists and still works; editing immutable migration history would be churn with no benefit.

## Modality & behavior
Refactor (consolidate onto one shared function) with a Migrate sliver. For a full no-arg run the end DB state is identical (re-derive every stream-bearing activity, idempotent). Migrate exceptions, all behavior-preserving at the level that matters:
- Streamless activities are now **excluded** rather than attempted-then-skipped (same end state — they were never successfully re-derived anyway).
- Ordering by `strava_activity_id` instead of `start_date` (irrelevant for a full run; for `--limit` it bounds to the newest N, matching "bound the run").
- Baseline recompute once-per-user instead of per-activity (idempotent full pass, identical result, faster).

## Verification
- New CLI tests (in `test_reanalyze_history_job.py`): run-to-completion across batch boundaries, `--limit` bound, eligibility inheritance from the shared function.
- Full reanalyze module green: **15 passed**.
- Entrypoint smoke: `python -m scripts.reanalyze_all --help` resolves (the `-m` invocation the eval docs rely on is intact).
- **Unverified surface:** I did not run the full `make seed-local` + `reanalyze_all` + `make eval` workflow end-to-end (needs a prod snapshot + `ANTHROPIC_API_KEY`). The CLI's behavior is covered transitively via the already-tested `reanalyze_history_batch` plus the new run-to-completion tests.