### PR TITLE
Trends: calendar period framing, typical line, clearer comparisons (#413)

### DIFF
--- a/backend/app/api/trends.py
+++ b/backend/app/api/trends.py
@@ -53,13 +53,16 @@ def get_training_load(db: Session = Depends(get_db)):
 @router.get("/trends/volume", response_model=VolumeReport)
 def get_volume(
     range: str = Query("7D", description="7D | 30D | 3M | 6M | 1Y"),
+    types: Optional[List[str]] = Query(None, description="Activity types to include (multi-select)"),
     db: Session = Depends(get_db),
 ):
     """Frequency-/volume-vs-norm report for the selected range, as of today:
     per-metric current vs the runner's norm, in rolling and calendar-period
-    framings scaled to the range (#400)."""
+    framings scaled to the range (#400). ``types`` scopes both the window and the
+    norm baseline so the comparison stays like-for-like with the filtered Trends
+    charts (#413)."""
     user_id = get_current_user_profile(db).user_id
-    return get_volume_report(db, user_id, range)
+    return get_volume_report(db, user_id, range, types=types)
 
 
 @router.get("/stats/weekly", response_model=WeeklyStatsResponse)

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -232,9 +232,10 @@ def _resolve_window(
     - ``rolling``: ``since`` is ``today - (N-1)`` and the previous window is the
       equal-length block immediately before it (unchanged behaviour).
     - ``calendar``: ``since`` is the start of the current calendar period (week/
-      month/quarter/half/year) and the previous window is the SAME span of days
-      from the prior period (e.g. Jun 1-20 vs May 1-20), so a partial period
-      compares like-for-like.
+      month/quarter/half/year) and the previous window is the ENTIRE previous
+      calendar period (e.g. Jun 1-20 to-date vs ALL of May), so "vs last month"
+      reads against last month's full total — it runs behind for most of the
+      period and catches up by period-end (#413).
     """
     today = today or date.today()
     days = _RANGE_DAYS.get(range_key.upper())
@@ -244,11 +245,11 @@ def _resolve_window(
         from app.services.coach.volume import _calendar_period
 
         p_start, _, _, _ = _calendar_period(range_key.upper(), today)
-        elapsed = (today - p_start).days + 1
         prev_p_start, _, _, _ = _calendar_period(
             range_key.upper(), p_start - timedelta(days=1)
         )
-        return p_start, prev_p_start, prev_p_start + timedelta(days=elapsed)
+        # Previous = the whole prior calendar period: [prev_p_start, p_start).
+        return p_start, prev_p_start, p_start
     since = today - timedelta(days=days - 1)
     return since, since - timedelta(days=days), since
 
@@ -368,13 +369,19 @@ def build_continuous_daily_facts(
     daily_facts: List[DailyFact],
     range_key: str = "30D",
     since: Optional[date] = None,
+    until: Optional[date] = None,
 ) -> List[DailyFact]:
     """
     Fill every day in the range so charts have continuous x-axes.
 
     Pass ``since`` to override the window start (the #400 calendar mode).
+    Pass ``until`` to override the window end (#413): calendar mode passes the
+    calendar period's last day so the chart frames the whole period (e.g. the
+    full Mon–Sun week for 7D), with days after today rendered as empty bars.
+    Defaults to today (rolling).
     """
     today = date.today()
+    end = until if until is not None else today
     if since is None:
         since = _resolve_since(range_key)
 
@@ -383,12 +390,12 @@ def build_continuous_daily_facts(
     elif daily_facts:
         start = daily_facts[0].local_date
     else:
-        start = today
+        start = end
 
     existing = {df.local_date: df for df in daily_facts}
     result: List[DailyFact] = []
     cursor = start
-    while cursor <= today:
+    while cursor <= end:
         result.append(existing.get(cursor, DailyFact(cursor)))
         cursor += timedelta(days=1)
 
@@ -399,12 +406,16 @@ def build_weekly_buckets(
     daily_facts: List[DailyFact],
     range_key: str = "30D",
     since: Optional[date] = None,
+    until: Optional[date] = None,
 ) -> List[WeekBucket]:
     """
     Roll daily facts into ISO-week buckets (Monday start).
     Fills every week in the range so charts have continuous x-axes.
 
     Pass ``since`` to override the window start (the #400 calendar mode).
+    Pass ``until`` to override the window end (#413): calendar mode passes the
+    calendar period's last day so the chart spans the whole period. Defaults to
+    today (rolling).
     """
     # Build buckets from actual data first
     buckets: dict[date, WeekBucket] = {}
@@ -415,8 +426,8 @@ def build_weekly_buckets(
         buckets[monday].add(df)
 
     # Determine the full span of weeks to show
-    today = date.today()
-    end_monday = today - timedelta(days=today.weekday())  # current week
+    end = until if until is not None else date.today()
+    end_monday = end - timedelta(days=end.weekday())  # last week to show
 
     if since is None:
         since = _resolve_since(range_key)
@@ -464,6 +475,7 @@ def build_continuous_suffer_scores(
     activity_facts: List[ActivityFact],
     range_key: str = "30D",
     since: Optional[date] = None,
+    until: Optional[date] = None,
 ) -> List[dict]:
     """
     Return one {date, effort_score} per day in the range.
@@ -471,8 +483,11 @@ def build_continuous_suffer_scores(
     Days without activities get effort_score = 0.
     Days with multiple activities sum their effort scores.
     Pass ``since`` to override the window start (the #400 calendar mode).
+    Pass ``until`` to override the window end (#413, calendar period frame).
+    Defaults to today (rolling).
     """
     today = date.today()
+    end = until if until is not None else today
     if since is None:
         since = _resolve_since(range_key)
 
@@ -481,7 +496,7 @@ def build_continuous_suffer_scores(
     elif activity_facts:
         start = activity_facts[0].local_date
     else:
-        start = today
+        start = end
 
     # Sum effort scores per day
     daily: dict[date, float] = {}
@@ -492,7 +507,7 @@ def build_continuous_suffer_scores(
 
     result: List[dict] = []
     cursor = start
-    while cursor <= today:
+    while cursor <= end:
         result.append({
             "date": cursor.isoformat(),
             "effort_score": round(daily.get(cursor, 0), 1),
@@ -700,6 +715,15 @@ def get_trends_report(
     # comparison spans [prev_start, prev_end). Calendar mode shifts both.
     since, prev_start, prev_end = _resolve_window(range_upper, mode)
 
+    # Chart x-axis frame end (#413): rolling stops at today (until=None); calendar
+    # spans the whole current period (e.g. Mon–Sun for 7D), so the period's last
+    # day frames the chart and days after today render as empty bars.
+    until: Optional[date] = None
+    if mode == "calendar" and range_upper in _RANGE_DAYS and _RANGE_DAYS[range_upper]:
+        from app.services.coach.volume import _calendar_period
+
+        _, until, _, _ = _calendar_period(range_upper, date.today())
+
     # 1. Activity-level facts (filtered by types if provided)
     activity_facts = build_activity_facts(
         db, range_upper, types=types, user_id=user_id, since=since
@@ -738,7 +762,9 @@ def get_trends_report(
         )
 
     # 3. Continuous daily facts (every day filled)
-    continuous_daily = build_continuous_daily_facts(daily_facts, range_key=range_upper, since=since)
+    continuous_daily = build_continuous_daily_facts(
+        daily_facts, range_key=range_upper, since=since, until=until
+    )
 
     daily_distance = [
         DailyDistancePoint(
@@ -759,7 +785,9 @@ def get_trends_report(
     ]
 
     # 4. Weekly buckets (continuous — includes empty weeks)
-    weekly = build_weekly_buckets(daily_facts, range_key=range_upper, since=since)
+    weekly = build_weekly_buckets(
+        daily_facts, range_key=range_upper, since=since, until=until
+    )
 
     weekly_distance = [
         WeeklyDistancePoint(
@@ -795,7 +823,9 @@ def get_trends_report(
     # 7. Daily suffer score (continuous — every day filled)
     daily_suffer_score = [
         DailySufferScorePoint(**p)
-        for p in build_continuous_suffer_scores(activity_facts, range_key=range_upper, since=since)
+        for p in build_continuous_suffer_scores(
+            activity_facts, range_key=range_upper, since=since, until=until
+        )
     ]
 
     # 8. Efficiency trend
@@ -832,13 +862,22 @@ def get_trends_report(
 
 
 def get_volume_report(
-    db: Session, user_id, range_key: str = "7D", as_of: Optional[date] = None
+    db: Session,
+    user_id,
+    range_key: str = "7D",
+    as_of: Optional[date] = None,
+    types: Optional[List[str]] = None,
 ) -> "VolumeReport":
     """The #400 frequency-/volume-vs-norm report for the Trends page, for the selected
     range (7D/30D/3M/6M/1Y) as of `as_of` (defaults to today). Reuses the same pure
     core as the coach pack, so the two never drift. Fetches a span covering the larger
     of the rolling window and the calendar period, plus the norm baseline, and
-    partitions by local day (#399)."""
+    partitions by local day (#399).
+
+    Pass ``types`` to scope BOTH the window and the norm baseline to the selected
+    activity types (#413), so the typical line / "vs typical" caption compares
+    like-for-like with the type-filtered Trends charts instead of measuring a
+    filtered window against an all-activity norm."""
     from app.services.coach.volume import (
         _RANGE_WINDOW_DAYS,
         _BASELINE_DAYS_BY_RANGE,
@@ -854,6 +893,6 @@ def get_volume_report(
     # Fetch back to the earliest window start plus the term-scaled norm baseline.
     earliest = min(roll_start, period_start) - timedelta(days=_BASELINE_DAYS_BY_RANGE[key] + 1)
     facts = _query_activity_facts(
-        db, earliest, resolved + timedelta(days=1), user_id=user_id
+        db, earliest, resolved + timedelta(days=1), types, user_id=user_id
     )
     return build_volume_report(facts, resolved, key)

--- a/backend/tests/test_trends_window.py
+++ b/backend/tests/test_trends_window.py
@@ -18,17 +18,20 @@ def _user(db) -> uuid.UUID:
     return user.id
 
 
-def _activity_on(db, user_id, on: date, *, distance_m: int = 5000) -> Activity:
+def _activity_on(
+    db, user_id, on: date, *, distance_m: int = 5000, type: str = "Run",
+    moving_time_s: int = 1500,
+) -> Activity:
     activity = Activity(
         user_id=user_id,
         strava_activity_id=int(uuid.uuid4().int % 1_000_000_000),
         # Midday so the local date is unambiguous regardless of run time.
         start_date=datetime.combine(on, time(12, 0)),
-        type="Run",
-        name="Run",
+        type=type,
+        name=type,
         distance_m=distance_m,
-        moving_time_s=1500,
-        elapsed_time_s=1500,
+        moving_time_s=moving_time_s,
+        elapsed_time_s=moving_time_s,
         elev_gain_m=0.0,
         raw_summary={},
     )
@@ -110,18 +113,19 @@ def test_resolve_window_rolling_matches_legacy():
 
 
 def test_resolve_window_calendar_week():
-    # 2026-06-20 is a Saturday -> Mon 06-15, 6 days elapsed; prior week same span.
+    # 2026-06-20 is a Saturday -> current week Mon 06-15; previous is the ENTIRE
+    # prior week Mon 06-08 .. Sun 06-14 (#413, vs the full previous calendar term).
     since, prev_start, prev_end = _resolve_window("7D", "calendar", _T)
     assert since == date(2026, 6, 15)
-    assert (prev_start, prev_end) == (date(2026, 6, 8), date(2026, 6, 14))  # Mon-Sat prior week
+    assert (prev_start, prev_end) == (date(2026, 6, 8), date(2026, 6, 15))  # [Mon, next Mon)
 
 
 def test_resolve_window_calendar_month():
-    # June, 20 days elapsed; previous is May 1-20 (same 20-day span).
+    # June to date; previous is ALL of May (the full prior calendar month, #413).
     since, prev_start, prev_end = _resolve_window("30D", "calendar", _T)
     assert since == date(2026, 6, 1)
     assert prev_start == date(2026, 5, 1)
-    assert prev_end == date(2026, 5, 21)  # exclusive -> May 1..20
+    assert prev_end == date(2026, 6, 1)  # exclusive -> all of May
 
 
 def test_resolve_window_calendar_quarter():
@@ -134,3 +138,85 @@ def test_resolve_window_calendar_quarter():
 def test_resolve_window_all_has_no_bounds():
     assert _resolve_window("ALL", "rolling", _T) == (None, None, None)
     assert _resolve_window("ALL", "calendar", _T) == (None, None, None)
+
+
+# --- #413 calendar charts frame the FULL period (not truncated at today) ------
+
+import calendar as _cal  # noqa: E402
+
+
+def test_calendar_7d_charts_frame_full_mon_to_sun_week(db):
+    """Calendar 7D spans the whole Mon–Sun week, with days after today rendered
+    as empty bars, so the week reads as a fixed frame rather than truncating at
+    today (#413)."""
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+    sunday = monday + timedelta(days=6)
+
+    report = get_trends_report(db, "7D", mode="calendar")
+
+    assert len(report.daily_distance) == 7
+    assert report.daily_distance[0].date == monday
+    assert report.daily_distance[-1].date == sunday
+    # The suffer-score chart frames the same week.
+    assert report.daily_suffer_score[0].date == monday
+    assert report.daily_suffer_score[-1].date == sunday
+
+
+def test_rolling_7d_still_ends_today(db):
+    """Rolling mode is unchanged: the frame stops at today, not the week end."""
+    report = get_trends_report(db, "7D", mode="rolling")
+    assert report.daily_distance[-1].date == date.today()
+
+
+def test_calendar_30d_charts_frame_full_month(db):
+    """Calendar 30D spans the entire calendar month (1st .. last day)."""
+    today = date.today()
+    first = today.replace(day=1)
+    last = today.replace(day=_cal.monthrange(today.year, today.month)[1])
+
+    report = get_trends_report(db, "30D", mode="calendar")
+
+    assert report.daily_distance[0].date == first
+    assert report.daily_distance[-1].date == last
+    assert len(report.daily_distance) == (last - first).days + 1
+
+
+def test_volume_report_honors_activity_type_filter(db):
+    """The volume norm / typical line must be scoped to the same activity-type
+    filter as the charts (#413), so a Run-only view never measures filtered run
+    bars against an all-activity norm. The window's current_all for moving_time
+    must drop the walks when types=["Run"]."""
+    from app.services.trends import get_volume_report
+
+    user_id = _user(db)
+    today = date.today()
+    # Two runs and two walks inside the rolling 7-day window.
+    _activity_on(db, user_id, today, type="Run", moving_time_s=1800)
+    _activity_on(db, user_id, today - timedelta(days=1), type="Run", moving_time_s=1800)
+    _activity_on(db, user_id, today - timedelta(days=2), type="Walk", moving_time_s=3600)
+    _activity_on(db, user_id, today - timedelta(days=3), type="Walk", moving_time_s=3600)
+
+    def _moving_current(report):
+        m = [x for x in report.rolling.metrics if x.metric == "moving_time_s"][0]
+        return m.current_all
+
+    all_report = get_volume_report(db, user_id, "7D")
+    run_report = get_volume_report(db, user_id, "7D", types=["Run"])
+
+    assert _moving_current(all_report) == 1800 + 1800 + 3600 + 3600
+    assert _moving_current(run_report) == 1800 + 1800  # walks excluded
+
+
+def test_calendar_3m_weekly_chart_reaches_quarter_end(db):
+    """Calendar 3M (a quarter) frames weekly buckets through the quarter's end
+    week, not just the week containing today."""
+    today = date.today()
+    q_first_month = ((today.month - 1) // 3) * 3 + 1
+    end_month = q_first_month + 2
+    quarter_last = date(today.year, end_month, _cal.monthrange(today.year, end_month)[1])
+    last_week_monday = quarter_last - timedelta(days=quarter_last.weekday())
+
+    report = get_trends_report(db, "3M", mode="calendar")
+
+    assert report.weekly_distance[-1].week_start == last_week_monday

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -13,7 +13,11 @@ import ZoneLoadChart from "@/components/trends/ZoneLoadChart";
 import ComparisonRows from "@/components/trends/ComparisonRows";
 import MetricSummaryCard from "@/components/trends/MetricSummaryCard";
 import { DIR_TEXT, dirFromPct } from "@/components/trends/direction";
-import type { VolumeMetricVsNorm, VolumeReport } from "@/lib/types/volume";
+import type {
+  VolumeMetricName,
+  VolumeMetricVsNorm,
+  VolumeReport,
+} from "@/lib/types/volume";
 
 type WindowMode = "rolling" | "calendar";
 
@@ -67,25 +71,60 @@ export default function TrendsPage() {
   }, [range, selectedTypes, effectiveMode, fetchTrends]);
 
   // The vs-norm comparison shown on the quick-view cards (no norm for "All").
+  // Pass the same activity-type filter as the charts (#413) so "typical" is
+  // scoped to the selected types and never compares a filtered window against an
+  // all-activity norm.
   useEffect(() => {
     if (range === "ALL") {
       setVolume(null);
       return;
     }
     let active = true;
-    fetchFromAPI(`/api/trends/volume?range=${range}`)
+    const params = new URLSearchParams({ range });
+    selectedTypes.forEach((t) => params.append("types", t));
+    fetchFromAPI(`/api/trends/volume?${params}`)
       .then((v: VolumeReport) => active && setVolume(v))
       .catch(() => active && setVolume(null));
     return () => {
       active = false;
     };
-  }, [range]);
+  }, [range, selectedTypes]);
 
   // Map each metric to its vs-norm comparison for the framing in view.
   const normByMetric: Partial<Record<string, VolumeMetricVsNorm>> = {};
   if (volume && volume.has_baseline) {
     for (const m of volume[effectiveMode].metrics) normByMetric[m.metric] = m;
   }
+
+  // "vs prev" labeling (#413): calendar mode names the period it compares to
+  // (e.g. "vs last month"), so a month-to-date comparison reads clearly; rolling
+  // stays "vs prev".
+  const PERIOD_NOUN: Partial<Record<TrendsRange, string>> = {
+    "7D": "week",
+    "30D": "month",
+    "3M": "quarter",
+    "6M": "half",
+    "1Y": "year",
+  };
+  const prevLabel =
+    effectiveMode === "calendar" && PERIOD_NOUN[range]
+      ? `vs last ${PERIOD_NOUN[range]}`
+      : "vs prev";
+
+  // The runner's typical level per chart bucket (#413), drawn as a reference line.
+  // The #400 norm is scaled to days_elapsed, so norm/days_elapsed is the true
+  // per-day rate; weekly charts multiply by 7. `scale` converts norm units to the
+  // chart's units (meters→km, seconds→min, effort raw). Undefined hides the line.
+  const framing = volume && volume.has_baseline ? volume[effectiveMode] : null;
+  const typicalPerBucket = (
+    metric: VolumeMetricName,
+    scale: number,
+  ): number | undefined => {
+    const m = normByMetric[metric];
+    if (!framing || !m || m.norm == null || framing.days_elapsed <= 0) return undefined;
+    const perDay = m.norm / framing.days_elapsed;
+    return perDay * (isDaily ? 1 : 7) * scale;
+  };
 
   return (
     <div className="space-y-6">
@@ -143,6 +182,7 @@ export default function TrendsPage() {
               current={data.summary.total_distance_m}
               previous={data.previous_summary?.total_distance_m}
               format={formatDistanceKm}
+              prevLabel={prevLabel}
             />
             <MetricSummaryCard
               label="Total Time"
@@ -151,6 +191,7 @@ export default function TrendsPage() {
               current={data.summary.total_moving_time_s}
               previous={data.previous_summary?.total_moving_time_s}
               format={formatDuration}
+              prevLabel={prevLabel}
             />
             <MetricSummaryCard
               label="Activities"
@@ -159,6 +200,7 @@ export default function TrendsPage() {
               current={data.summary.activity_count}
               previous={data.previous_summary?.activity_count}
               format={(v) => Math.round(v).toString()}
+              prevLabel={prevLabel}
             />
             <MetricSummaryCard
               label="Total Load"
@@ -167,6 +209,7 @@ export default function TrendsPage() {
               current={data.summary.total_suffer_score}
               previous={data.previous_summary?.total_suffer_score}
               format={(v) => Math.round(v).toLocaleString()}
+              prevLabel={prevLabel}
             />
           </div>
 
@@ -174,12 +217,14 @@ export default function TrendsPage() {
             type="distance"
             data={isDaily ? data.daily_distance : data.weekly_distance}
             granularity={granularity}
+            typical={typicalPerBucket("distance_m", 1 / 1000)}
             delta={
               <ComparisonRows
                 metric={normByMetric["distance_m"]}
                 current={data.summary.total_distance_m}
                 previous={data.previous_summary?.total_distance_m}
                 format={formatDistanceKm}
+                prevLabel={prevLabel}
               />
             }
           />
@@ -187,12 +232,14 @@ export default function TrendsPage() {
             type="time"
             data={isDaily ? data.daily_time : data.weekly_time}
             granularity={granularity}
+            typical={typicalPerBucket("moving_time_s", 1 / 60)}
             delta={
               <ComparisonRows
                 metric={normByMetric["moving_time_s"]}
                 current={data.summary.total_moving_time_s}
                 previous={data.previous_summary?.total_moving_time_s}
                 format={formatDuration}
+                prevLabel={prevLabel}
               />
             }
           />
@@ -200,12 +247,14 @@ export default function TrendsPage() {
           <SufferScoreChart
             data={isDaily ? data.daily_suffer_score : data.weekly_suffer_score}
             granularity={granularity}
+            typical={typicalPerBucket("effort_score", 1)}
             delta={
               <ComparisonRows
                 metric={normByMetric["effort_score"]}
                 current={data.summary.total_suffer_score}
                 previous={data.previous_summary?.total_suffer_score}
                 format={(v) => Math.round(v).toLocaleString()}
+                prevLabel={prevLabel}
               />
             }
           />
@@ -224,6 +273,7 @@ export default function TrendsPage() {
                         : undefined
                     }
                     format={(v) => `${v.toFixed(2)} m/beat`}
+                    prevLabel={prevLabel}
                   />
                 ) : undefined
               }

--- a/frontend/components/trends/ComparisonRows.tsx
+++ b/frontend/components/trends/ComparisonRows.tsx
@@ -16,11 +16,15 @@ export default function ComparisonRows({
   current,
   previous,
   format,
+  prevLabel = "vs prev",
 }: {
   metric?: VolumeMetricVsNorm;
   current: number;
   previous?: number | null;
   format: (n: number) => string;
+  /** Label for the period-over-period row. Calendar mode names the period
+   * (e.g. "vs last month"); rolling stays "vs prev" (#413). */
+  prevLabel?: string;
 }) {
   const hasNorm = !!metric && metric.direction !== "no_norm" && metric.norm !== null;
   const prevPct =
@@ -36,7 +40,9 @@ export default function ComparisonRows({
         <>
           <span className="text-gray-400 dark:text-gray-500">vs typical</span>
           <span className="text-gray-400 dark:text-gray-500">
-            <span className={`font-medium ${DIR_TEXT[metric.direction]}`}>
+            <span
+              className={`font-medium ${DIR_TEXT[dirFromPct(Math.round(metric.pct_vs_norm ?? 0))]}`}
+            >
               {signed(Math.round(metric.pct_vs_norm ?? 0))}
             </span>{" "}
             · {format(metric.norm as number)}
@@ -45,7 +51,7 @@ export default function ComparisonRows({
       )}
       {prevPct !== null && (
         <>
-          <span className="text-gray-400 dark:text-gray-500">vs prev</span>
+          <span className="text-gray-400 dark:text-gray-500">{prevLabel}</span>
           <span className="text-gray-400 dark:text-gray-500">
             <span className={`font-medium ${DIR_TEXT[dirFromPct(prevPct)]}`}>
               {signed(prevPct)}

--- a/frontend/components/trends/MetricSummaryCard.tsx
+++ b/frontend/components/trends/MetricSummaryCard.tsx
@@ -15,6 +15,7 @@ export default function MetricSummaryCard({
   current,
   previous,
   format,
+  prevLabel,
 }: {
   label: string;
   value: string;
@@ -22,6 +23,7 @@ export default function MetricSummaryCard({
   current: number;
   previous?: number | null;
   format: (n: number) => string;
+  prevLabel?: string;
 }) {
   const hasNorm = !!metric && metric.direction !== "no_norm" && metric.norm !== null;
 
@@ -34,10 +36,16 @@ export default function MetricSummaryCard({
         {value}
       </div>
       {hasNorm && metric && (
-        <NormGauge pct={metric.pct_vs_norm ?? 0} direction={metric.direction} />
+        <NormGauge pct={metric.pct_vs_norm ?? 0} />
       )}
       <div className="mt-1.5">
-        <ComparisonRows metric={metric} current={current} previous={previous} format={format} />
+        <ComparisonRows
+          metric={metric}
+          current={current}
+          previous={previous}
+          format={format}
+          prevLabel={prevLabel}
+        />
       </div>
     </div>
   );

--- a/frontend/components/trends/NormGauge.tsx
+++ b/frontend/components/trends/NormGauge.tsx
@@ -1,10 +1,9 @@
-import { DIR_FILL } from "./direction";
-import type { VolumeDirection } from "@/lib/types/volume";
+import { DIR_FILL, dirFromPct } from "./direction";
 
-// The track spans ±SCALE% around "typical" (center). DEADBAND is the in-line zone
-// (matches the backend), drawn as a lighter band so "inside the band = normal"
-// reads at a glance. The marker/fill take a calm directional colour (amber up /
-// sky down / grey in-line) — never red/green, since a down window isn't "bad".
+// The track spans ±SCALE% around "typical" (center). DEADBAND is drawn as a
+// lighter band so "your typical range" reads at a glance, but the marker/fill
+// colour is purely directional by SIGN (amber up / sky down / grey only at
+// exactly typical) — never red/green, since a down window isn't "bad".
 const SCALE = 50;
 const DEADBAND = 15;
 
@@ -14,19 +13,13 @@ const DEADBAND = 15;
  * band is the in-line zone. Reads "in your usual band / above / below" instantly,
  * across any unit.
  */
-export default function NormGauge({
-  pct,
-  direction,
-}: {
-  pct: number;
-  direction: VolumeDirection;
-}) {
+export default function NormGauge({ pct }: { pct: number }) {
   const clamped = Math.max(-SCALE, Math.min(SCALE, pct));
   const pos = 50 + (clamped / SCALE) * 50; // 0..100 along the track
   const bandInset = 100 - (50 + (DEADBAND / SCALE) * 50); // inset each side
   const fillLeft = Math.min(50, pos);
   const fillWidth = Math.abs(pos - 50);
-  const fill = DIR_FILL[direction] ?? DIR_FILL.in_line;
+  const fill = DIR_FILL[dirFromPct(Math.round(pct))];
 
   return (
     <div

--- a/frontend/components/trends/SufferScoreChart.tsx
+++ b/frontend/components/trends/SufferScoreChart.tsx
@@ -8,20 +8,25 @@ import {
   Tooltip,
   ResponsiveContainer,
   CartesianGrid,
+  ReferenceLine,
 } from "recharts";
 import { ReactNode } from "react";
 import { SufferScorePoint, DailySufferScorePoint, WeeklySufferScorePoint } from "@/lib/types";
 import { formatDateLabel } from "@/lib/format";
 import ChartTooltip from "@/components/charts/ChartTooltip";
+import { TYPICAL_LINE_PROPS, renderTypicalLabel } from "./typicalLine";
 
 interface Props {
   data: SufferScorePoint[] | DailySufferScorePoint[] | WeeklySufferScorePoint[];
   granularity: "daily" | "weekly";
   /** Period-over-period delta shown under the title (e.g. a <StatDiff>). */
   delta?: ReactNode;
+  /** Runner's typical load per bucket, in chart units (#413). Draws a dashed
+   * reference line; omitted when no norm exists. */
+  typical?: number;
 }
 
-export default function SufferScoreChart({ data, granularity, delta }: Props) {
+export default function SufferScoreChart({ data, granularity, delta, typical }: Props) {
   const chartData = data.map((d: any) => ({
     ...d,
     label: formatDateLabel(d.date ?? d.week_start),
@@ -72,6 +77,13 @@ export default function SufferScoreChart({ data, granularity, delta }: Props) {
               radius={[4, 4, 0, 0]}
               maxBarSize={40}
             />
+            {typical != null && typical > 0 && (
+              <ReferenceLine
+                y={typical}
+                {...TYPICAL_LINE_PROPS}
+                label={renderTypicalLabel(`typical · ${Math.round(typical).toLocaleString()}`)}
+              />
+            )}
           </BarChart>
         </ResponsiveContainer>
       )}

--- a/frontend/components/trends/TrendBarChart.tsx
+++ b/frontend/components/trends/TrendBarChart.tsx
@@ -8,10 +8,12 @@ import {
   Tooltip,
   ResponsiveContainer,
   CartesianGrid,
+  ReferenceLine,
 } from "recharts";
 import { ReactNode } from "react";
 import { formatDateLabel } from "@/lib/format";
 import ChartTooltip from "@/components/charts/ChartTooltip";
+import { TYPICAL_LINE_PROPS, renderTypicalLabel } from "./typicalLine";
 
 interface TrendBarChartProps {
   data: any[];
@@ -19,6 +21,9 @@ interface TrendBarChartProps {
   granularity: "daily" | "weekly";
   /** Period-over-period delta shown under the title (e.g. a <StatDiff>). */
   delta?: ReactNode;
+  /** Runner's typical level per bucket, in chart units (#413). Draws a dashed
+   * reference line. Omitted when no norm exists (thin history / ALL range). */
+  typical?: number;
 }
 
 function formatMinutes(seconds: number): string {
@@ -33,6 +38,7 @@ export default function TrendBarChart({
   type,
   granularity,
   delta,
+  typical,
 }: TrendBarChartProps) {
   // Configuration based on type
   const isDistance = type === "distance";
@@ -112,6 +118,17 @@ export default function TrendBarChart({
               radius={[4, 4, 0, 0]}
               maxBarSize={40}
             />
+            {typical != null && typical > 0 && (
+              <ReferenceLine
+                y={typical}
+                {...TYPICAL_LINE_PROPS}
+                label={renderTypicalLabel(
+                  `typical · ${
+                    isDistance ? `${typical.toFixed(1)} km` : formatMinutes(typical * 60)
+                  }`,
+                )}
+              />
+            )}
           </BarChart>
         </ResponsiveContainer>
       )}

--- a/frontend/components/trends/typicalLine.tsx
+++ b/frontend/components/trends/typicalLine.tsx
@@ -1,0 +1,53 @@
+// #413: shared styling for the dashed "typical" reference line drawn on the
+// single-series trend bar charts. Kept distinct from the faint 3-3 grey
+// gridlines (darker slate, longer dash, thicker stroke) and given a small
+// solid-background label pill so the line and its caption read clearly against
+// both the bars and the gridlines, in light and dark mode.
+
+import type { ReactElement } from "react";
+
+export const TYPICAL_LINE_PROPS = {
+  stroke: "#64748b", // slate-500 — calm, not the bar colour, darker than gridlines
+  strokeWidth: 1.5,
+  strokeDasharray: "7 3",
+  ifOverflow: "extendDomain" as const,
+};
+
+/** A right-aligned pill that sits just above the reference line, showing
+ * `text` (e.g. "typical · 5.6 km"). Returns a render function for ReferenceLine's
+ * `label`; recharts injects `viewBox`. The pill is sized to the text. */
+export function renderTypicalLabel(text: string) {
+  return function TypicalLabel({ viewBox }: any): ReactElement | null {
+    if (!viewBox) return null;
+    const { x, y, width } = viewBox;
+    const pillW = Math.max(52, Math.round(text.length * 6.3) + 14);
+    const pillH = 17;
+    const right = x + width - 2;
+    const pillX = right - pillW;
+    // Sit above the line, but clamp so it never escapes the top of the plot.
+    const pillY = Math.max(y - pillH - 2, 2);
+    return (
+      <g>
+        <rect
+          x={pillX}
+          y={pillY}
+          width={pillW}
+          height={pillH}
+          rx={4}
+          className="fill-white/85 dark:fill-gray-800/85"
+        />
+        <text
+          x={right - 6}
+          y={pillY + pillH / 2}
+          textAnchor="end"
+          dominantBaseline="central"
+          fontSize={11}
+          fontWeight={600}
+          className="fill-slate-600 dark:fill-slate-300"
+        >
+          {text}
+        </text>
+      </g>
+    );
+  };
+}


### PR DESCRIPTION
Closes #413.

## What changed

**Calendar mode frames the full period.** A calendar 7D week now renders the whole Mon–Sun frame, 30D the whole month, 3M the whole quarter, etc., with days after today shown as empty bars (so "where am I in the period" is legible). Rolling mode is unchanged.

**Typical reference line.** Distance, Time, and Accumulated Load charts gain a dashed "typical" line labelled with its value (e.g. `typical · 5.9 km`), derived from the #400 volume norm (`norm / days_elapsed`, ×7 for weekly). The volume norm now honours the active activity-type filter, so the line and the "vs typical" caption compare like-for-like with the filtered bars instead of measuring a filtered window against an all-activity norm. (Efficiency / Zone-Load get no line — a single level is ambiguous on a scatter / stacked chart.)

**Colour encodes sign only.** The ±15% deadband no longer drives colour on the comparison text or the gauge marker, so two negative deltas read the same colour. The backend `direction` field is retained (still used for the `no_norm` check).

**Clearer period-over-period label.** In calendar mode "vs prev" is named by period — "vs last week/month/quarter/half/year" — and compares against the **entire previous calendar period** (e.g. this-month-to-date vs all of last month), so it reads behind mid-period and catches up by period-end. Rolling keeps "vs prev" against the equal-length prior block.

## Tests
- `test_trends_window`: calendar frame spans the full period (7D Mon–Sun, 30D full month, 3M weekly to quarter-end), rolling still ends today, volume norm honours the type filter, calendar comparison uses the full previous period.
- Full backend suite green (1502 passed); frontend lint + build clean.
- Verified end-to-end against seeded real data in the browser (both modes, filtered/unfiltered, light/dark).

## Notes
- Read path only — no schema change, no persistence, no external systems.
- Considered but dropped per review: exact-range hover tooltips on "vs prev".