### PR TITLE
Clear iOS home indicator under the bottom nav

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -31,12 +31,15 @@ export const metadata: Metadata = {
 };
 
 // Lock the viewport so the app behaves like a native screen: no pinch-to-zoom
-// and no double-tap zoom on mobile.
+// and no double-tap zoom on mobile. `viewportFit: 'cover'` lets the layout
+// extend under the iOS safe areas so `env(safe-area-inset-*)` resolves to real
+// values, which the bottom tab bar uses to clear the home indicator.
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  viewportFit: 'cover',
 };
 
 export default function RootLayout({

--- a/frontend/components/BottomNav.tsx
+++ b/frontend/components/BottomNav.tsx
@@ -21,7 +21,7 @@ export default function BottomNav() {
 
   return (
     <nav
-      className="md:hidden fixed bottom-0 inset-x-0 z-40 border-t border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-900/95 pb-[env(safe-area-inset-bottom)]"
+      className="md:hidden fixed bottom-0 inset-x-0 z-40 border-t border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-900/95 pb-[max(0.5rem,env(safe-area-inset-bottom))]"
       aria-label="Primary"
     >
       <div className="flex items-stretch justify-around">


### PR DESCRIPTION
## Problem

On a real iPhone the home indicator (multitasking pull bar) overlaps the bottom tab bar labels. The bar padded itself with `env(safe-area-inset-bottom)`, but that inset only resolves to a non-zero value when the page opts into drawing under the safe areas — our viewport didn't, so the inset was `0` and there was no clearance.

## Fix

- **`app/layout.tsx`** — add `viewportFit: 'cover'` to the viewport config so iOS exposes real `env(safe-area-inset-*)` values.
- **`components/BottomNav.tsx`** — floor the bar's bottom padding with `max(0.5rem, env(safe-area-inset-bottom))`, so it clears the home indicator on iOS and still keeps breathing room on displays without an inset.

## Verification

- `next lint` clean.
- Confirmed the rendered viewport meta now includes `viewport-fit=cover`, and the bar's computed `padding-bottom` is the `0.5rem` floor on a zero-inset (desktop) display, designed to grow to the indicator height on iOS.
- No visual regression at mobile/desktop widths.
- Real-device confirmation (the actual ~34px inset clearing the home indicator) needs a check on an iPhone — can't be reproduced on a desktop display.