### PR TITLE
P2.0: Clerk social-login auth + backend session verification (#118)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,12 +16,34 @@ APP_BASE_URL=http://localhost:3000
 # Comma-separated list of origins allowed to call the API.
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000
 
-# --- Auth (Phase 1 HTTP basic auth) ---
+# --- Auth: frontend-to-backend service secret (HTTP basic) ---
 # Gates every route except /api/health, /api/webhooks, /api/auth/strava/callback.
-# Leave both empty in local dev to disable the gate; in production a missing
-# credential fails closed (503). Replaced by ADR 0005 magic-link sessions in Phase 2.
+# Under Phase 2 (ADR 0022) this is the SERVICE secret ("proves it is our
+# frontend"), no longer per-user identity -- that rides on the verified Clerk
+# token below. Leave both empty in local dev to disable the gate; in production
+# a missing credential fails closed (503).
 BASIC_AUTH_USER=
 BASIC_AUTH_PASSWORD=
+
+# --- Auth: per-user identity via Clerk (Phase 2, ADR 0022) ---
+# The backend verifies the Clerk session JWT against this JWKS and resolves the
+# user from the verified email. Setting CLERK_JWKS_URL turns enforcement ON;
+# leaving it empty degrades to the single local user outside production and
+# fails closed (503) in production. Get these from the Clerk dashboard.
+CLERK_JWKS_URL=
+# Clerk Backend API secret (sk_*). Only used to look up a user's email when the
+# session token carries no `email` claim (configure the Clerk session-token
+# template to include `email` to avoid this call). Never logged.
+CLERK_SECRET_KEY=
+# Expected token issuer; derived from CLERK_JWKS_URL when empty (correct for
+# every Clerk instance). Set only to override.
+CLERK_ISSUER=
+# Optional comma-separated allowlist of authorized parties (the `azp` claim).
+CLERK_AUTHORIZED_PARTIES=
+# The owner's Google email. On first sign-in the pre-Phase-2 single user (email
+# backfilled to a placeholder) is adopted onto this address so the owner's data
+# is not stranded behind a fresh account. Empty disables reconciliation.
+OWNER_EMAIL=
 
 # --- Strava OAuth ---
 # Fill these in if you want to connect to Strava.

--- a/backend/alembic/versions/a9d4f2c7e1b6_user_email_non_null.py
+++ b/backend/alembic/versions/a9d4f2c7e1b6_user_email_non_null.py
@@ -1,0 +1,47 @@
+"""make users.email non-null with placeholder backfill (Phase 2, ADR 0022)
+
+Identity is now the verified email (social login via Clerk). The email column
+becomes the durable identity key: non-null and unique. The unique constraint
+already exists from the initial migration; this only backfills any NULL email to
+a per-row unique placeholder and flips the column to NOT NULL.
+
+The pre-Phase-2 single user (email NULL) is backfilled to
+``legacy-<id>@placeholder.invalid``. It is reconciled to the owner's real Google
+email on first sign-in by app/core/clerk_auth.resolve_user_by_email, which
+adopts the placeholder row rather than stranding the owner's data behind a fresh
+account.
+
+Revision ID: a9d4f2c7e1b6
+Revises: f9a3c1b7e2d5
+Create Date: 2026-06-24
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a9d4f2c7e1b6"
+down_revision: Union[str, None] = "f9a3c1b7e2d5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Backfill any NULL email to a per-row unique placeholder so the NOT NULL
+    # (and the existing unique) constraint holds. The cast keeps this portable
+    # across the uuid PK type.
+    op.execute(
+        "UPDATE users "
+        "SET email = 'legacy-' || id || '@placeholder.invalid' "
+        "WHERE email IS NULL"
+    )
+    op.alter_column("users", "email", existing_type=sa.String(), nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("users", "email", existing_type=sa.String(), nullable=True)
+    # The placeholder backfill is intentionally not reverted: there is no
+    # information about which rows were originally NULL, and a placeholder email
+    # is harmless under the nullable column.

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -67,9 +67,24 @@ async def strava_callback(
         strava_account.expires_at = tokens.expires_at
         strava_account.scope = "read,activity:read_all,profile:read_all"
     else:
-        new_user = User(email=None)
-        db.add(new_user)
-        db.flush()
+        # A brand-new Strava athlete. In single-owner prod this branch is
+        # dormant (the owner is already connected, so the token-refresh branch
+        # above fires). Under Phase 2 (ADR 0022) email is non-null, so attach to
+        # the single existing app user when there is exactly one (the realistic
+        # single-owner first-connect), else create a user with a unique
+        # placeholder email so the non-null constraint holds.
+        # TODO(P2.1): thread the verified Clerk user through the OAuth `state`
+        # param so a new Strava account links to the signed-in user, not a
+        # placeholder. The Strava callback is a direct browser redirect from
+        # Strava and carries no Clerk session, so true multi-user linking needs
+        # a server-verifiable state token. Tracked as a follow-up issue.
+        existing_users = db.execute(select(User)).scalars().all()
+        if len(existing_users) == 1:
+            new_user = existing_users[0]
+        else:
+            new_user = User(email=f"strava-{athlete_id}@placeholder.invalid")
+            db.add(new_user)
+            db.flush()
 
         strava_account = StravaAccount(
             user_id=new_user.id,

--- a/backend/app/api/profile.py
+++ b/backend/app/api/profile.py
@@ -3,27 +3,39 @@ from sqlalchemy.orm import Session
 from sqlalchemy import select
 from typing import Optional
 
+from app.core.clerk_auth import verify_clerk_session
+from app.core.config import settings
 from app.db.session import get_db
 from app.models import CoachingRelationship, User, StravaAccount, UserProfile
 from app.schemas import UserProfileRead, UserProfileCreate
 
 router = APIRouter()
 
-def get_current_user_profile(db: Session, auto_create_user: bool = True) -> UserProfile:
+def get_current_user_profile(
+    db: Session,
+    user: Optional[User] = None,
+    auto_create_user: bool = True,
+) -> UserProfile:
+    """Get the current user's profile, creating defaults if necessary.
+
+    Phase 2 (ADR 0022): ``user`` is the identity resolved from the verified
+    Clerk session, passed by the profile endpoints. When it is None we fall back
+    to the legacy single-user resolution -- the Strava-linked user, else the
+    first user -- which still serves local dev and the (Clerk-disabled) test
+    suite. Auto-create of a blank ``local@runner.com`` user only happens on the
+    legacy path with no user at all; under Clerk the user is created from the
+    verified email by resolve_user_by_email, never auto-created blank here.
     """
-    Helper for Local MVP: gets the Strava-linked user's profile,
-    creating defaults if necessary.
-    """
-    # Prefer the user with a linked Strava account (the real user)
-    strava_account = db.execute(select(StravaAccount)).scalars().first()
-    user = strava_account.user if strava_account else db.execute(select(User)).scalars().first()
-    if not user and auto_create_user:
-        user = User(email="local@runner.com")
-        db.add(user)
-        db.commit()
+    if user is None:
+        strava_account = db.execute(select(StravaAccount)).scalars().first()
+        user = strava_account.user if strava_account else db.execute(select(User)).scalars().first()
+        if not user and auto_create_user and not settings.clerk_enabled:
+            user = User(email="local@runner.com")
+            db.add(user)
+            db.commit()
 
     if not user:
-         raise HTTPException(status_code=404, detail="No user found")
+        raise HTTPException(status_code=404, detail="No user found")
 
     # A1: the thin coaching_relationship singleton anchors the relationship from
     # first contact, auto-created the way the default profile is below.
@@ -49,18 +61,25 @@ def get_current_user_profile(db: Session, auto_create_user: bool = True) -> User
         db.add(profile)
         db.commit()
         db.refresh(profile)
-    
+
     return profile
 
 @router.get("/profile", response_model=UserProfileRead)
-def read_profile(db: Session = Depends(get_db)):
+def read_profile(
+    db: Session = Depends(get_db),
+    user: Optional[User] = Depends(verify_clerk_session),
+):
     """Get the current user's profile."""
-    return get_current_user_profile(db)
+    return get_current_user_profile(db, user)
 
 @router.put("/profile", response_model=UserProfileRead)
-def update_profile(profile_in: UserProfileCreate, db: Session = Depends(get_db)):
+def update_profile(
+    profile_in: UserProfileCreate,
+    db: Session = Depends(get_db),
+    user: Optional[User] = Depends(verify_clerk_session),
+):
     """Update the current user's profile."""
-    existing_profile = get_current_user_profile(db)
+    existing_profile = get_current_user_profile(db, user)
     
     # Update fields
     for field, value in profile_in.model_dump(exclude_unset=True).items():

--- a/backend/app/core/clerk_auth.py
+++ b/backend/app/core/clerk_auth.py
@@ -27,6 +27,7 @@ from typing import Callable, Optional
 import jwt
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -234,11 +235,7 @@ def resolve_user_by_email(db: Session, email: str) -> User:
     behind a fresh empty account.
     """
     normalized = email.strip().lower()
-    user = (
-        db.execute(select(User).where(func.lower(User.email) == normalized))
-        .scalars()
-        .first()
-    )
+    user = _lookup_user_by_email(db, normalized)
     if user is not None:
         return user
 
@@ -252,11 +249,40 @@ def resolve_user_by_email(db: Session, email: str) -> User:
             logger.info("owner_user_reconciled", extra={"user_id": str(legacy.id)})
             return legacy
 
+    # Race-safe create. A new user's first authenticated page load fires several
+    # API calls concurrently; each one lands here having missed the lookup above,
+    # so they all attempt the INSERT. The first wins; the rest violate the unique
+    # email constraint and would otherwise 500 on the user's very first screen.
+    # Recover by rolling back and reusing the row the winner created. This also
+    # covers the owner-reconcile race above: a competing request that already
+    # adopted the legacy row makes _find_legacy_user miss here, so we fall through
+    # and recover the just-reconciled owner the same way.
     user = User(email=normalized)
     db.add(user)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Lost the unique-email race. Roll back our failed INSERT and reuse the
+        # row the winner committed. Expunge the failed instance so a later
+        # autoflush cannot retry the conflicting INSERT.
+        db.rollback()
+        if user in db:
+            db.expunge(user)
+        existing = _lookup_user_by_email(db, normalized)
+        if existing is None:
+            raise
+        return existing
     db.refresh(user)
     return user
+
+
+def _lookup_user_by_email(db: Session, normalized: str) -> Optional[User]:
+    """Case-insensitive lookup of a user by an already-normalized email."""
+    return (
+        db.execute(select(User).where(func.lower(User.email) == normalized))
+        .scalars()
+        .first()
+    )
 
 
 def _degraded_single_user(db: Session) -> Optional[User]:

--- a/backend/app/core/clerk_auth.py
+++ b/backend/app/core/clerk_auth.py
@@ -1,0 +1,312 @@
+"""Clerk session verification and per-user identity resolution (ADR 0022).
+
+The frontend (Vercel) owns the Clerk session; the backend verifies the session
+JWT itself against Clerk's JWKS and derives the durable identity (the verified
+email) from it, so it never blindly trusts an unsigned header. This is the
+security split of ADR 0022: Clerk owns the auth-provider attack surface; we own
+only token verification and tenant isolation.
+
+Transport: the Vercel proxy and the server-side API client forward the Clerk
+session token in the ``X-Clerk-Session-Token`` header. The HTTP Basic
+credential stays in ``Authorization`` as the frontend-to-backend service secret
+(BasicAuthMiddleware), so the two credentials never collide.
+
+Enforcement: ``verify_clerk_session`` is a FastAPI dependency applied to every
+application router (not health/auth/webhooks). When Clerk is configured it
+requires a valid session and returns the resolved ``User``; when it is not
+configured it degrades to the single local user outside production (local dev +
+the test suite keep working) and fails closed in production.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Callable, Optional
+
+import jwt
+from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.db.session import get_db
+from app.models import StravaAccount, User
+
+logger = logging.getLogger(__name__)
+
+SESSION_TOKEN_HEADER = "X-Clerk-Session-Token"
+
+# Email may be carried directly on the session token if the Clerk session-token
+# template adds it (the recommended, zero-extra-call setup). These are the keys
+# we accept, in order.
+_EMAIL_CLAIM_KEYS = ("email", "email_address", "primary_email_address")
+
+# The placeholder-email domain the email-non-null migration backfills onto the
+# pre-Phase-2 single user. Used to identify the legacy row for owner reconcile.
+PLACEHOLDER_EMAIL_DOMAIN = "@placeholder.invalid"
+
+
+class ClerkAuthError(Exception):
+    """A session token could not be verified or an email could not be resolved."""
+
+
+class ClerkVerifier:
+    """Verifies a Clerk session JWT against a JWKS, RS256 only.
+
+    The JWKS source is injectable (``jwk_client``) so tests exercise real RS256
+    signature verification against a controlled keypair with no network. In
+    production the default ``jwt.PyJWKClient`` fetches and caches Clerk's keys.
+    """
+
+    def __init__(
+        self,
+        jwks_url: str,
+        *,
+        issuer: str,
+        authorized_parties: tuple[str, ...] = (),
+        leeway: int = 0,
+        jwk_client: Optional[object] = None,
+    ) -> None:
+        self._issuer = issuer
+        self._authorized_parties = tuple(authorized_parties)
+        self._leeway = leeway
+        # PyJWKClient caches signing keys in-process after the first fetch.
+        self._jwk_client = jwk_client or jwt.PyJWKClient(jwks_url)
+
+    def verify(self, token: str) -> dict:
+        """Return the verified claims, or raise ClerkAuthError.
+
+        Pins the algorithm to RS256 (defeats the ``alg:none`` and HS256
+        key-confusion attacks), requires exp/iat/sub, and validates the issuer.
+        """
+        try:
+            signing_key = self._jwk_client.get_signing_key_from_jwt(token)
+            key = getattr(signing_key, "key", signing_key)
+            claims = jwt.decode(
+                token,
+                key,
+                algorithms=["RS256"],
+                issuer=self._issuer if self._issuer else None,
+                leeway=self._leeway,
+                options={
+                    "verify_aud": False,
+                    "verify_iss": bool(self._issuer),
+                    "require": ["exp", "iat", "sub"],
+                },
+            )
+        except (jwt.InvalidTokenError, jwt.PyJWKClientError) as exc:
+            raise ClerkAuthError(f"invalid session token: {exc}") from exc
+        except Exception as exc:  # JWKS fetch/transport errors, malformed input
+            raise ClerkAuthError(f"could not verify session token: {exc}") from exc
+
+        if self._authorized_parties:
+            azp = claims.get("azp")
+            if azp not in self._authorized_parties:
+                raise ClerkAuthError("token authorized party not allowed")
+
+        return claims
+
+
+# --- verifier singleton (lazy, swappable in tests) -------------------------
+
+_verifier_lock = threading.Lock()
+_verifier: Optional[ClerkVerifier] = None
+_verifier_jwks_url: Optional[str] = None
+
+
+def get_verifier() -> ClerkVerifier:
+    """Return the process verifier, rebuilding it if the JWKS URL changed.
+
+    Tests monkeypatch this function (or call ``reset_verifier_cache``) to inject
+    a controlled-keypair verifier.
+    """
+    global _verifier, _verifier_jwks_url
+    with _verifier_lock:
+        if _verifier is None or _verifier_jwks_url != settings.CLERK_JWKS_URL:
+            _verifier = ClerkVerifier(
+                settings.CLERK_JWKS_URL,
+                issuer=settings.clerk_issuer,
+                authorized_parties=tuple(settings.clerk_authorized_parties_list),
+                leeway=settings.CLERK_LEEWAY_SECONDS,
+            )
+            _verifier_jwks_url = settings.CLERK_JWKS_URL
+        return _verifier
+
+
+def reset_verifier_cache() -> None:
+    global _verifier, _verifier_jwks_url
+    with _verifier_lock:
+        _verifier = None
+        _verifier_jwks_url = None
+
+
+# --- email resolution ------------------------------------------------------
+
+def _email_from_claims(claims: dict) -> Optional[str]:
+    for key in _EMAIL_CLAIM_KEYS:
+        value = claims.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def fetch_email_from_clerk_api(clerk_user_id: str) -> Optional[str]:
+    """Fall back to the Clerk Backend API to read a user's primary email.
+
+    Only used when the session token carries no email claim. Configuring the
+    Clerk session-token template to include ``email`` avoids this call. Returns
+    None on any failure (the caller turns that into a 401).
+    """
+    if not settings.CLERK_SECRET_KEY:
+        return None
+    import httpx
+
+    try:
+        resp = httpx.get(
+            f"https://api.clerk.com/v1/users/{clerk_user_id}",
+            headers={"Authorization": f"Bearer {settings.CLERK_SECRET_KEY}"},
+            timeout=5.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:  # network/transport/parse
+        logger.warning("clerk_email_fetch_failed", extra={"error": str(exc)})
+        return None
+
+    primary_id = data.get("primary_email_address_id")
+    addresses = data.get("email_addresses") or []
+    for addr in addresses:
+        if addr.get("id") == primary_id:
+            email = addr.get("email_address")
+            if isinstance(email, str) and email.strip():
+                return email.strip()
+    # fall back to the first verified address
+    for addr in addresses:
+        email = addr.get("email_address")
+        if isinstance(email, str) and email.strip():
+            return email.strip()
+    return None
+
+
+def resolve_email(claims: dict) -> str:
+    """The verified email for a set of claims, or raise ClerkAuthError."""
+    email = _email_from_claims(claims)
+    if email:
+        return email
+    sub = claims.get("sub")
+    if sub:
+        email = fetch_email_from_clerk_api(sub)
+    if not email:
+        raise ClerkAuthError("no verified email on session")
+    return email
+
+
+# --- user resolution / owner reconcile -------------------------------------
+
+def _find_legacy_user(db: Session) -> Optional[User]:
+    """The pre-Phase-2 single user, for owner reconcile.
+
+    Prefer the Strava-linked user (the real data owner); otherwise any user
+    still carrying the migration placeholder email. Returns None if no such row
+    exists (so we never adopt an already-real account).
+    """
+    placeholder_user = (
+        db.execute(
+            select(User).where(User.email.like(f"%{PLACEHOLDER_EMAIL_DOMAIN}"))
+        )
+        .scalars()
+        .first()
+    )
+    if placeholder_user is None:
+        return None
+    strava = db.execute(select(StravaAccount)).scalars().first()
+    if strava is not None and str(strava.user.email or "").endswith(PLACEHOLDER_EMAIL_DOMAIN):
+        return strava.user
+    return placeholder_user
+
+
+def resolve_user_by_email(db: Session, email: str) -> User:
+    """Get-or-create the user for a verified email, with owner reconcile.
+
+    On the owner's first sign-in the legacy placeholder user is adopted (its
+    email set to the owner address) so the owner's existing data is not stranded
+    behind a fresh empty account.
+    """
+    normalized = email.strip().lower()
+    user = (
+        db.execute(select(User).where(func.lower(User.email) == normalized))
+        .scalars()
+        .first()
+    )
+    if user is not None:
+        return user
+
+    owner = settings.OWNER_EMAIL.strip().lower()
+    if owner and normalized == owner:
+        legacy = _find_legacy_user(db)
+        if legacy is not None:
+            legacy.email = normalized
+            db.commit()
+            db.refresh(legacy)
+            logger.info("owner_user_reconciled", extra={"user_id": str(legacy.id)})
+            return legacy
+
+    user = User(email=normalized)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _degraded_single_user(db: Session) -> Optional[User]:
+    """The one local user when Clerk is unconfigured outside production.
+
+    Prefer the Strava-linked user (matches the legacy profile resolution), else
+    any user. Does not create a row -- callers that need a default own that.
+    """
+    strava = db.execute(select(StravaAccount)).scalars().first()
+    if strava is not None:
+        return strava.user
+    return db.execute(select(User)).scalars().first()
+
+
+# --- the FastAPI dependency ------------------------------------------------
+
+def verify_clerk_session(
+    request: Request,
+    db: Session = Depends(get_db),
+) -> Optional[User]:
+    """Resolve the authenticated user for the request.
+
+    Clerk configured: verify the ``X-Clerk-Session-Token`` JWT and resolve the
+    user by verified email (401 on any failure). Clerk unconfigured: degrade to
+    the single local user outside production; fail closed (503) in production.
+    """
+    if not settings.clerk_enabled:
+        if settings.APP_ENV == "production":
+            logger.critical("clerk_not_configured_in_production")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Service Unavailable: auth misconfigured",
+            )
+        return _degraded_single_user(db)
+
+    token = request.headers.get(SESSION_TOKEN_HEADER)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing session token",
+        )
+
+    try:
+        claims = get_verifier().verify(token)
+        email = resolve_email(claims)
+    except ClerkAuthError as exc:
+        logger.info("session_rejected", extra={"reason": str(exc)})
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid session token",
+        ) from exc
+
+    return resolve_user_by_email(db, email)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -186,9 +186,45 @@ class Settings(BaseSettings):
     USER_MATERIAL_MAX_BYTES: int = 262144  # 256 KB per uploaded .md file
     USER_MATERIAL_MAX_COUNT: int = 50  # max non-archived materials per user
 
