### PR TITLE
Raise advice-theme recognition recall (#165)

### DIFF
--- a/backend/app/services/coach/adherence.py
+++ b/backend/app/services/coach/adherence.py
@@ -212,6 +212,14 @@ _THEMES: Tuple[_Theme, ...] = (
             "introduce intensity", "introduce a workout", "speed work",
             "speedwork", "strides", "fartlek", "quality session",
             "tempo session", "interval workout", "do a tempo", "do intervals",
+            # Real-data additive phrasings the coach uses to ADD a quality
+            # session (verb-led "add/plan/adding/introduce a quality|tempo run").
+            # All single-intent "do a workout" requests; none are about
+            # executing/capturing a workout (lap button, pace discipline), which
+            # stay unrecognised by design.
+            "adding a quality", "add a quality run", "quality running session",
+            "add one quality", "plan your next quality", "plan next quality",
+            "plan your next tempo", "plan a quality", "plan a tempo",
         ),
         comparable=lambda c: True,  # every later run is a chance to have added quality
         verdict=_verdict_add_quality,
@@ -236,18 +244,41 @@ def _has_negation(text: str) -> bool:
     return any(phrase in text for phrase in _NEGATION_PHRASES)
 
 
+def _themes_matching(text: str) -> List[_Theme]:
+    return [t for t in _THEMES if any(kw in text for kw in t.keywords)]
+
+
 def _classify(step: dict) -> Optional[_Theme]:
     """Map a next_step to its theme, or None when unrecognised, multi-intent, or
     a negation/caution (which would otherwise invert the verdict).
 
     Classifies on `action` + `details` only — the `why` field is the rationale,
     not the action, and a rationale mentioning another theme must not re-theme
-    the step (e.g. "Focus on form, so you can add a tempo later")."""
-    text = " ".join(str(step.get(k) or "") for k in ("action", "details")).lower()
-    if _has_negation(text):
+    the step (e.g. "Focus on form, so you can add a tempo later").
+
+    The `action` is the imperative (the actual instruction); `details` is the
+    elaboration. Real coach advice routinely names a SECOND theme incidentally in
+    the details — "Plan your next quality session, focusing on easy recovery
+    rides in between" is unambiguously add_quality, but its details mention
+    "easy recovery", so scoring the combined text matched two themes and the step
+    abstained. So classify the ACTION first: when the imperative alone resolves to
+    exactly one theme, trust it. Only when the action is theme-silent do we widen
+    to action+details (so steps whose instruction lives in the details still
+    classify), keeping the multi-intent abstain there. The negation guard runs on
+    the full text either way, so a caution buried in the details still abstains."""
+    action_text = str(step.get("action") or "").lower()
+    full_text = " ".join(str(step.get(k) or "") for k in ("action", "details")).lower()
+    if _has_negation(full_text):
         return None
-    matched = [t for t in _THEMES if any(kw in text for kw in t.keywords)]
-    return matched[0] if len(matched) == 1 else None
+    action_matched = _themes_matching(action_text)
+    if len(action_matched) == 1:
+        return action_matched[0]
+    if len(action_matched) > 1:
+        return None  # the imperative itself is multi-intent -> abstain
+    # Action is theme-silent: fall back to the full text (the instruction may
+    # live in the details), keeping the multi-intent abstain.
+    full_matched = _themes_matching(full_text)
+    return full_matched[0] if len(full_matched) == 1 else None
 
 
 def build_adherence(

--- a/backend/tests/test_adherence.py
+++ b/backend/tests/test_adherence.py
@@ -149,6 +149,34 @@ def test_measurement_advice_does_not_classify_as_add_quality():
         assert ctx.outcomes == [], f"{action!r} should not classify"
 
 
+def test_more_measurement_advice_does_not_classify():
+    """#165: extra real-data capture/testing phrasings must still abstain — the
+    recall improvement must not start reading data-capture advice as add_quality."""
+    for action, details in (
+        ("Consider using structured intervals for future indoor rides",
+         "use your bike computer's lap button or interval timer to track work and rest periods"),
+        ("Consider using interval timing for structured rowing sessions",
+         "use the rowing machine's interval function or manual lap button"),
+        ("Consider heart rate zone calibration",
+         "schedule a lactate threshold or ramp test to establish personalized training zones"),
+        ("Consider using manual lap markers for structured indoor sessions",
+         "press lap button between intervals or efforts to improve workout detection"),
+    ):
+        ctx = build_adherence(
+            prior_report_date="2026-02-01T10:00:00+00:00",
+            prior_next_steps=[{"action": action, "details": details, "why": ""}],
+            candidates=[
+                CandidateActivity(
+                    date="2026-02-03T10:00:00+00:00", effort="tempo",
+                    duration_class="standard", structure="continuous", is_race=False,
+                    confidence="high", user_intent=None,
+                ),
+            ],
+            pushback=False,
+        )
+        assert ctx.outcomes == [], f"{action!r} should not classify as a theme"
+
+
 def test_easy_discipline_judges_first_comparable_run():
     """The verdict is the NEXT comparable run after the advice, not a later one."""
     ctx = build_adherence(
@@ -277,6 +305,76 @@ def test_add_quality_acted_on_fires_immediately():
         pushback=False,
     )
     assert ctx.outcomes[0].label == "acted_on"
+
+
+# --------------------------------------------------------------------------- #
+# #165 recall: real-data additive-quality phrasings now classify, and the
+# action-first rule rescues a quality instruction whose DETAILS incidentally
+# mention easy/recovery (the second-theme-in-the-rationale false abstain).
+# --------------------------------------------------------------------------- #
+
+def test_add_quality_real_phrasings_classify():
+    """Real production next_step actions the coach uses to ADD a quality session
+    that the v1 keyword set missed."""
+    for action in (
+        "Consider adding a quality running session",
+        "Add one quality session this week",
+        "Plan a tempo run",
+    ):
+        ctx = build_adherence(
+            prior_report_date="2026-02-01T10:00:00+00:00",
+            prior_next_steps=[_step(action)],
+            candidates=[_run("2026-02-02T10:00:00+00:00", effort="tempo")],
+            pushback=False,
+        )
+        assert len(ctx.outcomes) == 1, f"{action!r} should classify"
+        assert ctx.outcomes[0].theme == "add_quality", action
+
+
+def test_add_quality_action_survives_easy_mention_in_details():
+    """#165: the imperative is add_quality; the details name "easy recovery rides"
+    only as the rest BETWEEN quality work. Action-first classification trusts the
+    instruction instead of abstaining as multi-intent on the incidental mention."""
+    ctx = build_adherence(
+        prior_report_date="2026-02-01T10:00:00+00:00",
+        prior_next_steps=[_step(
+            "Plan your next quality session",
+            details="wait 2-3 days before another moderate or hard effort, "
+                    "focusing on easy recovery rides in between",
+        )],
+        candidates=[_run("2026-02-03T10:00:00+00:00", effort="tempo")],
+        pushback=False,
+    )
+    assert len(ctx.outcomes) == 1
+    assert ctx.outcomes[0].theme == "add_quality"
+    assert ctx.outcomes[0].label == "acted_on"
+
+
+def test_multi_intent_in_the_action_itself_still_abstains():
+    """Action-first must NOT defeat the multi-intent guard: when the imperative
+    ITSELF names two themes, the step is genuinely ambiguous -> abstain."""
+    ctx = build_adherence(
+        prior_report_date="2026-02-01T10:00:00+00:00",
+        prior_next_steps=[_step("Add a tempo run but keep your easy runs easy")],
+        candidates=[_run("2026-02-03T10:00:00+00:00", effort="tempo")],
+        pushback=False,
+    )
+    assert ctx.outcomes == []
+
+
+def test_caution_in_details_still_abstains_under_action_first():
+    """The negation guard runs on the full text, so a caution buried in the
+    details abstains even when the action keyword looks positive."""
+    ctx = build_adherence(
+        prior_report_date="2026-02-01T10:00:00+00:00",
+        prior_next_steps=[_step(
+            "Plan your next quality session",
+            details="but hold off until the knee settles",
+        )],
+        candidates=[_run("2026-02-03T10:00:00+00:00", effort="tempo")],
+        pushback=False,
+    )
+    assert ctx.outcomes == []
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What
Raises how reliably the coach recognises which KIND of advice a prior next-step was (`easy_discipline` / `add_quality` / `add_long_run`), so the M7 adherence loop and M10 preference signal fire more often. Without re-recognition most prior advice abstained and produced no signal.

## Why
Measured against the seeded production snapshot (86 real `coach_reports` next-steps), the dominant recall loss was `add_quality` advice abstaining as "multi-intent": the imperative is clearly "do a quality session", but the step's `details` incidentally name the easy/recovery rest BETWEEN the quality work (e.g. "Plan your next quality session ... focusing on easy recovery rides in between"), so scoring the combined action+details text matched two themes and the step abstained.

## Change
- `_classify` now classifies the `action` (the imperative) FIRST. When the action alone resolves to exactly one theme it is trusted; it falls back to the combined action+details text only when the action is theme-silent (so steps whose instruction lives in the details still classify). The negation/caution guard still runs on the full text, and the multi-intent abstain is preserved both on the action and on the fallback.
- Added real-data additive-quality phrasings to `add_quality` ("adding a quality", "add a quality run", "quality running session", "add one quality", "plan your next quality/tempo", "plan a quality/tempo").

## Real-data recall (seeded prod snapshot, n=86 next-steps)
- BEFORE: 54/86 recognised (62.8%) — by theme `{easy_discipline: 53, add_quality: 1}`
- AFTER: 59/86 recognised (68.6%) — by theme `{easy_discipline: 53, add_quality: 6}`
- +5 add_quality recognitions; `easy_discipline` unchanged at 53 (no positive advice re-themed).

## How misclassification is bounded
- Action-first only NARROWS or holds the match; it never widens past a single-theme action. Multi-intent in the action itself still abstains (regression test).
- I verified every real capture / execution / HR-zone-testing step still abstains: lap-button advice, "practice pace discipline in future tempo runs", "structured intervals for tracking", "heart rate zone calibration". These mention interval/tempo but are not advice to DO a session.
- Genuinely ambiguous / out-of-taxonomy advice (rest days, cross-training/strength, monitoring, HR-zone testing) remains unrecognised by design — abstaining stays the default.

## Tests (`backend/tests/test_adherence.py`)
- New: real add_quality phrasings classify; the action-survives-easy-mention-in-details case; action-level multi-intent still abstains; caution-in-details still abstains; 4 more real capture/testing phrasings stay unrecognised.
- Full suite: `make backend-test` -> 1516 passed, 4 deselected.

Closes #165