### PR TITLE
Regenerate coach reports when the runner's voice changes

### DIFF
--- a/backend/alembic/versions/f9a3c1b7e2d5_add_voice_key_to_coach_reports.py
+++ b/backend/alembic/versions/f9a3c1b7e2d5_add_voice_key_to_coach_reports.py
@@ -1,0 +1,35 @@
+"""add voice_key to coach_reports
+
+Records the voice fingerprint a coach report was generated under (P1.1), so a later
+voice change is detectable and the report can regenerate onto the new voice. Nullable
+and additive: existing rows backfill to NULL (read as stale on the active voice-aware
+prompt, so they regenerate once onto the current voice). Not part of the report's
+unique cache identity — there is still one row per (activity_id, prompt_id,
+schema_version); voice_key only tracks which voice that row currently speaks in.
+
+Revision ID: f9a3c1b7e2d5
+Revises: c2d5e8f1a9b4
+Create Date: 2026-06-21
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f9a3c1b7e2d5"
+down_revision: Union[str, None] = "c2d5e8f1a9b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "coach_reports",
+        sa.Column("voice_key", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("coach_reports", "voice_key")

--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -22,6 +22,7 @@ from app.services.coach.chat import get_chat_history, stream_chat_response
 from app.services.coach.service import (
     get_displayable_report_row,
     get_or_generate_coach_report,
+    report_voice_stale,
     _to_read,
 )
 
@@ -162,7 +163,12 @@ async def get_coach_report(
     if not force:
         existing = get_displayable_report_row(db, str(activity_id))
         if existing:
-            return _to_read(existing)
+            read = _to_read(existing)
+            # P1.1: flag a report still speaking in a now-changed voice so the
+            # frontend regenerates it onto the runner's current voice (async, on
+            # next view). A read-time flag only — the stored report is untouched.
+            read.meta.voice_stale = report_voice_stale(db, existing)
+            return read
         if not generate:
             raise HTTPException(status_code=404, detail="No cached report.")
 

--- a/backend/app/models/coach_report.py
+++ b/backend/app/models/coach_report.py
@@ -46,6 +46,16 @@ class CoachReport(Base):
         Boolean, nullable=False, server_default="false", default=False
     )
 
+    # P1.1 voice freshness (not cache IDENTITY): the fingerprint of the runner's
+    # declared voice this report was generated under, so a later voice change is
+    # detectable and the report can regenerate onto the new voice. Deliberately NOT
+    # in the unique constraint — there is still one row per (activity, prompt,
+    # schema); voice_key only records which voice that row currently speaks in.
+    # Null for a report generated under a non-voice-aware prompt (voice is inert) and
+    # for rows written before this column existed; a null on an active voice-aware
+    # row reads as stale, so it regenerates once onto the current voice.
+    voice_key: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/schemas/coach.py
+++ b/backend/app/schemas/coach.py
@@ -95,6 +95,13 @@ class CoachReportMeta(BaseModel):
     # missing/unusable (degrade-not-withhold). False for the legacy structured
     # family and for a clean message+tail. Defaulted so legacy stored meta validates.
     tail_degraded: bool = False
+    # P1.1 voice freshness — a READ-TIME flag, never stored. True when this report is
+    # the active-version row under a voice-aware prompt but was generated under a
+    # different voice than the runner's current one, so it should regenerate to honour
+    # the new voice (the frontend auto-triggers the async regen on a stale read). Set
+    # by the read endpoint; defaults False so stored meta (which never carries it) and
+    # every non-voice prompt validate unchanged.
+    voice_stale: bool = False
 
 
 class CoachReportContent(BaseModel):

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -51,6 +51,8 @@ from app.services.coach.prompts import (
     TWO_STAGE_PROMPT_IDS,
     build_system_prompt,
 )
+from app.services.coach.prompt_features import PromptFeature, has_feature
+from app.services.coach.receipt_voice import voice_fingerprint
 from app.services.coach.voice import resolve_voice
 from app.services.coach.stance import resolve_stance
 from app.services.coach.retrieval import fetch_latest_user_reply
@@ -167,6 +169,35 @@ def _resolve_voice_for_activity(db: Session, activity: Activity):
         .first()
     )
     return resolve_voice(relationship)
+
+
+def report_voice_stale(db: Session, row: Optional[CoachReport]) -> bool:
+    """True when `row` is the ACTIVE-version report under a voice-aware prompt but was
+    generated under a DIFFERENT voice than the runner's current one — so it should be
+    regenerated to honour the new voice (the read endpoint flags it and the frontend
+    auto-triggers the async regen on a stale view).
+
+    False for: a non-voice-aware active prompt (voice is inert), a cross-version
+    displayable fallback (#261 — left alone so a COACH_PROMPT_ID flip never storms
+    regens), or a row already on the current voice. A NULL voice_key on an active
+    voice-aware row reads as STALE: its voice is unknown (the row predates the
+    voice_key column or a non-voice prompt), so it regenerates ONCE onto the current
+    voice and is then current. This is the read-side mirror of the voice_key the
+    generate path stamps; it never itself writes or regenerates."""
+    if row is None:
+        return False
+    prompt_id = settings.COACH_PROMPT_ID
+    # Only the active-version row can be voice-stale; a stale-shape displayable
+    # fallback is intentionally served as-is (#261).
+    if row.prompt_id != prompt_id or row.schema_version != active_schema_version(prompt_id):
+        return False
+    if not has_feature(prompt_id, PromptFeature.VOICE):
+        return False
+    activity = db.query(Activity).filter(Activity.id == row.activity_id).first()
+    if activity is None:
+        return False
+    current = voice_fingerprint(_resolve_voice_for_activity(db, activity))
+    return (row.voice_key or None) != current
 
 
 def _resolve_stance_for_activity(db: Session, activity: Activity):
@@ -332,6 +363,7 @@ async def get_or_generate_coach_report(
         outcome=outcome,
         existing=existing,  # #273: in-place swap on force; None -> insert (first gen)
         fire_learning_loop=True,
+        voice=voice,
     )
     return read
 
@@ -419,6 +451,7 @@ async def generate_opener(db: Session, activity_id: str) -> Optional[OpenerResul
         outcome=outcome,
         existing=None,
         fire_learning_loop=False,  # the opener writes nothing to durable memory
+        voice=voice,
     )
     # Hybrid salience: the opener LLM's judgment OR the deterministic safety
     # override (the model can never stay quiet on a red-flag run). A fallback
@@ -533,6 +566,7 @@ async def generate_fuller(
         outcome=outcome,
         existing=existing,  # in-place update of the opener row, or None -> insert
         fire_learning_loop=True,
+        voice=voice,
     )
 
 
@@ -548,6 +582,7 @@ def _persist_report(
     outcome: "_GenOutcome",
     existing: Optional[CoachReport],
     fire_learning_loop: bool,
+    voice=None,
 ) -> Optional[CoachReportRead]:
     """Build the meta + digest, persist the report (in-place UPDATE of `existing`
     or a fresh INSERT), and optionally fire the learning loop. Shared by the
