### PR TITLE
Tighten bottom-nav gap above the iOS home indicator

### DIFF
--- a/frontend/components/BottomNav.tsx
+++ b/frontend/components/BottomNav.tsx
@@ -21,7 +21,7 @@ export default function BottomNav() {
 
   return (
     <nav
-      className="md:hidden fixed bottom-0 inset-x-0 z-40 border-t border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-900/95 pb-[max(0.5rem,env(safe-area-inset-bottom))]"
+      className="md:hidden fixed bottom-0 inset-x-0 z-40 border-t border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-900/95 pb-[max(0.375rem,calc(env(safe-area-inset-bottom)-0.75rem))]"
       aria-label="Primary"
     >
       <div className="flex items-stretch justify-around">


### PR DESCRIPTION
## Problem

After enabling `viewport-fit=cover` (#465), the bottom tab bar cleared the iPhone home indicator but left too much dead space between the labels and the indicator.

## Fix

`components/BottomNav.tsx` — change the bar's bottom padding from `max(0.5rem, env(safe-area-inset-bottom))` to `max(0.375rem, calc(env(safe-area-inset-bottom) - 0.75rem))`. On iOS this trims ~12px off the inset (≈34px → ≈22px) so the bar still clears the indicator with a tighter, more native gap; on displays with no inset it floors at `0.375rem`.

## Verification

- `next lint` clean.
- Pure spacing tweak. The exact on-device gap needs a final look on an iPhone (the inset value can't be reproduced on a desktop display).