### PR TITLE
Exclude soft-deleted activities from the All Activities list and detail view (#410)

### DIFF
--- a/backend/app/services/activity_queries.py
+++ b/backend/app/services/activity_queries.py
@@ -28,6 +28,9 @@ def get_activities(
         # per item (compose_headline -> sport_type/trainer reads raw_summary), so
         # without this the deferred column would lazy-load once per row -> N+1.
         .options(joinedload(Activity.metrics), undefer(Activity.raw_summary))
+        # Exclude soft-deleted activities (#410), consistent with every other
+        # read path (trends, readiness, training load, coach context/retrieval).
+        .filter(Activity.is_deleted == False)  # noqa: E712
     )
     if types:
         query = query.filter(Activity.type.in_(types))
@@ -64,5 +67,8 @@ def get_activity(db: Session, activity_id: str | uuid.UUID) -> Activity | None:
             undefer(Activity.raw_summary),
         )
         .filter(Activity.id == activity_id)
+        # A soft-deleted activity reads as not-present (#410): the detail view
+        # 404s on it, consistent with the list and every other read path.
+        .filter(Activity.is_deleted == False)  # noqa: E712
         .first()
     )

--- a/backend/tests/test_activity_list_filters.py
+++ b/backend/tests/test_activity_list_filters.py
@@ -12,7 +12,9 @@ import pytest
 from app.models import Activity, User
 
 
-def _make_activity(db, *, name: str, type_: str, start: datetime) -> Activity:
+def _make_activity(
+    db, *, name: str, type_: str, start: datetime, is_deleted: bool = False
+) -> Activity:
     user_id = uuid.uuid4()
     db.add(User(id=user_id, email=f"filt_{user_id}@example.com"))
     db.flush()
@@ -27,6 +29,7 @@ def _make_activity(db, *, name: str, type_: str, start: datetime) -> Activity:
         moving_time_s=3600,
         elapsed_time_s=3700,
         elev_gain_m=10.0,
+        is_deleted=is_deleted,
     )
     db.add(a)
     db.commit()
@@ -95,3 +98,44 @@ def test_empty_result_when_nothing_matches(client, seeded):
     resp = client.get("/api/activities?types=Swim")
     assert resp.status_code == 200, resp.text
     assert resp.json() == []
+
+
+def test_soft_deleted_excluded_from_list(client, db):
+    """A soft-deleted activity must not appear in the All Activities list (#410),
+    consistent with every other read path that filters is_deleted."""
+    _make_activity(
+        db, name="Live Run", type_="Run",
+        start=datetime(2026, 5, 1, 9, 0, tzinfo=timezone.utc),
+    )
+    _make_activity(
+        db, name="Deleted Run", type_="Run",
+        start=datetime(2026, 5, 2, 9, 0, tzinfo=timezone.utc),
+        is_deleted=True,
+    )
+    resp = client.get("/api/activities")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == {"Live Run"}
+
+
+def test_soft_deleted_excluded_with_type_filter(client, db):
+    """The type filter must not re-admit a soft-deleted activity (#410)."""
+    _make_activity(
+        db, name="Deleted Run", type_="Run",
+        start=datetime(2026, 5, 2, 9, 0, tzinfo=timezone.utc),
+        is_deleted=True,
+    )
+    resp = client.get("/api/activities?types=Run")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+def test_detail_view_404s_for_soft_deleted(client, db):
+    """The single-activity detail view reads a soft-deleted activity as
+    not-present and 404s, consistent with the list (#410)."""
+    a = _make_activity(
+        db, name="Deleted Run", type_="Run",
+        start=datetime(2026, 5, 2, 9, 0, tzinfo=timezone.utc),
+        is_deleted=True,
+    )
+    resp = client.get(f"/api/activities/{a.id}")
+    assert resp.status_code == 404, resp.text


### PR DESCRIPTION
## What
The All Activities list query (`activity_queries.get_activities`) and the single-activity detail query (`get_activity`) did not filter `Activity.is_deleted`, so an activity soft-deleted on Strava (the deletion handler in `webhooks.py` sets `is_deleted=True`) still appeared in the history and rendered on its detail page.

This applies the same `is_deleted == False` predicate already used by every other read path (trends, readiness, training load, coach context/retrieval) to both queries.

## Why
Strava deletions are soft deletes. The mismatch was user-visible: a deleted activity showed in the list and, because the type-filter options are drawn from non-deleted activities, could appear with no matching filter type.

## Detail-view decision
A soft-deleted activity now reads as not-present: the detail endpoint 404s on it (the `get_activity` query filters `is_deleted`, the endpoint already raises 404 on `None`). This is consistent with the list (the row is hidden) and with how the rest of the app treats soft-deletes everywhere else (they are excluded, never rendered with a marker). No "deleted marker" UI was added, as nothing in the app surfaces soft-deleted rows.

## Tests
Added to `tests/test_activity_list_filters.py`:
- soft-deleted activity absent from the list
- soft-deleted activity not re-admitted by a type filter
- detail view 404s for a soft-deleted activity

`make backend-test`: `1514 passed, 4 deselected`.

## Scope note
Change is localized to the two `is_deleted` filters in `activity_queries.py` to keep a later merge with #411 (date-filter work in the same file) clean.

Closes #410