### PR TITLE
Fix Trends crash when 2-week/month series is missing (#432 follow-up)

### DIFF
--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -43,19 +43,28 @@ export default function TrendsPage() {
   // Pick the series matching the effective granularity (#432). Typed as any[]
   // because the four series carry granularity-specific point shapes; the charts
   // narrow them via their own props.
+  //
+  // A series can be undefined when the backend is older than this frontend: the
+  // frontend (Vercel) and backend (Railway) deploy independently, so during a
+  // rollout the frontend can be live before the backend returns the new
+  // `biweekly_*` / `monthly_*` fields. Coalesce to [] so a missing series shows
+  // "no data" rather than crashing on `.map` of undefined (#432 follow-up).
   const bySeries = (
-    daily: any[],
-    weekly: any[],
-    biweekly: any[],
-    monthly: any[],
-  ): any[] =>
-    effectiveGranularity === "day"
-      ? daily
-      : effectiveGranularity === "week"
-      ? weekly
-      : effectiveGranularity === "2week"
-      ? biweekly
-      : monthly;
+    daily?: any[],
+    weekly?: any[],
+    biweekly?: any[],
+    monthly?: any[],
+  ): any[] => {
+    const series =
+      effectiveGranularity === "day"
+        ? daily
+        : effectiveGranularity === "week"
+        ? weekly
+        : effectiveGranularity === "2week"
+        ? biweekly
+        : monthly;
+    return series ?? [];
+  };
 
   // Fetch available activity types once on mount
   useEffect(() => {


### PR DESCRIPTION
Follow-up to #432 (#433).

## Problem
On production, selecting the **2-week** or **month** bar granularity on Trends throws a full-page client-side exception ("Application error: a client-side exception has occurred"). **Day** and **Week** work fine.

## Root cause
The `2week`/`month` options read the `biweekly_*` / `monthly_*` series, which **only the post-#432 backend returns**. The frontend (Vercel) and backend (Railway) deploy independently, so during a rollout the frontend can be live before the backend serves the new fields. The series is then `undefined`, and the chart crashes on `.map(undefined)`. Day/Week are unaffected because their `daily_*` / `weekly_*` series exist in both the old and new backend.

This is a frontend↔backend deploy-skew at a service seam that #432 didn't guard against.

## Fix
Guard `bySeries` in `frontend/app/trends/page.tsx` to coalesce a missing series to `[]`. Each chart already renders an empty "no data" state for an empty array, so during any skew window the page degrades gracefully instead of white-screening. Once the backend serves the new fields, the buckets populate normally.

## Note (ops)
This stops the crash, but 2-week/month will show **"no data"** until the **Railway backend** has deployed #432's new fields. If that backend deploy failed/was skipped, the new buckets stay empty until it completes — worth confirming separately.

## Testing
- `next lint` clean, `next build` clean.
- Verification limit: the crash fires on a client click and this environment has no headless-browser automation, so the fix was verified by symptom match (day/week present-in-both vs 2-week/month new-only), the guard's semantics, the build, and each chart's empty-state path — not by an automated click-repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WynX2NiFrQtHL629vqLhn1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WynX2NiFrQtHL629vqLhn1)_