### PR TITLE
feat(frontend): adopt three-typeface system (Fraunces / Hanken Grotesk / IBM Plex Mono)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -33,3 +33,10 @@ textarea,
 .selectable {
   user-select: text;
 }
+
+/* Display headings carry the serif voice (Fraunces); body and UI stay sans
+   (Hanken). Components keep their own size/weight utilities; only the family
+   changes here. */
+h1 {
+  font-family: var(--font-fraunces), Georgia, serif;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,10 +1,28 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
-import { Inter } from 'next/font/google';
+import { Fraunces, Hanken_Grotesk, IBM_Plex_Mono } from 'next/font/google';
 import NavBar from '@/components/NavBar';
 import ThemeProvider from '@/components/ThemeProvider';
 
-const inter = Inter({ subsets: ['latin'] });
+// Three deliberate type roles: Fraunces (serif) is the coach's voice + display
+// headings, Hanken Grotesk (sans) is body + UI, IBM Plex Mono is numbers/data.
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  style: ['normal', 'italic'],
+  variable: '--font-fraunces',
+  display: 'swap',
+});
+const hanken = Hanken_Grotesk({
+  subsets: ['latin'],
+  variable: '--font-hanken',
+  display: 'swap',
+});
+const plexMono = IBM_Plex_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  variable: '--font-plex-mono',
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: 'AI Running Coach',
@@ -26,8 +44,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.className} min-h-screen flex flex-col`}>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${hanken.variable} ${fraunces.variable} ${plexMono.variable}`}
+    >
+      <body className="font-sans min-h-screen flex flex-col">
         <ThemeProvider>
           <NavBar />
           <main className="flex-1 max-w-4xl w-full mx-auto px-4 py-8">

--- a/frontend/components/CoachReportPanel.tsx
+++ b/frontend/components/CoachReportPanel.tsx
@@ -286,7 +286,7 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
                   <>
                     {hasOpener && <hr className="my-4 border-gray-100 dark:border-gray-700" />}
                     {body.headline && (
-                      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">{body.headline}</h3>
+                      <h3 className="text-lg font-serif font-semibold text-gray-900 dark:text-gray-100 mb-2">{body.headline}</h3>
                     )}
                     <div className="prose prose-sm prose-gray dark:prose-invert max-w-none prose-p:my-2 prose-ul:my-2 prose-li:my-0.5 prose-headings:mt-3 prose-headings:mb-1.5">
                       <Markdown>{body.message}</Markdown>
@@ -405,7 +405,7 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
               {reRunButton}
             </div>
             {body.headline && (
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">{body.headline}</h3>
+              <h3 className="text-lg font-serif font-semibold text-gray-900 dark:text-gray-100 mb-2">{body.headline}</h3>
             )}
             {body.thesis && (
               <p className="text-sm text-gray-700 dark:text-gray-300 mb-3 leading-relaxed">{body.thesis}</p>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,7 +6,13 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['var(--font-hanken)', 'system-ui', 'sans-serif'],
+        serif: ['var(--font-fraunces)', 'Georgia', 'serif'],
+        mono: ['var(--font-plex-mono)', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+      },
+    },
   },
   plugins: [
     require('@tailwindcss/typography'),


### PR DESCRIPTION
Closes #394.

Replaces Inter-for-everything with the deliberate type system from the design exploration, giving the app a distinctive typographic identity.

## Roles
- **Fraunces** (serif) — the coach's voice and display headings (page-title `h1`s + the coach-report headline)
- **Hanken Grotesk** (sans) — body and UI, the new default
- **IBM Plex Mono** — numbers / data

## How
- Load the three faces via `next/font/google` as CSS variables in `app/layout.tsx`; drop Inter
- Map them in Tailwind (`sans` → Hanken, `serif` → Fraunces, `mono` → IBM Plex Mono), so every existing `font-mono` becomes Plex Mono and the body becomes Hanken with no component churn
- `h1` headings use Fraunces via a base rule; the coach-report headline gets `font-serif` explicitly

Foundation-level change to the root layout + Tailwind config. **No colour or layout changes** in this slice.

## Out of scope (later)
- Re-classing numbers to mono per component
- Broadening serif to smaller headings
- Any colour / layout work

## Verification
- `npm run test` (lint + build) green; all 8 routes generate, fonts fetch at build
- Rendered `/trends` and `/profile` on the dev server in **dark and light**: page-title `h1`s are Fraunces, body is Hanken, no breakage, colours/layout unchanged
- Not pixel-confirmed live (needs real backend data): the coach-report headline serif and the mono mapping — both compile and are standard Tailwind wiring