### PR TITLE
Fix All Activities date filter to match displayed local date (#411)

### DIFF
--- a/backend/app/services/activity_queries.py
+++ b/backend/app/services/activity_queries.py
@@ -1,6 +1,7 @@
 import uuid
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import date, datetime, time, timedelta
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload, undefer
 
 from app.models import Activity
@@ -18,10 +19,22 @@ def get_activities(
     """List activities newest-first, paginated, with optional filters (#404).
 
     ``types`` narrows to the given activity types (OR within the list). ``start_date``
-    and ``end_date`` bound the range on ``start_date`` (UTC) and are both inclusive of
-    the whole day. Filters compose; pagination is applied after filtering so it walks
-    the filtered history rather than the full one.
+    and ``end_date`` bound the range on the activity's LOCAL calendar day and are both
+    inclusive of the whole day. Filters compose; pagination is applied after filtering so
+    it walks the filtered history rather than the full one.
+
+    The bound is taken against ``coalesce(start_date_local, start_date)`` (#411): the
+    list renders each row by its own local wall-clock date (``start_date_local``, falling
+    back to UTC ``start_date`` for pre-#399 rows, mirroring ``Activity.local_start`` and
+    the frontend's ``activityStartDate``), so filtering on the UTC instant could
+    include/exclude a near-midnight row in disagreement with the date the runner sees.
+    Bounds are naive datetimes so they compare against the naive local wall-clock column.
+    ``start_date_local`` is not indexed (single-user, single-timezone today); the cost is
+    a sequential scan over the runner's history, acceptable at this scale.
     """
+    # The displayed/filtered day: the local wall-clock start, falling back to the UTC
+    # instant when no local time was stored (the same precedence local_start uses).
+    local_start = func.coalesce(Activity.start_date_local, Activity.start_date)
     query = (
         db.query(Activity)
         # undefer raw_summary (#359): the list composes a classification headline
@@ -35,14 +48,14 @@ def get_activities(
     if types:
         query = query.filter(Activity.type.in_(types))
     if start_date is not None:
-        # Bound on start_date (UTC, the indexed ordering column). The chosen date is
-        # treated as a UTC day, consistent with how the list orders/windows.
-        lower = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
-        query = query.filter(Activity.start_date >= lower)
+        # Bound on the local wall-clock day. Naive lower bound: midnight of the chosen
+        # local day, compared against the naive local-start column.
+        lower = datetime.combine(start_date, time.min)
+        query = query.filter(local_start >= lower)
     if end_date is not None:
-        # End inclusive: everything strictly before the start of the following day.
-        upper = datetime.combine(end_date + timedelta(days=1), time.min, tzinfo=timezone.utc)
-        query = query.filter(Activity.start_date < upper)
+        # End inclusive: everything strictly before the start of the following local day.
+        upper = datetime.combine(end_date + timedelta(days=1), time.min)
+        query = query.filter(local_start < upper)
     return (
         query
         .order_by(Activity.start_date.desc())

--- a/backend/tests/test_activity_list_filters.py
+++ b/backend/tests/test_activity_list_filters.py
@@ -13,7 +13,13 @@ from app.models import Activity, User
 
 
 def _make_activity(
-    db, *, name: str, type_: str, start: datetime, is_deleted: bool = False
+    db,
+    *,
+    name: str,
+    type_: str,
+    start: datetime,
+    start_local: datetime | None = None,
+    is_deleted: bool = False,
 ) -> Activity:
     user_id = uuid.uuid4()
     db.add(User(id=user_id, email=f"filt_{user_id}@example.com"))
@@ -25,6 +31,7 @@ def _make_activity(
         name=name,
         type=type_,
         start_date=start,
+        start_date_local=start_local,
         distance_m=10000,
         moving_time_s=3600,
         elapsed_time_s=3700,
@@ -139,3 +146,59 @@ def test_detail_view_404s_for_soft_deleted(client, db):
     )
     resp = client.get(f"/api/activities/{a.id}")
     assert resp.status_code == 404, resp.text
+
+
+@pytest.fixture
+def near_midnight(db):
+    """A run whose LOCAL day differs from its UTC day (#411).
+
+    Runner in a UTC-5 zone runs at 23:30 local on May 5; the UTC instant is
+    therefore May 6 04:30. The list displays this row as May 5 (the local day), so a
+    date filter must agree with May 5, not the UTC May 6.
+    """
+    _make_activity(
+        db,
+        name="Late Run",
+        type_="Run",
+        start=datetime(2026, 5, 6, 4, 30, tzinfo=timezone.utc),
+        start_local=datetime(2026, 5, 5, 23, 30),
+    )
+    return db
+
+
+def test_end_date_matches_displayed_local_day(client, near_midnight):
+    # end_date = the LOCAL day (May 5). The UTC instant is May 6, so a UTC filter would
+    # wrongly exclude it; the local-day filter must include it.
+    resp = client.get("/api/activities?end_date=2026-05-05")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == {"Late Run"}
+
+
+def test_start_date_excludes_on_utc_day_when_local_is_earlier(client, near_midnight):
+    # start_date = the UTC day (May 6). The row's displayed (local) day is May 5, so it
+    # falls BEFORE this lower bound and must be excluded.
+    resp = client.get("/api/activities?start_date=2026-05-06")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == set()
+
+
+def test_local_day_range_includes_near_midnight_row(client, near_midnight):
+    # A range whose end lands exactly on the displayed local day includes it.
+    resp = client.get("/api/activities?start_date=2026-05-01&end_date=2026-05-05")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == {"Late Run"}
+
+
+def test_filter_falls_back_to_utc_when_no_local_start(client, db):
+    # Pre-#399 rows have no start_date_local; the filter falls back to the UTC instant
+    # (mirroring Activity.local_start), so a same-day bound still matches.
+    _make_activity(
+        db,
+        name="Legacy Run",
+        type_="Run",
+        start=datetime(2026, 7, 4, 9, 0, tzinfo=timezone.utc),
+        start_local=None,
+    )
+    resp = client.get("/api/activities?start_date=2026-07-04&end_date=2026-07-04")
+    assert resp.status_code == 200, resp.text
+    assert _names(resp) == {"Legacy Run"}


### PR DESCRIPTION
## What
The All Activities date-range filter bounded on the UTC `start_date`, but the list renders each row by its own local wall-clock date (`start_date_local`). Near a day boundary the two can fall on different calendar days, so a row dated (say) the 5th could be excluded by a range ending on the 5th, or vice versa.

This makes the backend filter bound on the activity's LOCAL day instead, so filtering agrees with the date the runner actually sees on each row.

## Why this field
The displayed date comes from `frontend/lib/format.ts` `activityStartDate`, which prefers `start_date_local` (Strava's naive local wall-clock) and falls back to the UTC `start_date`. That is exactly `Activity.local_start`. The filter now bounds on `coalesce(start_date_local, start_date)` with naive day bounds, so it matches the displayed day by construction, including the null-local fallback for pre-#399 rows.

## Changes
- `backend/app/services/activity_queries.py`: bound the range on `coalesce(start_date_local, start_date)` with naive midnight bounds (was UTC `start_date`). Both ends stay inclusive of the whole local day; pagination and filter composition unchanged.
- `backend/tests/test_activity_list_filters.py`: added a near-midnight fixture (UTC-5 runner, 23:30 local on May 5 = 04:30 UTC May 6) and assertions that it is included by `end_date=2026-05-05`, excluded by `start_date=2026-05-06`, included in a May 1-5 local range; plus a null-local fallback test.

## Test evidence
- `make backend-test`: `1515 passed, 4 deselected` (was green before; no existing test weakened).
- Frontend untouched: `DateRangeFilter` already sends plain `YYYY-MM-DD`, so no client change is needed.

## Caveat
`start_date_local` is not indexed, so the bound is a sequential scan over the runner's history rather than an index range like the old UTC bound. Acceptable at the current single-user, single-timezone scale; adding an index is a schema change (ASK-first / separate migration) and is left as a follow-up if the table grows.

## Note for the reviewer
Branches from `main`, which does not yet have #410's `is_deleted == False` filter on the same file. The change here is localized to the date-range branch only, so the later merge stays clean.

Closes #411