### PR TITLE
Prevent metric value/unit wrapping on mobile trends cards

### DIFF
--- a/frontend/components/trends/MetricSummaryCard.tsx
+++ b/frontend/components/trends/MetricSummaryCard.tsx
@@ -30,7 +30,7 @@ export default function MetricSummaryCard({
       <div className="text-[11px] font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">
         {label}
       </div>
-      <div className="mt-1 font-mono text-2xl font-semibold tracking-tight tabular-nums text-gray-900 dark:text-gray-50">
+      <div className="mt-1 whitespace-nowrap font-mono text-2xl font-semibold tracking-tight tabular-nums text-gray-900 dark:text-gray-50">
         {value}
       </div>
       {hasNorm && metric && (


### PR DESCRIPTION
## Problem

On narrow mobile widths, the unit on the Trends summary cards (e.g. `74.71 km`) wrapped onto a second line. The value is rendered as a single string with a space between the number and unit (`"74.71 km"`), and that space became a wrap point.

## Fix

Added `whitespace-nowrap` to the value div in `MetricSummaryCard.tsx` so the number and unit stay on one line. This covers all four Trends cards (Total Distance, Total Time, Activities, Total Load) since they share this component. The label above still wraps normally.

## Verification

- Pure Tailwind className addition — no logic or type changes.
- `tsc --noEmit` showed only pre-existing missing-`node_modules` errors, none from this change.
- Visual confirmation on a real mobile viewport is a human checkpoint — please eyeball the narrowest widths to confirm the value doesn't clip/overflow.

## Out of scope (flagged, not changed)

`frontend/app/page.tsx` renders distance the same way in a 2-column mobile grid and could wrap identically. Left untouched since the report was specifically the Trends screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi36Y39VqX8mciEuiK97PV)_