### PR TITLE
Rework recent_training: modality-aware per-type + per-activity + vs-typical/vs-prev with basis (#444)

### DIFF
--- a/backend/app/schemas/coach_context.py
+++ b/backend/app/schemas/coach_context.py
@@ -563,6 +563,86 @@ class TrainingVolumeContext(BaseModel):
     has_baseline: bool
 
 
+class RecentTypeBreakdown(BaseModel):
+    """#444: one activity type's contribution to a recent-training window — counts,
+    per-type distance/time/load totals, and the type's SHARE of the window's sessions
+    (the modality mix as a precomputed number, so a walk is never read as a run)."""
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    count: int
+    distance_m: int
+    moving_time_s: int
+    effort_score: float
+    share_pct: float  # this type's share of the window's session COUNT (0-100)
+
+
+class RecentActivityItem(BaseModel):
+    """#444: one session in the recent (7d) window — its type and intensity/load
+    read, so the coach can speak to specific sessions, not only aggregates."""
+    model_config = ConfigDict(extra="forbid")
+
+    date: str
+    type: str
+    effort: Optional[str]  # HR-derived intensity axis (recovery|easy|moderate|tempo|hard)
+    effort_score: Optional[float]  # the TRIMP-like LOAD number (grows with duration)
+
+
+class RecentComparison(BaseModel):
+    """#444: one metric's current window value with its vs-TYPICAL and vs-PREV
+    comparison, ALL percentages precomputed and each carrying a self-describing
+    BASIS so the coach never cites a comparison whose reference it does not know.
+
+    `current_all` is holistic (every logged activity); `current_runs` is runs-only.
+    "typical" is the runner's own per-day rate over a trailing baseline (the Trends
+    definition, #444 decision 1); "prev" is the equal-length window immediately
+    before this one. A deterministic FACT the coach may cite; never an intensity
+    verdict (continuity with the load-vs-intensity rule) and never overrides the
+    run's re-derived DerivedMetric or the safety floor."""
+    model_config = ConfigDict(extra="forbid")
+
+    metric: str  # sessions | distance_m | moving_time_s | effort_score
+    current_all: Union[int, float]
+    current_runs: Union[int, float]
+    vs_typical_pct: Optional[float] = None
+    vs_typical_direction: str  # up | in_line | down | no_norm
+    vs_prev_pct: Optional[float] = None
+    vs_prev_direction: str     # up | in_line | down | no_norm
+    typical_basis: str
+    prev_basis: str
+
+
+class RecentTrainingWindow(BaseModel):
+    """#444: one window's modality-aware roll-up — the per-type breakdown + share and
+    overall totals, plus (7d/30d only) the vs-typical/vs-prev comparisons; the 7d
+    window also carries the bounded per-activity list (the longer windows do not)."""
+    model_config = ConfigDict(extra="forbid")
+
+    window: str  # last_7d | last_30d | previous_30d
+    days: int
+    activity_count: int
+    by_type: List[RecentTypeBreakdown]
+    total_distance_m: int
+    total_moving_time_s: int
+    total_effort: float
+    comparisons: List[RecentComparison]   # 7d/30d only; empty for previous_30d
+    activities: List[RecentActivityItem]  # 7d only; empty for the longer windows
+
+
+class RecentTrainingContext(BaseModel):
+    """#444: the modality-aware recent-training picture — the rich successor to
+    `recent_training_summary` (per-type breakdown + per-activity detail + vs-typical/
+    vs-prev with self-describing basis). Emitted ONLY under a recent-training-aware
+    prompt id, so the pack stays byte-stable otherwise. `has_baseline` is False when
+    history is too thin for any vs-typical norm (every direction then `no_norm`)."""
+    model_config = ConfigDict(extra="forbid")
+
+    last_7d: RecentTrainingWindow
+    last_30d: RecentTrainingWindow
+    previous_30d: RecentTrainingWindow
+    has_baseline: bool
+
+
 class CoachContextPack(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -620,6 +700,12 @@ class CoachContextPack(BaseModel):
     # stream-view-aware prompt id. It is a downsampled VIEW, never a measurement, and
     # never overrides the re-derived metrics (prompt addendum).
     stream_view: Optional[Dict[str, Any]] = None
+    # #444 modality-aware recent-training picture (per-type breakdown + per-activity
+    # detail + vs-typical/vs-prev with basis). None under every non-recent-training
+    # prompt and OMITTED from serialization entirely, exactly like the other gated
+    # sections, so the pack stays byte-stable pre/post #444; populated only under a
+    # recent-training-aware prompt id.
+    recent_training: Optional["RecentTrainingContext"] = None
     safety_rules: SafetyRules
 
     def to_serializable_dict(self) -> Dict[str, Any]:
@@ -652,6 +738,9 @@ class CoachContextPack(BaseModel):
             # #443: a non-stream-view prompt emits nothing — not even a null key, so
             # the pack stays byte-stable under v9 and below.
             data.pop("stream_view", None)
+        if data.get("recent_training") is None:
+            # #444: a non-recent-training prompt emits nothing — not even a null key.
+            data.pop("recent_training", None)
         return data
 
     def fingerprint(self) -> str:

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -41,6 +41,7 @@ from app.services.coach.corpus import DEFAULT_SCHOOL_ID
 from app.services.coach.prompts import (
     _describe_dial,
     is_corpus_prompt,
+    is_recent_training_prompt,
     is_stance_prompt,
     is_stream_view_prompt,
     is_training_load_prompt,
@@ -49,6 +50,7 @@ from app.services.coach.prompts import (
 )
 from app.services.coach.stance import StanceProfile, resolve_stance
 from app.services.coach.volume import build_training_volume
+from app.services.coach.recent_training import build_recent_training
 from app.services.readiness import build_readiness
 from app.services.coach.retrieval import (
     fetch_corpus,
@@ -74,6 +76,7 @@ from app.schemas.coach_context import (
     StanceEmphasisAxis,
     TrainingLoadContext,
     TrainingVolumeContext,
+    RecentTrainingContext,
     LongitudinalContext,
     MetricsContext,
     NarrativeContext,
@@ -254,6 +257,10 @@ def build_context_pack(
         # stream-view-aware prompt (focus.stream_view is None otherwise, dropped from
         # serialization), so the pack stays byte-stable under v9 and below.
         stream_view=f.stream_view,
+        # #444 modality-aware recent-training picture: emitted ONLY under a
+        # recent-training-aware prompt (the rich successor to recent_training_summary),
+        # computed read-time over the runner's local-day windows.
+        recent_training=_build_recent_training_context(db, activity, prompt_id),
         safety_rules=b.safety_rules,
     )
 
@@ -402,6 +409,28 @@ def _build_training_volume_context(
         db, as_of - timedelta(days=91), as_of + timedelta(days=1), user_id=activity.user_id
     )
     return build_training_volume(facts, as_of)
+
+
+def _build_recent_training_context(
+    db: Session, activity: Activity, prompt_id: Optional[str]
+) -> Optional[RecentTrainingContext]:
+    """The #444 modality-aware recent-training section, or None.
+
+    Emitted ONLY under a recent-training-aware prompt id, so the pack stays byte-stable
+    otherwise (the Optional-and-drop idiom). Computed read-time as of this activity's
+    LOCAL day over a ~210-day fact span (the 30d window plus its ~6-month vs-typical
+    baseline), reusing the Trends per-day-rate core so "typical" has one meaning across
+    the product. A deterministic FACT the coach may cite, but it never overrides the
+    run's re-derived DerivedMetric or the safety floor (the recent-training addendum).
+    Degrades gracefully: thin history yields `has_baseline=False` and `no_norm`
+    directions."""
+    if not is_recent_training_prompt(prompt_id):
+        return None
+    as_of = activity.local_start.date()
+    facts = _query_activity_facts(
+        db, as_of - timedelta(days=210), as_of + timedelta(days=1), user_id=activity.user_id
+    )
+    return build_recent_training(facts, as_of)
 
 
 def _build_block_context(db: Session, activity: Activity) -> Optional[BlockContext]:

--- a/backend/app/services/coach/prompt_features.py
+++ b/backend/app/services/coach/prompt_features.py
@@ -42,6 +42,7 @@ class PromptFeature(Enum):
     USER_MATERIALS = "user_materials"  # P4 distilled user materials (ADR 0017)
     VOLUME = "volume"                  # #400 frequency-/volume-vs-norm section
     STREAM_VIEW = "stream_view"        # #443 consolidated stream-view timeline in the default pack
+    RECENT_TRAINING = "recent_training"  # #444 modality-aware recent-training picture
 
 
 # One row per prompt id, listing its FULL capability set. Read a row to know
@@ -110,6 +111,23 @@ PROMPT_FEATURES: dict[str, frozenset[PromptFeature]] = {
             _F.USER_MATERIALS,
             _F.VOLUME,
             _F.STREAM_VIEW,
+        }
+    ),
+    # #444 — v11 = v10 + the RECENT_TRAINING capability (the modality-aware
+    # recent-training picture in the pack, plus its reading addendum). Same retuned
+    # base prose; adds one capability (an additive superset of v10). Ships INERT
+    # (the config default stays v8); the owner flips COACH_PROMPT_ID to activate.
+    "coach_message_v11": frozenset(
+        {
+            _F.TWO_STAGE,
+            _F.VOICE,
+            _F.CORPUS,
+            _F.STANCE,
+            _F.TRAINING_LOAD,
+            _F.USER_MATERIALS,
+            _F.VOLUME,
+            _F.STREAM_VIEW,
+            _F.RECENT_TRAINING,
         }
     ),
 }

--- a/backend/app/services/coach/prompts.py
+++ b/backend/app/services/coach/prompts.py
@@ -734,6 +734,52 @@ SYSTEM_PROMPT_MESSAGE_V10 = SYSTEM_PROMPT_MESSAGE_V9 + _STREAM_VIEW_ADDENDUM
 SYSTEM_PROMPT_MESSAGE_V10_OPENER = SYSTEM_PROMPT_MESSAGE_V9_OPENER + _STREAM_VIEW_ADDENDUM
 
 
+# ===========================================================================
+# coach_message_v11 (#444) — the recent-training-aware two-stage prompt.
+#
+# v11 = v10 + a STATIC RECENT-TRAINING addendum, for BOTH modes (fuller and opener),
+# the Vn = V(n-1) + addendum idiom. Because v11 builds on v10 it carries every v10
+# capability and the same retuned base prose; it ADDS the recent-training-reading
+# discipline. The PER-RUNNER figures are NOT baked into the constant — they ride the
+# `recent_training` pack section (per-type breakdown + per-activity detail + vs-typical
+# /vs-prev with self-describing basis), populated only under is_recent_training_prompt
+# by build_context_pack. The addendum's job: make the coach read the modality MIX
+# (not all runs), read each comparison WITH its basis, and treat a deliberate down
+# week as intentional — while keeping it a deterministic FACT that never overrides the
+# run's data or the floor.
+#
+# Consolidation note (#444 decisions 1 & 2): the rich `recent_training` section
+# supersedes the coarse `recent_training_summary` and reuses the Trends per-day-rate
+# "typical" so there is one definition of typical. Fully RETIRING the legacy
+# `recent_training_summary` and the overlapping `training_volume` section (still live
+# under v9) is a deliberate, live-behaviour reconciliation left to the owner: it
+# touches the shared base prose (rule 22 cites recent_training_summary) and removes a
+# live section, so v11 ships the rich section additively and the owner prunes the
+# overlap when adopting v11.
+#
+# coach_message_v1..v10 and coach_report_v1..v10 stay BYTE-STABLE above.
+# ===========================================================================
+
+_RECENT_TRAINING_ADDENDUM = """
+
+# RECENT TRAINING (the modality-aware picture; read each comparison with its basis)
+
+Your context may carry a `recent_training` section: a modality-aware read of the runner's recent training across three windows — `last_7d`, `last_30d`, and `previous_30d` (the 30 days before last_30d). For each window you get a per-activity-TYPE breakdown (`by_type`: counts and per-type distance/time/load, with each type's `share_pct` of the window's sessions) and the overall roll-up totals; `last_7d` also carries a bounded per-session list (`activities`, each with its type and intensity/load). The `last_7d` and `last_30d` windows carry `comparisons`: per metric, the current value (`current_all` holistic, `current_runs` runs-only) with a vs-typical and a vs-prev read.
+
+Read it as the runner's recent context, honouring two things:
+
+- READ THE MODALITY MIX, never assume all runs. The breakdown is by activity type for a reason: a week of 6 sessions might be 3 runs and 3 walks. Honour `by_type` and the runs-only figures — never read a walk, ride, or row as a run, and when sessions are up but runs are not, say so accurately.
+- CITE A COMPARISON ONLY WITH ITS BASIS. Every comparison carries a `typical_basis` and a `prev_basis` saying exactly what "typical" and "prev" mean (typical = the runner's own average daily rate over a trailing baseline, projected onto the window; prev = the equal-length window just before). When you cite a percentage, cite what it is measured against — never a bare "down 30%" whose reference the runner cannot tell. When a direction is `no_norm`, the baseline is too thin: say nothing about up or down for that metric.
+- A `down` window is frequently INTENTIONAL — a planned easy week, a taper, a recovery block, or just life. Do not treat lower-than-typical volume as a problem or nag about it by default; raise concern only if the run's own data or a safety signal independently warrants it. Equally, do not cheer an `up` window uncritically.
+- It is a deterministic FACT you may cite, but it is NOT an intensity verdict (volume and load grow with how MUCH was done, not how hard — take intensity from the effort axis and RPE), and it NEVER overrides this run's re-derived DerivedMetric or the safety floor.
+
+Let the recent-training picture inform HOW you frame the runner's week; never let it manufacture worry the data does not support, and never let it overrule the run's own data or the floor."""
+
+
+SYSTEM_PROMPT_MESSAGE_V11 = SYSTEM_PROMPT_MESSAGE_V10 + _RECENT_TRAINING_ADDENDUM
+SYSTEM_PROMPT_MESSAGE_V11_OPENER = SYSTEM_PROMPT_MESSAGE_V10_OPENER + _RECENT_TRAINING_ADDENDUM
+
+
 PROMPT_VERSIONS = {
     "coach_report_v1": SYSTEM_PROMPT_V1,
     "coach_report_v2": SYSTEM_PROMPT_V2,
@@ -767,6 +813,9 @@ PROMPT_VERSIONS = {
     # #443 stream-view-aware prompt (= v9 + the static STREAM-VIEW addendum). Ships
     # INERT (config default stays v8); owner flips COACH_PROMPT_ID to activate.
     "coach_message_v10": SYSTEM_PROMPT_MESSAGE_V10,
+    # #444 recent-training-aware prompt (= v10 + the static RECENT-TRAINING addendum).
+    # Ships INERT (config default stays v8); owner flips COACH_PROMPT_ID to activate.
+    "coach_message_v11": SYSTEM_PROMPT_MESSAGE_V11,
 }
 
 # Prompt-id prefixes that select the A3 prose-message output family (schema 2.x).
@@ -797,6 +846,7 @@ _OPENER_PROMPTS = {
     "coach_message_v8": SYSTEM_PROMPT_MESSAGE_V8_OPENER,
     "coach_message_v9": SYSTEM_PROMPT_MESSAGE_V9_OPENER,
     "coach_message_v10": SYSTEM_PROMPT_MESSAGE_V10_OPENER,
+    "coach_message_v11": SYSTEM_PROMPT_MESSAGE_V11_OPENER,
 }
 
 # The capability-gated prompt-id sets and predicates below are DERIVED VIEWS over
@@ -838,6 +888,10 @@ VOLUME_PROMPT_IDS = ids_with(PromptFeature.VOLUME)
 # context-pack section in the DEFAULT pack (gates the stream_view threading in
 # build_context_pack).
 STREAM_VIEW_PROMPT_IDS = ids_with(PromptFeature.STREAM_VIEW)
+
+# Prompt ids that carry the #444 recent-training addendum AND the `recent_training`
+# context-pack section (gates _build_recent_training_context).
+RECENT_TRAINING_PROMPT_IDS = ids_with(PromptFeature.RECENT_TRAINING)
 
 
 def is_corpus_prompt(prompt_id: Optional[str]) -> bool:
@@ -886,6 +940,15 @@ def is_stream_view_prompt(prompt_id: Optional[str]) -> bool:
     pack (byte-stable under v9 and below) and the signal is wholly inert under a
     rollback."""
     return has_feature(prompt_id, PromptFeature.STREAM_VIEW)
+
+
+def is_recent_training_prompt(prompt_id: Optional[str]) -> bool:
+    """True when the active prompt is recent-training-aware (#444): it carries the
+    recent-training addendum and its context pack carries the `recent_training`
+    section. False for every other prompt, so the modality-aware recent-training
+    picture stays out of the pack (byte-stable under v10 and below) and the signal
+    is wholly inert under a rollback."""
+    return has_feature(prompt_id, PromptFeature.RECENT_TRAINING)
 
 # ---------------------------------------------------------------------------
 # Activity-type playbooks — appended to the system prompt based on the playbook

--- a/backend/app/services/coach/recent_training.py
+++ b/backend/app/services/coach/recent_training.py
@@ -1,0 +1,221 @@
+"""#444: the modality-aware recent-training picture for the coach pack.
+
+A richer recent-training read than the four windowed all-activity sums of
+`recent_training_summary`. For each of three windows — recent (last 7 days), recent
+long (last 30 days) and the prior comparison window (the 30 days before that) — it
+reports:
+
+  - a per-activity-TYPE breakdown (counts + per-type distance/time/load totals), so
+    a walk is never read as a run and the coach sees the full cardio picture;
+  - a precomputed per-type SHARE of the window (the modality mix as a number to
+    read, not a division the model has to do);
+  - overall roll-up totals.
+
+The recent (7d) window also carries a bounded, capped per-activity list (each
+session's type and intensity/load), so the coach can speak to specific sessions.
+
+For the 7d and 30d windows it carries a vs-TYPICAL and a vs-PREV comparison per
+metric, with ALL percentages precomputed and a deadband direction (up/in_line/down/
+no_norm), each tagged with a self-describing BASIS so the coach never cites a
+comparison whose reference it does not know:
+
+  - "typical" is the runner's own average daily rate over a trailing baseline
+    (7d vs ~12 weeks, 30d vs ~6 months), projected onto the window — the SAME
+    per-day-rate definition the Trends page uses, reused via `build_volume_report`,
+    so "typical" has one meaning across the product (#444 decision 1).
+  - "prev" is the same metric over the equal-length window immediately before this
+    one.
+
+Pure functions over already-fetched `ActivityFact`s (no DB, no LLM); the DB read
+and pack wiring live in `context.py`.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any, List
+
+from app.schemas.coach_context import (
+    RecentActivityItem,
+    RecentComparison,
+    RecentTrainingContext,
+    RecentTrainingWindow,
+    RecentTypeBreakdown,
+)
+from app.services.coach.volume import _METRICS, _direction, _sum, build_volume_report
+
+# Cap on the per-activity list for the recent window (bounded by design — the longer
+# windows carry only the per-type roll-up, never a per-session list).
+_MAX_RECENT_ACTIVITIES = 12
+
+# Self-describing basis for the vs-typical comparison, by window length. Mirrors the
+# per-day-rate definition build_volume_report computes (12 weeks for 7d, 6 months for
+# 30d), so the label and the number always agree.
+_TYPICAL_BASIS = {
+    7: (
+        "your own average daily training over the last ~12 weeks, projected onto "
+        "7 days (rest days counted as zero)"
+    ),
+    30: (
+        "your own average daily training over the last ~6 months, projected onto "
+        "30 days (rest days counted as zero)"
+    ),
+}
+
+
+def _unknown_type(fact: Any) -> str:
+    return (getattr(fact, "activity_type", None) or "unknown")
+
+
+def _by_type(window_facts: List[Any]) -> List[RecentTypeBreakdown]:
+    """Per-activity-type counts + totals + the type's session share of the window,
+    most-frequent type first (ties broken by type name for determinism)."""
+    groups: dict = {}
+    for f in window_facts:
+        t = _unknown_type(f)
+        g = groups.setdefault(
+            t, {"count": 0, "distance_m": 0.0, "moving_time_s": 0.0, "effort_score": 0.0}
+        )
+        g["count"] += 1
+        g["distance_m"] += f.distance_m or 0
+        g["moving_time_s"] += f.moving_time_s or 0
+        g["effort_score"] += f.effort_score or 0
+
+    total = len(window_facts)
+    out: List[RecentTypeBreakdown] = []
+    for t in sorted(groups, key=lambda k: (-groups[k]["count"], k)):
+        g = groups[t]
+        out.append(
+            RecentTypeBreakdown(
+                type=t,
+                count=g["count"],
+                distance_m=int(g["distance_m"]),
+                moving_time_s=int(g["moving_time_s"]),
+                effort_score=round(g["effort_score"], 1),
+                share_pct=round(g["count"] / total * 100.0, 1) if total else 0.0,
+            )
+        )
+    return out
+
+
+def _recent_activities(window_facts: List[Any]) -> List[RecentActivityItem]:
+    """The recent window's sessions, newest-first and capped, each with its type and
+    intensity/load read (the per-activity detail the longer windows omit)."""
+    ordered = sorted(
+        window_facts, key=lambda f: (f.local_date, getattr(f, "activity_id", None) is None)
+    )
+    ordered = list(reversed(ordered))[:_MAX_RECENT_ACTIVITIES]
+    return [
+        RecentActivityItem(
+            date=f.local_date.isoformat(),
+            type=_unknown_type(f),
+            effort=getattr(f, "effort", None),  # HR-derived intensity axis, may be None
+            effort_score=round(f.effort_score, 1) if f.effort_score is not None else None,
+        )
+        for f in ordered
+    ]
+
+
+def _vs_prev_pct(window_facts: List[Any], prev_facts: List[Any], metric: str):
+    """(pct, direction) of the current window vs the immediately-prior equal window
+    for one metric, or (None, 'no_norm') when the prior window is empty for it."""
+    prev = _sum(prev_facts, metric)
+    if prev <= 0:
+        return None, "no_norm"
+    cur = _sum(window_facts, metric)
+    pct = round((cur - prev) / prev * 100.0, 1)
+    return pct, _direction(cur, prev, 1.0)
+
+
+def _comparisons(
+    facts: List[Any], as_of: date, n: int
+) -> List[RecentComparison]:
+    """The vs-typical (per-day-rate, reused from build_volume_report) + vs-prev
+    comparison per metric for a window of `n` days ending `as_of`."""
+    range_key = "7D" if n == 7 else "30D"
+    report = build_volume_report(facts, as_of, range_key)
+    typical_by_metric = {m.metric: m for m in report.rolling.metrics}
+
+    cur_start = as_of - timedelta(days=n - 1)
+    prev_end = cur_start - timedelta(days=1)
+    prev_start = prev_end - timedelta(days=n - 1)
+    window_facts = [f for f in facts if cur_start <= f.local_date <= as_of]
+    prev_facts = [f for f in facts if prev_start <= f.local_date <= prev_end]
+
+    out: List[RecentComparison] = []
+    for metric in _METRICS:
+        t = typical_by_metric.get(metric)
+        prev_pct, prev_dir = _vs_prev_pct(window_facts, prev_facts, metric)
+        out.append(
+            RecentComparison(
+                metric=metric,
+                current_all=t.current_all if t else _sum(window_facts, metric),
+                current_runs=t.current_runs if t else _sum(window_facts, metric, runs_only=True),
+                vs_typical_pct=t.pct_vs_norm if t else None,
+                vs_typical_direction=t.direction if t else "no_norm",
+                vs_prev_pct=prev_pct,
+                vs_prev_direction=prev_dir,
+                typical_basis=_TYPICAL_BASIS[n],
+                prev_basis=f"the {n} days immediately before this window",
+            )
+        )
+    return out
+
+
+def _window(
+    name: str,
+    n: int,
+    win_start: date,
+    win_end: date,
+    facts: List[Any],
+    *,
+    as_of: date,
+    with_comparisons: bool,
+    with_activities: bool,
+) -> RecentTrainingWindow:
+    window_facts = [f for f in facts if win_start <= f.local_date <= win_end]
+    return RecentTrainingWindow(
+        window=name,
+        days=n,
+        activity_count=len(window_facts),
+        by_type=_by_type(window_facts),
+        total_distance_m=int(_sum(window_facts, "distance_m")),
+        total_moving_time_s=int(_sum(window_facts, "moving_time_s")),
+        total_effort=round(_sum(window_facts, "effort_score"), 1),
+        comparisons=_comparisons(facts, as_of, n) if with_comparisons else [],
+        activities=_recent_activities(window_facts) if with_activities else [],
+    )
+
+
+def build_recent_training(facts: List[Any], as_of: date) -> RecentTrainingContext:
+    """Build the modality-aware recent-training picture as of `as_of` from facts
+    spanning at least the trailing ~200 days (the 30d window plus its ~6-month
+    vs-typical baseline). Facts are duck-typed `ActivityFact`s: each needs
+    `local_date`, `activity_type`, `distance_m`, `moving_time_s`, `effort_score`,
+    and (for the per-activity list) `effort`."""
+    last_7d = _window(
+        "last_7d", 7, as_of - timedelta(days=6), as_of, facts,
+        as_of=as_of, with_comparisons=True, with_activities=True,
+    )
+    last_30d = _window(
+        "last_30d", 30, as_of - timedelta(days=29), as_of, facts,
+        as_of=as_of, with_comparisons=True, with_activities=False,
+    )
+    previous_30d = _window(
+        "previous_30d", 30, as_of - timedelta(days=59), as_of - timedelta(days=30), facts,
+        as_of=as_of, with_comparisons=False, with_activities=False,
+    )
+
+    # has_baseline mirrors the vs-typical abstention: true when any 7d/30d metric
+    # resolved a norm (build_volume_report sets direction 'no_norm' when too thin).
+    has_baseline = any(
+        c.vs_typical_direction != "no_norm"
+        for c in (last_7d.comparisons + last_30d.comparisons)
+    )
+
+    return RecentTrainingContext(
+        last_7d=last_7d,
+        last_30d=last_30d,
+        previous_30d=previous_30d,
+        has_baseline=has_baseline,
+    )

--- a/backend/tests/test_message_prompt_v10.py
+++ b/backend/tests/test_message_prompt_v10.py
@@ -33,7 +33,8 @@ def test_v10_registered_carries_every_v9_capability_plus_stream_view():
     assert V10.startswith(MESSAGE_PROMPT_PREFIX)  # -> schema 2.0 by prefix
     assert V10 in VOLUME_PROMPT_IDS  # inherits v9's capabilities
     assert V10 in STREAM_VIEW_PROMPT_IDS  # ...plus the new STREAM_VIEW capability
-    assert STREAM_VIEW_PROMPT_IDS == {V10}
+    # v11 (#444) inherits STREAM_VIEW too.
+    assert STREAM_VIEW_PROMPT_IDS == {V10, "coach_message_v11"}
     assert V10 in _OPENER_PROMPTS  # has a distinct opener form (two-stage)
     # same schema family as v9 (so v10 reports regenerate, prior history retained).
     assert active_schema_version(V10) == active_schema_version(V9)

--- a/backend/tests/test_message_prompt_v11.py
+++ b/backend/tests/test_message_prompt_v11.py
@@ -1,0 +1,80 @@
+"""Structural pins for the #444 coach_message_v11 recent-training-aware prompt.
+
+v11 = v10 + a static RECENT-TRAINING addendum (fuller and opener), the Vn = V(n-1) +
+addendum idiom. It carries every v10 capability plus RECENT_TRAINING (an additive
+superset). The safety floor is invariant by construction: v10 is reused byte-for-byte
+as the prefix, so v11 differs from v10 ONLY by the appended recent-training addendum,
+and v1..v10 / the report chain stay byte-stable. v11 ships INERT (config default v8).
+"""
+
+from app.core.config import settings
+from app.services.coach.prompts import (
+    MESSAGE_PROMPT_PREFIX,
+    PROMPT_VERSIONS,
+    RECENT_TRAINING_PROMPT_IDS,
+    STREAM_VIEW_PROMPT_IDS,
+    SYSTEM_PROMPT_MESSAGE_V10,
+    SYSTEM_PROMPT_MESSAGE_V10_OPENER,
+    SYSTEM_PROMPT_MESSAGE_V11,
+    SYSTEM_PROMPT_MESSAGE_V11_OPENER,
+    _OPENER_PROMPTS,
+    _RECENT_TRAINING_ADDENDUM,
+    build_system_prompt,
+    is_recent_training_prompt,
+)
+from app.services.coach.service import active_schema_version
+
+V10 = "coach_message_v10"
+V11 = "coach_message_v11"
+
+
+def test_v11_registered_carries_every_v10_capability_plus_recent_training():
+    assert V11 in PROMPT_VERSIONS
+    assert V11.startswith(MESSAGE_PROMPT_PREFIX)  # -> schema 2.0 by prefix
+    assert V11 in STREAM_VIEW_PROMPT_IDS  # inherits v10's capabilities
+    assert V11 in RECENT_TRAINING_PROMPT_IDS  # ...plus the new RECENT_TRAINING capability
+    assert RECENT_TRAINING_PROMPT_IDS == {V11}
+    assert V11 in _OPENER_PROMPTS  # has a distinct opener form (two-stage)
+    # same schema family as v10 (so v11 reports regenerate, prior history retained).
+    assert active_schema_version(V11) == active_schema_version(V10)
+
+
+def test_v11_is_v10_plus_recent_training_addendum():
+    assert SYSTEM_PROMPT_MESSAGE_V11 == SYSTEM_PROMPT_MESSAGE_V10 + _RECENT_TRAINING_ADDENDUM
+    assert (
+        SYSTEM_PROMPT_MESSAGE_V11_OPENER
+        == SYSTEM_PROMPT_MESSAGE_V10_OPENER + _RECENT_TRAINING_ADDENDUM
+    )
+    # v10 preserved verbatim as the prefix -> safety floor invariant.
+    assert SYSTEM_PROMPT_MESSAGE_V11.startswith(SYSTEM_PROMPT_MESSAGE_V10)
+    assert SYSTEM_PROMPT_MESSAGE_V11_OPENER.startswith(SYSTEM_PROMPT_MESSAGE_V10_OPENER)
+
+
+def test_recent_training_addendum_present_in_v11_absent_in_v10():
+    assert _RECENT_TRAINING_ADDENDUM not in SYSTEM_PROMPT_MESSAGE_V10
+    assert _RECENT_TRAINING_ADDENDUM not in SYSTEM_PROMPT_MESSAGE_V10_OPENER
+    assert _RECENT_TRAINING_ADDENDUM in build_system_prompt(V11, mode="fuller", voice=None)
+    assert _RECENT_TRAINING_ADDENDUM in build_system_prompt(V11, mode="opener", voice=None)
+    assert _RECENT_TRAINING_ADDENDUM not in build_system_prompt(V10, mode="fuller", voice=None)
+    assert _RECENT_TRAINING_ADDENDUM not in build_system_prompt(V10, mode="opener", voice=None)
+
+
+def test_recent_training_addendum_holds_the_core_disciplines():
+    text = _RECENT_TRAINING_ADDENDUM.lower()
+    assert "recent_training" in text
+    assert "modality" in text or "by_type" in text  # read the type mix, not all runs
+    assert "basis" in text  # cite a comparison with its basis
+    assert "down" in text and "intentional" in text  # the anti-nag discipline
+    assert "never override" in text  # authority boundary held
+
+
+def test_is_recent_training_prompt_resolves():
+    assert is_recent_training_prompt(V11) is True
+    assert is_recent_training_prompt(V10) is False
+    assert is_recent_training_prompt(None) is False
+
+
+def test_v11_ships_inert():
+    """v11 is dormant until the owner flips COACH_PROMPT_ID — the config default is
+    unchanged by #444."""
+    assert settings.COACH_PROMPT_ID != V11

--- a/backend/tests/test_message_prompt_v9.py
+++ b/backend/tests/test_message_prompt_v9.py
@@ -40,9 +40,9 @@ def test_v9_registered_in_message_family_and_gate_sets():
     assert V9 in STANCE_PROMPT_IDS
     assert V9 in TRAINING_LOAD_PROMPT_IDS
     assert V9 in USER_MATERIALS_PROMPT_IDS
-    # ...plus the new VOLUME capability (v9 onward; v10 carries it too, #443).
+    # ...plus the new VOLUME capability (v9 onward; later versions inherit it).
     assert V9 in VOLUME_PROMPT_IDS
-    assert VOLUME_PROMPT_IDS == {V9, "coach_message_v10"}
+    assert VOLUME_PROMPT_IDS == {V9, "coach_message_v10", "coach_message_v11"}
     # same schema family as v8 (so v9 reports regenerate, prior history retained).
     assert active_schema_version(V9) == active_schema_version(V8)
 

--- a/backend/tests/test_prompt_features.py
+++ b/backend/tests/test_prompt_features.py
@@ -65,6 +65,18 @@ EXPECTED_CAPABILITIES = {
         F.VOLUME,
         F.STREAM_VIEW,
     },
+    # #444 — v11 = v10 + the RECENT_TRAINING capability.
+    "coach_message_v11": {
+        F.TWO_STAGE,
+        F.VOICE,
+        F.CORPUS,
+        F.STANCE,
+        F.TRAINING_LOAD,
+        F.USER_MATERIALS,
+        F.VOLUME,
+        F.STREAM_VIEW,
+        F.RECENT_TRAINING,
+    },
 }
 
 # Ids that must carry NO capabilities (the inert-under-rollback set).
@@ -98,6 +110,7 @@ def test_derived_sets_equal_manifest_views():
     assert prompts.USER_MATERIALS_PROMPT_IDS == ids_with(F.USER_MATERIALS)
     assert prompts.VOLUME_PROMPT_IDS == ids_with(F.VOLUME)
     assert prompts.STREAM_VIEW_PROMPT_IDS == ids_with(F.STREAM_VIEW)
+    assert prompts.RECENT_TRAINING_PROMPT_IDS == ids_with(F.RECENT_TRAINING)
 
 
 def test_derived_sets_match_captured_membership():
@@ -105,30 +118,35 @@ def test_derived_sets_match_captured_membership():
     assert prompts.TWO_STAGE_PROMPT_IDS == {
         "coach_message_v2", "coach_message_v3", "coach_message_v4",
         "coach_message_v5", "coach_message_v6", "coach_message_v7", "coach_message_v8",
-        "coach_message_v9", "coach_message_v10",
+        "coach_message_v9", "coach_message_v10", "coach_message_v11",
     }
     assert prompts.VOICE_PROMPT_IDS == {
         "coach_message_v3", "coach_message_v4", "coach_message_v5",
         "coach_message_v6", "coach_message_v7", "coach_message_v8", "coach_message_v9",
-        "coach_message_v10",
+        "coach_message_v10", "coach_message_v11",
     }
     assert prompts.CORPUS_PROMPT_IDS == {
         "coach_message_v4", "coach_message_v5", "coach_message_v6",
         "coach_message_v7", "coach_message_v8", "coach_message_v9", "coach_message_v10",
+        "coach_message_v11",
     }
     assert prompts.STANCE_PROMPT_IDS == {
         "coach_message_v5", "coach_message_v6", "coach_message_v7", "coach_message_v8",
-        "coach_message_v9", "coach_message_v10",
+        "coach_message_v9", "coach_message_v10", "coach_message_v11",
     }
     assert prompts.TRAINING_LOAD_PROMPT_IDS == {
         "coach_message_v6", "coach_message_v7", "coach_message_v8", "coach_message_v9",
-        "coach_message_v10",
+        "coach_message_v10", "coach_message_v11",
     }
     assert prompts.USER_MATERIALS_PROMPT_IDS == {
         "coach_message_v7", "coach_message_v8", "coach_message_v9", "coach_message_v10",
+        "coach_message_v11",
     }
-    assert prompts.VOLUME_PROMPT_IDS == {"coach_message_v9", "coach_message_v10"}
-    assert prompts.STREAM_VIEW_PROMPT_IDS == {"coach_message_v10"}
+    assert prompts.VOLUME_PROMPT_IDS == {
+        "coach_message_v9", "coach_message_v10", "coach_message_v11",
+    }
+    assert prompts.STREAM_VIEW_PROMPT_IDS == {"coach_message_v10", "coach_message_v11"}
+    assert prompts.RECENT_TRAINING_PROMPT_IDS == {"coach_message_v11"}
 
 
 def test_predicates_agree_with_has_feature():
@@ -141,6 +159,7 @@ def test_predicates_agree_with_has_feature():
         assert prompts.is_user_materials_prompt(pid) == has_feature(pid, F.USER_MATERIALS)
         assert prompts.is_volume_prompt(pid) == has_feature(pid, F.VOLUME)
         assert prompts.is_stream_view_prompt(pid) == has_feature(pid, F.STREAM_VIEW)
+        assert prompts.is_recent_training_prompt(pid) == has_feature(pid, F.RECENT_TRAINING)
 
 
 def test_opener_prompts_cover_exactly_two_stage_ids():
@@ -170,3 +189,5 @@ def test_message_version_capabilities_are_monotonic():
     assert PROMPT_FEATURES["coach_message_v9"] > PROMPT_FEATURES["coach_message_v8"]
     # #443 — v10 = v9 + STREAM_VIEW: a strict superset of v9.
     assert PROMPT_FEATURES["coach_message_v10"] > PROMPT_FEATURES["coach_message_v9"]
+    # #444 — v11 = v10 + RECENT_TRAINING: a strict superset of v10.
+    assert PROMPT_FEATURES["coach_message_v11"] > PROMPT_FEATURES["coach_message_v10"]

--- a/backend/tests/test_recent_training.py
+++ b/backend/tests/test_recent_training.py
@@ -1,0 +1,190 @@
+"""#444: the modality-aware recent-training builder + its pack wiring.
+
+`build_recent_training` is a pure function over duck-typed ActivityFacts: per-type
+breakdown + share, a bounded per-activity list for the recent window, and vs-typical
+(per-day-rate, reused from the Trends core) + vs-prev comparisons with self-describing
+basis labels. The pack integration test pins that the section rides the DEFAULT pack
+only under the recent-training-aware prompt (coach_message_v11) and is dropped (byte-
+stable) under v10 and the default path.
+"""
+
+import uuid
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+
+from app.models import Activity, DerivedMetric, User
+from app.services.coach.context import build_context_pack
+from app.services.coach.recent_training import _MAX_RECENT_ACTIVITIES, build_recent_training
+
+_AS_OF = date(2026, 6, 1)
+
+
+def _fact(days_ago, *, type="Run", dist=8000, time=2400, effort_score=50.0, effort="easy"):
+    return SimpleNamespace(
+        activity_id=uuid.uuid4(),
+        local_date=date.fromordinal(_AS_OF.toordinal() - days_ago),
+        activity_type=type,
+        distance_m=dist,
+        moving_time_s=time,
+        effort_score=effort_score,
+        effort=effort,
+    )
+
+
+# --- per-type breakdown + share --------------------------------------------
+
+def test_per_type_breakdown_counts_totals_and_share():
+    facts = [
+        _fact(1, type="Run", dist=10000),
+        _fact(2, type="Run", dist=8000),
+        _fact(3, type="Run", dist=6000),
+        _fact(4, type="Walk", dist=3000),
+        _fact(5, type="Walk", dist=2000),
+    ]
+    ctx = build_recent_training(facts, _AS_OF)
+    by_type = {b.type: b for b in ctx.last_7d.by_type}
+    assert by_type["Run"].count == 3
+    assert by_type["Run"].distance_m == 24000
+    assert by_type["Run"].share_pct == 60.0  # 3 of 5 sessions
+    assert by_type["Walk"].count == 2
+    assert by_type["Walk"].share_pct == 40.0
+    # most-frequent type first (modality mix is a number to read).
+    assert ctx.last_7d.by_type[0].type == "Run"
+    # roll-up totals across all types.
+    assert ctx.last_7d.activity_count == 5
+    assert ctx.last_7d.total_distance_m == 29000
+
+
+def test_mixed_modality_runs_only_differs_from_all():
+    facts = [_fact(1, type="Run"), _fact(2, type="Walk"), _fact(3, type="Ride")]
+    ctx = build_recent_training(facts, _AS_OF)
+    sessions = next(c for c in ctx.last_7d.comparisons if c.metric == "sessions")
+    assert sessions.current_all == 3
+    assert sessions.current_runs == 1  # a walk and a ride are never read as runs
+
+
+# --- per-activity list (recent window only) --------------------------------
+
+def test_recent_window_carries_capped_per_activity_list():
+    facts = [_fact(i % 7, effort="easy", effort_score=40.0 + i) for i in range(20)]
+    ctx = build_recent_training(facts, _AS_OF)
+    assert len(ctx.last_7d.activities) == _MAX_RECENT_ACTIVITIES  # bounded
+    item = ctx.last_7d.activities[0]
+    assert item.type == "Run" and item.effort == "easy"
+    assert item.effort_score is not None
+    # the longer windows do NOT carry a per-activity list (bounded by design).
+    assert ctx.last_30d.activities == []
+    assert ctx.previous_30d.activities == []
+
+
+# --- vs-prev ---------------------------------------------------------------
+
+def test_vs_prev_compares_equal_length_prior_window():
+    # 3 sessions in the last 7 days, 1 in the 7 days before that.
+    facts = [_fact(1), _fact(2), _fact(3), _fact(10)]
+    ctx = build_recent_training(facts, _AS_OF)
+    sessions = next(c for c in ctx.last_7d.comparisons if c.metric == "sessions")
+    assert sessions.vs_prev_pct == 200.0  # (3 - 1) / 1 * 100
+    assert sessions.vs_prev_direction == "up"
+    assert "immediately before" in sessions.prev_basis
+
+
+def test_vs_prev_abstains_when_prior_window_empty():
+    facts = [_fact(1), _fact(2)]  # nothing in the prior 7 days
+    ctx = build_recent_training(facts, _AS_OF)
+    sessions = next(c for c in ctx.last_7d.comparisons if c.metric == "sessions")
+    assert sessions.vs_prev_pct is None
+    assert sessions.vs_prev_direction == "no_norm"
+
+
+# --- vs-typical (per-day-rate baseline, reused from the Trends core) --------
+
+def test_vs_typical_resolves_with_enough_baseline_and_carries_basis():
+    # A baseline of weekly runs across the ~12 weeks before the current week, plus a
+    # heavier current week -> sessions read as up vs typical.
+    facts = [_fact(7 * w + 8) for w in range(10)]  # ~10 runs in the baseline window
+    facts += [_fact(1), _fact(2), _fact(3)]  # a busy current week
+    ctx = build_recent_training(facts, _AS_OF)
+    assert ctx.has_baseline is True
+    sessions = next(c for c in ctx.last_7d.comparisons if c.metric == "sessions")
+    assert sessions.vs_typical_direction in {"up", "in_line", "down"}
+    assert sessions.vs_typical_pct is not None
+    assert "average daily" in sessions.typical_basis and "12 weeks" in sessions.typical_basis
+
+
+def test_vs_typical_abstains_on_thin_history():
+    facts = [_fact(1), _fact(2)]  # only this week, no baseline
+    ctx = build_recent_training(facts, _AS_OF)
+    assert ctx.has_baseline is False
+    for window in (ctx.last_7d, ctx.last_30d):
+        for c in window.comparisons:
+            assert c.vs_typical_direction == "no_norm"
+            assert c.vs_typical_pct is None
+
+
+def test_windows_and_comparison_metrics_are_complete():
+    facts = [_fact(1)]
+    ctx = build_recent_training(facts, _AS_OF)
+    assert ctx.last_7d.window == "last_7d" and ctx.last_7d.days == 7
+    assert ctx.last_30d.window == "last_30d" and ctx.last_30d.days == 30
+    assert ctx.previous_30d.window == "previous_30d"
+    # 7d/30d carry comparisons over all four metrics; previous_30d carries none.
+    assert {c.metric for c in ctx.last_7d.comparisons} == {
+        "sessions", "distance_m", "moving_time_s", "effort_score"
+    }
+    assert ctx.previous_30d.comparisons == []
+
+
+# --- pack wiring (DB) ------------------------------------------------------
+
+def _seed(db) -> Activity:
+    user = User(id=uuid.uuid4(), email=f"rt-{uuid.uuid4()}@example.com")
+    db.add(user)
+    db.flush()
+    activity = Activity(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        strava_activity_id=abs(hash(str(uuid.uuid4()))) % 10**9,
+        name="Run",
+        type="Run",
+        start_date=datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc),
+        distance_m=10000,
+        moving_time_s=3600,
+        elapsed_time_s=3600,
+        avg_hr=150.0,
+        raw_summary={},
+    )
+    db.add(activity)
+    db.flush()
+    db.add(
+        DerivedMetric(
+            id=uuid.uuid4(),
+            activity_id=activity.id,
+            effort="easy",
+            structure="continuous",
+            duration_class="standard",
+            effort_score=80.0,
+            flags=[],
+            confidence="high",
+            confidence_reasons=[],
+        )
+    )
+    db.flush()
+    db.refresh(activity)
+    return activity
+
+
+def test_recent_training_in_default_pack_only_under_v11(db):
+    activity = _seed(db)
+
+    pack_v11 = build_context_pack(db, activity, prompt_id="coach_message_v11")
+    assert pack_v11.recent_training is not None
+    assert "recent_training" in pack_v11.to_serializable_dict()
+
+    pack_v10 = build_context_pack(db, activity, prompt_id="coach_message_v10")
+    assert pack_v10.recent_training is None
+    assert "recent_training" not in pack_v10.to_serializable_dict()
+
+    pack_default = build_context_pack(db, activity)
+    assert pack_default.recent_training is None
+    assert "recent_training" not in pack_default.to_serializable_dict()


### PR DESCRIPTION
Closes #444.

> **Stacked on #443** (base = `enhance/443-stream-view-default`). v11 builds on v10, so **merge #443 first**; GitHub will retarget this to `main` after that.

## What
Adds a rich `recent_training` coach-pack section — the modality-aware successor to the four windowed all-activity sums of `recent_training_summary`. Per window (`last_7d`, `last_30d`, `previous_30d`):
- a per-activity-**TYPE** breakdown (counts + per-type distance/time/load) with a precomputed per-type **share** of the window;
- overall roll-up totals.

The recent window (`last_7d`) also carries a bounded, capped per-activity list (type + intensity/load per session). The `last_7d` and `last_30d` windows carry **vs-typical** and **vs-prev** comparisons per metric, with ALL percentages precomputed, deadband directions, and a self-describing **BASIS** label on every comparison.

## Decisions made (the issue's "decisions to make")
1. **One definition of "typical."** The section reuses the Trends **per-day-rate** core (`build_volume_report`) for vs-typical (7d vs ~12 weeks, 30d vs ~6 months, projected onto the window), so "typical" has one meaning across the product. "prev" = the equal-length window immediately before.
2. **Norm = all-activities, runs-only alongside.** Each comparison carries `current_all` and `current_runs`; the norm is on the holistic total (matching `training_volume`).
3. **Per-activity cap = 12; windows aligned to 7D/30D** (the Trends/volume windows) plus `previous_30d`.
4. **Mixed-modality framing** via `by_type` + `current_runs` vs `current_all` (a walk is never read as a run).

## How it ships (a new INERT prompt version)
`coach_message_v11` = v10 + a static RECENT-TRAINING addendum (additive superset), shipped **inert** (config default stays v8). v9/v10 stay byte-stable — the section drops from serialization when None. To activate: `COACH_PROMPT_ID=coach_message_v11`.

## Deferred to you (deliberate, live-behaviour reconciliation)
Fully **retiring** the legacy `recent_training_summary` and the overlapping `training_volume` section is **not** done here, by design. It would touch shared base prose (rule 22 cites `recent_training_summary.total_effort`) and remove a section that is live under v9, so per the issue ("changes live coach behaviour, so reconcile it deliberately") v11 ships the rich section **additively** and you prune the overlap when adopting v11. Under v11 the pack therefore carries `recent_training` (rich, per-day typical) alongside the legacy `recent_training_summary` and `training_volume` (per-week typical); the v11 addendum points the coach at `recent_training`. Consolidating to one home is the natural follow-up at flip time.

## Acceptance
- [x] Per-window per-type breakdown (counts + totals) + precomputed per-type share.
- [x] Recent window capped per-activity breakdown (type + intensity/effort); longer windows omit it.
- [x] Overall roll-up totals retained.
- [x] 7D & 30D vs-typical + vs-prev, all percentages precomputed, deadband up/in_line/down.
- [x] Every comparison carries a basis label.
- [x] Abstains when the baseline is too thin (`no_norm`, `has_baseline=False`).
- [x] Mixed-modality framing.

## Tests
- `test_recent_training` (9): per-type breakdown + share, mixed-modality runs-vs-all, capped per-activity list, vs-prev (compare + abstain), vs-typical (resolve with basis + abstain on thin history), window/metric completeness, and the DB pack-wiring (present under v11, absent + dropped under v10 and the default path).
- `test_message_prompt_v11` (6): registration/capabilities, v11 == v10 + addendum (byte-stable prefix), addendum present in v11 / absent in v10, the core disciplines (modality / basis / down-is-intentional / never-override), `is_recent_training_prompt`, ships-inert.
- `test_prompt_features` / `test_message_prompt_v9` / `_v10`: updated for v11's membership in the inherited feature sets.

## Verification
- Targeted: 34 passed.
- Full backend suite: **1565 passed**, 2 skipped (no regressions; v9/v10 fingerprint/roundtrip tests pass — the new field drops when None).