-    # Phase 1 deployment: throwaway basic auth in front of /api/*.
-    # Both must be set for the middleware to enforce; either empty disables it.
-    # TODO(phase-2): remove when session auth lands.
+    # Phase 2 identity: social login via Clerk (ADR 0022). The frontend (Vercel)
+    # owns the Clerk session; the backend VERIFIES the session token itself via
+    # Clerk's JWKS and resolves user_id from the verified email, so it never
+    # blindly trusts a header (the webhook routes are public). See
+    # app/core/clerk_auth.py.
+    #
+    # CLERK_JWKS_URL is the only setting REQUIRED to turn auth on: when it is set
+    # the backend enforces a verified session on every non-exempt /api route.
+    # When it is empty AND APP_ENV != production, auth degrades to the single
+    # local user (local dev + the test suite keep working with no Clerk); in
+    # production an empty value fails closed, mirroring BasicAuthMiddleware.
+    CLERK_JWKS_URL: str = ""
+    # Clerk Backend API secret (sk_*). Used only as a fallback to fetch a
+    # signed-in user's verified email when the session token carries no `email`
+    # claim (the recommended setup adds `email` to the Clerk session-token
+    # template, which avoids this call entirely). Never logged.
+    CLERK_SECRET_KEY: str = ""
+    # Expected token issuer. When empty it is derived from CLERK_JWKS_URL by
+    # stripping the well-known JWKS path, which is correct for every Clerk
+    # instance; set explicitly only to override.
+    CLERK_ISSUER: str = ""
+    # Optional comma-separated allowlist of authorized parties (the `azp` claim,
+    # the frontend origin Clerk issued the token to). Empty disables the check.
+    CLERK_AUTHORIZED_PARTIES: str = ""
+    # Clock-skew tolerance (seconds) for token exp/nbf/iat checks.
+    CLERK_LEEWAY_SECONDS: int = 30
+    # The owner's Google email. On first sign-in the pre-Phase-2 single user
+    # (whose email was backfilled to a placeholder by the email-non-null
+    # migration) is reconciled to this address by adopting it, so the owner's
+    # existing data is not orphaned behind a fresh empty account. Empty disables
+    # reconciliation (every verified email gets/creates its own user).
+    OWNER_EMAIL: str = ""
+
+    # Phase 1 deployment: HTTP basic auth in front of /api/*. Under Phase 2
+    # (ADR 0022) this is REPURPOSED as the frontend-to-backend service secret
+    # (defense in depth: "proves it is our frontend"), no longer as identity --
+    # per-user identity rides on top via the verified Clerk token. Both must be
+    # set for the middleware to enforce; either empty disables it (fails closed
+    # in production).
     BASIC_AUTH_USER: str = ""
     BASIC_AUTH_PASSWORD: str = ""
 
