### PR TITLE
Wire coach question options to start the chat

### DIFF
--- a/frontend/app/activity/[id]/page.tsx
+++ b/frontend/app/activity/[id]/page.tsx
@@ -11,8 +11,7 @@ import { SplitsPanel } from '@/components/SplitsPanel';
 import { LapsPanel } from '@/components/LapsPanel';
 import StopsPanel from '@/components/StopsPanel';
 import EfficiencyPanel from '@/components/EfficiencyPanel';
-import CoachReportPanel from '@/components/CoachReportPanel';
-import CoachChat from '@/components/CoachChat';
+import CoachSection from '@/components/CoachSection';
 import TrainingLoadCard from '@/components/TrainingLoadCard';
 
 export const dynamic = 'force-dynamic';
@@ -79,11 +78,10 @@ export default async function ActivityDetail({ params }: { params: { id: string 
               <TrainingLoadCard data={activity.training_load} />
           )}
 
-          {/* Coach Analysis */}
-          <CoachReportPanel activityId={activity.id} hasMetrics={!!activity.metrics} />
+          {/* Coach Analysis + follow-up chat. The report's conversational
+              question options start the chat below (chat-as-continuation). */}
+          <CoachSection activityId={activity.id} hasMetrics={!!activity.metrics} />
 
-          {/* Coach Chat — follow-up conversation */}
-          {activity.metrics && <CoachChat activityId={activity.id} />}
 
           {/* Detailed Stream Charts */}
           {activity.streams && activity.streams.length > 0 && (

--- a/frontend/components/CoachChat.tsx
+++ b/frontend/components/CoachChat.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, forwardRef, useImperativeHandle } from 'react';
 import { ChatMessage, CoachReport, isMessageReport } from '@/lib/types';
 import { MessageCircle, Send, Loader2, RotateCcw, Sparkles } from 'lucide-react';
 import Markdown from 'react-markdown';
@@ -9,7 +9,15 @@ interface Props {
   activityId: string;
 }
 
-export default function CoachChat({ activityId }: Props) {
+// Imperative handle so a sibling (the report panel's question chips) can kick off
+// the chat without lifting all of the chat's state up. `ask` expands the chat,
+// brings it into view, and either sends `text` (a tapped quick-reply) or just
+// focuses the input for a free-form answer (no text).
+export interface CoachChatHandle {
+  ask: (text?: string) => void;
+}
+
+const CoachChat = forwardRef<CoachChatHandle, Props>(function CoachChat({ activityId }, ref) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [streaming, setStreaming] = useState(false);
@@ -84,7 +92,7 @@ export default function CoachChat({ activityId }: Props) {
     if (expanded) scrollToBottom();
   }, [messages, streamingText, expanded, scrollToBottom]);
 
-  const sendMessage = async (textArg?: string) => {
+  const sendMessage = useCallback(async (textArg?: string) => {
     // textArg lets a tapped starter chip send without going through the input box.
     const text = (textArg ?? input).trim();
     if (!text || streaming) return;
@@ -175,7 +183,7 @@ export default function CoachChat({ activityId }: Props) {
     } finally {
       setStreaming(false);
     }
-  };
+  }, [input, streaming, activityId]);
 
   const resetChat = async () => {
     try {
@@ -200,6 +208,30 @@ export default function CoachChat({ activityId }: Props) {
     setExpanded(true);
     void sendMessage(`Tell me more about this suggestion: ${action}`);
   };
+
+  // Let the report panel's question chips start the chat. Tapping a quick-reply
+  // sends its label; a "custom" option opens the chat focused so the runner can
+  // type their own answer. The timeout lets the expanded view mount before we
+  // scroll/focus (mirrors the expand button below, #226).
+  useImperativeHandle(
+    ref,
+    () => ({
+      ask: (text?: string) => {
+        if (streaming) return;
+        setExpanded(true);
+        const trimmed = text?.trim();
+        setTimeout(() => {
+          inputRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          if (trimmed) {
+            void sendMessage(trimmed);
+          } else {
+            inputRef.current?.focus({ preventScroll: true });
+          }
+        }, 100);
+      },
+    }),
+    [streaming, sendMessage],
+  );
 
   const renderStarters = () => {
     if (starters.length === 0) return null;
@@ -354,4 +386,6 @@ export default function CoachChat({ activityId }: Props) {
       </div>
     </div>
   );
-}
+});
+
+export default CoachChat;

--- a/frontend/components/CoachReportPanel.tsx
+++ b/frontend/components/CoachReportPanel.tsx
@@ -85,17 +85,22 @@ function humanizeRule(rule: string): string {
 interface Props {
   activityId: string;
   hasMetrics: boolean;
+  // I2 (chat-as-continuation): tapping a conversational question option
+  // (reply/dispute/custom) starts the coach chat. Wired by the parent that also
+  // renders CoachChat; undefined when there is no chat to start (the option then
+  // falls back to a non-interactive chip).
+  onStartChat?: (text?: string) => void;
 }
 
-export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
+export default function CoachReportPanel({ activityId, hasMetrics, onStartChat }: Props) {
   const [report, setReport] = useState<CoachReport | null>(null);
   const [status, setStatus] = useState<'checking' | 'idle' | 'loading' | 'regenerating' | 'loaded' | 'error'>('checking');
   const [errorMsg, setErrorMsg] = useState('');
 
   // I1a: tappable RPE/pain input. One answer per question; key by question index.
   // A tap writes a CheckIn (rpe → rpe, pain → pain_score) and the server fires the
-  // fuller turn when the exchange is open. Conversational reply/dispute options are
-  // out of scope here (they belong to I2 chat-as-continuation).
+  // fuller turn when the exchange is open. Conversational reply/dispute/custom
+  // options instead start the coach chat (I2 chat-as-continuation) via onStartChat.
   const [tapState, setTapState] = useState<Record<number, 'sending' | 'sent' | 'error'>>({});
   const [chosenOption, setChosenOption] = useState<Record<number, string>>({});
   const [copied, setCopied] = useState(false);
@@ -449,19 +454,38 @@ export default function CoachReportPanel({ activityId, hasMetrics }: Props) {
                         <div className="flex flex-wrap items-center gap-2 mt-2">
                           {q.options.map((opt) => {
                             // I1a delivers RPE/pain taps (the milestone's "quick
-                            // RPE/pain options"); other kinds render as before.
+                            // RPE/pain options"); the conversational kinds
+                            // (reply/dispute/custom) start the coach chat instead.
                             const interactive = opt.kind === 'rpe' || opt.kind === 'pain';
                             const answered = tapState[i] === 'sent';
                             const sending = tapState[i] === 'sending';
                             const isChosen = chosenOption[i] === opt.id;
                             if (!interactive) {
+                              // Conversational option: tapping starts the chat with
+                              // this answer (a "custom" option opens the chat for a
+                              // free-form reply, sending no canned text). With no
+                              // chat to start, fall back to a non-interactive chip.
+                              if (!onStartChat) {
+                                return (
+                                  <span
+                                    key={opt.id}
+                                    className="inline-flex items-center rounded-full border border-blue-300 dark:border-blue-700 bg-white dark:bg-gray-800 px-3 py-1 text-xs font-medium text-blue-700 dark:text-blue-300"
+                                  >
+                                    {opt.label}
+                                  </span>
+                                );
+                              }
                               return (
-                                <span
+                                <button
                                   key={opt.id}
-                                  className="inline-flex items-center rounded-full border border-blue-300 dark:border-blue-700 bg-white dark:bg-gray-800 px-3 py-1 text-xs font-medium text-blue-700 dark:text-blue-300"
+                                  type="button"
+                                  onClick={() =>
+                                    onStartChat(opt.kind === 'custom' ? undefined : opt.label)
+                                  }
+                                  className="inline-flex items-center rounded-full border border-blue-300 dark:border-blue-700 bg-white dark:bg-gray-800 px-3 py-1 text-xs font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors"
                                 >
                                   {opt.label}
-                                </span>
+                                </button>
                               );
                             }
                             return (

--- a/frontend/components/CoachSection.tsx
+++ b/frontend/components/CoachSection.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useRef } from 'react';
+import CoachReportPanel from '@/components/CoachReportPanel';
+import CoachChat, { CoachChatHandle } from '@/components/CoachChat';
+
+interface Props {
+  activityId: string;
+  hasMetrics: boolean;
+}
+
+// Bridges the coach report and the coach chat: the report's conversational
+// question options (reply/dispute/custom) start the chat below via an imperative
+// handle, so the two siblings coordinate without lifting the chat's state up.
+// The chat only exists when the activity has metrics (matching the previous
+// page-level gate), so the report's chips fall back to non-interactive when it
+// is absent.
+export default function CoachSection({ activityId, hasMetrics }: Props) {
+  const chatRef = useRef<CoachChatHandle>(null);
+
+  return (
+    <div className="space-y-6">
+      <CoachReportPanel
+        activityId={activityId}
+        hasMetrics={hasMetrics}
+        onStartChat={hasMetrics ? (text) => chatRef.current?.ask(text) : undefined}
+      />
+      {hasMetrics && <CoachChat ref={chatRef} activityId={activityId} />}
+    </div>
+  );
+}


### PR DESCRIPTION
The conversational quick-reply options on a coach report's questions (reply/dispute/custom kinds) rendered as inert chips — tapping them did nothing. Only the rpe/pain kinds were wired (to a check-in write); the others were left as static spans pending chat-as-continuation.

Wire them to the coach chat:
- CoachChat exposes an imperative `ask(text?)` handle that expands the chat, scrolls it into view, and either sends the text or focuses the input for a free-form reply.
- CoachReportPanel renders reply/dispute/custom options as buttons that call a new `onStartChat` prop (reply/dispute send the option label; custom opens the chat for the runner to type their own answer). Falls back to the non-interactive chip when no chat is wired.
- A new CoachSection client wrapper bridges the report panel and the chat via a ref so the two siblings coordinate without lifting chat state up.

sendMessage is memoized with useCallback so the imperative handle is not rebuilt every render.


Claude-Session: https://claude.ai/code/session_014J77QcPPiwFcFgZGYoHYaz