### PR TITLE
All Activities filters + Trends/Load nav cleanup (#404, #406)

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import Annotated, List, Optional
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -159,15 +159,23 @@ async def sync_activities(
 
 @router.get("/activities", response_model=List[ActivityRead])
 def read_activities(
-    skip: int = 0, 
-    limit: int = 20, 
+    skip: int = 0,
+    limit: int = 20,
+    types: Optional[List[str]] = Query(None, description="Activity types to include (multi-select)"),
+    start_date: Optional[date] = Query(None, description="Only activities on/after this date (UTC, inclusive)"),
+    end_date: Optional[date] = Query(None, description="Only activities on/before this date (UTC, inclusive)"),
     db: Session = Depends(get_db)
 ):
     """
-    Get stored activities (paginated).
+    Get stored activities (paginated), optionally filtered by type and date range (#404).
+
+    Filters apply server-side before pagination, so they narrow the whole history
+    rather than only the rows already loaded by the client.
     """
     # Note: In multi-user app, filter by current_user.id
-    activities = activity_queries.get_activities(db, skip=skip, limit=limit)
+    activities = activity_queries.get_activities(
+        db, skip=skip, limit=limit, types=types, start_date=start_date, end_date=end_date
+    )
     responses = []
     for activity in activities:
         response = ActivityRead.model_validate(activity)

--- a/backend/app/services/activity_queries.py
+++ b/backend/app/services/activity_queries.py
@@ -1,17 +1,47 @@
 import uuid
+from datetime import date, datetime, time, timedelta, timezone
 
 from sqlalchemy.orm import Session, joinedload, undefer
 
 from app.models import Activity
 
 
-def get_activities(db: Session, skip: int = 0, limit: int = 20) -> list[Activity]:
-    return (
+def get_activities(
+    db: Session,
+    skip: int = 0,
+    limit: int = 20,
+    *,
+    types: list[str] | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> list[Activity]:
+    """List activities newest-first, paginated, with optional filters (#404).
+
+    ``types`` narrows to the given activity types (OR within the list). ``start_date``
+    and ``end_date`` bound the range on ``start_date`` (UTC) and are both inclusive of
+    the whole day. Filters compose; pagination is applied after filtering so it walks
+    the filtered history rather than the full one.
+    """
+    query = (
         db.query(Activity)
         # undefer raw_summary (#359): the list composes a classification headline
         # per item (compose_headline -> sport_type/trainer reads raw_summary), so
         # without this the deferred column would lazy-load once per row -> N+1.
         .options(joinedload(Activity.metrics), undefer(Activity.raw_summary))
+    )
+    if types:
+        query = query.filter(Activity.type.in_(types))
+    if start_date is not None:
+        # Bound on start_date (UTC, the indexed ordering column). The chosen date is
+        # treated as a UTC day, consistent with how the list orders/windows.
+        lower = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
+        query = query.filter(Activity.start_date >= lower)
+    if end_date is not None:
+        # End inclusive: everything strictly before the start of the following day.
+        upper = datetime.combine(end_date + timedelta(days=1), time.min, tzinfo=timezone.utc)
+        query = query.filter(Activity.start_date < upper)
+    return (
+        query
         .order_by(Activity.start_date.desc())
         .offset(skip)
         .limit(limit)

--- a/backend/tests/test_activity_list_filters.py
+++ b/backend/tests/test_activity_list_filters.py
@@ -1,0 +1,97 @@
+"""All Activities list supports server-side type and date-range filters (#404).
+
+Filtering must apply to the whole history (before pagination) and compose, so these
+tests assert against the /api/activities endpoint with combinations of params.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from app.models import Activity, User
+
+
+def _make_activity(db, *, name: str, type_: str, start: datetime) -> Activity:
+    user_id = uuid.uuid4()
+    db.add(User(id=user_id, email=f"filt_{user_id}@example.com"))
+    db.flush()
+    a = Activity(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        strava_activity_id=abs(hash(str(uuid.uuid4()))) % 10**9,
+        name=name,
+        type=type_,
+        start_date=start,
+        distance_m=10000,
+        moving_time_s=3600,
+        elapsed_time_s=3700,
+        elev_gain_m=10.0,
+    )
+    db.add(a)
+    db.commit()
+    return a
+
+
+@pytest.fixture
+def seeded(db):
+    """A small mixed history across types and dates."""
+    _make_activity(db, name="Run Jan", type_="Run", start=datetime(2026, 1, 10, 9, 0, tzinfo=timezone.utc))
+    _make_activity(db, name="Walk Feb", type_="Walk", start=datetime(2026, 2, 15, 9, 0, tzinfo=timezone.utc))
+    _make_activity(db, name="Ride Mar", type_="Ride", start=datetime(2026, 3, 20, 9, 0, tzinfo=timezone.utc))
+    _make_activity(db, name="Run Apr", type_="Run", start=datetime(2026, 4, 5, 9, 0, tzinfo=timezone.utc))
+    return db
+
+
+def _names(resp):
+    return {item["name"] for item in resp.json()}
+
+
+def test_no_filter_returns_all(client, seeded):
+    resp = client.get("/api/activities")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == {"Run Jan", "Walk Feb", "Ride Mar", "Run Apr"}
+
+
+def test_single_type_filter(client, seeded):
+    resp = client.get("/api/activities?types=Run")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == {"Run Jan", "Run Apr"}
+
+
+def test_multi_type_filter_is_union(client, seeded):
+    resp = client.get("/api/activities?types=Run&types=Ride")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == {"Run Jan", "Ride Mar", "Run Apr"}
+
+
+def test_date_range_is_inclusive_both_ends(client, seeded):
+    # Bounds land exactly on the Feb and Mar activity dates; both must be included.
+    resp = client.get("/api/activities?start_date=2026-02-15&end_date=2026-03-20")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == {"Walk Feb", "Ride Mar"}
+
+
+def test_start_date_only(client, seeded):
+    resp = client.get("/api/activities?start_date=2026-03-01")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == {"Ride Mar", "Run Apr"}
+
+
+def test_end_date_only(client, seeded):
+    resp = client.get("/api/activities?end_date=2026-02-15")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == {"Run Jan", "Walk Feb"}
+
+
+def test_type_and_date_compose(client, seeded):
+    # Runs, but only from March onward -> excludes the January run.
+    resp = client.get("/api/activities?types=Run&start_date=2026-03-01")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == {"Run Apr"}
+
+
+def test_empty_result_when_nothing_matches(client, seeded):
+    resp = client.get("/api/activities?types=Swim")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []

--- a/frontend/app/activities/page.tsx
+++ b/frontend/app/activities/page.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Loader2 } from 'lucide-react';
+import { Loader2, X } from 'lucide-react';
 import { fetchFromAPI } from '@/lib/api';
 import ActivityList from '@/components/ActivityList';
+import ActivityTypeFilter from '@/components/trends/ActivityTypeFilter';
+import DateRangeFilter, { DateRange } from '@/components/activities/DateRangeFilter';
 
-// One request per "page". The backend GET /api/activities already returns
-// activities newest-first with skip/limit pagination, so this view just walks it.
+// One request per "page". The backend GET /api/activities returns activities
+// newest-first with skip/limit pagination and applies any filters server-side,
+// so this view walks the *filtered* history a page at a time.
 const PAGE_SIZE = 20;
 
 interface ActivityListItem {
@@ -20,17 +23,50 @@ interface ActivityListItem {
   headline?: string | null;
 }
 
+interface Filters {
+  types: string[];
+  startDate: string | null;
+  endDate: string | null;
+}
+
+const EMPTY_FILTERS: Filters = { types: [], startDate: null, endDate: null };
+
+function filtersActive(f: Filters): boolean {
+  return f.types.length > 0 || f.startDate !== null || f.endDate !== null;
+}
+
+function buildQuery(skip: number, f: Filters): string {
+  const params = new URLSearchParams();
+  params.set('skip', String(skip));
+  params.set('limit', String(PAGE_SIZE));
+  f.types.forEach((t) => params.append('types', t));
+  if (f.startDate) params.set('start_date', f.startDate);
+  if (f.endDate) params.set('end_date', f.endDate);
+  return params.toString();
+}
+
 export default function AllActivitiesPage() {
   const [activities, setActivities] = useState<ActivityListItem[]>([]);
   const [status, setStatus] = useState<'loading' | 'loaded' | 'loadingMore' | 'error'>('loading');
   const [hasMore, setHasMore] = useState(true);
+  const [availableTypes, setAvailableTypes] = useState<string[]>([]);
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
 
-  const loadFrom = useCallback(async (skip: number) => {
+  // The distinct activity types present in the history, for the type filter.
+  // Reuses the Trends endpoint (#404), which returns non-deleted types sorted.
+  useEffect(() => {
+    fetchFromAPI('/api/trends/types')
+      .then((types: string[] | null) => setAvailableTypes(types ?? []))
+      .catch(() => {});
+  }, []);
+
+  // `activeFilters` is passed explicitly so pagination never reads a stale closure.
+  const loadFrom = useCallback(async (skip: number, activeFilters: Filters) => {
     const isFirstPage = skip === 0;
     setStatus(isFirstPage ? 'loading' : 'loadingMore');
     try {
       const batch: ActivityListItem[] | null = await fetchFromAPI(
-        `/api/activities?skip=${skip}&limit=${PAGE_SIZE}`,
+        `/api/activities?${buildQuery(skip, activeFilters)}`,
       );
       const items = batch ?? [];
       setActivities((prev) => (isFirstPage ? items : [...prev, ...items]));
@@ -42,9 +78,15 @@ export default function AllActivitiesPage() {
     }
   }, []);
 
+  // Reload from the first page whenever the filters change (and on mount). The
+  // server reapplies the filters to the whole history, so the list stays correct
+  // rather than narrowing only the rows already loaded.
   useEffect(() => {
-    loadFrom(0);
-  }, [loadFrom]);
+    loadFrom(0, filters);
+  }, [filters, loadFrom]);
+
+  const isFiltered = filtersActive(filters);
+  const clearFilters = () => setFilters(EMPTY_FILTERS);
 
   return (
     <div className="space-y-6">
@@ -52,6 +94,30 @@ export default function AllActivitiesPage() {
         <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">All Activities</h1>
         <p className="text-gray-600 dark:text-gray-400 mt-1">Your full run history, newest first.</p>
       </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <ActivityTypeFilter
+          available={availableTypes}
+          selected={filters.types}
+          onChange={(types) => setFilters((f) => ({ ...f, types }))}
+        />
+        <DateRangeFilter
+          startDate={filters.startDate}
+          endDate={filters.endDate}
+          onChange={(r: DateRange) =>
+            setFilters((f) => ({ ...f, startDate: r.startDate, endDate: r.endDate }))
+          }
+        />
+        {isFiltered && (
+          <button
+            onClick={clearFilters}
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+          >
+            <X className="w-3.5 h-3.5" />
+            Clear filters
+          </button>
+        )}
+      </div>
 
       {status === 'loading' && (
         <div className="flex items-center justify-center gap-2 text-gray-500 dark:text-gray-400 py-10">
@@ -64,7 +130,7 @@ export default function AllActivitiesPage() {
         <div className="bg-red-50 dark:bg-red-900/30 rounded-xl border border-red-200 dark:border-red-800 p-6">
           <p className="text-red-700 dark:text-red-300 text-sm">Could not load activities.</p>
           <button
-            onClick={() => loadFrom(0)}
+            onClick={() => loadFrom(0, filters)}
             className="mt-2 text-sm text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-200 underline"
           >
             Try again
@@ -77,15 +143,28 @@ export default function AllActivitiesPage() {
       )}
 
       {status === 'loaded' && activities.length === 0 && (
-        <div className="text-gray-500 dark:text-gray-400 italic">
-          No activities found yet. Try syncing from the home page.
-        </div>
+        isFiltered ? (
+          <div className="text-gray-500 dark:text-gray-400">
+            No activities match these filters.{' '}
+            <button
+              onClick={clearFilters}
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Clear filters
+            </button>{' '}
+            to see your full history.
+          </div>
+        ) : (
+          <div className="text-gray-500 dark:text-gray-400 italic">
+            No activities found yet. Try syncing from the home page.
+          </div>
+        )
       )}
 
       {hasMore && activities.length > 0 && (
         <div className="flex justify-center">
           <button
-            onClick={() => loadFrom(activities.length)}
+            onClick={() => loadFrom(activities.length, filters)}
             disabled={status === 'loadingMore'}
             className="inline-flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-5 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:border-blue-300 dark:hover:border-blue-700 hover:text-blue-600 dark:hover:text-blue-400 transition-colors disabled:opacity-60 disabled:cursor-default"
           >

--- a/frontend/app/load/page.tsx
+++ b/frontend/app/load/page.tsx
@@ -91,11 +91,8 @@ export default function LoadPage() {
 
   return (
     <div className="space-y-6">
-      <header className="flex items-center justify-between">
+      <header>
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Training Load</h1>
-        <Link href="/trends" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
-          Trends →
-        </Link>
       </header>
 
       {/* Weekly score card */}

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Fragment, useEffect, useState, useCallback } from "react";
-import Link from "next/link";
 import { TrendsData, TrendsRange } from "@/lib/types";
 import { formatDistanceKm, formatDuration } from "@/lib/format";
 import { fetchFromAPI } from "@/lib/api";
@@ -121,12 +120,6 @@ export default function TrendsPage() {
               ))}
             </div>
           )}
-          <Link
-            href="/"
-            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700/50"
-          >
-            Dashboard
-          </Link>
         </div>
       </header>
 

--- a/frontend/components/activities/DateRangeFilter.tsx
+++ b/frontend/components/activities/DateRangeFilter.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+export interface DateRange {
+  startDate: string | null; // YYYY-MM-DD, inclusive
+  endDate: string | null; // YYYY-MM-DD, inclusive
+}
+
+interface Props {
+  startDate: string | null;
+  endDate: string | null;
+  onChange: (range: DateRange) => void;
+}
+
+// Preset windows expressed as days back from today; null = all time.
+const PRESETS: { key: string; label: string; days: number | null }[] = [
+  { key: "ALL", label: "All", days: null },
+  { key: "7D", label: "7D", days: 7 },
+  { key: "30D", label: "30D", days: 30 },
+  { key: "3M", label: "3M", days: 90 },
+  { key: "6M", label: "6M", days: 180 },
+  { key: "1Y", label: "1Y", days: 365 },
+];
+
+function toISO(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function daysAgoISO(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return toISO(d);
+}
+
+export default function DateRangeFilter({ startDate, endDate, onChange }: Props) {
+  // A preset is "active" when the current range matches the window it would set:
+  // a start `days` back and an open end. Editing a date input therefore clears the
+  // highlight automatically, since the range no longer matches any preset.
+  function applyPreset(days: number | null) {
+    if (days === null) onChange({ startDate: null, endDate: null });
+    else onChange({ startDate: daysAgoISO(days), endDate: null });
+  }
+
+  function isPresetActive(days: number | null): boolean {
+    if (days === null) return !startDate && !endDate;
+    return startDate === daysAgoISO(days) && !endDate;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-1 gap-0.5">
+        {PRESETS.map(({ key, label, days }) => (
+          <button
+            key={key}
+            onClick={() => applyPreset(days)}
+            className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+              isPresetActive(days)
+                ? "bg-blue-600 text-white shadow-sm"
+                : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="inline-flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400">
+        <input
+          type="date"
+          aria-label="From date"
+          value={startDate ?? ""}
+          max={endDate ?? undefined}
+          onChange={(e) => onChange({ startDate: e.target.value || null, endDate })}
+          className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1.5 text-gray-700 dark:text-gray-300"
+        />
+        <span aria-hidden="true" className="text-gray-400 dark:text-gray-500">
+          –
+        </span>
+        <input
+          type="date"
+          aria-label="To date"
+          value={endDate ?? ""}
+          min={startDate ?? undefined}
+          onChange={(e) => onChange({ startDate, endDate: e.target.value || null })}
+          className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1.5 text-gray-700 dark:text-gray-300"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #404. Closes #406.

## #404 — Filters on the All Activities view
Filter the All Activities list by **activity type** and **date range**. Filtering is server-side via new optional query params on `GET /api/activities`, so it applies to the **whole history before pagination** rather than only the rows already loaded (an acceptance criterion of the issue).

**Backend**
- `get_activities` gains keyword-only `types` / `start_date` / `end_date` filters: `types` is an OR-set, the date bounds are inclusive of the whole day (compared on `start_date`, the indexed UTC ordering column), and pagination runs after filtering.
- `read_activities` threads the params through, mirroring the existing `/trends` pattern.
- New `test_activity_list_filters.py` covers single/multi type, inclusive date bounds (both ends), start-only, end-only, type+date composition, and the empty-result case.

**Frontend**
- Reuses the existing `ActivityTypeFilter`; adds `DateRangeFilter` (presets **plus** custom from/to date inputs).
- Resets to the first page on any filter change and passes the active filters into each page fetch; adds a distinct "no activities match these filters" empty state with a clear-filters action.

## #406 — Remove redundant inline nav links
- Trends page: removed the **Dashboard** button next to the filters (and its now-unused `next/link` import).
- Training Load page: removed the **Trends →** header link.
- Both destinations remain reachable via the top nav bar.

## Verification
- Backend: 15/15 relevant tests pass (8 new filter tests exercise the real endpoint end-to-end).
- Frontend: `next lint` clean, production build succeeds, runtime smoke passes (app boots, all routes render, load-more terminator works).
- Not machine-verified (human review): visual/UX of the filter bar, date pickers, dark mode, and mobile layout.

## Follow-ups filed (not addressed here)
- #410 — the All Activities list shows soft-deleted activities (the one read path that doesn't exclude `is_deleted`).
- #411 — the date filter matches on UTC rather than the activity's displayed local date (boundary-near-midnight refinement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019hxVBnjrmc2UJ9D8ckYzVo)_