### PR TITLE
Default coach prompt to a feature-bearing id and warn when inert (#424)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,7 +40,10 @@ STRAVA_WEBHOOK_SUBSCRIPTION_ID=0
 # --- Coach AI ---
 ANTHROPIC_API_KEY=
 COACH_MODEL_ID=claude-sonnet-4-20250514
-COACH_PROMPT_ID=coach_report_v1
+# The active coach prompt. Must be a feature-bearing prompt id or the runner-facing
+# coaching surface (voice/corpus/stance/training-load/user-materials/volume) goes
+# inert; a startup warning fires if it is not (#424). Production runs coach_message_v8.
+COACH_PROMPT_ID=coach_message_v8
 
 # --- Email notifications (post-run coach report) ---
 # Leave SMTP_HOST empty to disable email delivery entirely.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -30,7 +30,14 @@ class Settings(BaseSettings):
     # Coach AI
     ANTHROPIC_API_KEY: str = ""
     COACH_MODEL_ID: str = "claude-sonnet-4-6"
-    COACH_PROMPT_ID: str = "coach_report_v10"
+    # The active coach prompt. The default tracks the production prompt (see
+    # project-context.md), NOT a legacy non-feature-bearing id: a prompt that
+    # carries none of the runner-facing coaching features (voice/corpus/stance/
+    # training-load/user-materials/volume) would silently disable that whole
+    # surface, including the runner's declared voice (#424). A deploy that
+    # resolves to an inert prompt is flagged loudly at startup by
+    # warn_if_coach_prompt_inert (app/core/observability.py).
+    COACH_PROMPT_ID: str = "coach_message_v8"
 
     # Coach-report notifications. Channel selection (see
     # app/services/notifications/__init__.py): Telegram when

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -118,6 +118,34 @@ def init_logging() -> None:
     root.setLevel(logging.INFO)
 
 
+def warn_if_coach_prompt_inert() -> None:
+    """Log a loud WARNING when the active coach prompt carries no runner-facing features.
+
+    The voice block, corpus, stance, training-load, user-materials, and volume
+    sections are all gated on COACH_PROMPT_ID. If a deploy resolves to a prompt
+    that carries none of them (a legacy ``coach_report_*`` id, ``coach_message_v1``,
+    a two-stage-only id, or an unknown id), that whole coaching surface goes inert
+    with no error. Rather than degrade silently (#424), surface it at startup so a
+    misconfigured deploy is visible in the logs instead of producing flat reports.
+    Called once per process group right after ``init_logging``.
+    """
+    # Imported lazily so this pure-logging module stays free of a coach-layer
+    # import at module load.
+    from app.services.coach.prompt_features import carries_runner_facing_features
+
+    prompt_id = settings.COACH_PROMPT_ID
+    if carries_runner_facing_features(prompt_id):
+        return
+    logging.getLogger(__name__).warning(
+        "coach_prompt_inert: active COACH_PROMPT_ID=%r carries no runner-facing "
+        "coaching features (voice/corpus/stance/training-load/user-materials/volume); "
+        "the entire prompt-gated coaching surface is disabled. Set COACH_PROMPT_ID to a "
+        "feature-bearing prompt (e.g. coach_message_v8).",
+        prompt_id,
+        extra={"coach_prompt_id": prompt_id},
+    )
+
+
 def sentry_capture_active() -> bool:
     """True only when Sentry error capture is actually live.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,10 +4,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.api import health, auth, activities, blocks, webhooks, profile, trends, coach, debug, strava_import, materials
 from app.core.auth import BasicAuthMiddleware
 from app.core.config import settings
-from app.core.observability import init_logging, init_sentry
+from app.core.observability import init_logging, init_sentry, warn_if_coach_prompt_inert
 
 init_logging()
 init_sentry("web")
+warn_if_coach_prompt_inert()
 
 app = FastAPI(
     title="Running Coach",

--- a/backend/app/services/coach/prompt_features.py
+++ b/backend/app/services/coach/prompt_features.py
@@ -98,9 +98,41 @@ PROMPT_FEATURES: dict[str, frozenset[PromptFeature]] = {
 }
 
 
+# The runner-facing capabilities. TWO_STAGE is the cadence shape (an operational
+# choice, inert under the receipt cadence and rolled back deliberately), so a prompt
+# that carries ONLY two-stage is not what we mean by "feature-bearing": this set is
+# the runner-visible coaching surface (voice/corpus/stance/training-load/
+# user-materials/volume) whose silent loss #424 guards against.
+RUNNER_FACING_FEATURES: frozenset[PromptFeature] = frozenset(
+    {
+        PromptFeature.VOICE,
+        PromptFeature.CORPUS,
+        PromptFeature.STANCE,
+        PromptFeature.TRAINING_LOAD,
+        PromptFeature.USER_MATERIALS,
+        PromptFeature.VOLUME,
+    }
+)
+
+
 def has_feature(prompt_id: Optional[str], feature: PromptFeature) -> bool:
     """True when ``prompt_id`` carries ``feature``. False for any unknown id or None."""
     return feature in PROMPT_FEATURES.get(prompt_id, frozenset())
+
+
+def features_for(prompt_id: Optional[str]) -> frozenset[PromptFeature]:
+    """The full capability set ``prompt_id`` carries (empty for any unknown id/None)."""
+    return PROMPT_FEATURES.get(prompt_id, frozenset())
+
+
+def carries_runner_facing_features(prompt_id: Optional[str]) -> bool:
+    """True when ``prompt_id`` activates at least one runner-visible coaching feature.
+
+    False for a legacy ``coach_report_*`` id, ``coach_message_v1``, a TWO_STAGE-only
+    id, ``None``, or any unknown id. This is the predicate #424 uses to detect a
+    silently degraded active prompt at startup.
+    """
+    return bool(features_for(prompt_id) & RUNNER_FACING_FEATURES)
 
 
 def ids_with(feature: PromptFeature) -> frozenset[str]:

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -9,7 +9,7 @@ import logging
 
 from rq import Queue, Worker
 
-from app.core.observability import init_logging, init_sentry
+from app.core.observability import init_logging, init_sentry, warn_if_coach_prompt_inert
 from app.core.queue import redis_conn
 
 LISTEN = ("default",)
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 def main() -> None:
     init_logging()
     init_sentry("worker")
+    warn_if_coach_prompt_inert()
     logger.info("Worker booting; listening on %s", ",".join(LISTEN))
     queues = [Queue(name, connection=redis_conn) for name in LISTEN]
     worker = Worker(queues, connection=redis_conn)

--- a/backend/tests/test_adherence_context.py
+++ b/backend/tests/test_adherence_context.py
@@ -251,9 +251,9 @@ def test_pack_unanalysed_intervening_run_is_skipped(db):
 
 class TestPromptVersioning:
     def test_v4_is_active_default(self):
-        # The active default has since advanced (#168 -> v8); v4 remains
-        # registered and byte-stable for its cached reports.
-        assert settings.COACH_PROMPT_ID == "coach_report_v10"
+        # The in-code default tracks the production feature-bearing prompt (#424);
+        # v4 remains registered and byte-stable for its cached reports.
+        assert settings.COACH_PROMPT_ID == "coach_message_v8"
 
     def test_v4_adds_adherence_rule(self):
         v4 = PROMPT_VERSIONS["coach_report_v4"]

--- a/backend/tests/test_belief_store.py
+++ b/backend/tests/test_belief_store.py
@@ -200,8 +200,9 @@ def test_loop_closes_through_context_pack(db):
 
 class TestPromptVersioning:
     def test_v5_is_active_default(self):
-        # Active default has since advanced (#168 -> v8); v7 stays byte-stable.
-        assert settings.COACH_PROMPT_ID == "coach_report_v10"
+        # The in-code default tracks the production feature-bearing prompt (#424);
+        # v5 stays registered and byte-stable for its cached reports.
+        assert settings.COACH_PROMPT_ID == "coach_message_v8"
 
     def test_v5_adds_believed_facts_rule(self):
         v5 = PROMPT_VERSIONS["coach_report_v5"]

--- a/backend/tests/test_calibration_context.py
+++ b/backend/tests/test_calibration_context.py
@@ -126,8 +126,9 @@ def test_no_referral_when_clean(db):
 
 class TestPromptVersioning:
     def test_v6_is_active_default(self):
-        # Active default has since advanced (#168 -> v8); v7 stays byte-stable.
-        assert settings.COACH_PROMPT_ID == "coach_report_v10"
+        # The in-code default tracks the production feature-bearing prompt (#424);
+        # v7 stays registered and byte-stable for its cached reports.
+        assert settings.COACH_PROMPT_ID == "coach_message_v8"
 
     def test_v6_adds_calibration_rule(self):
         v6 = PROMPT_VERSIONS["coach_report_v7"]

--- a/backend/tests/test_coach_eval_rubric.py
+++ b/backend/tests/test_coach_eval_rubric.py
@@ -649,7 +649,8 @@ class TestPromptVersioningV9:
 
     def test_v9_is_active_default(self):
         from app.core.config import settings
-        assert settings.COACH_PROMPT_ID == "coach_report_v10"
+        # The in-code default tracks the production feature-bearing prompt (#424).
+        assert settings.COACH_PROMPT_ID == "coach_message_v8"
 
     def test_v9_adds_coach_the_data_rule(self):
         from app.services.coach.prompts import PROMPT_VERSIONS

--- a/backend/tests/test_coach_prompt_default.py
+++ b/backend/tests/test_coach_prompt_default.py
@@ -1,0 +1,56 @@
+"""#424 — the active coach prompt default must be feature-bearing, and an inert
+active prompt must surface loudly at startup instead of silently disabling the
+whole prompt-gated coaching surface (voice/corpus/stance/training-load/
+user-materials/volume).
+"""
+
+import logging
+
+from app.core.config import settings
+from app.core.observability import warn_if_coach_prompt_inert
+from app.services.coach.prompt_features import (
+    RUNNER_FACING_FEATURES,
+    carries_runner_facing_features,
+    features_for,
+)
+
+
+def test_default_prompt_is_feature_bearing():
+    # A deploy that forgets the COACH_PROMPT_ID env override must still land on a
+    # prompt that activates the runner-facing coaching features, not a legacy id.
+    assert settings.COACH_PROMPT_ID == "coach_message_v8"
+    assert carries_runner_facing_features(settings.COACH_PROMPT_ID)
+
+
+def test_carries_runner_facing_features_predicate():
+    # Feature-bearing message prompts pass.
+    for pid in ("coach_message_v3", "coach_message_v8", "coach_message_v9"):
+        assert carries_runner_facing_features(pid), pid
+    # Legacy, two-stage-only, unknown, and None all read as inert.
+    for pid in ("coach_report_v10", "coach_report_v1", "coach_message_v1",
+                "coach_message_v2", "unknown_prompt_xyz", None):
+        assert not carries_runner_facing_features(pid), pid
+
+
+def test_runner_facing_set_excludes_two_stage():
+    # The cadence shape (two-stage) is an operational choice, not the runner-visible
+    # coaching surface #424 guards; a two-stage-only prompt must not read as
+    # feature-bearing.
+    assert not (features_for("coach_message_v2") & RUNNER_FACING_FEATURES)
+
+
+def test_inert_prompt_warns_at_startup(monkeypatch, caplog):
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_report_v10")
+    with caplog.at_level(logging.WARNING):
+        warn_if_coach_prompt_inert()
+    records = [r for r in caplog.records if "coach_prompt_inert" in r.getMessage()]
+    assert records, "expected a loud warning for an inert active prompt"
+    assert records[0].levelno == logging.WARNING
+    assert getattr(records[0], "coach_prompt_id", None) == "coach_report_v10"
+
+
+def test_feature_bearing_prompt_does_not_warn(monkeypatch, caplog):
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v8")
+    with caplog.at_level(logging.WARNING):
+        warn_if_coach_prompt_inert()
+    assert not [r for r in caplog.records if "coach_prompt_inert" in r.getMessage()]

--- a/backend/tests/test_coach_report_fallback_flag.py
+++ b/backend/tests/test_coach_report_fallback_flag.py
@@ -19,6 +19,15 @@ from app.models.coach_report import CoachReport
 from app.services.coach.service import get_or_generate_coach_report
 
 
+@pytest.fixture(autouse=True)
+def _pin_structured_prompt(monkeypatch):
+    # This suite exercises the STRUCTURED single-shot path; the active default now
+    # tracks the feature-bearing message prompt (#424), so pin the structured one.
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_report_v10")
+
+
 def _seed_activity_with_metrics(db) -> Activity:
     user = User(email=f"u-{uuid4()}@example.com")
     db.add(user)

--- a/backend/tests/test_coach_report_versioning.py
+++ b/backend/tests/test_coach_report_versioning.py
@@ -21,7 +21,15 @@ from app.services.coach.service import (
     get_or_generate_coach_report,
 )
 
-ACTIVE_PROMPT_ID = settings.COACH_PROMPT_ID
+# This suite exercises the STRUCTURED single-shot cache path (schema 1.2), so it
+# pins the structured prompt rather than following the active default, which now
+# tracks the feature-bearing message prompt (#424).
+ACTIVE_PROMPT_ID = "coach_report_v10"
+
+
+@pytest.fixture(autouse=True)
+def _pin_structured_prompt(monkeypatch):
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", ACTIVE_PROMPT_ID)
 
 _VALID_REPORT = {
     "key_takeaways": [{"text": "Cached takeaway one."}, {"text": "Cached takeaway two."}],

--- a/backend/tests/test_consolidation.py
+++ b/backend/tests/test_consolidation.py
@@ -308,7 +308,12 @@ async def test_consolidate_degrades_on_llm_error_without_clobbering(db):
 # --------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_report_path_enqueues_consolidation_and_does_not_block(db):
+async def test_report_path_enqueues_consolidation_and_does_not_block(db, monkeypatch):
+    # The structured single-shot path is exercised here (generate_json); the active
+    # default now tracks the feature-bearing message prompt (#424), so pin it.
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_report_v10")
+
     user = _seed_user(db)
     db.add(UserProfile(
         user_id=user.id, goal_type="general", experience_level="intermediate",

--- a/backend/tests/test_longitudinal_context.py
+++ b/backend/tests/test_longitudinal_context.py
@@ -312,8 +312,10 @@ def test_pack_omits_baseline_trend_when_no_matching_bucket(db):
 # --- prompt discipline ------------------------------------------------------
 
 def test_active_prompt_has_anti_restate_instruction():
-    from app.core.config import settings
-    prompt = build_system_prompt(settings.COACH_PROMPT_ID)
+    # Pins the M4 anti-restate wording in the structured coach_report chain. The
+    # active default now tracks the feature-bearing message prompt (#424), which
+    # carries the same discipline phrased differently; this asserts the v10 text.
+    prompt = build_system_prompt("coach_report_v10")
     lowered = prompt.lower()
     assert "advance the narrative" in lowered
     assert "longitudinal" in lowered

--- a/backend/tests/test_perceived_effort_context.py
+++ b/backend/tests/test_perceived_effort_context.py
@@ -146,9 +146,9 @@ class TestPerceivedEffortInPack:
 
 class TestPromptVersioning:
     def test_v4_is_active_default(self):
-        # The active prompt has since advanced (M7->v4 ... #168->v8); v3 remains
-        # registered and byte-stable for its cached reports.
-        assert settings.COACH_PROMPT_ID == "coach_report_v10"
+        # The in-code default tracks the production feature-bearing prompt (#424);
+        # v3 remains registered and byte-stable for its cached reports.
+        assert settings.COACH_PROMPT_ID == "coach_message_v8"
 
     def test_v3_adds_perceived_effort_rule(self):
         v3 = PROMPT_VERSIONS["coach_report_v3"]

--- a/backend/tests/test_pipeline_end_to_end.py
+++ b/backend/tests/test_pipeline_end_to_end.py
@@ -44,6 +44,9 @@ def configured(monkeypatch):
     monkeypatch.setattr(settings, "APP_BASE_URL", "http://localhost:3000")
     monkeypatch.setattr(settings, "SMTP_HOST", "smtp.example.com")
     monkeypatch.setattr(settings, "STRAVA_WEBHOOK_VERIFY_TOKEN", "x")
+    # Exercises the SINGLE-SHOT structured email pipeline; the active default now
+    # tracks the feature-bearing message prompt (#424), so pin the structured one.
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_report_v10")
 
 
 def _seed(db, athlete_id: int = 70707):

--- a/backend/tests/test_preference_context.py
+++ b/backend/tests/test_preference_context.py
@@ -91,8 +91,9 @@ def test_pack_preference_ignores_non_adherence_beliefs(db):
 
 class TestPromptVersioning:
     def test_v7_is_active_default(self):
-        # Active default has since advanced (#168 -> v8); v7 stays byte-stable.
-        assert settings.COACH_PROMPT_ID == "coach_report_v10"
+        # The in-code default tracks the production feature-bearing prompt (#424);
+        # v7 stays registered and byte-stable for its cached reports.
+        assert settings.COACH_PROMPT_ID == "coach_message_v8"
 
     def test_v7_adds_preference_rule(self):
         v7 = PROMPT_VERSIONS["coach_report_v7"]

--- a/backend/tests/test_process_new_activity_job.py
+++ b/backend/tests/test_process_new_activity_job.py
@@ -17,6 +17,13 @@ from app.services.strava_ingestion import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _pin_structured_prompt(monkeypatch):
+    # This suite exercises the SINGLE-SHOT structured pipeline; the active default
+    # now tracks the feature-bearing message prompt (#424), so pin the structured one.
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_report_v10")
+
+
 @pytest.fixture
 def strava_adapter():
     adapter = InMemoryStravaAdapter()

--- a/backend/tests/test_report_digest_storage.py
+++ b/backend/tests/test_report_digest_storage.py
@@ -14,6 +14,15 @@ from app.models.coach_report import CoachReport
 from app.services.coach.service import get_or_generate_coach_report
 
 
+@pytest.fixture(autouse=True)
+def _pin_structured_prompt(monkeypatch):
+    # This suite exercises the STRUCTURED single-shot path; the active default now
+    # tracks the feature-bearing message prompt (#424), so pin the structured one.
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_report_v10")
+
+
 def _seed_activity_with_metrics(db) -> Activity:
     user = User(email=f"u-{uuid4()}@example.com")
     db.add(user)

--- a/backend/tests/test_structured_fence_recovery.py
+++ b/backend/tests/test_structured_fence_recovery.py
@@ -20,6 +20,15 @@ from app.models.coach_report import CoachReport
 from app.services.coach.service import _strip_code_fences, get_or_generate_coach_report
 
 
+@pytest.fixture(autouse=True)
+def _pin_structured_prompt(monkeypatch):
+    # This regression is about the STRUCTURED single-shot path; the active default
+    # now tracks the feature-bearing message prompt (#424), so pin the structured one.
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_report_v10")
+
+
 class TestStripCodeFences:
     def test_fully_fenced(self):
         assert _strip_code_fences('```json\n{"a": 1}\n```') == '{"a": 1}'


### PR DESCRIPTION
## What

The in-code default for the active coach prompt (`COACH_PROMPT_ID`) was `coach_report_v10` and `.env.example` was `coach_report_v1`. Both are non-feature-bearing: per the `prompt_features.py` manifest they carry none of the runner-facing coaching features (voice/corpus/stance/training-load/user-materials/volume). A deploy that forgot the env override would silently disable the entire prompt-gated coaching surface, including the runner's declared voice, with no error and no log.

This change:

- Sets the in-code default and `.env.example` to the production prompt `coach_message_v8` (confirmed in project-context.md / memory), which carries the full feature set.
- Adds `warn_if_coach_prompt_inert()` (in `app/core/observability.py`), wired into both startup entrypoints that generate reports (`app/main.py` web, `app/worker.py` worker). It logs a loud `WARNING` when the resolved active prompt carries none of the runner-facing features, using the new manifest predicate `carries_runner_facing_features` in `prompt_features.py`.

## Why / design decision

The acceptance criteria allow either a hard fail at startup or a correct feature-bearing default. I chose the correct default PLUS a loud startup warning, and deliberately did NOT hard-fail the boot: the same image runs `alembic upgrade head` as the deploy release command, and a hard fail on a bad `COACH_PROMPT_ID` could brick a deploy. A correct default plus a visible warning satisfies "fails loudly ... rather than silently degrading" without that risk.

`TWO_STAGE` (the cadence shape) is intentionally excluded from `RUNNER_FACING_FEATURES`: it is an operational choice (inert under the receipt cadence, rolled back deliberately), not a runner-visible coaching surface, so a two-stage-only prompt still reads as inert for this check.

The scheduler entrypoint is intentionally not wired: it only enqueues polling and never generates reports, so it has no dependency on the prompt and the warning would be noise there.

## Assumptions

- Production runs `coach_message_v8` (per project-context.md and MEMORY.md); the default is set to match. If a later prod flip lands (e.g. v9), the default should follow, but that is out of scope here.

## Test evidence

- New `tests/test_coach_prompt_default.py` locks in: the default is feature-bearing, the predicate classifies feature-bearing vs inert/two-stage-only/unknown/None correctly, and the warning fires on an inert prompt but stays silent on a feature-bearing one.
- Reconciled tests that pinned the old default: value-corrected the six `*_is_active_default` assertions to `coach_message_v8` (their comments already acknowledged the default had advanced), and pinned the structured single-shot path suites (versioning, fallback, digest, fence-recovery, pipeline, one consolidation/longitudinal case) explicitly to `coach_report_v10` since they exercise the structured shape rather than "whatever the default is".
- `make backend-test`: **1516 passed, 4 deselected, 21 warnings**.
- Runtime check: booting settings with the default emits no warning; flipping to `coach_report_v10` emits the `coach_prompt_inert` WARNING.

## Not covered

- No live FastAPI/worker process run against a real DB+Redis; the logging path is exercised directly in tests and via a settings-boot python check.

Closes #424