### PR TITLE
P2.1: tenant-isolation sweep — scope every query to the authenticated user (#119)

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -5,8 +5,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from sqlalchemy import select
 
+from app.core.clerk_auth import require_current_user
 from app.db.session import get_db
-from app.models import Activity, StravaAccount, CheckIn
+from app.models import Activity, StravaAccount, User
 from app.models.user_profile import UserProfile
 from app.schemas import ActivityRead, ActivityDetailRead, CheckInCreate, CheckInRead, SyncResponse, ActivityIntentUpdate, DerivedMetricRead, TrainingLoadRead
 from app.services import activity_queries, analysis
@@ -19,15 +20,30 @@ from app.services.strava_ingestion import get_strava_port, ingest_recent_activit
 
 router = APIRouter()
 
+
+def _require_owned_activity(db: Session, activity_id: UUID, user: User) -> Activity:
+    """Load an activity, 404ing if it does not exist OR is not the user's (P2.1).
+
+    A cross-tenant id must be indistinguishable from a missing one, so the same
+    404 covers both — no information about other users' activities leaks.
+    """
+    activity = activity_queries.get_owned_activity(db, activity_id, user.id)
+    if activity is None:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    return activity
+
+
 @router.post("/activities/{activity_id}/process_deep", response_model=DerivedMetricRead)
 async def process_activity_deep(
     activity_id: UUID,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
     """
     Fetches full streams from Strava (if Rate Limits allow) and re-runs processing.
     Useful for detailed breakdown of 'Complex' runs.
     """
+    _require_owned_activity(db, activity_id, user)
     metrics = await analysis.analyze_with_streams(db, str(activity_id))
     if not metrics:
         raise HTTPException(status_code=400, detail="Processing failed or activity not found.")
@@ -38,6 +54,9 @@ async def process_activity_deep(
 
 @router.post("/activities/backfill-streams")
 def backfill_streams(db: Session = Depends(get_db)):
+    # Auth-gated by the router-level session dependency (P2.0). Per-user scoping
+    # of this owner-maintenance job (it currently processes all users' eligible
+    # activities) is a tracked follow-up; it returns no cross-tenant data.
     """Kick off a paced backfill of stream-derived analysis for historical
     summary-only activities (#110).
 
@@ -77,17 +96,14 @@ def reanalyze_history(db: Session = Depends(get_db)):
 def update_activity_intent(
     activity_id: UUID,
     payload: ActivityIntentUpdate,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
     """
     Updates the manual user intent for an activity and re-runs analysis.
     """
-    stmt = select(Activity).where(Activity.id == activity_id)
-    activity = db.execute(stmt).scalars().first()
-    
-    if not activity:
-        raise HTTPException(status_code=404, detail="Activity not found")
-        
+    activity = _require_owned_activity(db, activity_id, user)
+
     activity.user_intent = payload.user_intent
     db.add(activity)
     db.commit()
@@ -107,9 +123,6 @@ _STREAM_FETCH_WINDOW_DAYS = 30
 
 @router.post("/sync", response_model=SyncResponse)
 async def sync_activities(
-    # In a real app, we'd get current_user from token.
-    # Here, we optionally take an ID or default to the first account found.
-    strava_athlete_id: Optional[int] = None,
     since_days: Annotated[
         int,
         Query(
@@ -121,7 +134,8 @@ async def sync_activities(
             ),
         ),
     ] = _STREAM_FETCH_WINDOW_DAYS,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
     """
     Triggers a manual sync of the last `since_days` days of activities.
@@ -130,12 +144,10 @@ async def sync_activities(
     backfills summaries only (streams cost one Strava call each and would breach
     the rate limit over a long window); analysis still runs from the summary.
     """
-    if strava_athlete_id:
-        stmt = select(StravaAccount).where(StravaAccount.strava_athlete_id == strava_athlete_id)
-        account = db.execute(stmt).scalars().first()
-    else:
-        # Default: take the first account (Single Player Mode)
-        account = db.query(StravaAccount).first()
+    # P2.1: sync only the authenticated user's own Strava account.
+    account = db.execute(
+        select(StravaAccount).where(StravaAccount.user_id == user.id)
+    ).scalars().first()
 
     if not account:
         raise HTTPException(status_code=404, detail="No linked Strava account found. Connect Strava first.")
@@ -164,7 +176,8 @@ def read_activities(
     types: Optional[List[str]] = Query(None, description="Activity types to include (multi-select)"),
     start_date: Optional[date] = Query(None, description="Only activities on/after this date (UTC, inclusive)"),
     end_date: Optional[date] = Query(None, description="Only activities on/before this date (UTC, inclusive)"),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
     """
     Get stored activities (paginated), optionally filtered by type and date range (#404).
@@ -172,9 +185,9 @@ def read_activities(
     Filters apply server-side before pagination, so they narrow the whole history
     rather than only the rows already loaded by the client.
     """
-    # Note: In multi-user app, filter by current_user.id
     activities = activity_queries.get_activities(
-        db, skip=skip, limit=limit, types=types, start_date=start_date, end_date=end_date
+        db, skip=skip, limit=limit, user_id=user.id,
+        types=types, start_date=start_date, end_date=end_date,
     )
     responses = []
     for activity in activities:
@@ -188,10 +201,11 @@ def read_activities(
 
 @router.get("/activities/{activity_id}", response_model=ActivityDetailRead)
 def read_activity(
-    activity_id: UUID, 
-    db: Session = Depends(get_db)
+    activity_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
-    activity = activity_queries.get_activity(db, str(activity_id))
+    activity = activity_queries.get_activity(db, str(activity_id), user_id=user.id)
     if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
         
@@ -240,8 +254,11 @@ def read_activity(
 def create_checkin(
     activity_id: UUID,
     checkin_data: CheckInCreate,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
+    # P2.1: verify the activity is the user's before writing (404 otherwise).
+    _require_owned_activity(db, activity_id, user)
     # Shared with the Telegram inbound callback path (I1b) so both writes are
     # identical: upsert + re-analyze + conditional A4 fuller-turn trigger.
     return write_checkin(db, activity_id, checkin_data)

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -28,7 +28,14 @@ def strava_login():
 
 @router.get("/auth/strava/status", response_model=StravaConnectionStatus)
 def strava_status(db: Session = Depends(get_db)) -> StravaConnectionStatus:
-    """Reports whether a Strava account is linked, and surfaces the athlete id and token scope."""
+    """Reports whether a Strava account is linked, and surfaces the athlete id and token scope.
+
+    NOTE: the whole Strava OAuth surface (login/callback/status) is ADR-exempt
+    from the per-user session (ADR 0022 exempts /api/auth/*), so this stays
+    single-user (the first linked account) until the multi-user Strava-linking
+    follow-up threads the verified user through OAuth state. It returns no
+    training data; only the connection's athlete id and scope.
+    """
     account = db.execute(select(StravaAccount)).scalars().first()
     if account is None:
         return StravaConnectionStatus(connected=False)

--- a/backend/app/api/blocks.py
+++ b/backend/app/api/blocks.py
@@ -12,27 +12,41 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from app.core.clerk_auth import require_current_user
 from app.db.session import get_db
-from app.models import Activity, Block
+from app.models import Activity, Block, User
 from app.schemas.block import BlockMergeRequest, BlockRead, BlockSplitRequest
 from app.services.blocks import merge_blocks, split_block
 
 router = APIRouter()
 
 
-def _get_block(db: Session, block_id: uuid.UUID) -> Block:
-    block = db.query(Block).filter(Block.id == block_id).first()
+def _get_block(db: Session, block_id: uuid.UUID, user: User) -> Block:
+    # P2.1: a block of another user reads as not-found, so a correction can
+    # never reach across tenants.
+    block = (
+        db.query(Block)
+        .filter(Block.id == block_id, Block.user_id == user.id)
+        .first()
+    )
     if block is None:
         raise HTTPException(status_code=404, detail="Block not found")
     return block
 
 
 @router.post("/blocks/{block_id}/split", response_model=list[BlockRead])
-def split(block_id: uuid.UUID, request: BlockSplitRequest, db: Session = Depends(get_db)):
+def split(
+    block_id: uuid.UUID,
+    request: BlockSplitRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Split the block at the named member: it and every later member move to a
     new block. Returns both halves."""
-    block = _get_block(db, block_id)
-    activity = db.query(Activity).filter(Activity.id == request.activity_id).first()
+    block = _get_block(db, block_id, user)
+    activity = db.query(Activity).filter(
+        Activity.id == request.activity_id, Activity.user_id == user.id
+    ).first()
     if activity is None:
         raise HTTPException(status_code=404, detail="Activity not found")
     try:
@@ -43,11 +57,16 @@ def split(block_id: uuid.UUID, request: BlockSplitRequest, db: Session = Depends
 
 
 @router.post("/blocks/{block_id}/merge", response_model=BlockRead)
-def merge(block_id: uuid.UUID, request: BlockMergeRequest, db: Session = Depends(get_db)):
+def merge(
+    block_id: uuid.UUID,
+    request: BlockMergeRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Merge the named ADJACENT block into this one. Adjacency: no other block
     of the user lies between the two in time."""
-    block = _get_block(db, block_id)
-    other = _get_block(db, request.other_block_id)
+    block = _get_block(db, block_id, user)
+    other = _get_block(db, request.other_block_id, user)
 
     earlier, later = sorted([block, other], key=lambda b: b.start_date)
     between = (

--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -7,9 +7,11 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from app.api.profile import get_current_user_profile
+from app.core.clerk_auth import require_current_user
 from app.db.session import get_db
-from app.models import Activity, CoachingRelationship
+from app.models import Activity, CoachingRelationship, User
 from app.models.coach_report import CoachReport
+from app.services import activity_queries
 from app.schemas.chat import ChatHistoryResponse, ChatMessageSend
 from app.schemas.coach import CoachReportRead
 from app.schemas.voice import VoiceConfigRead, VoiceDials, build_catalog
@@ -45,14 +47,22 @@ def _sse_data(text: str) -> str:
     return f"data: {json.dumps(text)}\n\n"
 
 
-def _get_or_create_relationship(db: Session) -> CoachingRelationship:
-    """Resolve the current runner's coaching_relationship row, creating it if needed.
+def _require_owned_activity(db: Session, activity_id: UUID, user: User) -> Activity:
+    """404 unless the activity belongs to the authenticated user (P2.1)."""
+    activity = activity_queries.get_owned_activity(db, activity_id, user.id)
+    if activity is None:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    return activity
 
-    Reuses the profile helper's user resolution (Strava-linked user first), which
-    also auto-creates the thin relationship row the way it auto-creates the default
-    profile, so a runner who never edited their profile still has a row to read/write.
+
+def _get_or_create_relationship(db: Session, user: User) -> CoachingRelationship:
+    """Resolve the runner's coaching_relationship row, creating it if needed.
+
+    P2.1: scoped to the authenticated user. get_current_user_profile ensures the
+    thin relationship row exists (auto-created like the default profile), so a
+    runner who never edited their profile still has a row to read/write.
     """
-    profile = get_current_user_profile(db)
+    profile = get_current_user_profile(db, user)
     return (
         db.query(CoachingRelationship)
         .filter(CoachingRelationship.user_id == profile.user_id)
@@ -73,13 +83,20 @@ def _read_voice(relationship: CoachingRelationship) -> VoiceConfigRead:
 
 
 @router.get("/coach/voice", response_model=VoiceConfigRead)
-def get_voice(db: Session = Depends(get_db)):
+def get_voice(
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """The runner's declared coach voice plus the catalog the UI renders from."""
-    return _read_voice(_get_or_create_relationship(db))
+    return _read_voice(_get_or_create_relationship(db, user))
 
 
 @router.put("/coach/voice", response_model=VoiceConfigRead)
-def update_voice(voice_in: VoiceDials, db: Session = Depends(get_db)):
+def update_voice(
+    voice_in: VoiceDials,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Set the runner's declared coach voice (preset + four dials + free-text).
 
     Runner-sovereign (ADR 0012): this is the only writer of voice state — no
@@ -87,7 +104,7 @@ def update_voice(voice_in: VoiceDials, db: Session = Depends(get_db)):
     free-text is stored verbatim and framed as untrusted tone-data at prompt time,
     never as instructions.
     """
-    relationship = _get_or_create_relationship(db)
+    relationship = _get_or_create_relationship(db, user)
     relationship.voice_preset = voice_in.preset
     relationship.voice_warmth = voice_in.warmth
     relationship.voice_humor = voice_in.humor
@@ -122,20 +139,27 @@ def _read_stance(relationship: CoachingRelationship) -> StanceConfigRead:
 
 
 @router.get("/coach/stance", response_model=StanceConfigRead)
-def get_stance(db: Session = Depends(get_db)):
+def get_stance(
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """The runner's declared coaching stance plus the catalog the UI renders from."""
-    return _read_stance(_get_or_create_relationship(db))
+    return _read_stance(_get_or_create_relationship(db, user))
 
 
 @router.put("/coach/stance", response_model=StanceConfigRead)
-def update_stance(stance_in: StanceSelection, db: Session = Depends(get_db)):
+def update_stance(
+    stance_in: StanceSelection,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Set the runner's declared coaching stance (school + two emphasis dials).
 
     Runner-sovereign (ADR 0015): this is the only writer of stance state — no
     background job ever changes it. Stance reweights emphasis/method-framing only
     (ADR 0014/0015); it never overrides the run's measured data or the safety floor.
     """
-    relationship = _get_or_create_relationship(db)
+    relationship = _get_or_create_relationship(db, user)
     relationship.stance_school = stance_in.school
     relationship.stance_data_sentiment = stance_in.data_sentiment
     relationship.stance_process_outcome = stance_in.process_outcome
@@ -154,7 +178,10 @@ async def get_coach_report(
     generate: bool = Query(True, description="If false, only return cached report (404 if none)"),
     force: bool = Query(False, description="If true, regenerate the active-version report (prior versions retained)"),
     db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
+    # P2.1: the report rides an activity; deny if it is not the user's.
+    _require_owned_activity(db, activity_id, user)
     # Display-safe (#261): unless an explicit regenerate (force) was asked for,
     # prefer ANY cached report over a synchronous regeneration. A COACH_PROMPT_ID
     # flip (e.g. activating voice coach_message_v3) leaves prior-version reports
@@ -185,7 +212,11 @@ async def get_coach_report(
     "/activities/{activity_id}/coach-report/regenerate",
     status_code=202,
 )
-def regenerate_coach_report(activity_id: UUID, db: Session = Depends(get_db)):
+def regenerate_coach_report(
+    activity_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Kick off an asynchronous coach-report regeneration (#260).
 
     The two-stage generation is a 30-120s LLM call — far past the gateway timeout —
@@ -194,7 +225,11 @@ def regenerate_coach_report(activity_id: UUID, db: Session = Depends(get_db)):
     the GET endpoint for the fresh report. Returns 404 when the activity has no
     metrics to regenerate from.
     """
-    activity = db.query(Activity).filter(Activity.id == activity_id).first()
+    # P2.1: scope by owner; a cross-tenant activity is indistinguishable from one
+    # without metrics (both 404), leaking nothing.
+    activity = db.query(Activity).filter(
+        Activity.id == activity_id, Activity.user_id == user.id
+    ).first()
     if not activity or not activity.metrics:
         raise HTTPException(
             status_code=404,
@@ -226,15 +261,25 @@ def regenerate_coach_report(activity_id: UUID, db: Session = Depends(get_db)):
     "/activities/{activity_id}/coach-chat",
     response_model=ChatHistoryResponse,
 )
-def get_chat(activity_id: UUID, db: Session = Depends(get_db)):
+def get_chat(
+    activity_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Return conversation history for an activity."""
+    _require_owned_activity(db, activity_id, user)
     messages = get_chat_history(db, str(activity_id))
     return ChatHistoryResponse(messages=messages)
 
 
 @router.delete("/activities/{activity_id}/coach-chat", status_code=204)
-def delete_chat(activity_id: UUID, db: Session = Depends(get_db)):
+def delete_chat(
+    activity_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Clear conversation history for an activity."""
+    _require_owned_activity(db, activity_id, user)
     from app.models.coach_chat_message import CoachChatMessage
 
     db.query(CoachChatMessage).filter(
@@ -248,8 +293,11 @@ async def post_chat(
     activity_id: UUID,
     body: ChatMessageSend,
     db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
     """Send a message and stream the coach's response via SSE."""
+    # P2.1: deny before opening the stream if the activity is not the user's.
+    _require_owned_activity(db, activity_id, user)
     # Validate that a coach report exists
     existing = (
         db.query(CoachReport)

--- a/backend/app/api/materials.py
+++ b/backend/app/api/materials.py
@@ -30,9 +30,10 @@ from fastapi import (
 from sqlalchemy.orm import Session
 
 from app.api.profile import get_current_user_profile
+from app.core.clerk_auth import require_current_user
 from app.core.config import settings
 from app.db.session import get_db
-from app.models import UserMaterial
+from app.models import User, UserMaterial
 from app.schemas.material import MaterialKind, UserMaterialRead
 from app.services.coach.material_distiller import enqueue_distillation
 
@@ -69,6 +70,7 @@ async def upload_material(
     kind: MaterialKind = Form(...),
     title: Optional[str] = Form(None),
     db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
     """Accept one markdown coaching material, store the raw text, and kick off
     background distillation. Returns 202 with status=processing; the frontend polls
@@ -78,7 +80,7 @@ async def upload_material(
     re-uploads dedup on `content_hash`; re-uploading content that previously FAILED
     re-runs the distillation on the same row.
     """
-    profile = get_current_user_profile(db)
+    profile = get_current_user_profile(db, user)
     user_id = profile.user_id
 
     # Size cap, bounded read: read at most cap+1 bytes so an oversize file never
@@ -169,10 +171,11 @@ async def upload_material(
 def list_materials(
     include_archived: bool = False,
     db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
     """List the runner's materials, most recent first. Archived materials are
     excluded unless `include_archived=true`."""
-    profile = get_current_user_profile(db)
+    profile = get_current_user_profile(db, user)
     q = _owned_query(db, profile.user_id)
     if not include_archived:
         q = q.filter(UserMaterial.status != "archived")
@@ -180,9 +183,13 @@ def list_materials(
 
 
 @router.get("/coach/materials/{material_id}", response_model=UserMaterialRead)
-def get_material(material_id: UUID, db: Session = Depends(get_db)):
+def get_material(
+    material_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Fetch one material (the status-poll endpoint the frontend hits until active)."""
-    profile = get_current_user_profile(db)
+    profile = get_current_user_profile(db, user)
     material = (
         _owned_query(db, profile.user_id)
         .filter(UserMaterial.id == material_id)
@@ -194,10 +201,14 @@ def get_material(material_id: UUID, db: Session = Depends(get_db)):
 
 
 @router.post("/coach/materials/{material_id}/archive", response_model=UserMaterialRead)
-def archive_material(material_id: UUID, db: Session = Depends(get_db)):
+def archive_material(
+    material_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Soft-hide a material (status=archived). Reversible by re-uploading the same
     content; the distilled record is retained on the row."""
-    profile = get_current_user_profile(db)
+    profile = get_current_user_profile(db, user)
     material = (
         _owned_query(db, profile.user_id)
         .filter(UserMaterial.id == material_id)
@@ -213,9 +224,13 @@ def archive_material(material_id: UUID, db: Session = Depends(get_db)):
 
 
 @router.delete("/coach/materials/{material_id}", status_code=204)
-def delete_material(material_id: UUID, db: Session = Depends(get_db)):
+def delete_material(
+    material_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Hard-delete a material (raw text and distilled record removed)."""
-    profile = get_current_user_profile(db)
+    profile = get_current_user_profile(db, user)
     material = (
         _owned_query(db, profile.user_id)
         .filter(UserMaterial.id == material_id)

--- a/backend/app/api/strava_import.py
+++ b/backend/app/api/strava_import.py
@@ -4,23 +4,21 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from app.core.clerk_auth import require_current_user
 from app.db.session import get_db
-from app.models import StravaAccount, StravaImport
+from app.models import StravaAccount, StravaImport, User
 from app.schemas import StravaImportCreate, StravaImportRead
 
 router = APIRouter()
 
 
-def _resolve_account(db: Session, strava_athlete_id: Optional[int]) -> StravaAccount:
-    if strava_athlete_id:
-        account = (
-            db.query(StravaAccount)
-            .filter(StravaAccount.strava_athlete_id == strava_athlete_id)
-            .first()
-        )
-    else:
-        # Single-player mode: default to the only connected account.
-        account = db.query(StravaAccount).first()
+def _resolve_account(db: Session, user: User) -> StravaAccount:
+    # P2.1: the authenticated user's own Strava account, never the first found.
+    account = (
+        db.query(StravaAccount)
+        .filter(StravaAccount.user_id == user.id)
+        .first()
+    )
     if not account:
         raise HTTPException(
             status_code=404,
@@ -32,8 +30,8 @@ def _resolve_account(db: Session, strava_athlete_id: Optional[int]) -> StravaAcc
 @router.post("/strava/import", response_model=StravaImportRead)
 def start_import(
     payload: StravaImportCreate,
-    strava_athlete_id: Optional[int] = None,
     db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
     """Start a resumable historical Strava import from `since_date` to today.
 
@@ -45,7 +43,7 @@ def start_import(
     if payload.since_date > date.today():
         raise HTTPException(status_code=400, detail="since_date cannot be in the future.")
 
-    account = _resolve_account(db, strava_athlete_id)
+    account = _resolve_account(db, user)
 
     from app.jobs.strava_import import enqueue_import
 
@@ -55,14 +53,14 @@ def start_import(
 
 @router.get("/strava/import/status", response_model=Optional[StravaImportRead])
 def import_status(
-    strava_athlete_id: Optional[int] = None,
     db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
     """Return the most recent historical import for the account, or null if none.
 
     The frontend polls this to show import progress and the final summary.
     """
-    account = _resolve_account(db, strava_athlete_id)
+    account = _resolve_account(db, user)
     latest = (
         db.query(StravaImport)
         .filter(StravaImport.user_id == account.user_id)

--- a/backend/app/api/trends.py
+++ b/backend/app/api/trends.py
@@ -7,8 +7,9 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
-from app.api.profile import get_current_user_profile
+from app.core.clerk_auth import require_current_user
 from app.db.session import get_db
+from app.models import User
 from app.schemas.trends import (
     LoadResponse,
     TrendsResponse,
@@ -27,10 +28,12 @@ router = APIRouter()
 
 
 @router.get("/trends/types", response_model=List[str])
-def list_activity_types(db: Session = Depends(get_db)):
+def list_activity_types(
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Return distinct activity types available for filtering."""
-    user_id = get_current_user_profile(db).user_id
-    return get_available_types(db, user_id=user_id)
+    return get_available_types(db, user_id=user.id)
 
 
 @router.get("/trends", response_model=TrendsResponse)
@@ -39,15 +42,18 @@ def get_trends(
     types: Optional[List[str]] = Query(None, description="Activity types to include (multi-select)"),
     mode: str = Query("rolling", description="Window framing: rolling | calendar (#400)"),
     db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
-    user_id = get_current_user_profile(db).user_id
-    return get_trends_report(db, range, types, user_id=user_id, mode=mode)
+    return get_trends_report(db, range, types, user_id=user.id, mode=mode)
 
 
 @router.get("/trends/load", response_model=LoadResponse)
-def get_training_load(db: Session = Depends(get_db)):
+def get_training_load(
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Weekly training-load report: scores, optimal band, contributions (#209)."""
-    return get_load_report(db)
+    return get_load_report(db, user_id=user.id)
 
 
 @router.get("/trends/volume", response_model=VolumeReport)
@@ -55,18 +61,20 @@ def get_volume(
     range: str = Query("7D", description="7D | 30D | 3M | 6M | 1Y"),
     types: Optional[List[str]] = Query(None, description="Activity types to include (multi-select)"),
     db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
 ):
     """Frequency-/volume-vs-norm report for the selected range, as of today:
     per-metric current vs the runner's norm, in rolling and calendar-period
     framings scaled to the range (#400). ``types`` scopes both the window and the
     norm baseline so the comparison stays like-for-like with the filtered Trends
     charts (#413)."""
-    user_id = get_current_user_profile(db).user_id
-    return get_volume_report(db, user_id, range, types=types)
+    return get_volume_report(db, user.id, range, types=types)
 
 
 @router.get("/stats/weekly", response_model=WeeklyStatsResponse)
-def get_dashboard_weekly_stats(db: Session = Depends(get_db)):
+def get_dashboard_weekly_stats(
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
     """Rolling 7-day dashboard summary with the prior 7 days for comparison (#246, #248)."""
-    user_id = get_current_user_profile(db).user_id
-    return get_weekly_stats(db, user_id=user_id)
+    return get_weekly_stats(db, user_id=user.id)

--- a/backend/app/core/clerk_auth.py
+++ b/backend/app/core/clerk_auth.py
@@ -336,3 +336,29 @@ def verify_clerk_session(
         ) from exc
 
     return resolve_user_by_email(db, email)
+
+
+def require_current_user(
+    user: Optional[User] = Depends(verify_clerk_session),
+    db: Session = Depends(get_db),
+) -> User:
+    """The authenticated user, guaranteed non-None — the P2.1 scoping anchor.
+
+    Clerk mode: verify_clerk_session has already resolved the user (or raised
+    401), so it is non-None. Degrade mode (Clerk unconfigured, non-production):
+    returns the single local user, creating the default one for a fresh local DB
+    (preserving the legacy auto-create convenience for local dev + the test
+    suite). Endpoints scope every query to this user's id.
+    """
+    if user is not None:
+        return user
+    if settings.clerk_enabled:
+        # Defensive: verify_clerk_session would already have raised.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
+    new_user = User(email="local@runner.com")
+    db.add(new_user)
+    db.commit()
+    db.refresh(new_user)
+    return new_user

--- a/backend/app/services/activity_queries.py
+++ b/backend/app/services/activity_queries.py
@@ -12,6 +12,7 @@ def get_activities(
     skip: int = 0,
     limit: int = 20,
     *,
+    user_id: uuid.UUID,
     types: list[str] | None = None,
     start_date: date | None = None,
     end_date: date | None = None,
@@ -44,6 +45,9 @@ def get_activities(
         # Exclude soft-deleted activities (#410), consistent with every other
         # read path (trends, readiness, training load, coach context/retrieval).
         .filter(Activity.is_deleted == False)  # noqa: E712
+        # P2.1: scope to the authenticated user. A missing user_id filter here is
+        # a cross-tenant list leak, so user_id is a required argument.
+        .filter(Activity.user_id == user_id)
     )
     if types:
         query = query.filter(Activity.type.in_(types))
@@ -65,11 +69,16 @@ def get_activities(
     )
 
 
-def get_activity(db: Session, activity_id: str | uuid.UUID) -> Activity | None:
+def get_activity(
+    db: Session,
+    activity_id: str | uuid.UUID,
+    *,
+    user_id: uuid.UUID | None = None,
+) -> Activity | None:
     # Bind a real UUID: Postgres adapts a string, but SQLite (tests) does not.
     if isinstance(activity_id, str):
         activity_id = uuid.UUID(activity_id)
-    return (
+    query = (
         db.query(Activity)
         .options(
             joinedload(Activity.metrics),
@@ -83,5 +92,30 @@ def get_activity(db: Session, activity_id: str | uuid.UUID) -> Activity | None:
         # A soft-deleted activity reads as not-present (#410): the detail view
         # 404s on it, consistent with the list and every other read path.
         .filter(Activity.is_deleted == False)  # noqa: E712
+    )
+    # P2.1: when a user_id is supplied, another user's activity reads as absent
+    # (the endpoint then 404s) rather than leaking across tenants.
+    if user_id is not None:
+        query = query.filter(Activity.user_id == user_id)
+    return query.first()
+
+
+def get_owned_activity(
+    db: Session, activity_id: str | uuid.UUID, user_id: uuid.UUID
+) -> Activity | None:
+    """A lean ownership check: the activity by id IF it belongs to ``user_id``.
+
+    Returns None when the activity does not exist OR belongs to another user, so
+    the calling endpoint raises one 404 for both and leaks nothing about other
+    tenants' activities. No eager loads — callers that need the full graph use
+    get_activity. Soft-deleted state is intentionally not filtered here: this is
+    an ownership gate for the coach/checkin/intent write paths, which must reach
+    the same set of activities they did pre-P2.1 for the owning user.
+    """
+    if isinstance(activity_id, str):
+        activity_id = uuid.UUID(activity_id)
+    return (
+        db.query(Activity)
+        .filter(Activity.id == activity_id, Activity.user_id == user_id)
         .first()
     )

--- a/backend/app/services/training_load.py
+++ b/backend/app/services/training_load.py
@@ -128,7 +128,10 @@ def build_load_report(
     return LoadResponse(weeks=weeks)
 
 
-def get_load_report(db: Session, today: Optional[date] = None) -> LoadResponse:
+def get_load_report(
+    db: Session, *, user_id, today: Optional[date] = None
+) -> LoadResponse:
+    # P2.1: user_id is required so the weekly-load scan can never span tenants.
     # Bound the scan to the served window (#362). build_load_report only keeps
     # weeks from `earliest_served` onward, so an activity older than that Monday
     # is discarded anyway — fetching it was wasted work on an unbounded
@@ -162,6 +165,7 @@ def get_load_report(db: Session, today: Optional[date] = None) -> LoadResponse:
             DerivedMetric.is_race,
         )
         .join(DerivedMetric, DerivedMetric.activity_id == Activity.id)
+        .filter(Activity.user_id == user_id)
         .filter(Activity.is_deleted.is_(False))
         .filter(Activity.start_date >= earliest_served)
         # Deterministic chronological order. build_load_report sorts members
@@ -183,6 +187,7 @@ def get_load_report(db: Session, today: Optional[date] = None) -> LoadResponse:
     older_exists = (
         db.query(Activity.id)
         .join(DerivedMetric, DerivedMetric.activity_id == Activity.id)
+        .filter(Activity.user_id == user_id)
         .filter(Activity.is_deleted.is_(False))
         .filter(Activity.start_date < earliest_served)
         .first()

--- a/backend/tests/test_activity_list_filters.py
+++ b/backend/tests/test_activity_list_filters.py
@@ -21,9 +21,16 @@ def _make_activity(
     start_local: datetime | None = None,
     is_deleted: bool = False,
 ) -> Activity:
-    user_id = uuid.uuid4()
-    db.add(User(id=user_id, email=f"filt_{user_id}@example.com"))
-    db.flush()
+    # P2.1: the list endpoint now scopes to the authenticated user, which the
+    # test harness resolves to the single seeded user. Share one user across a
+    # test's activities (reuse the first) so they all belong to that user and the
+    # scoped list still returns the whole seeded history.
+    user = db.query(User).first()
+    if user is None:
+        user = User(id=uuid.uuid4(), email=f"filt_{uuid.uuid4()}@example.com")
+        db.add(user)
+        db.flush()
+    user_id = user.id
     a = Activity(
         id=uuid.uuid4(),
         user_id=user_id,

--- a/backend/tests/test_raw_summary_deferred.py
+++ b/backend/tests/test_raw_summary_deferred.py
@@ -131,7 +131,7 @@ def _list_query_count(db, n_activities: int) -> int:
         _seed_activity(db, uid, days_ago=i + 1)
     db.expire_all()
     with _capture(db) as cap:
-        activities = activity_queries.get_activities(db, limit=100)
+        activities = activity_queries.get_activities(db, limit=100, user_id=uid)
         # replicate the endpoint's per-item headline composition (reads raw_summary)
         for act in activities:
             if act.metrics:

--- a/backend/tests/test_tenant_isolation.py
+++ b/backend/tests/test_tenant_isolation.py
@@ -1,0 +1,231 @@
+"""P2.1 tenant-isolation negative contract (#119).
+
+The new security contract for multi-user: a request authenticated as user A must
+never read or mutate user B's data. These tests seed two independent users with a
+full data graph each, authenticate as one, and assert that the other's resources
+are DENIED (404) -- not served. The existing single-user suite is the positive
+oracle (behaviour preserved for the owning user); this file is the negative one.
+
+Auth is injected by overriding verify_clerk_session (the resolution itself is
+covered by test_clerk_auth); here we pin the QUERY scoping that rides on top.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.core.clerk_auth import verify_clerk_session
+from app.main import app
+from app.models import (
+    Activity,
+    Block,
+    CheckIn,
+    DerivedMetric,
+    StravaAccount,
+    User,
+    UserMaterial,
+    UserProfile,
+)
+from app.models.coach_chat_message import CoachChatMessage
+from app.models.coach_report import CoachReport
+
+
+def _seed_user(db, *, email, athlete_id, strava_activity_id, atype, hash_suffix):
+    """A full per-user data graph: user, profile, Strava account, activity (+
+    metric, report, chat), a block, and an uploaded material."""
+    user = User(email=email)
+    db.add(user)
+    db.commit()
+    db.add(UserProfile(
+        user_id=user.id, goal_type="general", experience_level="intermediate",
+        weekly_days_available=4, max_hr=190,
+    ))
+    db.add(StravaAccount(
+        user_id=user.id, strava_athlete_id=athlete_id, access_token="t",
+        refresh_token="r", expires_at=9999999999, scope="read",
+    ))
+    activity = Activity(
+        user_id=user.id, strava_activity_id=strava_activity_id,
+        start_date=datetime(2026, 5, 27, 10, 0, 0), type=atype, name=f"{atype} run",
+        distance_m=5000, moving_time_s=1500, elapsed_time_s=1500, elev_gain_m=10.0,
+        avg_hr=140, raw_summary={},
+    )
+    db.add(activity)
+    db.commit()
+    db.add(DerivedMetric(
+        activity_id=activity.id, effort="easy", structure="continuous",
+        duration_class="standard", effort_score=50.0, flags=[],
+        confidence="medium", confidence_reasons=[],
+    ))
+    db.add(CoachReport(
+        activity_id=activity.id,
+        report={"message": "Nice run.", "headline": "ok", "next_steps": [],
+                "risks": [], "questions": []},
+        meta={"confidence": "medium", "model_id": "m", "prompt_id": "x",
+              "schema_version": "2.0", "input_hash": "x",
+              "generated_at": datetime.now(timezone.utc).isoformat(), "policy_violations": []},
+        context_pack={}, prompt_id="x", schema_version="2.0", is_fallback=False,
+    ))
+    db.add(CoachChatMessage(activity_id=activity.id, role="user", content="hi"))
+    block = Block(
+        user_id=user.id, start_date=activity.start_date,
+        end_date=activity.start_date + timedelta(seconds=1500),
+        primary_activity_id=activity.id,
+    )
+    db.add(block)
+    db.add(UserMaterial(
+        user_id=user.id, kind="other", title="mine", filename="m.md",
+        raw_text="private", content_hash=f"hash-{hash_suffix}", status="active",
+    ))
+    db.commit()
+    db.refresh(activity)
+    db.refresh(block)
+    return SimpleNamespace(user=user, activity=activity, block=block)
+
+
+@pytest.fixture
+def two_users(db):
+    a = _seed_user(db, email="a@test.dev", athlete_id=101, strava_activity_id=1001,
+                   atype="Run", hash_suffix="a")
+    b = _seed_user(db, email="b@test.dev", athlete_id=202, strava_activity_id=2002,
+                   atype="Ride", hash_suffix="b")
+    yield a, b
+
+
+def _act_as(user):
+    app.dependency_overrides[verify_clerk_session] = lambda: user
+
+
+# --- reads -----------------------------------------------------------------
+
+def test_list_returns_only_own_activities(client, two_users):
+    a, b = two_users
+    _act_as(a.user)
+    resp = client.get("/api/activities")
+    assert resp.status_code == 200
+    ids = {row["id"] for row in resp.json()}
+    assert str(a.activity.id) in ids
+    assert str(b.activity.id) not in ids
+
+
+def test_detail_of_other_users_activity_is_404(client, two_users):
+    a, b = two_users
+    _act_as(a.user)
+    assert client.get(f"/api/activities/{b.activity.id}").status_code == 404
+    assert client.get(f"/api/activities/{a.activity.id}").status_code == 200
+
+
+def test_coach_report_of_other_user_is_404(client, two_users):
+    a, b = two_users
+    _act_as(a.user)
+    assert client.get(
+        f"/api/activities/{b.activity.id}/coach-report?generate=false"
+    ).status_code == 404
+    assert client.get(
+        f"/api/activities/{a.activity.id}/coach-report?generate=false"
+    ).status_code == 200
+
+
+def test_chat_history_of_other_user_is_404(client, two_users):
+    a, b = two_users
+    _act_as(a.user)
+    assert client.get(
+        f"/api/activities/{b.activity.id}/coach-chat"
+    ).status_code == 404
+
+
+def test_trends_types_scoped_to_own_activities(client, two_users):
+    a, b = two_users
+    _act_as(a.user)
+    types = client.get("/api/trends/types").json()
+    assert "Run" in types
+    assert "Ride" not in types  # B's Ride must not leak
+
+
+# --- writes ----------------------------------------------------------------
+
+def test_intent_write_on_other_users_activity_is_404(client, two_users, db):
+    a, b = two_users
+    _act_as(a.user)
+    resp = client.put(
+        f"/api/activities/{b.activity.id}/intent", json={"user_intent": "hard"}
+    )
+    assert resp.status_code == 404
+    db.refresh(b.activity)
+    assert b.activity.user_intent != "hard"
+
+
+def test_checkin_on_other_users_activity_is_404(client, two_users, db):
+    a, b = two_users
+    _act_as(a.user)
+    resp = client.post(
+        f"/api/activities/{b.activity.id}/checkin", json={"rpe": 9}
+    )
+    assert resp.status_code == 404
+    assert db.query(CheckIn).filter(CheckIn.activity_id == b.activity.id).count() == 0
+
+
+def test_process_deep_on_other_users_activity_is_404(client, two_users):
+    a, b = two_users
+    _act_as(a.user)
+    assert client.post(
+        f"/api/activities/{b.activity.id}/process_deep"
+    ).status_code == 404
+
+
+def test_regenerate_report_on_other_users_activity_is_404(client, two_users):
+    a, b = two_users
+    _act_as(a.user)
+    assert client.post(
+        f"/api/activities/{b.activity.id}/coach-report/regenerate"
+    ).status_code == 404
+
+
+def test_delete_chat_on_other_users_activity_is_404(client, two_users, db):
+    a, b = two_users
+    _act_as(a.user)
+    resp = client.delete(f"/api/activities/{b.activity.id}/coach-chat")
+    assert resp.status_code == 404
+    # B's chat is intact.
+    assert db.query(CoachChatMessage).filter(
+        CoachChatMessage.activity_id == b.activity.id
+    ).count() == 1
+
+
+def test_post_chat_on_other_users_activity_is_404(client, two_users):
+    a, b = two_users
+    _act_as(a.user)
+    resp = client.post(
+        f"/api/activities/{b.activity.id}/coach-chat", json={"message": "hi"}
+    )
+    assert resp.status_code == 404
+
+
+def test_block_split_on_other_users_block_is_404(client, two_users):
+    a, b = two_users
+    _act_as(a.user)
+    resp = client.post(
+        f"/api/blocks/{b.block.id}/split",
+        json={"activity_id": str(b.activity.id)},
+    )
+    assert resp.status_code == 404
+
+
+def test_block_merge_on_other_users_block_is_404(client, two_users):
+    a, b = two_users
+    _act_as(a.user)
+    resp = client.post(
+        f"/api/blocks/{a.block.id}/merge",
+        json={"other_block_id": str(b.block.id)},
+    )
+    # A owns the path block but not the other; merging across tenants must deny.
+    assert resp.status_code == 404
+
+
+def test_material_of_other_user_is_404(client, two_users, db):
+    a, b = two_users
+    _act_as(a.user)
+    b_material = db.query(UserMaterial).filter(UserMaterial.user_id == b.user.id).first()
+    assert client.get(f"/api/coach/materials/{b_material.id}").status_code == 404

--- a/backend/tests/test_training_load.py
+++ b/backend/tests/test_training_load.py
@@ -234,6 +234,6 @@ def test_same_day_activities_are_ordered_chronologically(db):
     _run("OrdTest-Mid", 12)
     db.commit()
 
-    resp = get_load_report(db, today=day.date())
+    resp = get_load_report(db, user_id=user_id, today=day.date())
     names = [a.name for w in resp.weeks for a in w.activities if a.name.startswith("OrdTest")]
     assert names == ["OrdTest-Early", "OrdTest-Mid", "OrdTest-Late"]


### PR DESCRIPTION
Part of the Phase 2 multi-user epic (#67). Implements **P2.1 — tenant-safe data isolation sweep**, the highest-risk phase: every read/write is scoped to the authenticated `user_id`, and a request for another user's resource is **denied (404), not served**.

> **Stacked on #468 (P2.0).** This branches off `feat/p2.0-clerk-auth` because it needs P2.0's `verify_clerk_session`/`require_current_user`. The base is set to the P2.0 branch so this PR's diff shows only the P2.1 changes. Merge #468 first; GitHub will retarget this to `main`. Built unattended; **do not merge yet.**

## What changed

- **`require_current_user`** (in `app/core/clerk_auth.py`): the guaranteed-non-None authenticated user — the scoping anchor every application endpoint now takes. In the Clerk-disabled degrade path it resolves the single local user (local dev + tests unchanged).
- **`activity_queries`**: `get_activities` now **requires** `user_id`; `get_activity` takes an optional `user_id`; new `get_owned_activity` ownership gate.
- **Endpoints scoped / ownership-checked** (a cross-tenant id is indistinguishable from a missing one — same 404, nothing leaks):
  - `activities`: list, detail, intent, checkin, process_deep, sync (own Strava account only)
  - `coach`: report GET, regenerate, chat GET/DELETE/POST, voice, stance
  - `trends`: types, trends, load, volume, weekly-stats
  - `blocks`: split, merge (both blocks must be the user's)
  - `materials`: all five (already `_owned_query`-scoped; now resolves the authenticated user)
  - `strava_import`: start, status
  - `training_load.get_load_report`: requires `user_id`, scopes both scans
- **No migration**: the `user_id` filter is already served by the existing composite index `(user_id, start_date, is_deleted)` from #360 (whose migration even notes it is "load-bearing for the imminent multi-user"). Alembic head unchanged.

## How it was built

1. A read-only **6-agent audit** mapped every cross-tenant query site across all routers + key services (kept the conclusion, not the file dumps).
2. **TDD**: `tests/test_tenant_isolation.py` (14 tests) was written **first** and confirmed red (12 real leaks + 2 coincidental passes), then the scoping made it green.

## Decisions made (owner unreachable — recommended option taken)

1. **Ownership at the API boundary, not threaded through every service.** Most service-layer "leak" findings (coach report lookups, chat, retrieval) operate on an `activity_id`; the endpoint verifies the user owns that activity before delegating. The endpoint is the trust boundary; the deeper functions are reached only for owned activities. Threading `user_id` through the whole analysis/coach pipeline would be a large change with regression risk and is deferred as defense-in-depth.
2. **Strava OAuth surface stays single-user.** ADR 0022 exempts `/api/auth/*` from the per-user session, so `login`/`callback`/`status` cannot carry one. `strava_status` returns only a connection's athlete id + scope (no training data). The whole multi-user Strava treatment is the deferred #469.
3. **Backfill/reanalyze maintenance jobs left global** (auth-gated, return no cross-tenant data). Per-user scoping touches the jobs' rate-limit/pacing plumbing and their test surface; deferred to #470 to keep this PR's high-risk user-facing isolation reviewable.

## Verification

- **Full backend suite: 1631 passed** (1617 + 14 new), 0 regressions, integration excluded — the single-user positive oracle is intact.
- **Negative contract**: 14 cross-user-denial tests, written red-first, now green. Auth is injected by overriding `verify_clerk_session` (resolution itself is covered by P2.0's `test_clerk_auth`); these pin the query scoping that rides on top.
- **No new migration**; alembic single head unchanged.

**Not covered (scoped):** two-real-user runtime e2e (no second real user yet, per the phase plan — do not onboard one until P2.1 + P2.3 land); the deferred items in Decisions 2–3 (#469, #470).

Closes #119 once merged.