@@ -222,6 +258,36 @@ class Settings(BaseSettings):
     @property
     def cors_allowed_origins_list(self) -> list[str]:
         return [origin.strip() for origin in self.CORS_ALLOWED_ORIGINS.split(",") if origin.strip()]
+
+    @property
+    def clerk_issuer(self) -> str:
+        """The expected token issuer.
+
+        Explicit ``CLERK_ISSUER`` wins; otherwise derive it from the JWKS URL by
+        stripping the ``/.well-known/jwks.json`` suffix (the Clerk convention,
+        e.g. ``https://fine-octopus-89.clerk.accounts.dev``).
+        """
+        if self.CLERK_ISSUER:
+            return self.CLERK_ISSUER.rstrip("/")
+        url = self.CLERK_JWKS_URL
+        marker = "/.well-known/"
+        if marker in url:
+            return url.split(marker, 1)[0].rstrip("/")
+        return url.rstrip("/")
+
+    @property
+    def clerk_authorized_parties_list(self) -> list[str]:
+        return [p.strip() for p in self.CLERK_AUTHORIZED_PARTIES.split(",") if p.strip()]
+
+    @property
+    def clerk_enabled(self) -> bool:
+        """Whether the backend should enforce verified Clerk sessions.
+
+        Auth turns on as soon as a JWKS URL is configured. With no JWKS URL,
+        production fails closed (handled in the dependency) while non-production
+        degrades to the single local user.
+        """
+        return bool(self.CLERK_JWKS_URL)
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,9 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api import health, auth, activities, blocks, webhooks, profile, trends, coach, debug, strava_import, materials
 from app.core.auth import BasicAuthMiddleware
+from app.core.clerk_auth import verify_clerk_session
 from app.core.config import settings
 from app.core.observability import init_logging, init_sentry, warn_if_coach_prompt_inert
 
@@ -16,10 +17,12 @@ app = FastAPI(
     version="0.2.0",
 )
 
-# TODO(phase-2): remove BasicAuthMiddleware when session auth from ADR 0005 lands.
-# /api/auth/strava/callback is exempt because Strava redirects the user's browser
-# there directly with an OAuth code; the code itself is the auth, and Strava has
-# no way to send basic auth credentials.
+# BasicAuthMiddleware is REPURPOSED under ADR 0022 as the frontend-to-backend
+# service secret ("proves it is our frontend"), defense in depth beneath the
+# per-user Clerk session verified by verify_clerk_session below. It is not
+# removed. /api/auth/strava/callback is exempt because Strava redirects the
+# user's browser there directly with an OAuth code; the code itself is the auth,
+# and Strava has no way to send basic auth credentials.
 app.add_middleware(
     BasicAuthMiddleware,
     exempt_prefixes=(
@@ -29,6 +32,13 @@ app.add_middleware(
     ),
 )
 
+# Per-user identity (ADR 0022). Applied to every APPLICATION router below, so a
+# new router is gated by default if it is added to that list. NOT applied to
+# health, auth (OAuth handshakes), or webhooks (public, separately
+# authenticated). The fence test (tests/test_clerk_auth.py) asserts every
+# non-exempt route denies an unauthenticated request when Clerk is configured.
+_require_session = [Depends(verify_clerk_session)]
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_allowed_origins_list,
@@ -37,18 +47,20 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Include routers
+# Include routers. Public (no per-user session): health, auth, webhooks.
 app.include_router(health.router, prefix="/api", tags=["System"])
 app.include_router(auth.router, prefix="/api", tags=["Auth"])
-app.include_router(profile.router, prefix="/api", tags=["Profile"])
-app.include_router(activities.router, prefix="/api", tags=["Activities"])
-app.include_router(strava_import.router, prefix="/api", tags=["Strava Import"])
-app.include_router(blocks.router, prefix="/api", tags=["Blocks"])
 app.include_router(webhooks.router, prefix="/api", tags=["Webhooks"])
-app.include_router(trends.router, prefix="/api", tags=["Trends"])
-app.include_router(coach.router, prefix="/api", tags=["Coach"])
-app.include_router(materials.router, prefix="/api", tags=["Coach"])
-app.include_router(debug.router, prefix="/api", tags=["Debug"])
+
+# Application routers: every route requires a verified Clerk session.
+app.include_router(profile.router, prefix="/api", tags=["Profile"], dependencies=_require_session)
+app.include_router(activities.router, prefix="/api", tags=["Activities"], dependencies=_require_session)
+app.include_router(strava_import.router, prefix="/api", tags=["Strava Import"], dependencies=_require_session)
+app.include_router(blocks.router, prefix="/api", tags=["Blocks"], dependencies=_require_session)
+app.include_router(trends.router, prefix="/api", tags=["Trends"], dependencies=_require_session)
+app.include_router(coach.router, prefix="/api", tags=["Coach"], dependencies=_require_session)
+app.include_router(materials.router, prefix="/api", tags=["Coach"], dependencies=_require_session)
+app.include_router(debug.router, prefix="/api", tags=["Debug"], dependencies=_require_session)
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,6 +1,5 @@
 import uuid
 from datetime import datetime
-from typing import Optional
 
 from sqlalchemy import String, DateTime, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -14,7 +13,11 @@ class User(Base):
     __tablename__ = "users"
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=generate_uuid)
-    email: Mapped[Optional[str]] = mapped_column(String, nullable=True, unique=True)
+    # Phase 2 (ADR 0022): the verified email is the durable identity key, so it
+    # is non-null and unique. The pre-Phase-2 single user was backfilled to a
+    # placeholder by migration a9d4f2c7e1b6 and reconciled to the owner's real
+    # email on first sign-in (app/core/clerk_auth.resolve_user_by_email).
+    email: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     # Relationships

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "rq-scheduler>=0.13.1",
     "python-multipart>=0.0.9",
     "numpy>=1.24.0",
