### PR TITLE
Disable misbehaving M8 belief loop and A2c narrative

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -109,6 +109,24 @@ class Settings(BaseSettings):
     # code change. Inert under a single-shot prompt (there is no fuller mode to fire).
     COACH_RECEIPT_CADENCE: bool = False
 
+    # Durable-memory kill switches. Both halves of durable memory were found to
+    # misbehave in prod (the M8 belief loop misclassified "take a rest day" advice
+    # as easy-discipline and reinforced a poisoned "ignores easy guidance" belief;
+    # the A2c narrative replayed that fixation back into every report), so they are
+    # disabled pending a recalibration of what each is meant to do.
+    #
+    # COACH_BELIEFS_ENABLED gates the entire M8 belief machinery: the believed_facts
+    # pack section, the M10 preference_profile section (a pure downstream consumer of
+    # the same belief store), and the post-report write-back. Off => both sections
+    # emit their new-runner empty form and no belief is ever written.
+    #
+    # COACH_NARRATIVE_ENABLED gates A2c: the narrative pack section and the
+    # background Consolidation job enqueue. Off => the section is empty and the job
+    # never runs. Re-enabling either is a pure config flip (the stored rows are left
+    # untouched, so a recalibrated re-enable resumes from existing history).
+    COACH_BELIEFS_ENABLED: bool = False
+    COACH_NARRATIVE_ENABLED: bool = False
+
     # Two-stage Exchange cadence (A4, ADR 0010). The opener fires immediately on a
     # finished activity; the conditional fuller turn fires on the runner's reply or
     # this timer, whichever is first. Only the two-stage prompt (coach_message_v2)

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, Optional
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload, undefer
 
+from app.core.config import settings
 from app.models import Activity, Block, DerivedMetric, RunnerBaseline, UserProfile
 from app.models.checkin import CheckIn
 from app.models.coach_chat_message import CoachChatMessage
@@ -556,10 +557,26 @@ def build_b_baseline(
             pain_scores=_recent_pain_scores(db, activity),
         ),
         adherence=_build_adherence_context(db, activity),
-        believed_facts=build_believed_facts(db, activity),
+        # M8 belief machinery (believed_facts + the M10 preference_profile that
+        # reads the same store) is gated off pending recalibration; off => the
+        # new-runner empty form, so the poisoned belief never reaches the prompt.
+        believed_facts=(
+            build_believed_facts(db, activity)
+            if settings.COACH_BELIEFS_ENABLED
+            else BelievedFactsContext(facts=[])
+        ),
         calibration=_build_calibration_context(db, activity),
-        preference_profile=_build_preference_profile(db, activity),
-        narrative=build_narrative_context(db, activity),
+        preference_profile=(
+            _build_preference_profile(db, activity)
+            if settings.COACH_BELIEFS_ENABLED
+            else build_preference_profile([])
+        ),
+        # A2c narrative is gated off pending recalibration; off => empty story.
+        narrative=(
+            build_narrative_context(db, activity)
+            if settings.COACH_NARRATIVE_ENABLED
+            else NarrativeContext()
+        ),
         salience=_build_salience_context(db, activity),
         safety_rules=SafetyRules(
             never_diagnose=True,

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -673,8 +673,13 @@ def _fire_learning_loop(db: Session, activity: Activity, pack: CoachContextPack)
     background — enqueued, never awaited, so the turn never blocks; idempotent, so
     no sentinel is needed.
     """
-    write_back_beliefs(db, activity, pack)
-    enqueue_consolidation(activity.user_id)
+    # Both durable-memory halves are gated off pending recalibration: no belief is
+    # written and no narrative consolidation is enqueued. The read side emits the
+    # empty form for each, so a turn carries neither.
+    if settings.COACH_BELIEFS_ENABLED:
+        write_back_beliefs(db, activity, pack)
+    if settings.COACH_NARRATIVE_ENABLED:
+        enqueue_consolidation(activity.user_id)
 
 
 @dataclass

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -79,3 +79,16 @@ def override_get_db(db):
     but normally 'client' fixture handles the override.
     """
     return db
+
+
+@pytest.fixture
+def enable_durable_memory(monkeypatch):
+    """Turn the M8 belief loop and A2c narrative back on for the tests that
+    exercise that machinery. Both default OFF in prod (the loop misclassified
+    rest-day advice and poisoned a belief; the narrative replayed it), so these
+    feature tests opt in explicitly rather than relying on the disabled default.
+    """
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "COACH_BELIEFS_ENABLED", True)
+    monkeypatch.setattr(settings, "COACH_NARRATIVE_ENABLED", True)

