### PR TITLE
Add mobile bottom tab bar navigation

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import { Fraunces, Hanken_Grotesk, IBM_Plex_Mono } from 'next/font/google';
 import NavBar from '@/components/NavBar';
+import BottomNav from '@/components/BottomNav';
 import ThemeProvider from '@/components/ThemeProvider';
 
 // Three deliberate type roles: Fraunces (serif) is the coach's voice + display
@@ -52,9 +53,10 @@ export default function RootLayout({
       <body className="font-sans min-h-screen flex flex-col">
         <ThemeProvider>
           <NavBar />
-          <main className="flex-1 max-w-4xl w-full mx-auto px-4 py-8">
+          <main className="flex-1 max-w-4xl w-full mx-auto px-4 py-8 pb-[calc(4rem+env(safe-area-inset-bottom)+1rem)] md:pb-8">
             {children}
           </main>
+          <BottomNav />
         </ThemeProvider>
       </body>
     </html>

--- a/frontend/components/BottomNav.tsx
+++ b/frontend/components/BottomNav.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Home, Activity, Gauge, TrendingUp, User, LucideIcon } from 'lucide-react';
+
+const TABS: { href: string; label: string; Icon: LucideIcon }[] = [
+  { href: '/', label: 'Home', Icon: Home },
+  { href: '/activities', label: 'Activities', Icon: Activity },
+  { href: '/load', label: 'Load', Icon: Gauge },
+  { href: '/trends', label: 'Trends', Icon: TrendingUp },
+  { href: '/profile', label: 'Profile', Icon: User },
+];
+
+// Native-app-style bottom tab bar. Mobile only (md:hidden); the top NavBar's
+// text links take over on larger screens.
+export default function BottomNav() {
+  const pathname = usePathname();
+
+  const isActive = (href: string) =>
+    href === '/' ? pathname === '/' : pathname.startsWith(href);
+
+  return (
+    <nav
+      className="md:hidden fixed bottom-0 inset-x-0 z-40 border-t border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-900/95 pb-[env(safe-area-inset-bottom)]"
+      aria-label="Primary"
+    >
+      <div className="flex items-stretch justify-around">
+        {TABS.map(({ href, label, Icon }) => {
+          const active = isActive(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              aria-current={active ? 'page' : undefined}
+              className={`flex flex-1 flex-col items-center justify-center gap-0.5 min-h-[56px] pt-2 pb-1 text-[11px] font-medium transition-colors ${
+                active
+                  ? 'text-blue-600 dark:text-blue-400'
+                  : 'text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400'
+              }`}
+            >
+              <Icon
+                className="h-6 w-6"
+                strokeWidth={active ? 2.4 : 1.9}
+                aria-hidden="true"
+              />
+              <span>{label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/frontend/components/BottomNav.tsx
+++ b/frontend/components/BottomNav.tsx
@@ -2,14 +2,13 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Home, Activity, Gauge, TrendingUp, User, LucideIcon } from 'lucide-react';
+import { Home, Activity, Gauge, TrendingUp, LucideIcon } from 'lucide-react';
 
 const TABS: { href: string; label: string; Icon: LucideIcon }[] = [
   { href: '/', label: 'Home', Icon: Home },
   { href: '/activities', label: 'Activities', Icon: Activity },
   { href: '/load', label: 'Load', Icon: Gauge },
   { href: '/trends', label: 'Trends', Icon: TrendingUp },
-  { href: '/profile', label: 'Profile', Icon: User },
 ];
 
 // Native-app-style bottom tab bar. Mobile only (md:hidden); the top NavBar's

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { User } from 'lucide-react';
 
 const LINKS = [
   { href: '/activities', label: 'Activities' },
@@ -40,6 +41,20 @@ export default function NavBar() {
             </Link>
           ))}
         </div>
+        {/* On mobile the nav links live in the bottom tab bar; Profile stays
+            here as a top-right icon (the bottom bar omits it). */}
+        <Link
+          href="/profile"
+          aria-label="Profile"
+          aria-current={isActive('/profile') ? 'page' : undefined}
+          className={`md:hidden flex items-center justify-center h-11 w-11 rounded-full transition-colors ${
+            isActive('/profile')
+              ? 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/30'
+              : 'text-gray-600 hover:text-blue-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:text-blue-400 dark:hover:bg-gray-800'
+          }`}
+        >
+          <User className="h-6 w-6" aria-hidden="true" />
+        </Link>
       </div>
     </nav>
   );

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -25,7 +25,7 @@ export default function NavBar() {
         >
           AI Coach
         </Link>
-        <div className="flex items-center gap-1 sm:gap-2">
+        <div className="hidden md:flex items-center gap-1 sm:gap-2">
           {LINKS.map(({ href, label }) => (
             <Link
               key={href}


### PR DESCRIPTION
## What

Make the navigation feel like a native app on mobile instead of a website. On small screens the top text links are replaced with a GitHub-app-style bottom tab bar of icons + labels; on desktop the existing top nav is unchanged.

## Changes

- **New `components/BottomNav.tsx`** — fixed bottom tab bar, mobile-only (`md:hidden`), four tabs with lucide icons: Home, Activities, Load, Trends. Active tab tracks the route, respects the iOS safe-area inset, translucent backdrop blur.
- **`components/NavBar.tsx`** — top text links become `hidden md:flex`; on mobile the bar shows just the brand plus a top-right **Profile** icon (kept out of the bottom bar by request, mirroring its desktop placement).
- **`app/layout.tsx`** — renders `<BottomNav />` and pads `<main>` at the bottom on mobile so the bar never overlaps content.

## Verification

- `next lint` clean.
- Visually checked against the running dev server at 390px (mobile) and 1280px (desktop): bottom bar shows only on mobile, top links return on desktop, active state follows the route (Home/Trends/Profile all confirmed). `next build` skipped intentionally because a dev server was live (building corrupts its shared `.next` chunks).
- Pure presentational change; no backend or data-path impact.