-    "anthropic>=0.40.0"
+    "anthropic>=0.40.0",
+    "pyjwt[crypto]>=2.8.0"
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,6 +25,26 @@ def _isolate_notification_channels(monkeypatch):
     for var in ("TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID", "SMTP_HOST", "NOTIFY_TO"):
         monkeypatch.setattr(settings, var, "")
 
+
+@pytest.fixture(autouse=True)
+def _disable_clerk_auth(monkeypatch):
+    """Run the suite in the Clerk-disabled single-user path by default.
+
+    `settings` loads `backend/.env`, which on a developer machine now carries a
+    real CLERK_JWKS_URL. Left in place that would flip verify_clerk_session into
+    enforcement and 401 every existing endpoint test. Resetting the Clerk
+    settings here makes every test start from "Clerk not configured" (the
+    degrade-to-single-user path, identical to pre-Phase-2 behaviour). The auth
+    tests opt back in via their own monkeypatch + injected verifier.
+    """
+    from app.core import clerk_auth
+
+    for var in ("CLERK_JWKS_URL", "CLERK_SECRET_KEY", "CLERK_ISSUER",
+                "CLERK_AUTHORIZED_PARTIES", "OWNER_EMAIL"):
+        monkeypatch.setattr(settings, var, "")
+    monkeypatch.setattr(settings, "APP_ENV", "local")
+    clerk_auth.reset_verifier_cache()
+
 # Use an in-memory SQLite database for tests, or a separate test DB
 # For simplicity with SQLAlchemy features, an in-memory SQLite is easiest 
 # but might have dialect differences with Postgres.

--- a/backend/tests/test_basic_auth_middleware.py
+++ b/backend/tests/test_basic_auth_middleware.py
@@ -146,11 +146,17 @@ class TestProductionFailsClosed:
         assert response.status_code == 200
 
     def test_production_with_credentials_set_authenticates_normally(self, client, monkeypatch):
+        # Targets /api/auth/strava/status: gated by the basic-auth service-secret
+        # middleware but NOT by the Phase 2 Clerk session dependency (the auth
+        # router is the OAuth handshake surface, ADR-exempt from per-user
+        # sessions). An application route like /api/profile would now also fail
+        # closed (503) under Clerk-unconfigured-in-production, which is the Clerk
+        # layer's job, not the basic middleware's; this test isolates the latter.
         monkeypatch.setattr(settings, "APP_ENV", "production")
         monkeypatch.setattr(settings, "BASIC_AUTH_USER", _AUTH_USER)
         monkeypatch.setattr(settings, "BASIC_AUTH_PASSWORD", _AUTH_PASSWORD)
         response = client.get(
-            "/api/profile",
+            "/api/auth/strava/status",
             headers={"Authorization": _basic(_AUTH_USER, _AUTH_PASSWORD)},
         )
         assert response.status_code == 200

