### PR TITLE
Use the runner's local time for coach reports and day-bucketing (#399)

### DIFF
--- a/backend/alembic/versions/c2d5e8f1a9b4_add_activities_start_date_local.py
+++ b/backend/alembic/versions/c2d5e8f1a9b4_add_activities_start_date_local.py
@@ -1,0 +1,50 @@
+"""add start_date_local on activities (#399)
+
+The runner's local wall-clock start, sourced from Strava's start_date_local.
+start_date stays UTC for ordering/windowing; this column is read only where a
+wall-clock time or calendar day is shown (the coach's time-of-day, trends/load
+day-bucketing). Nullable, with readers falling back to start_date.
+
+Backfills every existing row from the stored raw_summary payload, which carries
+start_date_local on every activity (the trailing Z is misleading — it is already
+local time, so it is parsed naive).
+
+Revision ID: c2d5e8f1a9b4
+Revises: b1f4a7c9d2e3
+Create Date: 2026-06-20 12:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'c2d5e8f1a9b4'
+down_revision: Union[str, None] = 'b1f4a7c9d2e3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'activities',
+        sa.Column('start_date_local', sa.DateTime(timezone=False), nullable=True),
+    )
+    # Backfill from the stored Strava payload. The value looks like
+    # "2026-06-20T09:00:18Z"; strip the misleading Z and cast to a naive timestamp
+    # (it is already the runner's local wall clock). Rows missing the key keep NULL
+    # and fall back to start_date at read time.
+    op.execute(
+        """
+        UPDATE activities
+        SET start_date_local =
+            replace(raw_summary->>'start_date_local', 'Z', '')::timestamp
+        WHERE raw_summary->>'start_date_local' IS NOT NULL
+          AND start_date_local IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('activities', 'start_date_local')

--- a/backend/app/models/activity.py
+++ b/backend/app/models/activity.py
@@ -28,6 +28,14 @@ class Activity(Base):
     strava_activity_id: Mapped[int] = mapped_column(BigInteger, unique=True)
 
     start_date: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    # The runner's local wall-clock start (Strava's start_date_local), stored
+    # timezone-naive. start_date stays UTC for ordering/windowing; this is read
+    # only where a wall-clock time or calendar day is shown to the runner/coach.
+    # Nullable for pre-#399 rows and any payload missing it; readers fall back to
+    # start_date via the local_start property.
+    start_date_local: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=False), nullable=True
+    )
     type: Mapped[str] = mapped_column(String)
     name: Mapped[str] = mapped_column(String)
 
@@ -116,3 +124,13 @@ class Activity(Base):
     )
     streams = relationship("ActivityStream", back_populates="activity", cascade="all, delete-orphan")
     block = relationship("Block", back_populates="activities", foreign_keys=[block_id])
+
+    @property
+    def local_start(self) -> datetime:
+        """The runner's local wall-clock start, for display/day-bucketing only.
+
+        Falls back to the UTC start_date for pre-#399 rows or payloads missing
+        start_date_local, so callers never have to null-check. Never use this for
+        ordering or windowing — start_date (UTC) is the correct instant there.
+        """
+        return self.start_date_local or self.start_date

--- a/backend/app/schemas/activity.py
+++ b/backend/app/schemas/activity.py
@@ -12,6 +12,10 @@ class ActivityBase(BaseModel):
     name: str
     type: str
     start_date: datetime
