### PR TITLE
docs: ADR 0022 + Phase 2 plan (social login via Clerk supersedes magic-link)

### DIFF
--- a/docs/adr/0022-identity-is-social-login-via-clerk-strava-stays-an-integration.md
+++ b/docs/adr/0022-identity-is-social-login-via-clerk-strava-stays-an-integration.md
@@ -1,0 +1,49 @@
+# Identity is social login via Clerk; email is the durable key; data sources stay integrations
+
+This supersedes the *mechanism* of [ADR 0005](0005-magic-link-is-identity-strava-is-an-integration.md) while keeping its *principle*. ADR 0005's principle stands unchanged: identity lives at the email level, and Strava (with Garmin Connect and Apple Health as planned peers) is a connected integration, not the identity. What changes is how a user proves that email.
+
+## Why ADR 0005's mechanism no longer fits
+
+ADR 0005 specified an in-house magic-link flow and explicitly delivered the link by reusing `SMTPNotifier`. The deployment stack has since moved to Railway, and **Railway blocks outbound SMTP** from the app services. That is not a minor detail: it is the same constraint that forced coach-report notifications off email and onto Telegram (#127). ADR 0005's delivery mechanism does not exist on the current stack, so the in-house magic-link plan cannot ship as written without first adding an HTTP email API anyway.
+
+Re-opening the choice surfaced two standing constraints that now pull against ADR 0005's "build it ourselves, no managed provider" stance:
+
+- The owner's stated priority is **"as easy as possible AND secure."** Hand-rolling auth (token tables, session crypto, rate limiting, CSRF, account recovery) is the canonical surface where "looks easy" hides a security minefield. It is the single highest-risk thing in the multi-user effort, alongside tenant isolation, and it is exactly the kind of work a managed provider exists to take off our hands.
+- **Per-user LLM cost caps are the owner's #1 going-live concern** (see `docs/vision/going-live-cost-control.md`) and they cannot exist until per-user identity does. Whatever ships must put a reliable `user_id` on every request, not a fragile bespoke session layer.
+
+The initial audience is friends/beta (a handful of known users), which removes any need for a heavyweight in-house identity build and argues for the lowest-friction option that is still secure.
+
+## Decision
+
+Identity is **social login through Clerk**, a managed auth provider integrated at the Vercel/Next.js layer.
+
+- **One mechanism: social login, starting with Google only.** No magic-link, no passwords, no SMTP. One button, no inbox round-trip, the lowest-friction UX for a beta and the smallest security surface we own. A single mechanism keeps one identity per person and one code path.
+- **The durable identity key is the verified email, not the social provider's user id.** This is precisely ADR 0005's identity model ("subsequent verifies match by email"). Keying on the verified email means we are not locked to Google: adding Apple, or even an email magic-link later, links to the same account, and Garmin-first / Apple-first users remain expressible without a Strava account. The principle of ADR 0005 is preserved; only the proof-of-email mechanism changes.
+- **Data sources stay peer integrations.** `StravaAccount` today; `GarminAccount`, `AppleHealthAccount` later. Garmin/Apple are confirmed still on the roadmap, so identity must remain decoupled from any one source. Social login authenticates the *person*; it does not collapse identity into a data source the way "sign in with Strava" would. This is why we still reject Strava-as-identity.
+
+### Why Clerk, and the trust boundary
+
+We choose **Clerk** over rolling our own and over Auth.js (NextAuth):
+
+- Drop-in Next.js components, social providers configured in a dashboard, hosted session management, CSRF and account-recovery handled, a free tier that comfortably covers a beta, and a verifiable JWT for the backend.
+- The accepted cost is a vendor dependency and a bill at real scale. **Auth.js is the documented fallback** if we later want to drop the vendor and keep auth data in our own Postgres; it runs in the Next.js app and is free, at the price of wiring session storage and the backend token check ourselves. Either way the rest of this ADR (email-keyed identity, integrations-as-peers, the isolation sweep) is unchanged.
+
+Trust boundary, exploiting the existing topology where the browser never talks to the backend directly:
+
+- The Vercel proxy already fronts the Railway backend and injects a server-side credential. It now also forwards the Clerk session token.
+- **The FastAPI backend verifies that token itself, via Clerk's JWKS**, and derives `user_id` from the verified email. The backend stays authoritative on identity and never blindly trusts an unsigned header. This matters because the webhook routes are publicly exposed.
+- The existing HTTP Basic credential is **retained as the service-to-service secret** between Vercel and Railway (defense in depth), not as the identity. `BasicAuthMiddleware`'s role narrows from "proves it is the one user" to "proves it is our frontend"; per-user identity rides on top via the verified token.
+
+This split is the security win: Clerk owns the auth-provider attack surface (credentials, sessions, social OAuth, recovery); we own only token verification and tenant isolation.
+
+## Consequences
+
+- **Clerk setup (operator action):** a Clerk application, Google OAuth credentials wired into it, and new env vars (publishable key on the frontend; secret key and the JWKS/issuer config on the backend). Documented in `topology.md` when the code lands.
+- **`User` gains a non-null `email` with a unique index** (alembic migration). The existing single prod/dev user gets a backfilled placeholder, then is reconciled to the owner's real Google email on first sign-in by email match.
+- **Backend session verification dependency** (JWKS-based) replaces auto-create-on-first-read in `app/api/profile.py`. Every `/api/*` route except `/api/auth/*`, `/api/webhooks/*`, and `/api/health` resolves `user_id` from the verified token.
+- **The tenant-isolation sweep is unchanged and remains the largest, highest-risk chunk** (#119): every query that reads "the one user" must filter by the authenticated `user_id`. Cross-tenant leakage is the top correctness risk, identical under any auth choice.
+- **Per-user notification routing becomes a real design item, not a swap of `NOTIFY_TO`.** The deployed channel is Telegram, bound to one `TELEGRAM_CHAT_ID` for the whole deployment. Multi-user routing needs a per-user channel binding (each user links their own Telegram chat, or we add the HTTP email API ADR 0005 assumed). Tracked in #120; not resolved by this ADR.
+- **Account deletion (#121) must also delete the Clerk user**, not only cascade local rows, so a deleted account cannot sign back in into an empty shell.
+- **`BasicAuthMiddleware` is not removed**, contrary to ADR 0005; it is repurposed as the frontend-to-backend service secret. The `TODO(phase-2): remove` in `app/core/auth.py` becomes "repurpose."
+- **[ADR 0006](0006-multi-user-drops-polling-for-user-triggered-self-healing.md) is unaffected.** It is a Strava-rate-limit decision independent of how users authenticate.
+- **Future Garmin / Apple Health integrations slot in as peer side-tables behind the integration port**, with no change to the identity layer. This is the property ADR 0005 was protecting, and social-login-by-email keeps it.

--- a/docs/deployment/phase-2-plan.md
+++ b/docs/deployment/phase-2-plan.md
@@ -1,0 +1,87 @@
+# Phase 2 plan: multi-user readiness
+
+How the single-user MVP becomes a multi-user app, on the current Railway (backend) + Vercel (frontend) stack. Identity decision is [ADR 0022](../adr/0022-identity-is-social-login-via-clerk-strava-stays-an-integration.md) (social login via Clerk, superseding the magic-link mechanism of ADR 0005). Sync decision is [ADR 0006](../adr/0006-multi-user-drops-polling-for-user-triggered-self-healing.md). Cost framing is `docs/vision/going-live-cost-control.md`.
+
+This is the planning entry point for the #67 epic. Implementation lands across the sub-issues (#118–#124), one PR per phase below.
+
+## Goal
+
+Open the app to a handful of beta users (friends/beta scale) with per-user identity, strict tenant isolation, and a structural per-user LLM cost cap, without changing the deployment topology beyond what multi-user requires.
+
+## Guiding constraints
+
+- Easiest secure option wins; do not hand-roll auth (ADR 0022).
+- Identity is the verified email; data sources (Strava, later Garmin/Apple) stay peer integrations.
+- Per-user cost cap must be structural, not alert-only (the owner's hard rule).
+- Tenant isolation is the top correctness risk; treat its phase as higher-risk.
+
+## Phases
+
+Sequenced by dependency. Each phase is one PR and maps to one issue.
+
+### P2.0 — Auth foundation (#118, Clerk social login)
+
+- **Modality:** Feature (new auth surface) + Configure (Clerk/Google as a real external system).
+- **What changes (user-visible):** an unauthenticated visitor sees a Google sign-in; signing in lands on their own account; a returning user reaches the same account by email.
+- **Approach:** Clerk app + Google provider; Next.js sign-in UI and session; Vercel proxy forwards the Clerk session token; FastAPI verifies it via Clerk JWKS and resolves `user_id` from the verified email; `User.email` becomes non-null + unique (migration + placeholder backfill reconciled to the owner's Google email on first sign-in); `app/api/profile.py` stops auto-creating the single user. `BasicAuthMiddleware` is repurposed as the frontend↔backend service secret, not removed.
+- **Oracle:** the real Clerk/Google flow (Configure modality: exercise the live provider, not a mock); identity-by-email behaviour per ADR 0022.
+- **Higher-risk:** crosses the Vercel↔Railway seam and touches a third-party integration. Runtime validation required: a real sign-in end-to-end, plus a verified-token rejection path (bad/expired token denied).
+- **Verification:** end-to-end sign-in on the real provider; token-verification negative path; confirms backend resolves the correct `user_id`.
+
+### P2.1 — Tenant-safe data isolation sweep (#119) — HIGHEST RISK
+
+- **Modality:** Refactor (behaviour-preserving for one user) crossed with a security audit.
+- **What changes:** every read/write is scoped to the authenticated `user_id`; a request for another user's resource is denied, not served. Covers activities, streams, derived metrics, blocks, exchanges, check-ins, coach reports, chat, profile, baseline, coaching relationship/context/narrative, user materials, trends, training load, Strava connection.
+- **Approach:** audit every `db.query(...).first()` / `select(...)` that assumes the one local user (start from `activity_queries.py`, `trends.py`, `training_load.py`, `blocks.py`, the coach service report lookups, `checkins.py`); add `user_id` filters; add a DB index on `user_id` where it becomes a hot filter (the performance audit already flagged this for multi-user, [[project_performance_audit_2026_06_18]]).
+- **Oracle:** current single-user behaviour is preserved for the owning user (captured behaviour); cross-user access is the new negative contract.
+- **Higher-risk:** persistent state shared across the whole app; a missed filter is a cross-tenant leak.
+- **Verification:** negative-path tests asserting cross-user access is rejected on list, detail, trends, and coach lookups; the existing suite must still pass for the owning user.
+
+### P2.2 — Per-user LLM cost cap (#122)
+
+- **Modality:** Feature, on the structural-cap design in the going-live doc.
+- **What changes:** each user has a bounded LLM budget over a window; at the cap, generation is refused/deferred with a clear signal (degrade to the existing `is_fallback` / deterministic receipt path), never silently failed; one user hitting the cap never affects another.
+- **Approach:** the Redis budget gate from the going-live doc (Ring 3), checked before every call in `llm.py`, keyed by activity-owner `user_id`; configurable per-user ceiling; plus the regenerate cooldown + deterministic `job_id` (closes the worst lever, going-live landmine 1).
+- **Oracle:** the budget arithmetic (token counts × the per-MTok price table) and the degrade-not-crash contract.
+- **Verification:** a user driven over the cap degrades to fallback while a second user is unaffected; the cap is observed before the call, not after.
+
+### P2.3 — Account deletion with full cascade (#121)
+
+- **Modality:** Feature + Delete (destructive, hard to reverse).
+- **What changes:** a user can delete their own account and all derived data; no orphaned rows; one deletion never touches another user's data; the Clerk user is deleted too (ADR 0022) so a deleted account cannot sign back into an empty shell.
+- **Approach:** deletion endpoint scoped to the authenticated user; cascade across the *current* table set — Activity, ActivityStream, DerivedMetric, Block, Exchange, CheckIn, CoachReport, CoachChatMessage, CoachingRelationship, CoachingContext, CoachNarrative, RunnerBaseline, UserMaterial, StravaAccount, UserProfile, User — plus the Clerk-side user delete.
+- **Oracle:** the schema's FK graph (no row referencing the deleted user survives).
+- **Higher-risk:** destructive and cross-table. Verification: post-deletion, assert zero rows remain for that user across every table, and another user's data is intact.
+
+### P2.4 — Per-user notification routing (#120) — OPEN DESIGN
+
+- **Modality:** Feature, but blocked on a design decision (see Open decisions).
+- **What changes:** a coach-report notification reaches the owning user only, on their own channel; no deployment-wide recipient; at-most-once-per-activity-per-channel preserved; a user with no deliverable channel simply gets nothing without breaking the pipeline.
+- **Constraint:** the deployed channel is Telegram bound to one `TELEGRAM_CHAT_ID`. Multi-user needs either per-user Telegram chat binding (each user links their own chat) or the HTTP email API ADR 0005 assumed (which also finally fixes coach email, [[project_railway_smtp_egress_blocked]]). Decide before building.
+
+### P2.5 — Drop polling for self-healing sync (#123, ADR 0006)
+
+- **Modality:** Refactor + Delete (remove the polling job and scheduler process).
+- **What changes:** the recurring polling job and the `rqscheduler` process are gone (runtime drops to web + worker); missed activities are detected on authenticated app-open and via a manual refresh affordance; the check is bounded (≤ one per user per minute) so rapid repeats do not multiply Strava calls; per-activity dedup preserved; local single-user manual sync unaffected.
+- **Oracle:** ADR 0006; the existing dedup guarantee (`coach_notification_sent_at` / receipt sentinels) is the invariant.
+- **Higher-risk:** changes data-flow between processes and touches the Strava integration. Verification: a missed-webhook activity is caught on app-open end-to-end; the bound prevents call multiplication.
+
+### P2.6 — Custom domain (#124) — operator action
+
+- Acquire a domain; serve the Vercel frontend and reach the Railway backend on stable hostnames; confirm the proxy seam works over the new hostnames. Domain/DNS are operator actions outside the working tree; the only code-side concern is CORS origins and any hardcoded hostnames.
+
+## Sequencing and dependencies
+
+P2.0 is the prerequisite for P2.1–P2.4 (they all need `user_id`). Recommended order: **P2.0 → P2.1 → P2.2 → P2.3**, with P2.5 (sync) and P2.6 (domain) parallelizable once P2.0 lands. P2.4 (notifications) is gated on the open channel decision and can land last. Do not onboard a second real user until P2.1 (isolation) and P2.3 (deletion) are both done.
+
+## Open decisions (owner)
+
+1. **Notification channel for multi-user (P2.4):** per-user Telegram binding, or add the HTTP email API? The email API also fixes coach email; Telegram keeps the current channel but needs per-user linking UX.
+2. **Monthly + per-user spend ceilings (P2.2):** the actual numbers, and "at the cap: degrade or hard-block?"
+3. **Clerk vs Auth.js if vendor-aversion grows:** ADR 0022 picks Clerk; Auth.js is the documented fallback with no plan change beyond the auth wiring.
+
+## Testing notes
+
+- Backend has unit/integration coverage for analysis, coach, webhooks, sync; **no auth tests exist** (none needed under single-user Basic auth) and **no frontend component tests** beyond lint + build + smoke. P2.0 and P2.1 must add the first auth and isolation tests.
+- The tenant-isolation phase needs negative-path tests as first-class coverage, not an afterthought; a green single-user suite is structurally blind to cross-tenant leaks.
+- Auth and sync phases require runtime end-to-end validation against the real provider / real Strava behaviour, not mock-only.


### PR DESCRIPTION
Re-evaluates the Phase 2 multi-user identity approach for the current Railway (backend) + Vercel (frontend) stack, and re-aligns the GitHub issues to it.

## Why
ADR 0005 chose an in-house email magic-link flow and delivered the link via `SMTPNotifier`. The stack has since moved to Railway, which **blocks outbound SMTP** (the same reason notifications run over Telegram, #127), so that delivery mechanism does not exist on the current stack. Hand-rolling auth also fails the owner's "easy + secure" bar, and per-user LLM cost caps (the #1 going-live concern) need reliable per-user identity to exist.

## What's here (docs only)
- **ADR 0022** — supersedes ADR 0005's *mechanism* while keeping its *principle*. Identity becomes **social login (Google) via Clerk**, keyed on the verified email; Strava/Garmin/Apple stay peer integrations. Backend verifies the Clerk token via JWKS; `BasicAuthMiddleware` is repurposed as the frontend↔backend service secret, not removed. Auth.js documented as the no-vendor fallback.
- **docs/deployment/phase-2-plan.md** — the #67 epic as one-PR-per-phase, sequenced by dependency, each with modality / oracle / risk / verification.

## Issue cleanup (already applied on GitHub)
- #118 repurposed magic-link → Clerk social login (number kept; dependents reference it)
- #67 epic scope refreshed + linked to ADR 0022 / the plan
- #120 reframed off "email" onto per-user channel routing (open decision: per-user Telegram vs HTTP email API)
- #121 deletion cascade refreshed to the current schema + Clerk-user delete
- #119 / #122 / #123 / #124 left intact (still accurate)

## Open decisions called out in the plan
1. Multi-user notification channel (#120): per-user Telegram binding vs adding an HTTP email API.
2. Monthly + per-user spend ceilings, and degrade-vs-hard-block at the cap.
3. Clerk vs Auth.js if vendor-aversion grows.

No code paths touched; verification was confirming all cross-references resolve and ADR/issue numbering is correct.

Refs #67 #118 #119 #120 #121 #122 #123 #124
