### PR TITLE
Fix #436: calendar "vs typical" uses the full-period typical, not pro-rated

### DIFF
--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -188,9 +188,10 @@ class VolumeMetricVsNorm(BaseModel):
 
     `current_all` is holistic (every logged activity); `current_runs` is the
     runs-only figure alongside. `norm`/`norm_recent` are the runner's typical output
-    over a window of the same length (per-day rate over a 12-week / 4-week baseline
-    before the window, scaled to the window's elapsed days), so the comparison is
-    fair across ranges and partial calendar periods. `direction` carries a deadband.
+    over a FULL period of the framing's length (per-day rate over a 12-week / 4-week
+    baseline before the window, scaled to the full period — #436), so a calendar
+    period-to-date total is compared against a typical full period rather than a
+    pro-rated slice. `direction` carries a deadband.
     """
     metric: str  # sessions | distance_m | moving_time_s | effort_score
     current_all: float

--- a/backend/app/services/coach/volume.py
+++ b/backend/app/services/coach/volume.py
@@ -223,15 +223,18 @@ def _norm_per_day(
 def _report_metric(
     metric: str,
     window_facts: List[Any],
-    days_elapsed: int,
+    norm_days: int,
     norm_pd: Dict[str, Optional[float]],
 ) -> VolumeMetricVsNorm:
     current_all = _sum(window_facts, metric)
     current_runs = _sum(window_facts, metric, runs_only=True)
     pd = norm_pd.get(metric)
-    # Scale the per-day norm to the window's elapsed days, so a partial calendar
-    # period is judged against an equally-partial norm.
-    norm = pd * days_elapsed if pd is not None else None
+    # Scale the per-day norm to the framing's FULL period length (#436), so the
+    # period-to-date total is judged against the runner's typical full-period total
+    # — e.g. a Monday's run vs a typical full week, not vs a single typical day.
+    # For rolling, norm_days == the window length, so this is unchanged there; only
+    # a partial calendar period changes (it no longer reads "in line" mid-period).
+    norm = pd * norm_days if pd is not None else None
 
     pct: Optional[float] = None
     if norm is not None and norm > 0:
@@ -284,7 +287,9 @@ def _report_framing(
         baseline_start=b_start,
         baseline_end=b_end,
         metrics=[
-            _report_metric(m, window_facts, days_elapsed, norm_pd) for m in _METRICS
+            # Scale the norm by the FULL period length (#436), not days_elapsed, so
+            # the "vs typical" read is full-period (consistent with "vs last period").
+            _report_metric(m, window_facts, window_days, norm_pd) for m in _METRICS
         ],
     )
 
@@ -321,8 +326,11 @@ def _calendar_period(range_key: str, as_of: date) -> Tuple[date, date, int, str]
 def build_volume_report(facts: List[Any], as_of: date, range_key: str) -> VolumeReport:
     """The Trends-page volume-vs-norm report for `range_key` (7D/30D/3M/6M/1Y) as of
     `as_of`. Two framings — rolling (trailing N days) and calendar (current period to
-    date) — each metric vs the runner's norm scaled to the window. Reuses the same
-    pure core as the coach pack so the two never drift."""
+    date) — each metric vs the runner's norm for a FULL period of that length (#436):
+    rolling compares a complete window, and calendar compares the period-to-date total
+    against the typical full-period total (so it reads as progress through the period,
+    consistent with "vs last period", rather than pro-rating to days elapsed). Reuses
+    the same pure core as the coach pack so the two never drift."""
     n = _RANGE_WINDOW_DAYS[range_key]
     baseline_days = _BASELINE_DAYS_BY_RANGE[range_key]
     roll_start = as_of - timedelta(days=n - 1)

--- a/backend/tests/test_volume.py
+++ b/backend/tests/test_volume.py
@@ -213,3 +213,53 @@ def test_report_baseline_label_scales_with_term():
     facts = _history(as_of, 400)
     assert build_volume_report(facts, as_of, "7D").baseline_label == "the last 12 weeks"
     assert build_volume_report(facts, as_of, "3M").baseline_label == "the last year"
+
+
+# --- #436: calendar "vs typical" is the FULL-period typical, not pro-rated --------
+
+
+def test_report_calendar_vs_typical_is_full_period_not_prorated():
+    """A partial calendar week is judged against the typical FULL week (#436), so a
+    week 3 days in reads `down`, not `in_line`. Contrast with the coach pack's
+    calendar_week, which stays pro-rated (test_calendar_week_is_partial_and_prorated)."""
+    as_of = date(2026, 6, 17)  # Wednesday -> Mon..Wed elapsed (3 of 7 days)
+    assert as_of.weekday() == 2
+    # Uniform history: 1 activity/day of 10km, so the per-day norm is exactly
+    # 1 session / 10000 m / 3600 s / 50 effort.
+    cal = build_volume_report(_history(as_of, 200), as_of, "7D").calendar
+    assert cal.days_elapsed == 3
+    assert cal.complete is False
+    d = _by(cal)["distance_m"]
+    assert d.current_all == 30000          # Mon+Tue+Wed at 10km
+    assert d.norm == 70000.0               # typical FULL week = 10km/day * 7, not * 3
+    assert d.pct_vs_norm == -57.1          # (30000-70000)/70000
+    assert d.direction == "down"
+    s = _by(cal)["sessions"]
+    assert s.current_all == 3
+    assert s.norm == 7.0                   # 1/day * 7 days
+
+
+def test_report_rolling_unchanged_by_full_period_norm():
+    """Rolling is a complete window (days_elapsed == window_days), so the #436 change
+    is a no-op there: a uniform trailing week still reads in_line against its norm."""
+    as_of = date(2026, 6, 17)
+    roll = build_volume_report(_history(as_of, 200), as_of, "7D").rolling
+    assert roll.days_elapsed == roll.window_days == 7
+    d = _by(roll)["distance_m"]
+    assert d.current_all == 70000          # full trailing 7 days at 10km
+    assert d.norm == 70000.0
+    assert d.pct_vs_norm == 0.0
+    assert d.direction == "in_line"
+
+
+def test_report_calendar_full_period_applies_to_longer_terms():
+    """The full-period typical applies to every range, not just 7D (#436): a month
+    20 days in is judged against the typical full month."""
+    as_of = date(2026, 6, 20)  # June (30 days), 20 elapsed
+    cal = build_volume_report(_history(as_of, 400), as_of, "30D").calendar
+    assert cal.days_elapsed == 20
+    d = _by(cal)["distance_m"]
+    assert d.current_all == 200000         # 20 days at 10km
+    assert d.norm == 300000.0              # typical FULL month = 10km/day * 30
+    assert d.pct_vs_norm == -33.3
+    assert d.direction == "down"

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -148,8 +148,11 @@ export default function TrendsPage() {
   // `baseline_label` already names the norm's history span per range ("the last
   // 6 months" for 30D). "vs typical" is omitted when there's no baseline, since
   // the cards hide that row too.
+  const typicalNoun = PERIOD_NOUN[range] ?? "period";
   const typicalHelp = volume?.has_baseline
-    ? `Your average daily rate over ${volume.baseline_label}, projected over the days elapsed in this window.`
+    ? effectiveMode === "calendar"
+      ? `Your typical total for a full ${typicalNoun}, averaged over ${volume.baseline_label}. This ${typicalNoun}'s running total is compared against it, so it climbs toward typical as the ${typicalNoun} progresses.`
+      : `Your typical total for a ${typicalNoun}-length window, averaged over ${volume.baseline_label}.`
     : undefined;
   const periodNoun = PERIOD_NOUN[range];
   const prevHelp =
@@ -158,19 +161,19 @@ export default function TrendsPage() {
       : "This window against the equal-length window immediately before it.";
 
   // The runner's typical level per chart bucket (#413), drawn as a reference line.
-  // The #400 norm is scaled to days_elapsed, so norm/days_elapsed is the true
-  // per-day rate; each bucket multiplies by its day span (#432: 1/7/14/~30.44),
-  // so the line stays coherent with the chosen granularity. `scale` converts norm
-  // units to the chart's units (meters→km, seconds→min, effort raw). Undefined
-  // hides the line.
+  // The norm is scaled to the framing's full period length (#436), so
+  // norm/window_days is the true per-day rate; each bucket multiplies by its day
+  // span (#432: 1/7/14/~30.44), so the line stays coherent with the chosen
+  // granularity. `scale` converts norm units to the chart's units (meters→km,
+  // seconds→min, effort raw). Undefined hides the line.
   const framing = volume && volume.has_baseline ? volume[effectiveMode] : null;
   const typicalPerBucket = (
     metric: VolumeMetricName,
     scale: number,
   ): number | undefined => {
     const m = normByMetric[metric];
-    if (!framing || !m || m.norm == null || framing.days_elapsed <= 0) return undefined;
-    const perDay = m.norm / framing.days_elapsed;
+    if (!framing || !m || m.norm == null || framing.window_days <= 0) return undefined;
+    const perDay = m.norm / framing.window_days;
     return perDay * DAYS_PER_BUCKET[effectiveGranularity] * scale;
   };
 


### PR DESCRIPTION
## Problem
On the Trends page in **Calendar** mode, "vs typical" on the headline totals (Total Distance/Time/Activities/Load) pro-rated the norm to the days elapsed so far. Early in a period a barely-started week read as roughly in line with typical — e.g. one Monday run showed `-1% · 5.45 km` because "typical" had collapsed to a single day's rate. It also contradicted the adjacent `vs last <period>` row, which already compares the period-to-date total against the *full* previous period (so the two rows on the same card disagreed by ~83 points).

Reported in #436.

## Change
Scale the calendar framing's norm by the **full period length** instead of days-elapsed, so the running total is judged against the runner's typical full-period total and climbs toward typical as the period progresses — consistent with the `vs last <period>` row.

- **Rolling mode is unchanged** (its window is already a full N days, so the scaling is a no-op there).
- **The coach pack (`build_training_volume`) is untouched** — its `calendar_week` stays pro-rated; only the Trends-page report (`build_volume_report`) changes.
- Applies uniformly to all ranges (7D → 1Y).

With the screenshot's scenario (Monday, one 5.41 km run, ~5.4 km/day history) "vs typical" now reads `-86% · 37.80 km` (typical full week) instead of `-1% · 5.45 km`, and the chart's per-day typical line is unchanged at 5.40 km/day.

### Files
- `backend/app/services/coach/volume.py` — scale calendar norm by `window_days`.
- `backend/app/schemas/trends.py` — document the new calendar norm semantics.
- `frontend/app/trends/page.tsx` — per-day typical reference line derived from `window_days`; mode-aware "vs typical" Key copy.
- `backend/tests/test_volume.py` — regression tests for the full-period calendar norm across ranges; rolling unchanged.

## Verification
- New regression tests fail against the old pro-rated behaviour and pass now; full backend suite **1539 passed (+3), 0 regressions**; the coach-pack pro-rating test stays green.
- Frontend `tsc --noEmit` clean; `npm run lint && build` succeeds.
- Ran `build_volume_report` on screenshot-shaped data to confirm the numbers end-to-end at the data layer.

### Not verified (reviewer's call)
- **Visual rendering** wasn't run live. Worth confirming the NormGauge reading strongly "down" early in a calendar period (e.g. −86% on a Monday) is acceptable, and that the Key copy reads well — this is the intended design tradeoff (it mirrors `vs last period`).
- The live HTTP endpoint path (DB/Strava) wasn't exercised — no creds in the build environment; the underlying function was tested directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnT7EHGPUT12oCDkjdmB4p)_