@@ -602,6 +637,17 @@ def _persist_report(
         tail_degraded=outcome.tail_degraded,
     )
 
+    # P1.1 voice freshness: stamp the voice this report speaks in, so a later voice
+    # change is detectable (report_voice_stale). Null under a non-voice-aware prompt
+    # (voice is inert there). Stamped on EVERY persist — including a fallback — so a
+    # regenerated row is always current and a persistent LLM failure can never loop
+    # the auto-regen (a fallback row reads as not-stale; the runner can still Re-run).
+    voice_key = (
+        voice_fingerprint(voice)
+        if voice is not None and has_feature(prompt_id, PromptFeature.VOICE)
+        else None
+    )
+
     # A2a digest: only for a complete non-fallback report (not an opener-only row,
     # not a fallback). Guarded so a digest hiccup never blocks storage.
     report_digest = None
@@ -625,6 +671,7 @@ def _persist_report(
         existing.raw_llm_response = outcome.raw_response
         existing.is_fallback = outcome.is_fallback
         existing.digest = report_digest
+        existing.voice_key = voice_key
         db.add(existing)
         db.commit()
         db.refresh(existing)
@@ -640,6 +687,7 @@ def _persist_report(
             raw_llm_response=outcome.raw_response,
             is_fallback=outcome.is_fallback,
             digest=report_digest,
+            voice_key=voice_key,
         )
         db.add(db_report)
         try:

--- a/backend/tests/test_voice_staleness.py
+++ b/backend/tests/test_voice_staleness.py
@@ -1,0 +1,194 @@
+"""Voice freshness for coach reports (P1.1 follow-up).
+
+A coach report stamps the voice it was generated under (`voice_key`); a later voice
+change makes the active-version report read as STALE so it regenerates onto the new
+voice. These tests cover the read-side predicate `report_voice_stale` directly (no
+LLM) and assert the generate path actually stamps the fingerprint.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.config import settings
+from app.models import Activity, DerivedMetric, StravaAccount, User, UserProfile
+from app.models.coach_report import CoachReport
+from app.models.coaching_relationship import CoachingRelationship
+from app.services.coach.llm import MessageResult
+from app.services.coach.receipt_voice import voice_fingerprint
+from app.services.coach.service import (
+    active_schema_version,
+    generate_opener,
+    get_active_report_row,
+    report_voice_stale,
+)
+from app.services.coach.voice import resolve_voice
+
+
+# --- seeding ------------------------------------------------------------------
+
+
+def _seed_activity(db) -> Activity:
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    db.add(UserProfile(
+        user_id=user.id, goal_type="general", experience_level="intermediate",
+        weekly_days_available=4, max_hr=190,
+    ))
+    db.add(StravaAccount(
+        user_id=user.id, strava_athlete_id=abs(hash(str(user.id))) % 10**9,
+        access_token="t", refresh_token="r", expires_at=9999999999, scope="read",
+    ))
+    activity = Activity(
+        user_id=user.id, strava_activity_id=abs(hash(str(uuid4()))) % 10**9,
+        start_date=datetime(2026, 5, 27, 10, 0, 0), type="Run", name="Test run",
+        distance_m=5000, moving_time_s=1500, elapsed_time_s=1500, elev_gain_m=10.0,
+        avg_hr=140, raw_summary={},
+    )
+    db.add(activity)
+    db.commit()
+    db.add(DerivedMetric(
+        activity_id=activity.id, effort="easy", structure="continuous",
+        duration_class="standard", effort_score=50.0, flags=[],
+        confidence="medium", confidence_reasons=[],
+    ))
+    db.commit()
+    db.refresh(activity)
+    return activity
+
+
+def _set_voice(db, activity, **dials) -> CoachingRelationship:
+    rel = CoachingRelationship(user_id=activity.user_id, **dials)
+    db.add(rel)
+    db.commit()
+    return rel
+
+
+def _seed_report(db, activity, *, prompt_id, schema_version, voice_key) -> CoachReport:
+    row = CoachReport(
+        activity_id=activity.id, prompt_id=prompt_id, schema_version=schema_version,
+        report={}, meta={}, context_pack={}, voice_key=voice_key,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+# --- report_voice_stale (read-side predicate) ---------------------------------
+
+
+def test_stale_when_voice_key_differs_under_voice_prompt(db, monkeypatch):
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
+    activity = _seed_activity(db)
+    _set_voice(db, activity, voice_preset="roast")  # a declared, non-default voice
+    current = voice_fingerprint(resolve_voice(db.query(CoachingRelationship).first()))
+    row = _seed_report(
+        db, activity, prompt_id="coach_message_v3",
+        schema_version=active_schema_version("coach_message_v3"),
+        voice_key="some-other-voice",
+    )
+    assert current != "some-other-voice"
+    assert report_voice_stale(db, row) is True
+
+
+def test_not_stale_when_voice_key_matches(db, monkeypatch):
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
+    activity = _seed_activity(db)
+    _set_voice(db, activity, voice_preset="roast")
+    current = voice_fingerprint(resolve_voice(db.query(CoachingRelationship).first()))
+    row = _seed_report(
+        db, activity, prompt_id="coach_message_v3",
+        schema_version=active_schema_version("coach_message_v3"),
+        voice_key=current,
+    )
+    assert report_voice_stale(db, row) is False
+
+
+def test_null_voice_key_reads_as_stale_on_active_voice_prompt(db, monkeypatch):
+    """The bug case: a report written before voice_key existed (NULL) regenerates
+    once onto the current voice rather than silently keeping the old one."""
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
+    activity = _seed_activity(db)
+    _set_voice(db, activity, voice_preset="roast")
+    row = _seed_report(
+        db, activity, prompt_id="coach_message_v3",
+        schema_version=active_schema_version("coach_message_v3"),
+        voice_key=None,
+    )
+    assert report_voice_stale(db, row) is True
+
+
+def test_default_voice_is_not_stale(db, monkeypatch):
+    """An undeclared (default) voice stamps the 'default' sentinel; a report carrying
+    it is not stale, so we never burn a regen on the undeclared centre."""
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
+    activity = _seed_activity(db)  # no relationship => default voice
+    row = _seed_report(
+        db, activity, prompt_id="coach_message_v3",
+        schema_version=active_schema_version("coach_message_v3"),
+        voice_key="default",
+    )
+    assert report_voice_stale(db, row) is False
+
+
+def test_non_voice_prompt_is_never_stale(db, monkeypatch):
+    """Under a non-voice-aware prompt the voice block is inert, so voice can never
+    make a report stale even if the stored key differs."""
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_report_v10")
+    activity = _seed_activity(db)
+    _set_voice(db, activity, voice_preset="roast")
+    row = _seed_report(
+        db, activity, prompt_id="coach_report_v10",
+        schema_version=active_schema_version("coach_report_v10"),
+        voice_key="anything",
+    )
+    assert report_voice_stale(db, row) is False
+
+
+def test_cross_version_fallback_left_alone(db, monkeypatch):
+    """A displayable row from a DIFFERENT prompt version (#261) is served as-is and
+    never voice-regenerated — that path must not storm regens after a prompt flip."""
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
+    activity = _seed_activity(db)
+    _set_voice(db, activity, voice_preset="roast")
+    row = _seed_report(  # an older prompt's report
+        db, activity, prompt_id="coach_message_v2", schema_version="2.0",
+        voice_key=None,
+    )
+    assert report_voice_stale(db, row) is False
+
+
+# --- generate path stamps voice_key -------------------------------------------
+
+
+def _opener_result():
+    blocks = [
+        {"type": "text", "text": "Nice work getting that one done!"},
+        {"type": "tool_use", "name": "record_coach_tail", "input": {
+            "headline": "Quick reaction", "next_steps": [], "risks": [],
+            "questions": [], "schedule_fuller_turn": False,
+        }},
+    ]
+    return MessageResult(content_blocks=blocks, stop_reason="end_turn")
+
+
+@pytest.mark.asyncio
+async def test_generate_stamps_current_voice_fingerprint(db, monkeypatch):
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
+    activity = _seed_activity(db)
+    _set_voice(db, activity, voice_preset="roast")
+    expected = voice_fingerprint(resolve_voice(db.query(CoachingRelationship).first()))
+
+    fake = AsyncMock()
+    fake.generate_coach_message = AsyncMock(return_value=_opener_result())
+    with patch("app.services.coach.service.AnthropicClient", return_value=fake):
+        await generate_opener(db, str(activity.id))
+
+    row = get_active_report_row(db, activity.id)
+    assert row is not None
+    assert row.voice_key == expected
+    assert report_voice_stale(db, row) is False

--- a/frontend/components/CoachReportPanel.tsx
+++ b/frontend/components/CoachReportPanel.tsx
@@ -197,6 +197,11 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
   const regenBaseline = useRef<string | null>(null);
   const regenAttempts = useRef(0);
   const [regenTick, setRegenTick] = useState(0);
+  // P1.1: a loaded report can be voice-stale (generated under a now-changed voice).
+  // We kick the existing async regen ONCE so it is rewritten in the runner's current
+  // voice ("regenerate on next view"). The ref guards against re-firing while polling
+  // and against a loop — the regenerated report is no longer stale.
+  const voiceRegenKicked = useRef(false);
 
   const regenerate = useCallback(async () => {
     regenBaseline.current = report?.meta.generated_at ?? null;
@@ -245,6 +250,17 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
     }, REGEN_POLL_INTERVAL_MS);
     return () => clearTimeout(id);
   }, [status, regenTick, activityId]);
+
+  // P1.1: when a freshly-loaded report is voice-stale, regenerate it onto the
+  // runner's current voice. Fires once (the ref survives the regen + poll), and the
+  // rewritten report comes back not-stale, so there is no loop. A fallback regen also
+  // returns not-stale, so a persistent failure cannot hammer the worker.
+  useEffect(() => {
+    if (status !== 'loaded' || !report || !report.meta.voice_stale) return;
+    if (voiceRegenKicked.current) return;
+    voiceRegenKicked.current = true;
+    regenerate();
+  }, [status, report, regenerate]);
 
   if (!hasMetrics) return null;
 

--- a/frontend/lib/types/coach.ts
+++ b/frontend/lib/types/coach.ts
@@ -36,6 +36,10 @@ export interface CoachReportMeta {
   policy_violations?: string[];
   // A3: a prose message was produced but its structured tail was missing/unusable.
   tail_degraded?: boolean;
+  // P1.1: this report was generated under a different voice than the runner's
+  // current one, so it should regenerate to honour the new voice. A read-time flag
+  // set by the backend; the panel auto-triggers the async regen once when it is true.
+  voice_stale?: boolean;
 }
 
 export interface CoachReportContent {


### PR DESCRIPTION
## Problem
A coach report was cached per `(activity, prompt, schema)` only. Changing the voice dials or the free-text note never invalidated an existing report, so a runner who set or changed their voice kept seeing a report that ignored it (both the note **and** the dials) until a manual Re-run. Reported as "the coach report seemed to completely ignore my note about how to respond."

## Change
Make the runner's voice part of a report's freshness:

- **`coach_reports.voice_key`** — stamps the voice fingerprint a report was generated under (reuses the existing receipt `voice_fingerprint`). `null` for non-voice-aware prompts; `"default"` for the undeclared centre. **Not** part of the unique cache identity — still one row per version; this only records which voice that row speaks in. Additive nullable migration off head `c2d5e8f1a9b4`.
- **`report_voice_stale()`** — flags the active-version row under a voice-aware prompt whose stored voice differs from the runner's current voice. A `null` key reads as stale, so reports written before this column regenerate once onto the current voice. Cross-version displayable fallbacks are deliberately left alone, so a `COACH_PROMPT_ID` flip never storms regenerations (#261).
- **`voice_stale`** surfaced on the report read; the panel auto-triggers the existing async regenerate-and-poll once on a stale view ("regenerate on next view"). The key is stamped on every persist including fallbacks, so a persistent LLM failure can't loop the regen.

## Tests
- Backend: full non-integration suite green (1508 passed), plus a new `test_voice_staleness.py` covering the read predicate (match / mismatch / null / default / non-voice prompt / cross-version) and `voice_key` stamping through the generate path.
- Frontend: `lint && build` clean.

## Not in scope (filed as follow-ups)
- The free-text note is fenced as tone-data and may still be under-applied to tone even after regeneration — #423.
- The active coach-prompt default points at a non-voice-aware prompt; an unset env var would silently disable voice and other prompt-gated features — #424.

## Verification not done here
No live app+worker+Postgres run was possible in this environment, so end-to-end regenerate-on-view was not exercised against a real stack, and the migration was exercised via SQLite (`create_all`), not a real `alembic upgrade`. It's a trivial additive nullable column, but worth a glance on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZedRAhPZFmHX1DR3CP6FY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZedRAhPZFmHX1DR3CP6FY)_