### PR TITLE
feat(coach-report): surface surviving policy violations in the frontend (#283)

### DIFF
--- a/frontend/components/CoachReportPanel.tsx
+++ b/frontend/components/CoachReportPanel.tsx
@@ -25,6 +25,17 @@ const SHOW_DEBUG_PANEL =
   process.env.NEXT_PUBLIC_SHOW_DEBUG_PANEL === 'true' ||
   process.env.NEXT_PUBLIC_SHOW_DEBUG_PANEL === '1';
 
+// #283: the policy rule whose surviving violation forces a templated fallback
+// rather than a stored report (degrade-not-withhold does NOT apply to it). It can
+// never reach a stored, rendered report, but we exclude it defensively so the
+// advisory below is provably scoped to the non-medical "kept anyway" case.
+const MEDICAL_OVERREACH_RULE = 'medical_overreach';
+
+// #283: turn a backend policy-rule id (e.g. "uncalibrated_zone") into reader text.
+function humanizeRule(rule: string): string {
+  return rule.replace(/_/g, ' ');
+}
+
 interface Props {
   activityId: string;
   hasMetrics: boolean;
@@ -231,6 +242,13 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
   // #338: the internal confidence rating is no longer surfaced to the runner
   // (it still flows over the API in report.meta.confidence; display-only change).
   const { generated_at } = report.meta;
+
+  // #283: a report can trip a non-medical policy rule and still be stored and
+  // rendered (degrade-not-withhold). Surface that so a known-imperfect report is
+  // distinguishable from a clean one instead of looking fully authoritative.
+  const surfacedViolations = (report.meta.policy_violations ?? []).filter(
+    (rule) => rule !== MEDICAL_OVERREACH_RULE,
+  );
 
   // A3 (ADR 0009): the prose-message shape (schema 2.0) renders the message as
   // markdown with tappable-option chips; the legacy structured shape renders the
@@ -484,6 +502,28 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
             </div>
           )}
         </>
+      )}
+
+      {/* #283: surviving (non-medical) policy violations — the report was kept
+          despite an automated quality check flagging it, so mark it as such
+          rather than rendering it identically to a clean report. Renders nothing
+          when the report is clean. Placed once here so it covers both the prose
+          and the legacy structured shapes. */}
+      {surfacedViolations.length > 0 && (
+        <div
+          role="note"
+          title={`Policy rules flagged: ${surfacedViolations.join(', ')}`}
+          className="flex items-start gap-2 rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-xs text-amber-800 dark:text-amber-300"
+        >
+          <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+          <span>
+            Heads up — an automated quality check flagged this analysis
+            {' ('}
+            {surfacedViolations.map(humanizeRule).join(', ')}
+            {'). '}
+            It was kept as written, so read it with extra care.
+          </span>
+        </div>
       )}
 
       {/* Meta footer */}


### PR DESCRIPTION
Closes #283.

## What
When a stored coach report carries surviving **non-medical** policy violations — degrade-not-withhold kept it even though an automated quality check flagged it — make it distinguishable to the reader instead of rendering it identically to a clean report.

## Change
Frontend-only, presentational. The data was already plumbed end-to-end (`meta.policy_violations` on `CoachReportRead`, already typed on the frontend `CoachReportMeta`), so no backend change was needed. `CoachReportPanel.tsx` now renders a subtle amber advisory above the meta footer when `meta.policy_violations` contains any non-medical rule:

> ⚠ Heads up — an automated quality check flagged this analysis (uncalibrated zone). It was kept as written, so read it with extra care.

The humanized rule names are shown inline; the raw rule ids are also in the element's `title` tooltip for operational detail. A clean report renders exactly as before.

## Decisions made (you were away — flagging for review)
- **Subtle amber note, placed once before the meta footer.** One render site covers both report shapes (prose schema 2.0 and legacy structured 1.x), and an understated tone fits a *kept* report (it is intentionally stored, not an error). I avoided a loud top-of-report banner so a minor non-medical nit does not over-alarm. Easy to relocate/restyle if you'd prefer it more prominent.
- **Show humanized rule names inline.** This is effectively a single-user app, so the specific rule is genuinely useful to you; the surrounding sentence keeps it legible to any reader. Raw ids stay in the tooltip.
- **`medical_overreach` excluded defensively.** It forces a templated fallback (whose `meta.policy_violations` defaults to `[]`) rather than a stored report, so it can never reach this surface — out of scope per the issue. Filtering it keeps the advisory provably scoped to the non-medical "kept anyway" case even across report shapes.

## Verification
- `npm run test` (next lint + type-check + next build): **pass** (the new `meta.policy_violations` access and JSX type-check clean).
- `npm run smoke`: **pass** — routes load; the clean-report happy path is unaffected (advisory is gated on a non-empty filtered array).
- Backend trace confirming the condition is correctly scoped: `_to_read` exposes `meta.policy_violations`; both fallback outcomes default it to `[]`; the medical case returns a fallback *before* the non-fallback outcome is built.
- **Unverified surface:** no live screenshot of the flagged state — the smoke mock returns no violations and there is no frontend component-test runner, so reproducing a flagged report needs crafted data. Visual sign-off is yours. The markup mirrors the existing Risks boxes in the same component.