### PR TITLE
perf(coach): trim recent_training pack redundancy (~380 tok/report)

### DIFF
--- a/backend/app/schemas/coach_context.py
+++ b/backend/app/schemas/coach_context.py
@@ -602,17 +602,25 @@ class RecentComparison(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     metric: str  # sessions | distance_m | moving_time_s | effort_score
-    current_all: Union[int, float]
-    current_runs: Union[int, float]
+    # Pack trim: current_all/current_runs are no longer emitted per row — they duplicate
+    # the window's own roll-up (current_all == total_*/activity_count, current_runs ==
+    # the by_type["Run"] entry) and, for the 7d window, training_volume's rolling_7d.
+    # Kept Optional so a pre-trim stored pack (extra="forbid") still validates; dropped
+    # from serialization when None.
+    current_all: Optional[Union[int, float]] = None
+    current_runs: Optional[Union[int, float]] = None
     vs_typical_pct: Optional[float] = None
-    vs_typical_direction: str  # up | in_line | down | no_norm
+    # Optional/None on the 7d window, which carries no vs-typical read (#451: its weekly
+    # vs-norm verdict lives in `training_volume`). A real direction on the 30d window.
+    # Dropped from serialization when None.
+    vs_typical_direction: Optional[str] = None  # up | in_line | down | no_norm
     vs_prev_pct: Optional[float] = None
     vs_prev_direction: str     # up | in_line | down | no_norm
-    # #451: None on a window that carries no vs-typical read (the 7d window — its
-    # weekly vs-norm verdict lives in `training_volume`, so recent_training does not
-    # duplicate it). Present (a self-describing string) wherever vs_typical is computed.
+    # Pack trim: the self-describing basis strings moved UP to the window level (one copy
+    # per window, not one per metric row — they were identical across all four). Kept
+    # Optional here so a pre-trim stored pack still validates; dropped when None.
     typical_basis: Optional[str] = None
-    prev_basis: str
+    prev_basis: Optional[str] = None
 
 
 class RecentTrainingWindow(BaseModel):
@@ -630,6 +638,12 @@ class RecentTrainingWindow(BaseModel):
     total_effort: float
     comparisons: List[RecentComparison]   # 7d/30d only; empty for previous_30d
     activities: List[RecentActivityItem]  # 7d only; empty for the longer windows
+    # Pack trim: the comparison basis strings live once per window now (they were
+    # identical across every metric row). `prev_basis` is set on any window that carries
+    # comparisons; `typical_basis` only on the window with a vs-typical read (30d). Both
+    # Optional (absent on previous_30d and on pre-trim stored packs); dropped when None.
+    prev_basis: Optional[str] = None
+    typical_basis: Optional[str] = None
 
 
 class RecentTrainingContext(BaseModel):
@@ -750,6 +764,25 @@ class CoachContextPack(BaseModel):
         if data.get("recent_training") is None:
             # #444: a non-recent-training prompt emits nothing — not even a null key.
             data.pop("recent_training", None)
+        else:
+            # Pack trim: drop the deduplicated/empty fields from the recent-training
+            # section so they cost no tokens. Per window: the basis strings now live once
+            # on the window (None on previous_30d). Per comparison: current_all/
+            # current_runs (already in the window totals/by_type and in training_volume),
+            # the per-row basis (moved up a level), and the 7d vs_typical_direction are
+            # all None and dropped. Re-parse stays safe — every dropped field is Optional
+            # and defaults to None when absent.
+            rt = data["recent_training"]
+            for wkey in ("last_7d", "last_30d", "previous_30d"):
+                win = rt.get(wkey)
+                if not win:
+                    continue
+                for k in ("prev_basis", "typical_basis"):
+                    if win.get(k) is None:
+                        win.pop(k, None)
+                for comp in win.get("comparisons", []):
+                    for k in [k for k, v in comp.items() if v is None]:
+                        comp.pop(k, None)
         if data.get("recent_training_summary") is None:
             # #451: the legacy summary is retired and no longer populated; drop the
             # null key so new packs omit it. A pre-#451 stored pack still carries the

--- a/backend/app/services/coach/recent_training.py
+++ b/backend/app/services/coach/recent_training.py
@@ -132,8 +132,12 @@ def _comparisons(
     """The vs-prev comparison per metric for a window of `n` days ending `as_of`, plus
     the vs-typical (per-day-rate, reused from build_volume_report) ONLY when
     `with_typical` (the 30d window). The 7d window omits vs-typical (#451): its weekly
-    vs-norm verdict lives in `training_volume`, so recent_training does not duplicate
-    it — those metrics carry vs-prev and a `no_norm` vs-typical with no basis."""
+    vs-norm verdict lives in `training_volume`, so those rows carry only vs-prev and a
+    null vs-typical direction.
+
+    Pack-trimmed: the per-metric current_all/current_runs (already in the window roll-up
+    + by_type and in training_volume) and the self-describing basis strings (now carried
+    once per window, set by `_window`) are NOT re-emitted on each row."""
     typical_by_metric: dict = {}
     if with_typical:
         range_key = "7D" if n == 7 else "30D"
@@ -153,14 +157,10 @@ def _comparisons(
         out.append(
             RecentComparison(
                 metric=metric,
-                current_all=t.current_all if t else _sum(window_facts, metric),
-                current_runs=t.current_runs if t else _sum(window_facts, metric, runs_only=True),
                 vs_typical_pct=t.pct_vs_norm if t else None,
-                vs_typical_direction=t.direction if t else "no_norm",
+                vs_typical_direction=t.direction if t else None,
                 vs_prev_pct=prev_pct,
                 vs_prev_direction=prev_dir,
-                typical_basis=_TYPICAL_BASIS[n] if with_typical else None,
-                prev_basis=f"the {n} days immediately before this window",
             )
         )
     return out
@@ -193,6 +193,12 @@ def _window(
             else []
         ),
         activities=_recent_activities(window_facts) if with_activities else [],
+        # Pack trim: the comparison basis strings live once per window now. prev_basis on
+        # any window with comparisons; typical_basis only where a vs-typical read exists.
+        prev_basis=(
+            f"the {n} days immediately before this window" if with_comparisons else None
+        ),
+        typical_basis=(_TYPICAL_BASIS[n] if (with_comparisons and with_typical) else None),
     )
 
 
@@ -219,11 +225,11 @@ def build_recent_training(facts: List[Any], as_of: date) -> RecentTrainingContex
 
     # has_baseline mirrors the vs-typical abstention: true when a 30d metric resolved a
     # norm (build_volume_report sets direction 'no_norm' when too thin). Only the 30d
-    # window carries vs-typical now (#451), so the 7d comparisons are all 'no_norm' and
-    # do not contribute — checking both is harmless and keeps the intent explicit.
+    # window carries vs-typical now (#451); the 7d rows carry a null vs-typical direction
+    # (pack trim), so a resolved norm is read off the 30d window alone.
     has_baseline = any(
-        c.vs_typical_direction != "no_norm"
-        for c in (last_7d.comparisons + last_30d.comparisons)
+        c.vs_typical_direction not in (None, "no_norm")
+        for c in last_30d.comparisons
     )
 
     return RecentTrainingContext(

--- a/backend/tests/test_recent_training.py
+++ b/backend/tests/test_recent_training.py
@@ -13,6 +13,7 @@ from datetime import date, datetime, timezone
 from types import SimpleNamespace
 
 from app.models import Activity, DerivedMetric, User
+from app.schemas.coach_context import RecentTrainingContext
 from app.services.coach.context import build_context_pack
 from app.services.coach.recent_training import _MAX_RECENT_ACTIVITIES, build_recent_training
 
@@ -55,12 +56,18 @@ def test_per_type_breakdown_counts_totals_and_share():
     assert ctx.last_7d.total_distance_m == 29000
 
 
-def test_mixed_modality_runs_only_differs_from_all():
+def test_mixed_modality_runs_only_readable_from_by_type():
     facts = [_fact(1, type="Run"), _fact(2, type="Walk"), _fact(3, type="Ride")]
     ctx = build_recent_training(facts, _AS_OF)
+    # Pack trim: the comparison rows no longer re-emit current totals — they duplicated
+    # the window roll-up + by_type (and, for 7d, training_volume's rolling_7d).
     sessions = next(c for c in ctx.last_7d.comparisons if c.metric == "sessions")
-    assert sessions.current_all == 3
-    assert sessions.current_runs == 1  # a walk and a ride are never read as runs
+    assert sessions.current_all is None
+    assert sessions.current_runs is None
+    # the runs-vs-all modality split is still fully readable from the per-type breakdown.
+    by_type = {b.type: b for b in ctx.last_7d.by_type}
+    assert ctx.last_7d.activity_count == 3  # all sessions
+    assert by_type["Run"].count == 1        # a walk and a ride are never read as runs
 
 
 # --- per-activity list (recent window only) --------------------------------
@@ -86,7 +93,9 @@ def test_vs_prev_compares_equal_length_prior_window():
     sessions = next(c for c in ctx.last_7d.comparisons if c.metric == "sessions")
     assert sessions.vs_prev_pct == 200.0  # (3 - 1) / 1 * 100
     assert sessions.vs_prev_direction == "up"
-    assert "immediately before" in sessions.prev_basis
+    # Pack trim: the basis lives once on the window, not on every metric row.
+    assert sessions.prev_basis is None
+    assert "immediately before" in ctx.last_7d.prev_basis
 
 
 def test_vs_prev_abstains_when_prior_window_empty():
@@ -111,14 +120,17 @@ def test_vs_typical_resolves_on_30d_window_and_carries_basis():
     s30 = next(c for c in ctx.last_30d.comparisons if c.metric == "sessions")
     assert s30.vs_typical_direction in {"up", "in_line", "down"}
     assert s30.vs_typical_pct is not None
-    assert s30.typical_basis is not None
-    assert "average daily" in s30.typical_basis and "6 months" in s30.typical_basis
+    # Pack trim: the typical basis lives once on the window, not on every metric row.
+    assert s30.typical_basis is None
+    assert ctx.last_30d.typical_basis is not None
+    assert "average daily" in ctx.last_30d.typical_basis and "6 months" in ctx.last_30d.typical_basis
 
-    # 7d keeps vs-prev but carries NO vs-typical read (basis None, direction no_norm).
+    # 7d keeps vs-prev but carries NO vs-typical read (direction None, no basis).
     s7 = next(c for c in ctx.last_7d.comparisons if c.metric == "sessions")
     assert s7.vs_typical_pct is None
-    assert s7.vs_typical_direction == "no_norm"
+    assert s7.vs_typical_direction is None
     assert s7.typical_basis is None
+    assert ctx.last_7d.typical_basis is None  # window carries no typical basis either
     assert s7.vs_prev_pct is not None  # the vs-prev comparison is still present
 
 
@@ -126,10 +138,13 @@ def test_vs_typical_abstains_on_thin_history():
     facts = [_fact(1), _fact(2)]  # only this week, no baseline
     ctx = build_recent_training(facts, _AS_OF)
     assert ctx.has_baseline is False
-    for window in (ctx.last_7d, ctx.last_30d):
-        for c in window.comparisons:
-            assert c.vs_typical_direction == "no_norm"
-            assert c.vs_typical_pct is None
+    # 7d carries no vs-typical read at all (direction None); 30d abstains as no_norm.
+    for c in ctx.last_7d.comparisons:
+        assert c.vs_typical_direction is None
+        assert c.vs_typical_pct is None
+    for c in ctx.last_30d.comparisons:
+        assert c.vs_typical_direction == "no_norm"
+        assert c.vs_typical_pct is None
 
 
 def test_windows_and_comparison_metrics_are_complete():
@@ -204,3 +219,71 @@ def test_recent_training_in_default_pack_only_under_v11(db):
     for pack in (pack_v11, pack_v10, pack_default):
         assert pack.recent_training_summary is None
         assert "recent_training_summary" not in pack.to_serializable_dict()
+
+
+def test_serialization_drops_deduplicated_recent_training_fields(db):
+    """Pack trim: the serialized recent-training section omits the deduplicated/empty
+    fields so they cost no tokens — per-row current_all/current_runs/basis and the 7d
+    vs_typical_direction are gone; the basis lives once on the window."""
+    activity = _seed(db)
+    rt = build_context_pack(
+        db, activity, prompt_id="coach_message_v11"
+    ).to_serializable_dict()["recent_training"]
+
+    # the basis lives once on the window that carries comparisons, not per row.
+    assert "prev_basis" in rt["last_7d"]
+    for comp in rt["last_7d"]["comparisons"]:
+        assert "current_all" not in comp
+        assert "current_runs" not in comp
+        assert "prev_basis" not in comp
+        assert "typical_basis" not in comp
+        assert "vs_typical_direction" not in comp  # 7d carries no vs-typical read
+        assert comp["vs_prev_direction"]  # the live comparison survives
+    # previous_30d carries no comparisons and no basis.
+    assert rt["previous_30d"]["comparisons"] == []
+    assert "prev_basis" not in rt["previous_30d"]
+
+
+def test_pre_trim_recent_training_pack_still_validates():
+    """A stored pack from BEFORE the field trim (per-row current_all/current_runs, a
+    per-row prev_basis, a string vs_typical_direction, no window-level basis) must still
+    validate under extra='forbid' — the chat read path and eval harness strict-parse old
+    stored packs (CoachContextPack.model_validate)."""
+    def _old_comp(metric):
+        return {
+            "metric": metric,
+            "current_all": 3,
+            "current_runs": 1,
+            "vs_typical_pct": None,
+            "vs_typical_direction": "no_norm",
+            "vs_prev_pct": 200.0,
+            "vs_prev_direction": "up",
+            "typical_basis": None,
+            "prev_basis": "the 7 days immediately before this window",
+        }
+
+    def _old_window(name, days):
+        return {
+            "window": name, "days": days, "activity_count": 3,
+            "by_type": [], "total_distance_m": 0, "total_moving_time_s": 0,
+            "total_effort": 0.0,
+            "comparisons": [_old_comp(m) for m in
+                            ("sessions", "distance_m", "moving_time_s", "effort_score")],
+            "activities": [],
+            # note: no window-level prev_basis / typical_basis (new fields)
+        }
+
+    old = {
+        "last_7d": _old_window("last_7d", 7),
+        "last_30d": _old_window("last_30d", 30),
+        "previous_30d": {
+            "window": "previous_30d", "days": 30, "activity_count": 0, "by_type": [],
+            "total_distance_m": 0, "total_moving_time_s": 0, "total_effort": 0.0,
+            "comparisons": [], "activities": [],
+        },
+        "has_baseline": False,
+    }
+    ctx = RecentTrainingContext.model_validate(old)
+    # the pre-trim fields are preserved verbatim on the way in (no data loss on re-parse).
+    assert ctx.last_7d.comparisons[0].current_all == 3
+    assert ctx.last_7d.comparisons[0].prev_basis == "the 7 days immediately before this window"


### PR DESCRIPTION
## What

Tier-1 context-pack bloat reduction. `recent_training` was ~35% of the live v11 context pack and re-stated the same window figures 3-4 times. Three byte-dedup trims, **no coaching-signal change**:

1. **Drop per-row `current_all`/`current_runs` from `comparisons`.** They duplicate the window roll-up (`total_*`/`activity_count`) + the `by_type["Run"]` entry, and for 7d, `training_volume.rolling_7d`. The runs-vs-all modality split stays fully readable in `by_type`.
2. **Move the self-describing basis strings up to the window.** One `prev_basis`/`typical_basis` per window instead of one per metric row (they were byte-identical across all four metrics).
3. **Drop the dead 7d `vs_typical_direction`.** The 7d weekly verdict lives in `training_volume` since #451, so 7d rows now carry only the live `vs_prev`.

## Why it is safe

Every nested pack model is `extra="forbid"`, and stored v11 packs get strict-parsed by the chat read path (`chat.py`) and the eval harness (`harness.py`). So each trimmed field stays **declared `Optional`** (a pre-trim stored pack still validates) and is dropped at serialization in `to_serializable_dict`. No value is lost: each dropped figure is still present elsewhere in the pack (window totals / `by_type` / `training_volume`).

## Verification

- Full backend suite green (1584 passed), incl. two new tests: a serialization-drop assertion and a pre-trim-pack-still-validates guard.
- Re-validated all 45 seeded prod packs against the new schema: the 3 carrying old-shape `recent_training` validate. (3 pre-existing `coach_report_v1` failures are unrelated, on `adherence`/`calibration`, confirmed identical without this change.)

## Measured savings (captured v11 run)

- `recent_training`: 4767 -> 3248 B (-32%)
- total pack: 13662 -> 12143 B (~380 tokens/report); larger in prod where history is deeper.

The companion diagram update (regenerated flow-graph data reflecting this trim) is in the `chore/refresh-flow-graph-latest-run` PR; merge this one with or before it so the diagram and code stay consistent.