--- a/backend/tests/test_belief_store.py
+++ b/backend/tests/test_belief_store.py
@@ -22,6 +22,11 @@ from app.services.coach.belief_store import (
 from app.services.coach.context import build_context_pack
 from app.services.coach.prompts import PROMPT_VERSIONS, SYSTEM_PROMPT_V4
 
+import pytest
+
+# This module exercises the M8 belief loop, which defaults OFF in prod.
+pytestmark = pytest.mark.usefixtures("enable_durable_memory")
+
 _HEAT_DISCOUNT = {
     "hr_drift_pct": 9.0,
     "likely_inflated_by": ["heat"],

--- a/backend/tests/test_consolidation.py
+++ b/backend/tests/test_consolidation.py
@@ -41,6 +41,9 @@ from app.services.coach.narrative_store import (
 from app.services.coach.service import get_or_generate_coach_report
 from app.services.coach.validator import validate_policy
 
+# This module exercises the A2c narrative + M8 belief machinery (OFF by default).
+pytestmark = pytest.mark.usefixtures("enable_durable_memory")
+
 
 # --------------------------------------------------------------------------
 # Helpers

--- a/backend/tests/test_durable_memory_disabled.py
+++ b/backend/tests/test_durable_memory_disabled.py
@@ -1,0 +1,100 @@
+"""The durable-memory kill switches (COACH_BELIEFS_ENABLED / COACH_NARRATIVE_ENABLED).
+
+Both halves of durable memory default OFF in prod after the M8 belief loop was
+found to misclassify "take a rest day" advice as easy-discipline and reinforce a
+poisoned "ignores easy guidance" belief, which the A2c narrative then replayed.
+
+These tests pin the DISABLED-by-default behaviour: even when belief and narrative
+rows exist in the database, the context pack carries the empty (new-runner) form
+for the believed_facts, preference_profile, and narrative sections, and the
+post-report learning loop writes nothing. They deliberately do NOT request the
+`enable_durable_memory` fixture, so they run against the prod default.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from app.models import Activity, DerivedMetric
+from app.models.coach_narrative import CoachNarrative
+from app.models.coaching_context import CoachingContext
+from app.models.user import User
+from app.services.coach.context import build_context_pack
+from app.services.coach.service import _fire_learning_loop
+
+
+def _user(db):
+    uid = uuid.uuid4()
+    db.add(User(id=uid, email=f"test_{uid}@example.com"))
+    db.flush()
+    return uid
+
+
+def _activity(db, uid):
+    a = Activity(
+        id=uuid.uuid4(), user_id=uid,
+        strava_activity_id=abs(hash(str(uuid.uuid4()))) % 10**9,
+        name="Run", type="Run",
+        start_date=datetime(2026, 3, 10, 8, 0, tzinfo=timezone.utc),
+        distance_m=10000, moving_time_s=3600, elapsed_time_s=3700,
+        avg_hr=150.0, max_hr=175.0, avg_cadence=170.0, elev_gain_m=10.0,
+        average_speed_mps=2.78, raw_summary={},
+    )
+    db.add(a); db.flush()
+    db.add(DerivedMetric(
+        id=uuid.uuid4(), activity_id=a.id, effort="easy", duration_class="standard",
+        structure="continuous", is_hilly=False, is_race=False, effort_score=3.0,
+        confidence="high", confidence_reasons=[], flags=[],
+    ))
+    db.flush()
+    return a
+
+
+def _seed_belief_and_narrative(db, uid):
+    """A poisoned belief and a populated narrative, exactly the prod state."""
+    db.add(CoachingContext(
+        id=uuid.uuid4(), user_id=uid, kind="adherence_pattern", key="easy_discipline",
+        value={"acted": 5, "total": 8, "statement": "mixed response to easy guidance"},
+        confidence="high", observation_count=23,
+        first_observed_at=datetime.now(timezone.utc),
+        last_reinforced_at=datetime.now(timezone.utc),
+    ))
+    db.add(CoachNarrative(
+        id=uuid.uuid4(), user_id=uid,
+        narrative="This runner reliably ignores the rest days I prescribe.",
+    ))
+    db.flush()
+
+
+def test_pack_carries_no_beliefs_when_disabled(db):
+    """believed_facts and preference_profile stay empty even with a stored belief."""
+    uid = _user(db)
+    _seed_belief_and_narrative(db, uid)
+    act = _activity(db, uid)
+
+    pack = build_context_pack(db, act)
+    assert pack.believed_facts.facts == []
+    assert pack.preference_profile.themes == []
+
+
+def test_pack_carries_no_narrative_when_disabled(db):
+    """The narrative section is empty even with a stored narrative row."""
+    uid = _user(db)
+    _seed_belief_and_narrative(db, uid)
+    act = _activity(db, uid)
+
+    assert build_context_pack(db, act).narrative.narrative is None
+
+
+def test_learning_loop_writes_nothing_when_disabled(db):
+    """No belief write-back and no consolidation enqueue under the default flags."""
+    uid = _user(db)
+    act = _activity(db, uid)
+    pack = build_context_pack(db, act)
+
+    with patch("app.services.coach.service.write_back_beliefs") as wb, \
+         patch("app.services.coach.service.enqueue_consolidation") as ec:
+        _fire_learning_loop(db, act, pack)
+
+    wb.assert_not_called()
+    ec.assert_not_called()

--- a/backend/tests/test_preference_context.py
+++ b/backend/tests/test_preference_context.py
@@ -13,6 +13,11 @@ from app.models.user import User
 from app.services.coach.context import build_context_pack
 from app.services.coach.prompts import PROMPT_VERSIONS, SYSTEM_PROMPT_V6
 
+import pytest
+
+# M10 preference reads the M8 belief store, which defaults OFF in prod.
+pytestmark = pytest.mark.usefixtures("enable_durable_memory")
+
 
 def _user(db):
     uid = uuid.uuid4()

--- a/backend/tests/test_two_stage_service.py
+++ b/backend/tests/test_two_stage_service.py
@@ -160,6 +160,7 @@ async def test_opener_idempotent_no_second_llm_call(db, _v2):
 # --- fuller -------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures("enable_durable_memory")  # asserts the M8/A2c loop fires
 async def test_fuller_updates_opener_row_in_place_preserving_opener(db, _v2):
     activity = _seed(db)
     with patch("app.services.coach.service.AnthropicClient",

--- a/backend/tests/test_writeback_is_llm_free.py
+++ b/backend/tests/test_writeback_is_llm_free.py
@@ -39,6 +39,11 @@ from app.services.coach.beliefs import extract_belief_deltas
 from app.services.coach.belief_store import write_back_beliefs
 from app.services.coach.context import build_context_pack
 
+import pytest
+
+# Pins the belief write-back boundary; needs the M8/A2c machinery (OFF by default).
+pytestmark = pytest.mark.usefixtures("enable_durable_memory")
+
 # A heat confound that an LLM "explanation" insists on, but whose STRUCTURED
 # confidence is too low to qualify — the gate is the field, not the prose.
 _LOW_CONF_HEAT = {


### PR DESCRIPTION
## Why
Investigating the owner's two coach reports ("obsessed with rest days / you never rest", produced even after a genuine complete rest day) against real prod data confirmed both halves of durable memory are misbehaving:

- **M8 belief loop:** the only stored behavioural belief was `adherence_pattern/easy_discipline`, confidence high, **observation_count 23**, "mixed response to keeping easy runs easy (acted on 5 of 8)". Rest-day advice ("take a genuine rest day, leave the log empty") has no theme, so it misclassifies as `easy_discipline`; with no rest detection, the next logged activity (often a walk/ride/row, since the runner logs holistically) scores "ignored" and reinforces the belief. It is then replayed into every report's `believed_facts` and into M10 `preference_profile`.
- **A2c narrative:** consolidation re-grounded the relationship story into an accusatory rest-day frame ("reliably ignores the rest days I prescribe"), and the longitudinal digest replayed the coach's own escalating fixation back to it ("round three").

The runner's genuine rest day (2026-06-19, an empty activity log - exactly what the coach asked for) was invisible to the pipeline and read as a suspicious gap.

## What this does
Adds two kill switches, **both default off**, so the fix lands on deploy with no env change:

- `COACH_BELIEFS_ENABLED` gates `believed_facts`, the M10 `preference_profile` (a pure downstream consumer of the same belief store), and the post-report belief write-back.
- `COACH_NARRATIVE_ENABLED` gates the `narrative` section and the background Consolidation enqueue.

Off => each section emits its new-runner empty form and nothing is written. **Stored belief/narrative rows are left untouched**, so a recalibrated re-enable resumes from existing history.

This is a stop-the-bleeding disable. Recalibrating what each is meant to do is tracked in **#401** (M8) and **#402** (A2c).

## Scope note for review
The owner asked to disable "M8 beliefs and A2c narrative". M10 `preference_profile` reads `retrieve_beliefs` directly (`context.py:_build_preference_profile`), so it is folded under the beliefs flag - otherwise the poisoned belief would still reach the prompt via the preference section. Non-run activities are deliberately **not** dropped (holistic-fitness view is intended).

## Tests
- Machinery tests (belief_store, consolidation, preference_context, writeback-is-llm-free, the one two-stage learning-loop assertion) opt back in via a shared `enable_durable_memory` fixture - not weakened, they verify the machinery works when enabled.
- New `test_durable_memory_disabled.py` pins the disabled default: with a poisoned belief and a narrative row present in the DB, the pack still carries empty `believed_facts`/`preference_profile`/`narrative` and the learning loop writes nothing.
- Full backend suite green: **1457 passed, 2 skipped**.

## Deploy note
Default is off in code, so prod picks up the disabled behaviour on the next web+worker redeploy with no Railway env change. Re-enabling later is a pure config flip once #401/#402 land.

Not included (separate filed issues): #399 (activity time shown in UTC not local), #400 (frequency-vs-norm signal).