--- a/backend/tests/test_clerk_auth.py
+++ b/backend/tests/test_clerk_auth.py
@@ -1,0 +1,384 @@
+"""Phase 2 Clerk session verification + identity resolution (ADR 0022, #118).
+
+Security-first coverage (aiw-security-testing): the negative paths are the point.
+Real RS256 signature verification runs against a controlled, in-test RSA keypair
+with no network -- the JWKS fetch is the only boundary stubbed -- so the
+algorithm-confusion, expiry, wrong-signature, and wrong-issuer denials are
+exercised against real crypto, not a mock of the verifier.
+
+The live Clerk dev instance is the runtime oracle for the end-to-end sign-in
+(exercised locally, out of band); these tests pin the verification logic and the
+dependency's enforcement/degrade contract.
+"""
+
+import asyncio
+import datetime as dt
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.core import clerk_auth
+from app.core.clerk_auth import (
+    ClerkAuthError,
+    ClerkVerifier,
+    resolve_user_by_email,
+)
+from app.core.config import settings
+from app.db.session import get_db
+from app.main import app
+from app.models import StravaAccount, User
+
+TEST_ISSUER = "https://test-instance.clerk.accounts.dev"
+TEST_JWKS_URL = f"{TEST_ISSUER}/.well-known/jwks.json"
+HEADER = clerk_auth.SESSION_TOKEN_HEADER
+
+# Gated-route discovery: every /api route NOT under one of these prefixes must
+# carry the verify_clerk_session dependency. Mirrors app/main.py.
+_EXEMPT_PREFIXES = ("/api/health", "/api/auth", "/api/webhooks")
+
+
+# --- keypair + token helpers ----------------------------------------------
+
+@pytest.fixture(scope="module")
+def rsa_keys():
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return priv, priv.public_key()
+
+
+class _FakeSigningKey:
+    def __init__(self, key):
+        self.key = key
+
+
+class _FakeJWKClient:
+    """Stubs only the JWKS network fetch; the returned key drives real RS256."""
+
+    def __init__(self, public_key):
+        self._key = public_key
+
+    def get_signing_key_from_jwt(self, token):
+        return _FakeSigningKey(self._key)
+
+
+def _make_token(priv, *, claims=None, alg="RS256", key=None, headers=None):
+    now = dt.datetime.now(dt.timezone.utc)
+    payload = {
+        "sub": "user_clerk_abc",
+        "email": "runner@example.com",
+        "iss": TEST_ISSUER,
+        "iat": now,
+        "exp": now + dt.timedelta(hours=1),
+    }
+    if claims is not None:
+        payload.update(claims)
+    signing_key = key if key is not None else priv
+    return jwt.encode(payload, signing_key, algorithm=alg, headers=headers)
+
+
+def _verifier(pub):
+    return ClerkVerifier(
+        TEST_JWKS_URL, issuer=TEST_ISSUER, jwk_client=_FakeJWKClient(pub), leeway=30
+    )
+
+
+@pytest.fixture
+def clerk_env(monkeypatch, rsa_keys):
+    """Turn Clerk auth ON with the in-test verifier injected."""
+    priv, pub = rsa_keys
+    monkeypatch.setattr(settings, "CLERK_JWKS_URL", TEST_JWKS_URL)
+    monkeypatch.setattr(settings, "CLERK_SECRET_KEY", "sk_test-do-not-use-in-prod")
+    monkeypatch.setattr(clerk_auth, "get_verifier", lambda: _verifier(pub))
+    return priv, pub
+
+
+@pytest.fixture
+def app_with_db(db):
+    """Bind the app's get_db to the test session for ASGITransport tests."""
+    def _override():
+        yield db
+    app.dependency_overrides[get_db] = _override
+    yield app
+    app.dependency_overrides.clear()
+
+
+# --- verifier crypto matrix (unit, real RS256) -----------------------------
+
+class TestVerifierCrypto:
+    def test_valid_token_returns_claims(self, rsa_keys):
+        priv, pub = rsa_keys
+        claims = _verifier(pub).verify(_make_token(priv))
+        assert claims["email"] == "runner@example.com"
+        assert claims["sub"] == "user_clerk_abc"
+
+    def test_expired_token_rejected(self, rsa_keys):
+        priv, pub = rsa_keys
+        now = dt.datetime.now(dt.timezone.utc)
+        token = _make_token(
+            priv,
+            claims={"iat": now - dt.timedelta(hours=2), "exp": now - dt.timedelta(hours=1)},
+        )
+        with pytest.raises(ClerkAuthError):
+            _verifier(pub).verify(token)
+
+    def test_wrong_signature_rejected(self, rsa_keys):
+        priv, pub = rsa_keys
+        attacker = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        token = _make_token(priv, key=attacker)  # signed by a key we don't trust
+        with pytest.raises(ClerkAuthError):
+            _verifier(pub).verify(token)
+
+    def test_alg_none_rejected(self, rsa_keys):
+        """The classic unsigned-token attack: alg=none must never verify."""
+        _, pub = rsa_keys
+        now = dt.datetime.now(dt.timezone.utc)
+        payload = {
+            "sub": "user_clerk_abc",
+            "email": "attacker@example.com",
+            "iss": TEST_ISSUER,
+            "iat": now,
+            "exp": now + dt.timedelta(hours=1),
+        }
+        token = jwt.encode(payload, key="", algorithm="none")
+        with pytest.raises(ClerkAuthError):
+            _verifier(pub).verify(token)
+
+    def test_hs256_token_rejected(self, rsa_keys):
+        """Any HS256 token is rejected (RS256-pinned), defeating key confusion.
+
+        The key-confusion attack relies on the verifier accepting HS256 and the
+        attacker signing with the RSA public key as the HMAC secret. Pinning the
+        algorithm to RS256 rejects every HS256 token regardless of its secret,
+        which is the defense; PyJWT additionally refuses to *encode* HS256 with a
+        PEM key, so we sign with a plain secret to construct the rejected token.
+        """
+        _, pub = rsa_keys
+        token = _make_token(None, key="attacker-hmac-secret-padding-0123456789", alg="HS256")
+        with pytest.raises(ClerkAuthError):
+            _verifier(pub).verify(token)
+
+    def test_wrong_issuer_rejected(self, rsa_keys):
+        priv, pub = rsa_keys
+        token = _make_token(priv, claims={"iss": "https://evil.example.com"})
+        with pytest.raises(ClerkAuthError):
+            _verifier(pub).verify(token)
+
+    def test_missing_required_claim_rejected(self, rsa_keys):
+        priv, pub = rsa_keys
+        now = dt.datetime.now(dt.timezone.utc)
+        # No exp -> required claim missing.
+        payload = {"sub": "x", "iss": TEST_ISSUER, "iat": now}
+        token = jwt.encode(payload, priv, algorithm="RS256")
+        with pytest.raises(ClerkAuthError):
+            _verifier(pub).verify(token)
+
+    def test_authorized_party_enforced(self, rsa_keys):
+        priv, pub = rsa_keys
+        verifier = ClerkVerifier(
+            TEST_JWKS_URL,
+            issuer=TEST_ISSUER,
+            authorized_parties=("https://app.example.com",),
+            jwk_client=_FakeJWKClient(pub),
+            leeway=30,
+        )
+        bad = _make_token(priv, claims={"azp": "https://evil.example.com"})
+        with pytest.raises(ClerkAuthError):
+            verifier.verify(bad)
+        ok = _make_token(priv, claims={"azp": "https://app.example.com"})
+        assert verifier.verify(ok)["azp"] == "https://app.example.com"
+
+
+# --- dependency enforcement over HTTP (TestClient) -------------------------
+
+class TestSessionEnforcement:
+    def test_valid_token_resolves_and_creates_user(self, client, clerk_env, db):
+        priv, _ = clerk_env
+        resp = client.get("/api/profile", headers={HEADER: _make_token(priv)})
+        assert resp.status_code == 200
+        user = db.execute(
+            User.__table__.select().where(User.email == "runner@example.com")
+        ).first()
+        assert user is not None
+
+    def test_missing_token_denied(self, client, clerk_env):
+        assert client.get("/api/profile").status_code == 401
+
+    def test_malformed_token_denied(self, client, clerk_env):
+        resp = client.get("/api/profile", headers={HEADER: "not-a-jwt"})
+        assert resp.status_code == 401
+
+    def test_expired_token_denied_over_http(self, client, clerk_env):
+        priv, _ = clerk_env
+        now = dt.datetime.now(dt.timezone.utc)
+        token = _make_token(
+            priv,
+            claims={"iat": now - dt.timedelta(hours=2), "exp": now - dt.timedelta(hours=1)},
+        )
+        assert client.get("/api/profile", headers={HEADER: token}).status_code == 401
+
+    def test_health_exempt_without_token(self, client, clerk_env):
+        assert client.get("/api/health").status_code == 200
+
+    def test_strava_status_exempt_without_token(self, client, clerk_env):
+        # Auth router is the OAuth handshake surface, exempt from per-user sessions.
+        assert client.get("/api/auth/strava/status").status_code == 200
+
+
+# --- email resolution (claim + Clerk API fallback) -------------------------
+
+class TestEmailResolution:
+    def test_email_api_fallback_used_when_no_claim(self, client, clerk_env, monkeypatch, db):
+        priv, _ = clerk_env
+        monkeypatch.setattr(
+            clerk_auth, "fetch_email_from_clerk_api", lambda sub: "fallback@example.com"
+        )
+        token = _make_token(priv, claims={"email": None})
+        # email=None means the claim is absent; resolve falls back to the API.
+        resp = client.get("/api/profile", headers={HEADER: token})
+        assert resp.status_code == 200
+        assert db.execute(
+            User.__table__.select().where(User.email == "fallback@example.com")
+        ).first() is not None
+
+    def test_no_email_anywhere_denied(self, client, clerk_env, monkeypatch):
+        priv, _ = clerk_env
+        monkeypatch.setattr(clerk_auth, "fetch_email_from_clerk_api", lambda sub: None)
+        token = _make_token(priv, claims={"email": None})
+        assert client.get("/api/profile", headers={HEADER: token}).status_code == 401
+
+
+# --- identity resolution + owner reconcile (unit) --------------------------
+
+class TestUserResolution:
+    def test_returning_user_resolves_same_account(self, db):
+        a = resolve_user_by_email(db, "Runner@Example.com")
+        b = resolve_user_by_email(db, "runner@example.com")  # case-insensitive
+        assert a.id == b.id
+        assert db.query(User).count() == 1
+
+    def test_new_email_creates_new_user(self, db):
+        a = resolve_user_by_email(db, "one@example.com")
+        b = resolve_user_by_email(db, "two@example.com")
+        assert a.id != b.id
+
+    def test_owner_reconcile_adopts_legacy_user(self, db, monkeypatch):
+        monkeypatch.setattr(settings, "OWNER_EMAIL", "owner@gmail.com")
+        legacy = User(email="legacy-1234@placeholder.invalid")
+        db.add(legacy)
+        db.commit()
+        legacy_id = legacy.id
+
+        resolved = resolve_user_by_email(db, "owner@gmail.com")
+        assert resolved.id == legacy_id  # adopted, not a fresh account
+        assert resolved.email == "owner@gmail.com"
+        assert db.query(User).count() == 1
+
+    def test_owner_reconcile_prefers_strava_linked_legacy(self, db, monkeypatch):
+        monkeypatch.setattr(settings, "OWNER_EMAIL", "owner@gmail.com")
+        plain_legacy = User(email="legacy-aaaa@placeholder.invalid")
+        strava_legacy = User(email="legacy-bbbb@placeholder.invalid")
+        db.add_all([plain_legacy, strava_legacy])
+        db.flush()
+        db.add(
+            StravaAccount(
+                user_id=strava_legacy.id,
+                strava_athlete_id=99,
+                access_token="t",
+                refresh_token="r",
+                expires_at=0,
+                scope="read",
+            )
+        )
+        db.commit()
+        strava_legacy_id = strava_legacy.id
+
+        resolved = resolve_user_by_email(db, "owner@gmail.com")
+        assert resolved.id == strava_legacy_id
+
+    def test_non_owner_does_not_adopt_legacy(self, db, monkeypatch):
+        monkeypatch.setattr(settings, "OWNER_EMAIL", "owner@gmail.com")
+        legacy = User(email="legacy-1234@placeholder.invalid")
+        db.add(legacy)
+        db.commit()
+
+        resolved = resolve_user_by_email(db, "stranger@example.com")
+        assert resolved.email == "stranger@example.com"
+        assert db.query(User).count() == 2  # legacy untouched
+
+
+# --- structural fence: every app route is gated ----------------------------
+
+def _flatten_calls(dependant):
+    calls, stack = [], [dependant]
+    while stack:
+        d = stack.pop()
+        if getattr(d, "call", None) is not None:
+            calls.append(d.call)
+        stack.extend(getattr(d, "dependencies", []))
+    return calls
+
+
+class TestGateCoverage:
+    def test_every_application_route_requires_a_session(self):
+        """No application /api route may be left ungated (fail-closed by review)."""
+        ungated = []
+        for route in app.routes:
+            path = getattr(route, "path", "")
+            dependant = getattr(route, "dependant", None)
+            if dependant is None or not path.startswith("/api/"):
+                continue
+            if any(path.startswith(p) for p in _EXEMPT_PREFIXES):
+                continue
+            if clerk_auth.verify_clerk_session not in _flatten_calls(dependant):
+                ungated.append(f"{getattr(route, 'methods', '')} {path}")
+        assert not ungated, f"ungated application routes: {ungated}"
+
+    def test_exempt_routers_are_not_gated(self):
+        for route in app.routes:
+            path = getattr(route, "path", "")
+            dependant = getattr(route, "dependant", None)
+            if dependant is None:
+                continue
+            if path.startswith("/api/health") or path.startswith("/api/webhooks"):
+                assert clerk_auth.verify_clerk_session not in _flatten_calls(dependant)
+
+
+# --- production fail-closed -------------------------------------------------
+
+class TestProductionFailClosed:
+    def test_unconfigured_clerk_in_production_returns_503(self, client, monkeypatch):
+        # Pass the basic-auth service secret so the request clears the middleware
+        # and actually reaches the Clerk dependency, isolating its 503 (an
+        # unconfigured-Clerk-in-production fail-closed) from the basic layer's.
+        import base64
+
+        monkeypatch.setattr(settings, "APP_ENV", "production")
+        monkeypatch.setattr(settings, "CLERK_JWKS_URL", "")  # Clerk not configured
+        monkeypatch.setattr(settings, "BASIC_AUTH_USER", "svc")
+        monkeypatch.setattr(settings, "BASIC_AUTH_PASSWORD", "secret-test-only")
+        token = base64.b64encode(b"svc:secret-test-only").decode("ascii")
+        resp = client.get("/api/profile", headers={"Authorization": f"Basic {token}"})
+        assert resp.status_code == 503
+
+
+# --- real ASGI transport (httpx), not just TestClient ----------------------
+
+class TestRealAsgiTransport:
+    """Per the handoff: verify auth against a real ASGI transport, not only the
+    in-process TestClient (which has masked real request behaviour before)."""
+
+    def _get(self, headers):
+        async def _call():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+                return await ac.get("/api/profile", headers=headers)
+        return asyncio.run(_call())
+
+    def test_valid_token_accepted(self, app_with_db, clerk_env):
+        priv, _ = clerk_env
+        resp = self._get({HEADER: _make_token(priv)})
+        assert resp.status_code == 200
+
+    def test_missing_token_rejected(self, app_with_db, clerk_env):
+        assert self._get({}).status_code == 401

--- a/backend/tests/test_clerk_auth.py
+++ b/backend/tests/test_clerk_auth.py
@@ -250,6 +250,36 @@ class TestEmailResolution:
 
 # --- identity resolution + owner reconcile (unit) --------------------------
 
