### PR TITLE
Stop comparison value/unit wrapping on mobile trends cards

### DIFF
--- a/frontend/components/trends/ComparisonRows.tsx
+++ b/frontend/components/trends/ComparisonRows.tsx
@@ -45,7 +45,7 @@ export default function ComparisonRows({
             >
               {signed(Math.round(metric.pct_vs_norm ?? 0))}
             </span>{" "}
-            · {format(metric.norm as number)}
+            · <span className="whitespace-nowrap">{format(metric.norm as number)}</span>
           </span>
         </>
       )}
@@ -56,7 +56,7 @@ export default function ComparisonRows({
             <span className={`font-medium ${DIR_TEXT[dirFromPct(prevPct)]}`}>
               {signed(prevPct)}
             </span>{" "}
-            · {format(previous as number)}
+            · <span className="whitespace-nowrap">{format(previous as number)}</span>
           </span>
         </>
       )}


### PR DESCRIPTION
## Problem

Follow-up to #415. That fix stopped the **headline** metric value (e.g. `186.01 km`) from wrapping, but the **comparison rows** below it still wrapped on narrow mobile widths — `vs typical +5% · 178.02 km` dropped the `km` (and `vs prev`, and the duration cards' `29h 52m` / `33h 36m`) onto a second line.

## Cause

`ComparisonRows` renders the reference value via `format()`, which returns a value with a space before its unit (`"178.02 km"`, `"29h 52m"`). In the narrow `1fr` grid column that internal space was a wrap point.

## Fix

Wrap each formatted value in `whitespace-nowrap` so the number and unit stay together. The `+N% ·` prefix can still wrap if space is genuinely tight, so nothing overflows. Applies to all four Trends cards and both the rolling and calendar (`prevLabel`) layouts, since they share this component.

## Verification

- One-file, two-line change; diff is only the two `whitespace-nowrap` spans on top of current `main` (no impact on #413's calendar work).
- Visual confirmation on a real mobile viewport is a human checkpoint — please eyeball the narrowest widths to confirm the value sits on one line and doesn't clip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi36Y39VqX8mciEuiK97PV)_