### PR TITLE
P2.2: per-user LLM cost cap — structural budget gate + regenerate cooldown (#122)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -67,6 +67,20 @@ COACH_MODEL_ID=claude-sonnet-4-20250514
 # inert; a startup warning fires if it is not (#424). Production runs coach_message_v8.
 COACH_PROMPT_ID=coach_message_v8
 
+# --- Per-user LLM cost cap (P2.2, Ring 3) ---
+# A Redis-backed running spend counter degrades coach generation to the
+# deterministic fallback once a window is at/over its USD ceiling, so one user
+# can never drain the shared Anthropic budget. 0 disables that window (all-zero
+# = no cap, the safe default until the owner sets real dollar numbers).
+LLM_BUDGET_USER_DAILY_USD=0
+LLM_BUDGET_USER_MONTHLY_USD=0
+LLM_BUDGET_GLOBAL_DAILY_USD=0
+LLM_BUDGET_GLOBAL_MONTHLY_USD=0
+# Min seconds between on-demand coach-report regenerations for one activity; the
+# regenerate endpoint is the most exposed cost lever, so rapid re-taps are
+# deduped by an atomic Redis cooldown + a deterministic per-activity job id.
+COACH_REGEN_COOLDOWN_SECONDS=60
+
 # --- Email notifications (post-run coach report) ---
 # Leave SMTP_HOST empty to disable email delivery entirely.
 SMTP_HOST=

--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -241,6 +241,25 @@ def regenerate_coach_report(
     from app.core.queue import queue
     from app.jobs.process_new_activity import PIPELINE_RETRY, regenerate_report_job
 
+    # P2.2 / going-live landmine 1: the regenerate endpoint is the single most
+    # exposed cost lever — a stuck "Regenerate" button can fan out full two-stage
+    # LLM generations. A per-activity cooldown (atomic Redis SET NX EX) dedups
+    # rapid re-taps: the first within the window acquires the key and enqueues;
+    # later taps short-circuit. A deterministic job id makes RQ collapse any
+    # racing enqueue onto one job rather than queuing duplicates. The cooldown
+    # degrades open (enqueues) if Redis is unreachable — a cost guard must never
+    # block a legitimate single regeneration.
+    cooldown_key = f"coach_regen_cooldown:{activity_id}"
+    job_id = f"coach-regenerate:{activity_id}"
+    try:
+        acquired = queue.connection.set(
+            cooldown_key, "1", nx=True, ex=settings.COACH_REGEN_COOLDOWN_SECONDS,
+        )
+    except Exception:  # noqa: BLE001 — Redis blip must not block regeneration
+        acquired = True
+    if not acquired:
+        return {"status": "cooldown"}
+
     # job_timeout (#264): the two-stage regeneration runs ~120-360s, past RQ's 180s
     # default; without this the worker's death penalty kills it before it stores the
     # report. (The queue default_timeout also covers it; explicit here documents it.)
@@ -251,6 +270,7 @@ def regenerate_coach_report(
     # RQ level rather than silently leaving the runner with a stale fallback report.
     queue.enqueue(
         regenerate_report_job, str(activity_id),
+        job_id=job_id,
         job_timeout=settings.RQ_JOB_TIMEOUT_SECONDS,
         retry=PIPELINE_RETRY,
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -30,6 +30,25 @@ class Settings(BaseSettings):
     # Coach AI
     ANTHROPIC_API_KEY: str = ""
     COACH_MODEL_ID: str = "claude-sonnet-4-6"
+
+    # Per-user LLM cost cap (P2.2, #122, Ring 3 of docs/vision/going-live-cost-control.md).
+    # A Redis-backed running spend counter degrades coach generation to the
+    # deterministic is_fallback path once a window is at or over its dollar
+    # ceiling, so one user can never drain the shared Anthropic budget. Each
+    # ceiling is a USD amount; 0 disables that window (so all-zero defaults are a
+    # no-op until the owner sets real numbers — the owner owns the real dollars).
+    # Per-user windows cap any single runner; the global windows cap the whole
+    # deployment. See app/services/coach/budget.py.
+    LLM_BUDGET_USER_DAILY_USD: float = 0.0
+    LLM_BUDGET_USER_MONTHLY_USD: float = 0.0
+    LLM_BUDGET_GLOBAL_DAILY_USD: float = 0.0
+    LLM_BUDGET_GLOBAL_MONTHLY_USD: float = 0.0
+    # Minimum seconds between on-demand coach-report regenerations for one
+    # activity (#122 / going-live landmine 1). The regenerate endpoint is the
+    # single most exposed cost lever (it enqueues a full two-stage generation);
+    # this cooldown plus a deterministic per-activity job id dedups rapid
+    # re-taps so a stuck "Regenerate" button cannot fan out LLM spend.
+    COACH_REGEN_COOLDOWN_SECONDS: int = 60
     # The active coach prompt. The default tracks the production prompt (see
     # project-context.md), NOT a legacy non-feature-bearing id: a prompt that
     # carries none of the runner-facing coaching features (voice/corpus/stance/

--- a/backend/app/services/coach/budget.py
+++ b/backend/app/services/coach/budget.py
@@ -1,0 +1,218 @@
+"""Per-user LLM cost cap — the Ring 3 structural budget gate (P2.2, #122).
+
+The owner's #1 going-live concern is that one user (abusive or buggy) can drain
+the shared Anthropic budget. This is the structural cap: a Redis-backed running
+spend counter checked BEFORE every coach generation and incremented after every
+sub-call (so the multiplicative retry fan-out is counted, not just the first
+call). At the cap, generation DEGRADES to the existing deterministic fallback
+(`is_fallback=True`) rather than hard-blocking — the product still ships a
+report, it just isn't the LLM one. One user hitting the cap never affects
+another: the per-user counter is keyed by activity-owner `user_id`.
+
+Windows: a daily and a monthly counter, per-user and global. Each ceiling is a
+configurable dollar amount (0 = that window disabled). Over-budget is true when
+ANY enabled window is at or over its ceiling.
+
+Backend: Redis when reachable (cross-process — the worker generates reports),
+else an in-process dict (local dev + the test suite, where Redis may be absent).
+The gate degrades to a permissive no-op if the backend errors, so a Redis blip
+never breaks generation — a cost cap must never become an availability risk.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from typing import Dict, Optional
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Per-MTok (input, output) USD list price, kept in sync with the model the coach
+# runs (COACH_MODEL_ID). Unknown models price as Opus (the most expensive tier)
+# so a misconfiguration over-counts rather than under-counts.
+PRICE_PER_MTOK: Dict[str, tuple[float, float]] = {
+    "claude-opus-4-8": (5.0, 25.0),
+    "claude-opus-4-7": (5.0, 25.0),
+    "claude-opus-4-6": (5.0, 25.0),
+    "claude-opus-4-5": (5.0, 25.0),
+    "claude-sonnet-4-6": (3.0, 15.0),
+    "claude-sonnet-4-5": (3.0, 15.0),
+    "claude-haiku-4-5": (1.0, 5.0),
+    "claude-fable-5": (10.0, 50.0),
+}
+_DEFAULT_PRICE = (5.0, 25.0)  # conservative: assume Opus tier when unknown
+
+
+def cost_usd(model: str, input_tokens: int, output_tokens: int) -> float:
+    """List-price cost of one call in USD."""
+    price_in, price_out = PRICE_PER_MTOK.get(model, _DEFAULT_PRICE)
+    return (input_tokens * price_in + output_tokens * price_out) / 1_000_000
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _day_key(d: date) -> str:
+    return d.isoformat()
+
+
+def _month_key(d: date) -> str:
+    return d.strftime("%Y-%m")
+
+
+@dataclass
+class _InMemoryBackend:
+    """A process-local spend accumulator (tests + local dev without Redis)."""
+    spend: Dict[str, float] = field(default_factory=dict)
+
+    def incr(self, key: str, amount: float, ttl_seconds: int) -> None:
+        self.spend[key] = self.spend.get(key, 0.0) + amount
+
+    def get(self, key: str) -> float:
+        return self.spend.get(key, 0.0)
+
+
+class _RedisBackend:
+    """Cross-process spend accumulator. INCRBYFLOAT + EXPIRE per window key."""
+
+    def __init__(self, client) -> None:
+        self._r = client
+
+    def incr(self, key: str, amount: float, ttl_seconds: int) -> None:
+        pipe = self._r.pipeline()
+        pipe.incrbyfloat(key, amount)
+        pipe.expire(key, ttl_seconds)
+        pipe.execute()
+
+    def get(self, key: str) -> float:
+        raw = self._r.get(key)
+        return float(raw) if raw is not None else 0.0
+
+
+# Keep a day's and a month's counters alive a little past their window so a
+# late-night call still sees the day's accrued spend.
+_DAILY_TTL = 60 * 60 * 36          # 36h
+_MONTHLY_TTL = 60 * 60 * 24 * 40   # 40d
+
+
+class BudgetGate:
+    """The spend gate. Reads ceilings from settings at call time so a config flip
+    (or a test monkeypatch) takes effect without rebuilding the gate."""
+
+    _PREFIX = "coach_budget"
+
+    def __init__(self, backend) -> None:
+        self._backend = backend
+
+    # --- ceilings (read live from settings) ---
+    @property
+    def _user_daily(self) -> float:
+        return settings.LLM_BUDGET_USER_DAILY_USD
+
+    @property
+    def _user_monthly(self) -> float:
+        return settings.LLM_BUDGET_USER_MONTHLY_USD
+
+    @property
+    def _global_daily(self) -> float:
+        return settings.LLM_BUDGET_GLOBAL_DAILY_USD
+
+    @property
+    def _global_monthly(self) -> float:
+        return settings.LLM_BUDGET_GLOBAL_MONTHLY_USD
+
+    def _key(self, scope: str, window: str) -> str:
+        return f"{self._PREFIX}:{scope}:{window}"
+
+    def over_budget(self, user_id) -> bool:
+        """True when any enabled window is at or over its ceiling. Errors degrade
+        to False (permissive) so the cap never becomes an availability risk."""
+        today = _now().date()
+        day, month = _day_key(today), _month_key(today)
+        uid = str(user_id)
+        try:
+            checks = [
+                (self._user_daily, self._key(f"user:{uid}", day)),
+                (self._user_monthly, self._key(f"user:{uid}", month)),
+                (self._global_daily, self._key("global", day)),
+                (self._global_monthly, self._key("global", month)),
+            ]
+            for ceiling, key in checks:
+                if ceiling > 0 and self._backend.get(key) >= ceiling:
+                    logger.warning(
+                        "llm_budget_exceeded", extra={"key": key, "ceiling": ceiling}
+                    )
+                    return True
+            return False
+        except Exception as exc:  # noqa: BLE001 — a cap must not break availability
+            logger.warning("llm_budget_check_failed", extra={"error": str(exc)})
+            return False
+
+    def record(self, user_id, model: str, input_tokens: int, output_tokens: int) -> None:
+        """Add one call's list-price cost to the user's and the global windows."""
+        amount = cost_usd(model, input_tokens, output_tokens)
+        if amount <= 0:
+            return
+        today = _now().date()
+        day, month = _day_key(today), _month_key(today)
+        uid = str(user_id)
+        try:
+            self._backend.incr(self._key(f"user:{uid}", day), amount, _DAILY_TTL)
+            self._backend.incr(self._key(f"user:{uid}", month), amount, _MONTHLY_TTL)
+            self._backend.incr(self._key("global", day), amount, _DAILY_TTL)
+            self._backend.incr(self._key("global", month), amount, _MONTHLY_TTL)
+        except Exception as exc:  # noqa: BLE001 — recording must never break generation
+            logger.warning("llm_budget_record_failed", extra={"error": str(exc)})
+
+
+# --- module-level gate (lazy, swappable in tests) --------------------------
+
+_gate: Optional[BudgetGate] = None
+_gate_lock = threading.Lock()
+
+
+def _build_gate() -> BudgetGate:
+    """A Redis-backed gate when REDIS_URL is reachable, else an in-process one."""
+    try:
+        import redis
+
+        client = redis.from_url(settings.REDIS_URL, socket_connect_timeout=1)
+        client.ping()
+        return BudgetGate(_RedisBackend(client))
+    except Exception as exc:  # noqa: BLE001 — no Redis -> degrade to in-process
+        logger.info("llm_budget_using_in_memory_backend", extra={"reason": str(exc)})
+        return BudgetGate(_InMemoryBackend())
+
+
+def get_gate() -> BudgetGate:
+    global _gate
+    if _gate is None:
+        with _gate_lock:
+            if _gate is None:
+                _gate = _build_gate()
+    return _gate
+
+
+def set_gate(gate: Optional[BudgetGate]) -> None:
+    """Test seam: inject a controlled gate (None resets to lazy rebuild)."""
+    global _gate
+    with _gate_lock:
+        _gate = gate
+
+
+def new_in_memory_gate() -> BudgetGate:
+    """A fresh in-process gate, for tests that drive a user over the cap."""
+    return BudgetGate(_InMemoryBackend())
+
+
+def over_budget(user_id) -> bool:
+    return get_gate().over_budget(user_id)
+
+
+def record(user_id, model: str, input_tokens: int, output_tokens: int) -> None:
+    get_gate().record(user_id, model, input_tokens, output_tokens)

--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -361,6 +361,21 @@ async def stream_chat_response(
         yield ChatStreamEvent(text="Activity not found.")
         return
 
+    # P2.2: chat resends the full report + context every turn, so it is an
+    # unbounded input-token lever. At the per-user/global spend cap, decline the
+    # turn with a plain message instead of calling the LLM (cap observed before
+    # the call), keyed by activity-owner user_id.
+    from app.services.coach.budget import over_budget as _over_budget
+
+    if _over_budget(activity.user_id):
+        yield ChatStreamEvent(
+            text=(
+                "I've hit the usage limit for now, so I can't write a full reply "
+                "to this one. Your data is all saved — try again a little later."
+            )
+        )
+        return
+
     # Build context from the stored context pack
     context_pack = report_row.context_pack or {}
     report_content = report_row.report or {}

--- a/backend/app/services/coach/llm.py
+++ b/backend/app/services/coach/llm.py
@@ -41,6 +41,9 @@ class MessageResult:
     logic stays out of the client."""
     content_blocks: List[Any]
     stop_reason: Optional[str]
+    # Usage for the per-user budget gate (P2.2); 0 when no usage was returned.
+    input_tokens: int = 0
+    output_tokens: int = 0
 
 
 class LLMClient(Protocol):
@@ -226,9 +229,12 @@ class AnthropicClient:
                     timeout=_MESSAGE_TIMEOUT_SECONDS,
                 ) as stream:
                     final = await stream.get_final_message()
+                usage = getattr(final, "usage", None)
                 return MessageResult(
                     content_blocks=list(final.content),
                     stop_reason=final.stop_reason,
+                    input_tokens=getattr(usage, "input_tokens", 0) or 0,
+                    output_tokens=getattr(usage, "output_tokens", 0) or 0,
                 )
             except (
                 anthropic.APITimeoutError,

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -30,6 +30,7 @@ from app.schemas.coach import (
     CoachReportRead,
 )
 from app.schemas.coach_context import CoachContextPack, ContinuityContext
+from app.services.coach.budget import over_budget as budget_over, record as budget_record
 from app.services.coach.belief_store import write_back_beliefs
 from app.services.coach.consolidation import enqueue_consolidation
 from app.services.coach.context import build_context_pack
@@ -348,9 +349,13 @@ async def get_or_generate_coach_report(
     # Dispatch on prompt family (ADR 0009): the A3 prose-message path vs the
     # legacy structured path. Both normalise to a _GenOutcome so storage is shared.
     if prompt_id.startswith(MESSAGE_PROMPT_PREFIX):
-        outcome = await _generate_message(client, system_prompt, user_message, pack)
+        outcome = await _generate_message(
+            client, system_prompt, user_message, pack, user_id=activity.user_id
+        )
     else:
-        outcome = await _generate_structured(client, system_prompt, user_message, pack)
+        outcome = await _generate_structured(
+            client, system_prompt, user_message, pack, user_id=activity.user_id
+        )
 
     read = _persist_report(
         db,
@@ -437,7 +442,7 @@ async def generate_opener(db: Session, activity_id: str) -> Optional[OpenerResul
         api_key=settings.ANTHROPIC_API_KEY, model=settings.COACH_MODEL_ID
     )
     outcome = await _generate_message(
-        client, system_prompt, user_message, pack, is_opener=True
+        client, system_prompt, user_message, pack, is_opener=True, user_id=activity.user_id
     )
 
     read = _persist_report(
@@ -535,7 +540,9 @@ async def generate_fuller(
     client = AnthropicClient(
         api_key=settings.ANTHROPIC_API_KEY, model=settings.COACH_MODEL_ID
     )
-    outcome = await _generate_message(client, system_prompt, user_message, pack)
+    outcome = await _generate_message(
+        client, system_prompt, user_message, pack, user_id=activity.user_id
+    )
 
     # Preserve the opener prose on the evolving row — the fuller LLM does not emit
     # opener_message, so carry it forward so the two-line thread (opener + fuller)
@@ -769,10 +776,19 @@ async def _generate_structured(
     system_prompt: str,
     user_message: str,
     pack: CoachContextPack,
+    *,
+    user_id=None,
 ) -> _GenOutcome:
     """The legacy structured path: constrained-JSON generation, policy gate, one
     corrective retry, templated fallback on failure. Behaviour preserved from the
     prior inline implementation."""
+    # P2.2: at the per-user/global spend cap, degrade to the deterministic
+    # fallback BEFORE spending any tokens (the cap is observed before the call).
+    if user_id is not None and budget_over(user_id):
+        logger.info("coach_budget_degraded_structured", extra={"user_id": str(user_id)})
+        return _GenOutcome(
+            report_dump=_structured_fallback_dump(), raw_response="", is_fallback=True,
+        )
     raw_response = ""
     policy_violations: List[str] = []
     try:
@@ -848,13 +864,19 @@ async def _call_message(
     user_message: str,
     *,
     max_tokens: int = _MESSAGE_MAX_TOKENS,
+    user_id=None,
 ):
-    return await client.generate_coach_message(
+    result = await client.generate_coach_message(
         system=system_prompt,
         user=user_message,
         tools=[RECORD_COACH_TAIL_TOOL],
         max_tokens=max_tokens,
     )
+    # P2.2: count EVERY sub-call's spend (the retry/escalation fan-out is the
+    # cost lever the going-live doc flags), keyed by activity-owner user_id.
+    if user_id is not None:
+        budget_record(user_id, client.model, result.input_tokens, result.output_tokens)
+    return result
 
 
 async def _reattempt_if_truncated(
@@ -865,6 +887,7 @@ async def _reattempt_if_truncated(
     *,
     escalated: int,
     context: str,
+    user_id=None,
 ):
     """If a prose-message call stopped on the token ceiling, re-attempt it ONCE at
     a larger budget and return whichever result is better (#295/#282).
@@ -888,7 +911,7 @@ async def _reattempt_if_truncated(
         context,
     )
     retried = await _call_message(
-        client, system_prompt, user_message, max_tokens=escalated
+        client, system_prompt, user_message, max_tokens=escalated, user_id=user_id
     )
     if retried.stop_reason != "refusal":
         result = retried
@@ -947,6 +970,7 @@ async def _generate_message(
     pack: CoachContextPack,
     *,
     is_opener: bool = False,
+    user_id=None,
 ) -> _GenOutcome:
     """The prose-message path: one adaptive-thinking call producing prose + a tool
     tail, with stop_reason-aware retries, the policy gate over message+tail, and
@@ -968,6 +992,12 @@ async def _generate_message(
     escalated = _OPENER_MAX_TOKENS_ESCALATED if is_opener else _MESSAGE_MAX_TOKENS_ESCALATED
     merge = merge_opener if is_opener else merge_report
     fallback = _opener_fallback_outcome if is_opener else _message_fallback_outcome
+    # P2.2: at the spend cap, degrade to the deterministic fallback BEFORE the
+    # call (cap observed before tokens are spent; one user's cap never affects
+    # another since the counter is keyed by activity-owner user_id).
+    if user_id is not None and budget_over(user_id):
+        logger.info("coach_budget_degraded_message", extra={"user_id": str(user_id)})
+        return fallback()
     # #217: the prose call occasionally returns no text block at all (an empty-prose
     # response, observed as transient — an immediate re-run recovers it). A single
     # in-process retry turns that one hiccup into a real turn instead of a fallback,
@@ -984,7 +1014,9 @@ async def _generate_message(
     for attempt in range(_EMPTY_PROSE_ATTEMPTS):
         budget = max_tokens if attempt == 0 else escalated
         try:
-            result = await _call_message(client, system_prompt, user_message, max_tokens=budget)
+            result = await _call_message(
+                client, system_prompt, user_message, max_tokens=budget, user_id=user_id
+            )
             if result.stop_reason == "refusal":
                 logger.warning("coach message refused; storing fallback")
                 return fallback()
@@ -992,7 +1024,7 @@ async def _generate_message(
             # Shared with the policy-fix retry's truncation re-attempt (#282).
             result = await _reattempt_if_truncated(
                 client, system_prompt, user_message, result,
-                escalated=escalated, context="first attempt",
+                escalated=escalated, context="first attempt", user_id=user_id,
             )
 
             parsed = parse_blocks(result.content_blocks)
@@ -1002,7 +1034,7 @@ async def _generate_message(
                 logger.info("coach message skipped the tail tool; one corrective retry")
                 nudge = f"{user_message}\n\n{_TAIL_REMINDER}"
                 result2 = await _call_message(
-                    client, system_prompt, nudge, max_tokens=budget
+                    client, system_prompt, nudge, max_tokens=budget, user_id=user_id
                 )
                 parsed2 = parse_blocks(result2.content_blocks)
                 if parsed2.tail is not None and parsed2.message.strip():
@@ -1042,7 +1074,7 @@ async def _generate_message(
         )
         retry_attempt = await _retry_message_with_fixes(
             client, system_prompt, user_message, pack, chosen.violations,
-            is_opener=is_opener,
+            is_opener=is_opener, user_id=user_id,
         )
         if retry_attempt is not None:
             # #274: store the BETTER attempt — a complete attempt is not clobbered by
@@ -1082,6 +1114,7 @@ async def _retry_message_with_fixes(
     violations: List[PolicyViolation],
     *,
     is_opener: bool = False,
+    user_id=None,
 ) -> Optional[_MsgAttempt]:
     """Re-prompt once with fix instructions for the message-policy violations.
     Returns the retry as a _MsgAttempt (#274), or None when the retry produced
@@ -1109,7 +1142,7 @@ async def _retry_message_with_fixes(
     )
     try:
         result = await _call_message(
-            client, system_prompt, retry_message, max_tokens=max_tokens
+            client, system_prompt, retry_message, max_tokens=max_tokens, user_id=user_id
         )
         if result.stop_reason == "refusal":
             return None
@@ -1119,7 +1152,7 @@ async def _retry_message_with_fixes(
         # re-attempt refuses, so the refusal check above still covers that case.
         result = await _reattempt_if_truncated(
             client, system_prompt, retry_message, result,
-            escalated=escalated, context="policy retry",
+            escalated=escalated, context="policy retry", user_id=user_id,
         )
         report = merge(parse_blocks(result.content_blocks))
     except (EmptyMessageError, anthropic.APIError) as e:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -45,6 +45,23 @@ def _disable_clerk_auth(monkeypatch):
     monkeypatch.setattr(settings, "APP_ENV", "local")
     clerk_auth.reset_verifier_cache()
 
+
+@pytest.fixture(autouse=True)
+def _isolate_llm_budget():
+    """Pin the P2.2 LLM budget gate to a fresh in-process backend per test.
+
+    The coach generation path now consults the budget gate, which otherwise
+    lazily builds a Redis-backed gate (polluting a developer's local Redis and
+    leaking spend across tests). An in-memory gate plus the all-zero default
+    ceilings makes the gate a no-op for every test that does not opt in; the cost
+    cap tests inject their own capped gate.
+    """
+    from app.services.coach import budget
+
+    budget.set_gate(budget.new_in_memory_gate())
+    yield
+    budget.set_gate(None)
+
 # Use an in-memory SQLite database for tests, or a separate test DB
 # For simplicity with SQLAlchemy features, an in-memory SQLite is easiest 
 # but might have dialect differences with Postgres.

--- a/backend/tests/test_async_regenerate.py
+++ b/backend/tests/test_async_regenerate.py
@@ -33,6 +33,32 @@ class TestRegenerateEndpoint:
         assert call.kwargs.get("job_timeout") == settings.RQ_JOB_TIMEOUT_SECONDS
         assert settings.RQ_JOB_TIMEOUT_SECONDS > 180
 
+    def test_passes_deterministic_job_id(self, client: TestClient, db):
+        # P2.2: a deterministic per-activity job id lets RQ collapse a racing
+        # re-tap onto one job instead of queuing duplicate generations.
+        activity = _seed_activity(db)
+        fake_queue = MagicMock()
+        with patch("app.core.queue.queue", fake_queue):
+            client.post(f"/api/activities/{activity.id}/coach-report/regenerate")
+        assert fake_queue.enqueue.call_args.kwargs.get("job_id") == (
+            f"coach-regenerate:{activity.id}"
+        )
+
+    def test_cooldown_dedups_rapid_retaps(self, client: TestClient, db):
+        # P2.2 / going-live landmine 1: the atomic Redis cooldown (SET NX EX)
+        # short-circuits a second rapid regenerate so a stuck button cannot fan
+        # out LLM spend. First tap acquires the key (set -> True), second is
+        # within the window (set -> None).
+        activity = _seed_activity(db)
+        fake_queue = MagicMock()
+        fake_queue.connection.set.side_effect = [True, None]
+        with patch("app.core.queue.queue", fake_queue):
+            first = client.post(f"/api/activities/{activity.id}/coach-report/regenerate")
+            second = client.post(f"/api/activities/{activity.id}/coach-report/regenerate")
+        assert first.json() == {"status": "regenerating"}
+        assert second.json() == {"status": "cooldown"}
+        fake_queue.enqueue.assert_called_once()  # only the first tap enqueued
+
     def test_404_when_activity_missing(self, client: TestClient, db):
         from uuid import uuid4
         fake_queue = MagicMock()

--- a/backend/tests/test_llm_budget.py
+++ b/backend/tests/test_llm_budget.py
@@ -1,0 +1,152 @@
+"""Per-user LLM cost cap (P2.2, #122).
+
+The structural contract: at the per-user (or global) spend cap, coach generation
+DEGRADES to the deterministic is_fallback path BEFORE spending any tokens, and
+one user hitting the cap never affects another. Plus the gate arithmetic and the
+window/ceiling logic.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.core.config import settings
+from app.services.coach import budget
+from app.services.coach.service import get_or_generate_coach_report
+
+# Reuse the message-service fixtures (valid MessageResult + mock client + seed).
+from tests.test_message_service import (
+    _message_client,
+    _seed_activity_with_metrics,
+    _stored,
+    _tail,
+    _text,
+)
+
+
+# --- gate arithmetic + windows (unit) --------------------------------------
+
+def test_cost_usd_matches_price_table():
+    # Opus: $5/MTok in, $25/MTok out.
+    assert budget.cost_usd("claude-opus-4-8", 1_000_000, 0) == pytest.approx(5.0)
+    assert budget.cost_usd("claude-opus-4-8", 0, 1_000_000) == pytest.approx(25.0)
+    # Sonnet: $3/$15.
+    assert budget.cost_usd("claude-sonnet-4-6", 1_000_000, 1_000_000) == pytest.approx(18.0)
+    # Unknown model prices as Opus (conservative over-count).
+    assert budget.cost_usd("mystery-model", 1_000_000, 0) == pytest.approx(5.0)
+
+
+def test_over_budget_is_per_user(monkeypatch):
+    monkeypatch.setattr(settings, "LLM_BUDGET_USER_DAILY_USD", 1.0)
+    gate = budget.new_in_memory_gate()
+    # Spend enough Opus tokens to clear the $1 daily ceiling for user A only.
+    gate.record("user-A", "claude-opus-4-8", 1_000_000, 0)  # $5
+    assert gate.over_budget("user-A") is True
+    assert gate.over_budget("user-B") is False  # B is untouched
+
+
+def test_global_ceiling_trips_for_everyone(monkeypatch):
+    monkeypatch.setattr(settings, "LLM_BUDGET_USER_DAILY_USD", 0.0)
+    monkeypatch.setattr(settings, "LLM_BUDGET_GLOBAL_DAILY_USD", 4.0)
+    gate = budget.new_in_memory_gate()
+    gate.record("user-A", "claude-opus-4-8", 1_000_000, 0)  # $5 global
+    # Over the GLOBAL ceiling, so even a user who never spent is blocked.
+    assert gate.over_budget("user-B") is True
+
+
+def test_zero_ceiling_disables_the_window(monkeypatch):
+    for var in (
+        "LLM_BUDGET_USER_DAILY_USD", "LLM_BUDGET_USER_MONTHLY_USD",
+        "LLM_BUDGET_GLOBAL_DAILY_USD", "LLM_BUDGET_GLOBAL_MONTHLY_USD",
+    ):
+        monkeypatch.setattr(settings, var, 0.0)
+    gate = budget.new_in_memory_gate()
+    gate.record("user-A", "claude-opus-4-8", 100_000_000, 100_000_000)  # huge
+    assert gate.over_budget("user-A") is False  # all windows disabled => never over
+
+
+# --- the degrade-not-crash contract over the real service path -------------
+
+@pytest.fixture
+def _single_shot_prompt(monkeypatch):
+    # coach_message_v1 routes get_or_generate through _generate_message directly
+    # (not the two-stage cadence), so the budget gate at its entry is exercised.
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v1")
+
+
+@pytest.fixture
+def _capped_gate(monkeypatch):
+    monkeypatch.setattr(settings, "LLM_BUDGET_USER_DAILY_USD", 1.0)
+    gate = budget.new_in_memory_gate()
+    budget.set_gate(gate)
+    yield gate
+    budget.set_gate(None)
+
+
+def _valid_blocks():
+    return [
+        _text("Nice steady aerobic run. You held your effort well throughout."),
+        _tail(
+            headline="Solid easy run",
+            next_steps=[{"action": "Easy run", "details": "30 min", "why": "Recovery"}],
+            risks=[], questions=[],
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_over_budget_user_degrades_to_fallback_without_calling_llm(
+    db, _single_shot_prompt, _capped_gate
+):
+    activity = _seed_activity_with_metrics(db)
+    # Push this activity's owner over the $1 daily cap.
+    _capped_gate.record(str(activity.user_id), "claude-opus-4-8", 1_000_000, 0)
+
+    client = _message_client(_valid_blocks())
+    with patch("app.services.coach.service.AnthropicClient", return_value=client):
+        read = await get_or_generate_coach_report(db, str(activity.id))
+
+    # Degraded to the deterministic fallback, and the LLM was never called (the
+    # cap is observed BEFORE the call).
+    client.generate_coach_message.assert_not_called()
+    stored = _stored(db, activity)
+    assert stored.is_fallback is True
+
+
+@pytest.mark.asyncio
+async def test_under_budget_user_unaffected(db, _single_shot_prompt, _capped_gate):
+    activity = _seed_activity_with_metrics(db)
+    # This user has spent nothing; they are under the cap.
+    client = _message_client(_valid_blocks())
+    with patch("app.services.coach.service.AnthropicClient", return_value=client):
+        read = await get_or_generate_coach_report(db, str(activity.id))
+
+    client.generate_coach_message.assert_called()
+    stored = _stored(db, activity)
+    assert stored.is_fallback is False
+    # Spend was recorded for this user after the call.
+    assert _capped_gate.over_budget(str(activity.user_id)) is False
+    # The per-user isolation contract (one user's cap never blocks another) is
+    # proven at the gate level by test_over_budget_is_per_user, combined with the
+    # degrade + under-budget service paths above.
+
+
+@pytest.mark.asyncio
+async def test_chat_declines_over_budget_without_calling_llm(db, _capped_gate):
+    """Chat resends the full context every turn (an unbounded input-token lever),
+    so at the cap it declines with a plain message and never calls the LLM."""
+    from tests.test_coach_chat_stream import _seed_activity_with_report
+    from app.services.coach.chat import stream_chat_response
+    from app.services.coach.llm import AnthropicClient
+
+    activity = _seed_activity_with_report(db)
+    _capped_gate.record(str(activity.user_id), "claude-opus-4-8", 1_000_000, 0)
+
+    with patch.object(
+        AnthropicClient, "stream_chat", side_effect=AssertionError("LLM must not be called")
+    ):
+        events = [
+            ev async for ev in stream_chat_response(db, str(activity.id), "How did I do?")
+        ]
+    text = "".join(ev.text for ev in events if ev.text)
+    assert "usage limit" in text.lower()


### PR DESCRIPTION
Part of the Phase 2 multi-user epic (#67). Implements **P2.2 — per-user LLM cost cap**, the structural Ring 3 of `docs/vision/going-live-cost-control.md`: the owner's #1 going-live concern that one user (abusive or buggy) drains the shared Anthropic budget.

Branches off `main` (independent of P2.0/P2.1 — the gate keys on the activity's owner `user_id`, which already exists). Built unattended; **do not merge yet.**

## What changed

- **`app/services/coach/budget.py`** (new): a Redis-backed running spend counter — per-user **and** global, **daily and monthly** windows — checked **before** every coach generation and incremented **after every sub-call** (so the retry/escalation fan-out is counted, not just the first call). Over budget → generation **degrades to the deterministic `is_fallback` path**; it never hard-blocks. Keyed by **activity-owner `user_id`**, so one user's cap never affects another. Per-MTok price table (Opus $5/$25, Sonnet $3/$15, Haiku $1/$5; unknown → Opus, conservative). Backend is **Redis when reachable, else in-process** (local dev + tests); the gate **degrades open** on any backend error — a cost cap must never become an availability risk.
- **`service.py`**: gate-check at `_generate_message`/`_generate_structured` entry (the **cap is observed before tokens are spent**); record spend in `_call_message` from the new `MessageResult` usage (`llm.py`).
- **`chat.py`**: at the cap, decline a turn with a plain message instead of calling the LLM (chat resends the full report + context every turn — an unbounded input-token lever).
- **`coach.py` regenerate** (going-live landmine 1): an **atomic Redis cooldown** (`SET NX EX`) + a **deterministic per-activity job id** dedup rapid re-taps, so a stuck "Regenerate" button can't fan out full two-stage LLM generations.
- **Config**: `LLM_BUDGET_{USER,GLOBAL}_{DAILY,MONTHLY}_USD` and `COACH_REGEN_COOLDOWN_SECONDS`.

## Decisions made (owner unreachable — recommended option taken)

1. **Degrade, not hard-block, at the cap.** The product still ships a report (the deterministic fallback), as the going-live doc's open decision favours; hard-block is new UX. (Open decision #2 in the plan.)
2. **Ceilings are configurable env vars with all-zero (no-op) defaults.** No hardcoded dollars — the owner sets the real numbers. With the defaults, the gate is inert (every window disabled), so this PR changes no behaviour until ceilings are set. (Open decision #2.)
3. **Wired at the service layer, not inside `llm.py`.** The going-live doc says "in `llm.py`", but the service layer is where both the activity-owner `user_id` and the `is_fallback` degrade decision live, so the gate and the degrade are co-located; `MessageResult` now carries usage so spend is recorded from the real call.
4. **Scope = the dominant cost drivers** (report generation + chat + the regenerate lever). The cheap, low-frequency Haiku auxiliary paths (material distiller, narrative consolidation, receipt-voice) are deferred to **#472**.

## Verification

- **Full suite: 1600 passed**, 0 regressions, integration excluded.
- **New tests (9)**: price arithmetic vs the table; `over_budget` per-user / global / zero-window-disabled; **over-budget user degrades to `is_fallback` and the LLM is never called** (cap observed before the call); under-budget user unaffected + spend recorded; chat declines over budget without calling the LLM; regenerate passes the deterministic job id; the cooldown dedups rapid re-taps (enqueue once). TDD: the over-budget-degrades contract test is the spec.
- **Runtime**: the **Redis-backed** gate (the prod cross-process path) validated against the local Redis — an over-cap owner is blocked, another user is unaffected, keys cleaned up.
- **No flow-diagram change**: none of these edits alter the coach context pack or system prompt the LLM receives.

**Not covered (scoped):** the auxiliary Haiku paths (#472); real dollar ceilings (owner-set; defaults are a no-op); two-real-user runtime e2e (no 2nd user yet per the phase plan).

## Owner action
Set real `LLM_BUDGET_*` dollar ceilings on Railway (web **and** worker — the worker generates reports) once wave-one size is decided. Until then the gate is a no-op.

Closes #122 once merged.