+    # The runner's local wall-clock start (#399), serialised naive (no offset) so
+    # the frontend renders the activity's own local time regardless of the
+    # viewer's timezone. Null for any pre-#399 row not yet backfilled.
+    start_date_local: Optional[datetime] = None
     distance_m: int
     moving_time_s: int
     elapsed_time_s: int

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -448,7 +448,7 @@ def build_focus_payload(
 
     return FocusPayload(
         activity=ActivityContext(
-            date=subject.start_date.isoformat(),
+            date=subject.local_start.isoformat(),  # local wall-clock (#399)
             name=subject.name,
             type=subject.user_intent or subject.type,
             distance_m=subject.distance_m,
@@ -753,7 +753,7 @@ def _adherence_candidates(
             continue  # unanalysed -> not a fair comparable
         candidates.append(
             CandidateActivity(
-                date=act.start_date.isoformat(),
+                date=act.local_start.isoformat(),  # local wall-clock (#399)
                 effort=metrics.effort,
                 duration_class=metrics.duration_class,
                 structure=metrics.structure,

--- a/backend/app/services/strava_ingestion/ingestion.py
+++ b/backend/app/services/strava_ingestion/ingestion.py
@@ -152,6 +152,15 @@ def upsert_activity(db: Session, raw: dict, user_id) -> Activity:
         "name": raw.get("name", "Unknown Run"),
         "type": raw.get("type", "Run"),
         "start_date": datetime.strptime(raw["start_date"], "%Y-%m-%dT%H:%M:%SZ"),
+        # Strava's local wall-clock start (#399). Same string format as start_date
+        # but the trailing Z is misleading — it is already the runner's local time,
+        # so parse it naive and store it as-is. Absent on rare payloads -> None,
+        # and readers fall back to start_date via Activity.local_start.
+        "start_date_local": (
+            datetime.strptime(raw["start_date_local"], "%Y-%m-%dT%H:%M:%SZ")
+            if raw.get("start_date_local")
+            else None
+        ),
         "distance_m": int(raw.get("distance", 0)),
         "moving_time_s": raw.get("moving_time", 0),
         "elapsed_time_s": raw.get("elapsed_time", 0),

--- a/backend/app/services/training_load.py
+++ b/backend/app/services/training_load.py
@@ -150,6 +150,7 @@ def get_load_report(db: Session, today: Optional[date] = None) -> LoadResponse:
             Activity.id,
             Activity.name,
             Activity.start_date,
+            Activity.start_date_local,
             Activity.type,
             Activity.distance_m,
             Activity.raw_summary,
@@ -192,7 +193,9 @@ def get_load_report(db: Session, today: Optional[date] = None) -> LoadResponse:
     for r in rows:
         if r.effort_score is None:
             continue
-        start = r.start_date.date() if isinstance(r.start_date, datetime) else r.start_date
+        # Bucket by the runner's local calendar day (#399), falling back to UTC.
+        local = r.start_date_local or r.start_date
+        start = local.date() if isinstance(local, datetime) else local
         metrics = SimpleNamespace(
             effort_score=r.effort_score,
             effort=r.effort,

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -51,8 +51,8 @@ class ActivityFact:
 
     def __init__(self, activity: Activity):
         self.activity_id = activity.id
-        # Use the timezone-aware start_date, convert to local date
-        self.local_date: date = activity.start_date.date()
+        # Bucket by the runner's local calendar day (#399), falling back to UTC.
+        self.local_date: date = activity.local_start.date()
         self.activity_type = activity.type
         self.user_intent = activity.user_intent
         self.distance_m = activity.distance_m or 0
@@ -86,7 +86,8 @@ class ActivityFact:
         """
         self = cls.__new__(cls)
         self.activity_id = row.id
-        self.local_date = row.start_date.date()
+        # Bucket by the runner's local calendar day (#399), falling back to UTC.
+        self.local_date = (row.start_date_local or row.start_date).date()
         self.activity_type = row.type
         self.user_intent = row.user_intent
         self.distance_m = row.distance_m or 0
@@ -264,6 +265,7 @@ def _query_activity_facts(
         select(
             Activity.id,
             Activity.start_date,
+            Activity.start_date_local,
             Activity.type,
             Activity.user_intent,
             Activity.distance_m,

--- a/backend/tests/test_local_start_time.py
+++ b/backend/tests/test_local_start_time.py
@@ -1,0 +1,147 @@
+"""The runner's local wall-clock start (#399).
+
+start_date stays UTC for ordering/windowing; start_date_local (Strava's
+start_date_local) is what the coach states as the time of day and what
+trends/load bucket the calendar day by. Readers fall back to start_date when
+start_date_local is absent (pre-#399 rows / payloads missing it).
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+from types import SimpleNamespace
+
+from app.models import Activity, DerivedMetric
+from app.models.user import User
+from app.services.coach.context import build_context_pack
+from app.services.strava_ingestion.ingestion import upsert_activity
+from app.services.trends import ActivityFact
+
+
+def _user(db):
+    uid = uuid.uuid4()
+    db.add(User(id=uid, email=f"test_{uid}@example.com"))
+    db.flush()
+    return uid
+
+
+def _raw(strava_id, *, with_local):
+    raw = {
+        "id": strava_id,
+        "name": "Morning Run",
+        "type": "Run",
+        "start_date": "2026-06-20T08:00:18Z",  # UTC
+        "distance": 5000, "moving_time": 1800, "elapsed_time": 1900,
+        "total_elevation_gain": 10.0, "average_speed": 2.78,
+    }
+    if with_local:
+        raw["start_date_local"] = "2026-06-20T09:00:18Z"  # local wall clock (+1h)
+    return raw
+
+
+# --- ingestion ----------------------------------------------------------------
+
+
+def test_ingestion_stores_local_start(db):
+    uid = _user(db)
+    act = upsert_activity(db, _raw(111, with_local=True), uid)
+    db.flush()
+    assert act.start_date_local == datetime(2026, 6, 20, 9, 0, 18)  # naive local
+    assert act.start_date == datetime(2026, 6, 20, 8, 0, 18)        # UTC unchanged
+    assert act.local_start == datetime(2026, 6, 20, 9, 0, 18)
+
+
+def test_ingestion_without_local_falls_back(db):
+    uid = _user(db)
+    act = upsert_activity(db, _raw(222, with_local=False), uid)
+    db.flush()
+    assert act.start_date_local is None
+    assert act.local_start == act.start_date  # property falls back to UTC
+
+
+def test_resync_backfills_local_start(db):
+    """A first sync without the field, then a re-sync that carries it, populates it."""
+    uid = _user(db)
+    upsert_activity(db, _raw(333, with_local=False), uid)
+    db.flush()
+    act = upsert_activity(db, _raw(333, with_local=True), uid)
+    db.flush()
+    assert act.start_date_local == datetime(2026, 6, 20, 9, 0, 18)
+
+
+# --- coach context (the reported bug) -----------------------------------------
+
+
+def _activity_with_local(db, uid, *, start_utc, start_local):
+    a = Activity(
+        id=uuid.uuid4(), user_id=uid,
+        strava_activity_id=abs(hash(str(uuid.uuid4()))) % 10**9,
+        name="Run", type="Run",
+        start_date=start_utc, start_date_local=start_local,
+        distance_m=10000, moving_time_s=3600, elapsed_time_s=3700,
+        avg_hr=150.0, max_hr=175.0, avg_cadence=170.0, elev_gain_m=10.0,
+        average_speed_mps=2.78, raw_summary={},
+    )
+    db.add(a); db.flush()
+    db.add(DerivedMetric(
+        id=uuid.uuid4(), activity_id=a.id, effort="easy", duration_class="standard",
+        structure="continuous", is_hilly=False, is_race=False, effort_score=3.0,
+        confidence="high", confidence_reasons=[], flags=[],
+    ))
+    db.flush()
+    return a
+
+
+def test_coach_pack_states_local_time(db):
+    """The LLM-facing activity date is the runner's 09:00, not the 08:00 UTC."""
+    uid = _user(db)
+    act = _activity_with_local(
+        db, uid,
+        start_utc=datetime(2026, 6, 20, 8, 0, 18, tzinfo=timezone.utc),
+        start_local=datetime(2026, 6, 20, 9, 0, 18),
+    )
+    pack = build_context_pack(db, act)
+    assert pack.activity.date.startswith("2026-06-20T09:00:18")
+
+
+def test_coach_pack_falls_back_without_local(db):
+    uid = _user(db)
+    act = _activity_with_local(
+        db, uid,
+        start_utc=datetime(2026, 6, 20, 8, 0, 18, tzinfo=timezone.utc),
+        start_local=None,
+    )
+    pack = build_context_pack(db, act)
+    assert pack.activity.date.startswith("2026-06-20T08:00:18")
+
+
+# --- trends/load day bucketing ------------------------------------------------
+
+
+def test_trends_buckets_on_local_day_across_midnight():
+    """A 23:30 UTC run whose local time is 00:30 the next day buckets locally."""
+    row = SimpleNamespace(
+        id=uuid.uuid4(),
+        start_date=datetime(2026, 6, 20, 23, 30, tzinfo=timezone.utc),
+        start_date_local=datetime(2026, 6, 21, 0, 30),
+        type="Run", user_intent=None,
+        distance_m=5000, moving_time_s=1800, elapsed_time_s=1900,
+        elev_gain_m=10.0, avg_hr=150.0, avg_cadence=170.0, average_speed_mps=2.78,
+        effort_score=10.0, effort="easy", time_in_zones=None,
+    )
+    fact = ActivityFact.from_row(row)
+    assert fact.local_date == datetime(2026, 6, 21).date()
+
+
+def test_trends_bucket_falls_back_without_local():
+    row = SimpleNamespace(
+        id=uuid.uuid4(),
+        start_date=datetime(2026, 6, 20, 23, 30, tzinfo=timezone.utc),
+        start_date_local=None,
+        type="Run", user_intent=None,
+        distance_m=5000, moving_time_s=1800, elapsed_time_s=1900,
+        elev_gain_m=10.0, avg_hr=150.0, avg_cadence=170.0, average_speed_mps=2.78,
+        effort_score=10.0, effort="easy", time_in_zones=None,
+    )
+    fact = ActivityFact.from_row(row)
+    assert fact.local_date == datetime(2026, 6, 20).date()

--- a/frontend/app/activities/page.tsx
+++ b/frontend/app/activities/page.tsx
@@ -14,6 +14,7 @@ interface ActivityListItem {
   name: string;
   type: string;
   start_date: string;
+  start_date_local?: string | null;
   distance_m: number;
   moving_time_s: number;
   headline?: string | null;

--- a/frontend/app/activity/[id]/page.tsx
+++ b/frontend/app/activity/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { fetchFromAPI } from '@/lib/api';
 import { format } from 'date-fns';
-import { formatPace, formatDuration, formatDistanceKm } from '@/lib/format';
+import { formatPace, formatDuration, formatDistanceKm, activityStartDate } from '@/lib/format';
 import CheckInForm from '@/components/CheckInForm';
 import Link from 'next/link';
 import { Activity } from '@/lib/types';
@@ -40,7 +40,7 @@ export default async function ActivityDetail({ params }: { params: { id: string 
             <div className="min-w-0">
                 <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 break-words">{activity.name}</h1>
                 <div className="flex flex-wrap gap-x-4 gap-y-2 mt-2 text-gray-600 dark:text-gray-400 items-center">
-                    <span>{format(new Date(activity.start_date), 'PPPP p')}</span>
+                    <span>{format(activityStartDate(activity), 'PPPP p')}</span>
                     <span>{formatDistanceKm(activity.distance_m)}</span>
                     {activity.metrics?.headline && (
                         <span className="inline-block px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 text-sm font-medium">

--- a/frontend/components/ActivityList.tsx
+++ b/frontend/components/ActivityList.tsx
@@ -2,11 +2,14 @@ import Link from 'next/link';
 import { format } from 'date-fns';
 import { ChevronRight } from 'lucide-react';
 
+import { activityStartDate } from '@/lib/format';
+
 interface Activity {
   id: string;
   name: string;
   type: string;
   start_date: string;
+  start_date_local?: string | null;
   distance_m: number;
   moving_time_s: number;
   headline?: string | null;
@@ -36,7 +39,7 @@ export default function ActivityList({ activities }: { activities: Activity[] })
                 )}
               </div>
               <div className="text-sm text-gray-500 dark:text-gray-400 flex flex-wrap gap-x-3 gap-y-1 mt-1">
-                <span>{format(new Date(activity.start_date), 'MMM d, yyyy')}</span>
+                <span>{format(activityStartDate(activity), 'MMM d, yyyy')}</span>
                 <span aria-hidden="true">•</span>
                 <span>{(activity.distance_m / 1000).toFixed(2)} km</span>
                 <span aria-hidden="true">•</span>

--- a/frontend/lib/format.ts
+++ b/frontend/lib/format.ts
@@ -4,6 +4,29 @@
  * Extract reusable display logic here instead of inlining it in components.
  */
 
+/**
+ * The activity's own local wall-clock start as a Date (#399).
+ *
+ * Prefers start_date_local (Strava's local time, a naive "YYYY-MM-DDTHH:MM:SS"
+ * string with no offset) and rebuilds it through the local Date constructor, so
+ * the wall-clock numbers are preserved exactly regardless of the viewer's
+ * timezone (a run logged at 09:00 always shows 09:00, even abroad). Falls back to
+ * the UTC start_date (converted to the browser's zone) when no local time exists.
+ */
+export function activityStartDate(a: {
+  start_date: string;
+  start_date_local?: string | null;
+}): Date {
+  const local = a.start_date_local;
+  if (local) {
+    const [datePart, timePart = "00:00:00"] = local.replace("Z", "").split("T");
+    const [y, m, d] = datePart.split("-").map(Number);
+    const [hh, mm, ss] = timePart.split(":").map(Number);
+    return new Date(y, (m || 1) - 1, d, hh || 0, mm || 0, ss || 0);
+  }
+  return new Date(a.start_date);
+}
+
 /** Format a pace in min:ss /km given metres and seconds. */
 export function formatPace(distanceM: number, timeS: number): string {
   const mps = distanceM / timeS;

--- a/frontend/lib/types/activity.ts
+++ b/frontend/lib/types/activity.ts
@@ -43,6 +43,7 @@ export interface Activity {
   id: string;
   name: string;
   start_date: string;
+  start_date_local?: string | null;
   distance_m: number;
   moving_time_s: number;
   avg_hr?: number;


### PR DESCRIPTION
Closes #399.

## The bug
The coach stated activity times in **UTC**: a run started at **09:00 local** was reported as "Morning slot at 8:00" (the runner is UTC+1). Ingestion stored only Strava's UTC `start_date` and discarded `start_date_local`, and the coach serialised that UTC value straight to the LLM. The frontend, separately, converted the UTC instant to the *viewer's* browser zone, so the displayed time was wrong for a runner viewing from a different timezone than where they ran.

Confirmed on the actual prod row: `start_date = 2026-06-20 08:00:18+00`, while the payload's `start_date_local` is `09:00:18`.

## Approach (owner-selected)
New **`start_date_local`** column (timezone-naive, Strava's value), populated on ingest and **backfilled for all existing rows** from the stored `raw_summary` payload. Verified every one of the 464 prod rows carries `start_date_local`, so the backfill is complete.

`start_date` stays **UTC** for ordering/windowing/clustering (the correct instant). Anything that shows a wall-clock or calendar day takes local, falling back to UTC when local is absent:
- **Backend** via the `Activity.local_start` property.
- **Frontend** via a new `activityStartDate` helper that rebuilds the naive local string through the local `Date` constructor, so the activity's wall-clock numbers render identically regardless of the viewer's timezone (verified 9:00 under Tokyo / New York / London).

## What now reads local
- The coach's LLM-facing activity date — subject run **and** comparable candidates.
- Trends per-day bucketing and training-load weekly bucketing.
- The frontend: activity detail (time + date) and the activity list (date), plus the home page list (reuses `ActivityList`).

Every other `start_date` use (ORDER BY, EWMA windows, block clustering, block bounds) is left on UTC by design.

## Deliberately out of scope
- **Window-anchor date math** (`recent_training_summary`, chat trends `_build_trends_summary`) stays on the UTC `start_date.date()` anchor. The facts inside now bucket local, so there's a possible 1-day edge effect near local midnight; aligning the anchors is a small follow-up best done with **#400** (which reworks these windows anyway).

## Verification
- Migration **applied to a real Postgres** seeded with prod data: column created, all rows backfilled, today's run → `09:00:18`. The previously-failing integration `test_models` passes against the migrated DB.
- Backfill expression dry-run read-only on prod: correct local values for all 464 rows.
- New `test_local_start_time.py`: ingest store / fallback / re-sync backfill, the coach pack stating **09:00 not 08:00**, trends bucketing on the **local day across a UTC-midnight boundary**.
- Frontend `activityStartDate` proven timezone-invariant (9:00 under Tokyo/New York/London); lint + build + type-check green.
- Backend baseline: **1462 passed** (`make backend-test`).

## Deploy note
The backfill runs inside the migration, so `alembic upgrade head` on the web service deploy fixes both new and historical activities in one step. No env change.