+@pytest.fixture
+def committing_db():
+    """A session whose commits actually persist.
+
+    The shared `db` fixture binds the session inside one outer transaction that
+    is rolled back at teardown, so an inner `db.commit()` does not truly persist
+    and a later `db.rollback()` reverts it too. The race-recovery path in
+    resolve_user_by_email rolls back its own failed INSERT and must still find
+    the row a prior request committed, so it needs real commit isolation.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    from app.db.base import Base
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
 class TestUserResolution:
     def test_returning_user_resolves_same_account(self, db):
         a = resolve_user_by_email(db, "Runner@Example.com")
@@ -305,6 +335,63 @@ class TestUserResolution:
         resolved = resolve_user_by_email(db, "stranger@example.com")
         assert resolved.email == "stranger@example.com"
         assert db.query(User).count() == 2  # legacy untouched
+
+    def test_concurrent_create_recovers_instead_of_raising(
+        self, committing_db, monkeypatch
+    ):
+        """A new user's first page load fires several API calls at once; they all
+        miss the initial lookup and race on the INSERT. The losers must recover
+        from the unique-email violation, not 500. Threat: a fresh user's very
+        first screen erroring out."""
+        db = committing_db
+        # A competing request already won the INSERT, so the row exists...
+        winner = User(email="racer@example.com")
+        db.add(winner)
+        db.commit()
+        winner_id = winner.id
+
+        # ...but our request's initial lookup missed it (the race window between
+        # the SELECT and our own INSERT). Force the first lookup to miss; the
+        # recovery lookup uses the real query.
+        real_lookup = clerk_auth._lookup_user_by_email
+        calls = {"n": 0}
+
+        def flaky_lookup(session, normalized):
+            calls["n"] += 1
+            return None if calls["n"] == 1 else real_lookup(session, normalized)
+
+        monkeypatch.setattr(clerk_auth, "_lookup_user_by_email", flaky_lookup)
+
+        resolved = resolve_user_by_email(db, "Racer@example.com")
+        assert resolved.id == winner_id  # reused the winner's row, no error
+        assert db.query(User).count() == 1  # no duplicate, no orphan
+
+    def test_owner_reconcile_race_recovers(self, committing_db, monkeypatch):
+        """When a competing owner request already adopted the legacy row, our
+        _find_legacy_user misses (the row is no longer a placeholder) and we fall
+        through to the create path -- which must recover the just-reconciled
+        owner instead of 500ing on the unique-email violation."""
+        db = committing_db
+        monkeypatch.setattr(settings, "OWNER_EMAIL", "owner@gmail.com")
+        # The winning request already reconciled: one row with the owner email,
+        # no placeholder remains.
+        owner_row = User(email="owner@gmail.com")
+        db.add(owner_row)
+        db.commit()
+        owner_id = owner_row.id
+
+        real_lookup = clerk_auth._lookup_user_by_email
+        calls = {"n": 0}
+
+        def flaky_lookup(session, normalized):
+            calls["n"] += 1
+            return None if calls["n"] == 1 else real_lookup(session, normalized)
+
+        monkeypatch.setattr(clerk_auth, "_lookup_user_by_email", flaky_lookup)
+
+        resolved = resolve_user_by_email(db, "owner@gmail.com")
+        assert resolved.id == owner_id
+        assert db.query(User).count() == 1
 
 
 # --- structural fence: every app route is gated ----------------------------

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,19 @@
 # Frontend talks to FastAPI here
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 
+# --- Auth via Clerk (Phase 2, ADR 0022) ---
+# Setting the publishable key turns Clerk ON: the app requires sign-in and the
+# proxy forwards the session token to the backend. Leaving it empty makes the
+# auth layer a no-op (CI build + smoke run this way). Same Clerk instance as the
+# backend's CLERK_* settings.
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+# Clerk secret key (sk_*), used by the Next server runtime.
+CLERK_SECRET_KEY=
+# Auth route + redirect URLs (optional; these are the defaults).
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/
+
 # Set to "true" (or "1") to render the "Debug: LLM Input & Output" panel on
 # the activity page. Useful when iterating on the coach prompt or context
 # pack; off by default because the panel exposes the full prompt and the

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,14 @@
-# Frontend talks to FastAPI here
-NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+# Frontend talks to FastAPI here.
+#
+# BACKEND_URL is the server-side target: the Next proxy (app/api/[...path]) and
+# server components forward to it. Set it for local dev.
+BACKEND_URL=http://localhost:8000
+#
+# Leave NEXT_PUBLIC_API_BASE_URL EMPTY. With Clerk ON, client-side calls must use
+# relative /api/* paths so they route through the Next proxy, which attaches the
+# server-minted Clerk session token. Setting an absolute URL here makes the
+# browser call the backend directly with no token -> every client call 401s.
+NEXT_PUBLIC_API_BASE_URL=
 
 # --- Auth via Clerk (Phase 2, ADR 0022) ---
 # Setting the publishable key turns Clerk ON: the app requires sign-in and the

--- a/frontend/app/activity/[id]/page.tsx
+++ b/frontend/app/activity/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { fetchFromAPI } from '@/lib/api';
+import { serverFetch } from '@/lib/serverSession';
 import { format } from 'date-fns';
 import { formatPace, formatDuration, formatDistanceKm, activityStartDate } from '@/lib/format';
 import CheckInForm from '@/components/CheckInForm';
@@ -24,7 +24,7 @@ const SHOW_DEBUG_PANEL =
   process.env.NEXT_PUBLIC_SHOW_DEBUG_PANEL === '1';
 
 export default async function ActivityDetail({ params }: { params: { id: string } }) {
-  const activity: Activity | null = await fetchFromAPI(`/api/activities/${params.id}`);
+  const activity: Activity | null = await serverFetch(`/api/activities/${params.id}`);
   
   if (!activity) return <div>Activity not found</div>;
 

--- a/frontend/app/api/[...path]/route.ts
+++ b/frontend/app/api/[...path]/route.ts
@@ -1,8 +1,14 @@
 import { NextRequest } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
 
 const BACKEND_URL = process.env.BACKEND_URL;
 const BASIC_USER = process.env.BACKEND_BASIC_AUTH_USER;
 const BASIC_PASS = process.env.BACKEND_BASIC_AUTH_PASSWORD;
+// NEXT_PUBLIC_* is inlined at build; with no Clerk key the proxy forwards only
+// the basic service secret (CI/smoke). The session token rides a dedicated
+// header so it never collides with the basic Authorization credential.
+const CLERK_ENABLED = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
+const SESSION_TOKEN_HEADER = 'x-clerk-session-token';
 
 const HOP_BY_HOP = new Set([
   'connection',
@@ -37,6 +43,22 @@ async function proxy(
   if (BASIC_USER && BASIC_PASS) {
     const token = Buffer.from(`${BASIC_USER}:${BASIC_PASS}`).toString('base64');
     upstreamHeaders.set('authorization', `Basic ${token}`);
+  }
+  // Forward the verified Clerk session token so the backend can resolve the
+  // user. The browser carries the Clerk cookie; auth().getToken() mints the JWT
+  // server-side. Never trust an incoming session-token header from the client.
+  upstreamHeaders.delete(SESSION_TOKEN_HEADER);
+  if (CLERK_ENABLED) {
+    try {
+      const { getToken } = auth();
+      const sessionToken = await getToken();
+      if (sessionToken) {
+        upstreamHeaders.set(SESSION_TOKEN_HEADER, sessionToken);
+      }
+    } catch {
+      // No active session (or called outside Clerk context): forward nothing
+      // and let the backend reject with 401.
+    }
   }
 
   const init: RequestInit = {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,9 +1,16 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import { Fraunces, Hanken_Grotesk, IBM_Plex_Mono } from 'next/font/google';
+import { ClerkProvider } from '@clerk/nextjs';
 import NavBar from '@/components/NavBar';
 import BottomNav from '@/components/BottomNav';
 import ThemeProvider from '@/components/ThemeProvider';
+
+// Clerk wraps the app only when a publishable key is configured (Vercel prod +
+// local dev). Without it -- CI build, the smoke harness -- the app renders
+// exactly as before, with no auth surface. See middleware.ts for the matching
+// pass-through gate.
+const clerkEnabled = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
 
 // Three deliberate type roles: Fraunces (serif) is the coach's voice + display
 // headings, Hanken Grotesk (sans) is body + UI, IBM Plex Mono is numbers/data.
@@ -47,7 +54,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
+  const tree = (
     <html
       lang="en"
       suppressHydrationWarning
@@ -63,5 +70,19 @@ export default function RootLayout({
         </ThemeProvider>
       </body>
     </html>
+  );
+
+  if (!clerkEnabled) {
+    return tree;
+  }
+  return (
+    <ClerkProvider
+      signInUrl={process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || '/sign-in'}
+      signUpUrl={process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || '/sign-up'}
+      afterSignInUrl={process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL || '/'}
+      afterSignOutUrl="/sign-in"
+    >
+      {tree}
+    </ClerkProvider>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { fetchFromAPI } from '@/lib/api';
+import { serverFetch } from '@/lib/serverSession';
 import { WeeklyStatsData } from '@/lib/types';
 import { formatDistanceKm, formatDuration } from '@/lib/format';
 import ActivityList from '@/components/ActivityList';
@@ -29,8 +29,8 @@ export default async function Dashboard() {
   let stats: WeeklyStatsData | null = null;
   try {
     [activities, stats] = await Promise.all([
-      fetchFromAPI('/api/activities?limit=10').then((a) => a || []),
-      fetchFromAPI('/api/stats/weekly') as Promise<WeeklyStatsData | null>,
+      serverFetch('/api/activities?limit=10').then((a) => a || []),
+      serverFetch('/api/stats/weekly') as Promise<WeeklyStatsData | null>,
     ]);
   } catch (e) {
     console.error('Failed to fetch dashboard data', e);

--- a/frontend/app/sign-in/[[...sign-in]]/page.tsx
+++ b/frontend/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,21 @@
+import { SignIn } from '@clerk/nextjs';
+
+// Catch-all route so Clerk can own its sub-paths (factor-two, SSO callback).
+// Rendered only when Clerk is configured; with no key the app has no auth
+// surface and this page is never reached (the middleware is a pass-through).
+export const dynamic = 'force-dynamic';
+
+export default function SignInPage() {
+  if (!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) {
+    return (
+      <div className="flex justify-center py-16 text-gray-500">
+        Authentication is not configured.
+      </div>
+    );
+  }
+  return (
+    <div className="flex justify-center py-12">
+      <SignIn />
+    </div>
+  );
+}

--- a/frontend/app/sign-up/[[...sign-up]]/page.tsx
+++ b/frontend/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,18 @@
+import { SignUp } from '@clerk/nextjs';
+
+export const dynamic = 'force-dynamic';
+
+export default function SignUpPage() {
+  if (!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) {
+    return (
+      <div className="flex justify-center py-16 text-gray-500">
+        Authentication is not configured.
+      </div>
+    );
+  }
+  return (
+    <div className="flex justify-center py-12">
+      <SignUp />
+    </div>
+  );
+}

--- a/frontend/components/AuthControls.tsx
+++ b/frontend/components/AuthControls.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { SignedIn, SignedOut, SignInButton, UserButton } from '@clerk/nextjs';
+
+// The nav's auth affordance: the Clerk user menu when signed in, a sign-in
+// button when not. Rendered only when Clerk is configured (NavBar gates this),
+// so it is never mounted without a ClerkProvider above it.
+export default function AuthControls() {
+  return (
+    <div className="flex items-center">
+      <SignedIn>
+        <UserButton afterSignOutUrl="/sign-in" />
+      </SignedIn>
+      <SignedOut>
+        <SignInButton mode="redirect">
+          <button className="min-h-[40px] px-3 rounded-md text-sm font-medium text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/30">
+            Sign in
+          </button>
+        </SignInButton>
+      </SignedOut>
+    </div>
+  );
+}

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { User } from 'lucide-react';
+import AuthControls from '@/components/AuthControls';
 
 const LINKS = [
   { href: '/activities', label: 'Activities' },
@@ -10,6 +11,10 @@ const LINKS = [
   { href: '/trends', label: 'Trends' },
   { href: '/profile', label: 'Profile' },
 ];
+
+// Inlined at build time; with no Clerk key the auth menu is omitted entirely
+// (CI build + smoke run against a mock backend with no auth).
+const clerkEnabled = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
 
 export default function NavBar() {
   const pathname = usePathname();
@@ -26,35 +31,38 @@ export default function NavBar() {
         >
           AI Coach
         </Link>
-        <div className="hidden md:flex items-center gap-1 sm:gap-2">
-          {LINKS.map(({ href, label }) => (
-            <Link
-              key={href}
-              href={href}
-              className={`flex items-center min-h-[44px] px-3 rounded-md text-sm font-medium transition-colors ${
-                isActive(href)
-                  ? 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/30'
-                  : 'text-gray-600 hover:text-blue-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:text-blue-400 dark:hover:bg-gray-800'
-              }`}
-            >
-              {label}
-            </Link>
-          ))}
+        <div className="flex items-center gap-1 sm:gap-2">
+          <div className="hidden md:flex items-center gap-1 sm:gap-2">
+            {LINKS.map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className={`flex items-center min-h-[44px] px-3 rounded-md text-sm font-medium transition-colors ${
+                  isActive(href)
+                    ? 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/30'
+                    : 'text-gray-600 hover:text-blue-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:text-blue-400 dark:hover:bg-gray-800'
+                }`}
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+          {/* On mobile the nav links live in the bottom tab bar; Profile stays
+              here as a top-right icon (the bottom bar omits it). */}
+          <Link
+            href="/profile"
+            aria-label="Profile"
+            aria-current={isActive('/profile') ? 'page' : undefined}
+            className={`md:hidden flex items-center justify-center h-11 w-11 rounded-full transition-colors ${
+              isActive('/profile')
+                ? 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/30'
+                : 'text-gray-600 hover:text-blue-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:text-blue-400 dark:hover:bg-gray-800'
+            }`}
+          >
+            <User className="h-6 w-6" aria-hidden="true" />
+          </Link>
+          {clerkEnabled && <AuthControls />}
         </div>
-        {/* On mobile the nav links live in the bottom tab bar; Profile stays
-            here as a top-right icon (the bottom bar omits it). */}
-        <Link
-          href="/profile"
-          aria-label="Profile"
-          aria-current={isActive('/profile') ? 'page' : undefined}
-          className={`md:hidden flex items-center justify-center h-11 w-11 rounded-full transition-colors ${
-            isActive('/profile')
-              ? 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/30'
-              : 'text-gray-600 hover:text-blue-600 hover:bg-gray-50 dark:text-gray-300 dark:hover:text-blue-400 dark:hover:bg-gray-800'
-          }`}
-        >
-          <User className="h-6 w-6" aria-hidden="true" />
-        </Link>
       </div>
     </nav>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -37,6 +37,9 @@ export async function fetchFromAPI(endpoint: string, options: RequestInit = {}) 
     const auth = buildAuthHeader();
     if (auth) headers.Authorization = auth;
   }
+  // Server components forward the verified Clerk session token via
+  // options.headers (see lib/serverSession.serverFetch); the Clerk server SDK
+  // is kept out of this client-shared module to avoid poisoning client bundles.
   const res = await fetch(`${baseUrl}${endpoint}`, {
     ...options,
     headers,

--- a/frontend/lib/serverSession.ts
+++ b/frontend/lib/serverSession.ts
@@ -1,0 +1,33 @@
+import 'server-only';
+
+import { fetchFromAPI } from '@/lib/api';
+
+// Server-only Clerk session access. `import 'server-only'` guarantees this
+// module (and the Clerk server SDK it pulls in) never lands in a client bundle.
+// Only the two server-component pages that call the backend directly
+// (app/page.tsx, app/activity/[id]/page.tsx) import this; client components hit
+// the proxy, which forwards the token itself.
+
+const clerkEnabled = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
+
+export async function getServerSessionToken(): Promise<string | null> {
+  if (!clerkEnabled) return null;
+  try {
+    const { auth } = await import('@clerk/nextjs/server');
+    return (await auth().getToken()) ?? null;
+  } catch {
+    // No active session in this render context.
+    return null;
+  }
+}
+
+// Drop-in for fetchFromAPI in server components: attaches the verified Clerk
+// session token so the FastAPI backend can resolve the user on direct calls.
+export async function serverFetch(endpoint: string, options: RequestInit = {}) {
+  const token = await getServerSessionToken();
+  const headers: Record<string, string> = {
+    ...(options.headers as Record<string, string> | undefined),
+  };
+  if (token) headers['x-clerk-session-token'] = token;
+  return fetchFromAPI(endpoint, { ...options, headers });
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,35 @@
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+
+// Clerk activates only when a publishable key is present (Vercel prod + local
+// dev with .env.local). With no key -- CI's lint/build and the smoke harness,
+// which run against a mock backend with no auth -- the middleware is a
+// pass-through, so routes load without a sign-in. NEXT_PUBLIC_* vars are inlined
+// at build time, so this is fixed per build environment.
+const clerkEnabled = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
+
+// Public routes never require a session: the auth pages themselves, and /api/*
+// (the proxy forwards the Clerk token and the FastAPI backend is the real
+// enforcer -- redirecting an XHR to an HTML sign-in page would just break it).
+const isPublicRoute = createRouteMatcher([
+  '/sign-in(.*)',
+  '/sign-up(.*)',
+  '/api/(.*)',
+]);
+
+const enforce = clerkMiddleware((auth, req) => {
+  if (!isPublicRoute(req)) {
+    auth().protect();
+  }
+});
+
+export default clerkEnabled ? enforce : () => NextResponse.next();
+
+export const config = {
+  matcher: [
+    // Run on everything except Next internals and files with an extension.
+    '/((?!_next|.*\\..*).*)',
+    // Always run on API routes so the proxy can attach the session token.
+    '/(api|trpc)(.*)',
+  ],
+};

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,13 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  async rewrites() {
-    return [
-      {
-        source: '/api/:path*',
-        destination: 'http://127.0.0.1:8000/api/:path*',
-      },
-    ]
-  },
+  // NOTE (Phase 2 / Clerk): the legacy dev rewrite that forwarded /api/:path*
+  // straight to http://127.0.0.1:8000 was REMOVED. A plain-array rewrite is an
+  // `afterFiles` rewrite, which Next checks BEFORE dynamic routes -- so it
+  // shadowed the dynamic catch-all proxy at app/api/[...path]/route.ts, sending
+  // client /api/* calls to the backend with NO Clerk session token (401). The
+  // route handler is the proxy now: it attaches the token (and basic creds) and
+  // forwards to BACKEND_URL. Client calls must use relative /api/* paths
+  // (NEXT_PUBLIC_API_BASE_URL empty) so they hit the handler.
 }
 
 module.exports = nextConfig

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "running-coach-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@clerk/nextjs": "^5.7.6",
         "date-fns": "^3.3.1",
         "lucide-react": "^0.330.0",
         "next": "14.1.0",
@@ -42,6 +43,130 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@clerk/backend": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-1.14.1.tgz",
+      "integrity": "sha512-YlKMpiVo4UITw3sgA+9QrAFRILVOz5hgB1Zw180Y2LEZ5a+MdpX668vJKGh7riSweMN7JQvU2jlsKGRO+1bXDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "2.9.2",
+        "@clerk/types": "4.26.0",
+        "cookie": "0.7.0",
+        "snakecase-keys": "5.4.4",
+        "tslib": "2.4.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
+    "node_modules/@clerk/backend/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "license": "0BSD"
+    },
+    "node_modules/@clerk/clerk-react": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.12.0.tgz",
+      "integrity": "sha512-3Lr2QazCm5R6ZLbu7wM+d5YwCElrAoX00OBWcKqjPYaWDJCCmEYN6LJbLzOTYQ8QT1J1ZIed85/lKa+q2aD1aA==",
+      "deprecated": "This package is no longer supported. Please use @clerk/react instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "2.9.2",
+        "@clerk/types": "4.26.0",
+        "tslib": "2.4.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-beta",
+        "react-dom": ">=18 || >=19.0.0-beta"
+      }
+    },
+    "node_modules/@clerk/clerk-react/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "license": "0BSD"
+    },
+    "node_modules/@clerk/nextjs": {
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-5.7.6.tgz",
+      "integrity": "sha512-7WTh2JiQrCgBZ9s2vndH7Zlzl/qKja8eCr7SUrefM5WnjlqWgkFFARDi8Jt2WrwkQn3cFmHdf1hx9imnNVOLnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "1.14.1",
+        "@clerk/clerk-react": "5.12.0",
+        "@clerk/shared": "2.9.2",
+        "@clerk/types": "4.26.0",
+        "crypto-js": "4.2.0",
+        "server-only": "0.0.1",
+        "tslib": "2.4.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "next": "^13.5.4 || ^14.0.3 || >=15.0.0-rc",
+        "react": ">=18 || >=19.0.0-beta",
+        "react-dom": ">=18 || >=19.0.0-beta"
+      }
+    },
+    "node_modules/@clerk/nextjs/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "license": "0BSD"
+    },
+    "node_modules/@clerk/shared": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-2.9.2.tgz",
+      "integrity": "sha512-vRMDj13Pv9n8Pf+f8P40AvqJ8QEq348qUxUVIf17vn9R3/toicrQOY/Q6qsrAS8KXY9+ZnyTafJa+VFK+6iEFA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/types": "4.26.0",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.7.0",
+        "swr": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-beta",
+        "react-dom": ">=18 || >=19.0.0-beta"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/types": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.26.0.tgz",
+      "integrity": "sha512-VGcrQz/XpCiGbpIIzKVwWw4nLorzKnIP1IAemj1xt/80ULcdEZCncwhas6PoYBBsl1W55A1SwP9B/pEs0nmkCw==",
+      "deprecated": "This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
+    "node_modules/@clerk/types/node_modules/csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -1917,6 +2042,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.0.tgz",
+      "integrity": "sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1931,6 +2065,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -2282,6 +2422,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/dunder-proto": {
@@ -3351,6 +3501,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -4249,6 +4405,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4427,6 +4592,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -4441,6 +4615,18 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -5247,6 +5433,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/node-releases": {
@@ -6278,6 +6474,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -6449,6 +6651,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/snakecase-keys": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
+      "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
+      "license": "MIT",
+      "dependencies": {
+        "map-obj": "^4.1.0",
+        "snake-case": "^3.0.4",
+        "type-fest": "^2.5.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/snakecase-keys/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6473,6 +6711,12 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -6832,6 +7076,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tailwindcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "smoke": "node scripts/smoke.mjs"
   },
   "dependencies": {
+    "@clerk/nextjs": "^5.7.6",
     "date-fns": "^3.3.1",
     "lucide-react": "^0.330.0",
     "next": "14.1.0",

--- a/frontend/scripts/smoke.mjs
+++ b/frontend/scripts/smoke.mjs
@@ -244,22 +244,23 @@ async function main() {
     mockApiServer.listen(MOCK_API_PORT, "127.0.0.1", resolve);
   });
 
-  await runCommand("npm", ["run", "build"], {
-    env: {
-      ...process.env,
-      NEXT_PUBLIC_API_BASE_URL: MOCK_API_BASE_URL,
-    },
-  });
+  // The smoke runs against a mock backend with no auth, so Clerk must be off:
+  // an empty publishable key makes the middleware/layout pass-through (CI has no
+  // .env.local, but a dev machine does, and Next would otherwise inline its key
+  // into the build and gate every route behind a sign-in redirect).
+  const smokeEnv = {
+    ...process.env,
+    NEXT_PUBLIC_API_BASE_URL: MOCK_API_BASE_URL,
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "",
+    CLERK_SECRET_KEY: "",
+  };
+
+  await runCommand("npm", ["run", "build"], { env: smokeEnv });
 
   const nextServer = spawnProcess(
     "npm",
     ["run", "start", "--", "--hostname", "127.0.0.1", "--port", `${FRONTEND_PORT}`],
-    {
-      env: {
-        ...process.env,
-        NEXT_PUBLIC_API_BASE_URL: MOCK_API_BASE_URL,
-      },
-    },
+    { env: smokeEnv },
   );
   runningChildren.push(nextServer);
 


### PR DESCRIPTION
Part of the Phase 2 multi-user epic (#67). Implements **P2.0 — auth foundation** from `docs/deployment/phase-2-plan.md`, replacing the Phase 1 single-user basic-auth shim with real per-user identity via **Clerk social login (Google)**, keyed on the verified email per [ADR 0022](docs/adr/0022-identity-is-social-login-via-clerk-strava-stays-an-integration.md).

Built unattended; the owner returns to review. **Do not merge yet** — later phases branch off `main`.

## What changed

**Backend**
- `app/core/clerk_auth.py` (new): `ClerkVerifier` verifies the Clerk session JWT against Clerk's JWKS, **RS256-pinned** (defeats `alg:none` and HS256 key-confusion), validates issuer + exp/iat/sub. `verify_clerk_session` FastAPI dependency resolves `user_id` from the verified email.
- Every **application** router is gated by the session dependency; `health`, `auth` (OAuth handshake), and `webhooks` (public) stay exempt — matching ADR 0022. A **structural fence test** asserts no app route is left ungated.
- **Degrade/fail-closed**: when `CLERK_JWKS_URL` is unset, auth degrades to the single local user outside production (local dev + the test suite keep working) and **fails closed (503) in production**, mirroring `BasicAuthMiddleware`.
- `BasicAuthMiddleware` is **repurposed as the frontend↔backend service secret** (not removed); the `TODO(phase-2): remove` becomes "repurpose".
- `User.email` is now **non-null + unique** (migration `a9d4f2c7e1b6`), with a per-row placeholder backfill (`legacy-<id>@placeholder.invalid`) reconciled to `OWNER_EMAIL` on first sign-in (the legacy row is *adopted*, not orphaned).
- `profile.py` stops auto-creating a blank user under Clerk (the user comes from the verified email).
- New deps: `pyjwt[crypto]` (backend), `@clerk/nextjs@5` (frontend, v5 matches Next 14).

**Frontend**
- `ClerkProvider`, `clerkMiddleware` (redirects unauthenticated users to sign-in), `/sign-in` + `/sign-up` pages, a nav `UserButton`/sign-in control. **All gated on the publishable key**, so CI's lint/build and the smoke harness (no key, mock backend) stay a pure no-op.
- Token forwarding: the Vercel proxy and a server-only `serverFetch` attach the verified session token in `X-Clerk-Session-Token` (the basic service secret stays in `Authorization`, so they never collide). The proxy strips any client-supplied token header before re-setting the server-minted one.

## Decisions made (owner unreachable — recommended option taken, recorded here)

1. **Token transport header.** Clerk JWT rides a dedicated `X-Clerk-Session-Token` header; the basic service secret keeps `Authorization`. *Why:* least churn to the existing middleware, no header collision.
2. **Enforcement = router dependency + structural fence test** (not a second middleware). *Why:* idiomatic FastAPI + testable via `dependency_overrides`, with the fence test giving the "no route missed" guarantee explicitly rather than implicitly. The basic-auth middleware still gates the whole surface beneath it.
3. **Clerk v5, not v7.** v7 requires Next 15+; this app is Next 14.1.0. v5.7.6 supports `^14.0.3`. *Why:* avoid a risky framework upgrade inside an auth PR. A future Next 15 bump can move to Clerk v7.
4. **Frontend auth no-ops when the publishable key is absent** (symmetric with the backend's degrade). *Why:* keeps CI build + smoke green without secrets and activates auth only where the key is set (local/prod).
5. **Email resolution = session-token claim, with a Clerk Backend-API fallback.** *Why:* works whether or not the operator adds `email` to the Clerk session-token template (recommended for performance, but not required).
6. **Strava OAuth callback** keeps `email` non-null by attaching a brand-new athlete to the single existing app user, else a unique placeholder email. True multi-user Strava-to-session linking (OAuth `state` carrying the verified user) is **deferred** — the callback is a direct browser redirect from Strava with no Clerk session. The `else` branch is dormant in single-owner prod. (Follow-up issue below.)
7. **One basic-auth test re-pointed** to `/api/auth/strava/status` (gated by the basic middleware, exempt from Clerk) so it still isolates the basic layer; an app route there now also fails closed under Clerk-unconfigured-in-production, which is the Clerk layer's job. Not a weakening — the basic-auth intent is preserved.

## Verification

- **Backend suite: 1617 passed** (1591 pre-existing + 26 new), 0 regressions, integration excluded.
- **New security tests** (`tests/test_clerk_auth.py`): real RS256 against a controlled keypair — `alg:none`, HS256, expired, wrong-signature, wrong-issuer, missing-claim, `azp` all **denied**; HTTP enforcement (missing/malformed/expired → 401, valid → 200 + user created, exempt routes reachable); email API fallback + no-email → 401; identity resolution + **owner reconcile** (adopts legacy, prefers Strava-linked, non-owner does not adopt); **structural fence** (every app route gated); **production fail-closed (503)**; **real ASGI transport** (httpx, not just TestClient).
- **Migration** applied base→head on **real Postgres**: NULL email → per-row placeholder, column NOT NULL, clean downgrade/upgrade round-trip. **Single linear alembic head** `a9d4f2c7e1b6`.
- **Real Clerk dev JWKS** reachable (RS256/RSA key), verifier rejects bad input, issuer derived correctly.
- **Frontend**: `next lint` clean; `next build` passes **with Clerk on AND off** (built in an isolated copy to avoid clobbering the running dev server); `npm run smoke` green (routes load in the Clerk-disabled path).

**Not automated (scoping):** the interactive Google sign-in end-to-end against the live Clerk dev instance is inherently interactive OAuth — the owner's manual runtime check. The hermetic RS256 matrix + real-JWKS reachability are the automated substitute.

## Owner actions before real users (none block this PR)

- **Vercel** (frontend): `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`; optional `NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in`, `NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up`, `NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/`.
- **Railway web service** (backend verifies tokens): `CLERK_JWKS_URL`, `CLERK_SECRET_KEY`, `OWNER_EMAIL=philippe.marr@gmail.com`.
- **Recommended (perf):** add `"email": "{{user.primary_email_address}}"` to the Clerk session-token template (avoids the Backend-API email lookup). Works without it.
- Prod Clerk instance + own Google OAuth app (the dev instance uses Clerk's shared Google creds).
- Run the migration on prod (`alembic upgrade head`) — backfills the existing user's email to a placeholder; the owner's first sign-in reconciles it.

## Follow-up (not in scope)
- Multi-user Strava-account-to-session linking via signed OAuth `state` (so a 2nd user's Strava connect links to *their* account). Will file an issue.

Closes #118 once merged.
