### PR TITLE
P2.3: account deletion with full FK-ordered cascade + Clerk-user delete (#121)

### DIFF
--- a/backend/app/api/account.py
+++ b/backend/app/api/account.py
@@ -1,0 +1,36 @@
+"""Account deletion (P2.3, #121, ADR 0022).
+
+The authenticated user deletes their own account and all derived data. The Clerk
+user is removed FIRST so a deleted account cannot sign back in into an empty
+shell; only if that succeeds does the local FK-ordered cascade run. A Clerk
+failure aborts before any local deletion, so the operation is all-or-nothing and
+retryable.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.clerk_auth import delete_clerk_user_by_email, require_current_user
+from app.db.session import get_db
+from app.models import User
+from app.services.account_deletion import delete_user_account
+
+router = APIRouter()
+
+
+@router.delete("/account", status_code=status.HTTP_204_NO_CONTENT)
+def delete_account(
+    db: Session = Depends(get_db),
+    user: User = Depends(require_current_user),
+):
+    """Delete the authenticated user's account and every row owned by it.
+
+    Removes the Clerk user first (so re-sign-in cannot create an empty shell); if
+    Clerk removal fails, nothing local is touched and the caller can retry.
+    """
+    if not delete_clerk_user_by_email(user.email):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Could not remove the authentication account; please retry.",
+        )
+    delete_user_account(db, user.id)

--- a/backend/app/core/clerk_auth.py
+++ b/backend/app/core/clerk_auth.py
@@ -190,6 +190,43 @@ def fetch_email_from_clerk_api(clerk_user_id: str) -> Optional[str]:
     return None
 
 
+def delete_clerk_user_by_email(email: str) -> bool:
+    """Delete the Clerk user for ``email`` via the Backend API (P2.3, ADR 0022).
+
+    Returns True when the Clerk side is clean (deleted, no such user, or Clerk
+    not configured so there is nothing to delete) and False on a hard API error.
+    The caller blocks the local cascade on a False so a half-delete never leaves a
+    signed-in account whose data is gone (an empty shell). Best-effort, never raises.
+    """
+    if not settings.CLERK_SECRET_KEY:
+        return True  # Clerk not configured (local/test) — nothing to delete
+    import httpx
+
+    headers = {"Authorization": f"Bearer {settings.CLERK_SECRET_KEY}"}
+    try:
+        resp = httpx.get(
+            "https://api.clerk.com/v1/users",
+            params={"email_address": [email]},
+            headers=headers,
+            timeout=10.0,
+        )
+        resp.raise_for_status()
+        users = resp.json() or []
+        for user in users:
+            uid = user.get("id")
+            if not uid:
+                continue
+            d = httpx.delete(
+                f"https://api.clerk.com/v1/users/{uid}", headers=headers, timeout=10.0
+            )
+            if d.status_code not in (200, 404):  # 404 = already gone
+                d.raise_for_status()
+        return True
+    except Exception as exc:  # noqa: BLE001 — surface as False, never raise
+        logger.warning("clerk_user_delete_failed", extra={"error": str(exc)})
+        return False
+
+
 def resolve_email(claims: dict) -> str:
     """The verified email for a set of claims, or raise ClerkAuthError."""
     email = _email_from_claims(claims)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api import health, auth, activities, blocks, webhooks, profile, trends, coach, debug, strava_import, materials
+from app.api import health, auth, activities, blocks, webhooks, profile, trends, coach, debug, strava_import, materials, account
 from app.core.auth import BasicAuthMiddleware
 from app.core.clerk_auth import verify_clerk_session
 from app.core.config import settings
@@ -54,6 +54,7 @@ app.include_router(webhooks.router, prefix="/api", tags=["Webhooks"])
 
 # Application routers: every route requires a verified Clerk session.
 app.include_router(profile.router, prefix="/api", tags=["Profile"], dependencies=_require_session)
+app.include_router(account.router, prefix="/api", tags=["Account"], dependencies=_require_session)
 app.include_router(activities.router, prefix="/api", tags=["Activities"], dependencies=_require_session)
 app.include_router(strava_import.router, prefix="/api", tags=["Strava Import"], dependencies=_require_session)
 app.include_router(blocks.router, prefix="/api", tags=["Blocks"], dependencies=_require_session)

--- a/backend/app/services/account_deletion.py
+++ b/backend/app/services/account_deletion.py
@@ -1,0 +1,111 @@
+"""Full account deletion with FK-ordered cascade (P2.3, #121, ADR 0022).
+
+A user deletes their own account and ALL derived data, leaving no orphaned row.
+There is no DB-level ON DELETE cascade on the foreign keys, so the cascade is
+application-level and MUST run children-before-parents to satisfy the
+constraints. The one wrinkle is the activities<->blocks cycle
+(``activities.block_id`` <-> ``blocks.primary_activity_id``): we null
+``activities.block_id`` before deleting blocks so neither side blocks the other.
+
+The Clerk user is deleted separately by the endpoint (ADR 0022: a deleted
+account must not be able to sign back in into an empty shell).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import (
+    Activity,
+    ActivityStream,
+    Block,
+    CheckIn,
+    CoachChatMessage,
+    CoachNarrative,
+    CoachReport,
+    CoachingContext,
+    CoachingRelationship,
+    DerivedMetric,
+    Exchange,
+    RunnerBaseline,
+    StravaAccount,
+    StravaImport,
+    User,
+    UserMaterial,
+    UserProfile,
+)
+
+logger = logging.getLogger(__name__)
+
+# Models hung off an Activity (FK -> activities.id). Deleted by the user's
+# activity id set before the activities themselves.
+_ACTIVITY_CHILDREN = (ActivityStream, CheckIn, CoachChatMessage, CoachReport, DerivedMetric)
+
+# Singletons / collections hung directly off the user (FK -> users.id), with no
+# rows referencing THEM. Deleted after activities/blocks, before the user row.
+_USER_OWNED = (
+    CoachNarrative,
+    CoachingContext,
+    CoachingRelationship,
+    RunnerBaseline,
+    StravaAccount,
+    StravaImport,
+    UserMaterial,
+    UserProfile,
+)
+
+
+def delete_user_account(db: Session, user_id) -> dict:
+    """Delete every row owned by ``user_id`` in FK-safe order, then the user.
+
+    Returns a per-table count of deleted rows (audit/verification). Commits once
+    at the end so the whole cascade is atomic — a failure leaves the account
+    intact rather than half-deleted.
+    """
+    counts: dict[str, int] = {}
+    activity_ids = select(Activity.id).where(Activity.user_id == user_id)
+
+    # 1. Exchanges (FK -> blocks, users) — nothing references them.
+    counts["exchanges"] = (
+        db.query(Exchange).filter(Exchange.user_id == user_id)
+        .delete(synchronize_session=False)
+    )
+
+    # 2. Activity-children (FK -> activities) for this user's activities.
+    for model in _ACTIVITY_CHILDREN:
+        counts[model.__tablename__] = (
+            db.query(model).filter(model.activity_id.in_(activity_ids))
+            .delete(synchronize_session=False)
+        )
+
+    # 3. Break the activities<->blocks cycle, then delete blocks, then activities.
+    db.query(Activity).filter(Activity.user_id == user_id).update(
+        {Activity.block_id: None}, synchronize_session=False
+    )
+    counts["blocks"] = (
+        db.query(Block).filter(Block.user_id == user_id)
+        .delete(synchronize_session=False)
+    )
+    counts["activities"] = (
+        db.query(Activity).filter(Activity.user_id == user_id)
+        .delete(synchronize_session=False)
+    )
+
+    # 4. Direct user-owned rows (FK -> users).
+    for model in _USER_OWNED:
+        counts[model.__tablename__] = (
+            db.query(model).filter(model.user_id == user_id)
+            .delete(synchronize_session=False)
+        )
+
+    # 5. The user row itself.
+    counts["users"] = (
+        db.query(User).filter(User.id == user_id).delete(synchronize_session=False)
+    )
+
+    db.commit()
+    logger.info("account_deleted", extra={"user_id": str(user_id), "counts": counts})
+    return counts

--- a/backend/tests/test_account_deletion.py
+++ b/backend/tests/test_account_deletion.py
@@ -1,0 +1,159 @@
+"""Account deletion with full cascade (P2.3, #121).
+
+Oracle = the schema's FK graph: after deleting a user, NO row in any table still
+references them, and another user's data is untouched. The endpoint removes the
+Clerk user first (ADR 0022) and aborts the local cascade if that fails, so the
+operation is all-or-nothing.
+"""
+
+from datetime import date, datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
+
+from app.core.clerk_auth import verify_clerk_session
+from app.main import app
+from app.models import (
+    Activity,
+    ActivityStream,
+    Block,
+    CheckIn,
+    CoachChatMessage,
+    CoachNarrative,
+    CoachReport,
+    CoachingContext,
+    CoachingRelationship,
+    DerivedMetric,
+    Exchange,
+    RunnerBaseline,
+    StravaAccount,
+    StravaImport,
+    User,
+    UserMaterial,
+    UserProfile,
+)
+from app.services.account_deletion import delete_user_account
+
+
+def _seed_full_user(db, *, email, athlete_id, strava_activity_id, hash_suffix):
+    """One row in every user-owned table, so the cascade is proven per table."""
+    user = User(email=email)
+    db.add(user)
+    db.commit()
+    db.add(UserProfile(
+        user_id=user.id, goal_type="general", experience_level="intermediate",
+        weekly_days_available=4, max_hr=190,
+    ))
+    db.add(StravaAccount(
+        user_id=user.id, strava_athlete_id=athlete_id, access_token="t",
+        refresh_token="r", expires_at=1999999999, scope="read",  # 32-bit-safe
+    ))
+    db.add(StravaImport(user_id=user.id, since_date=date(2026, 1, 1)))
+    db.add(CoachingRelationship(user_id=user.id))
+    db.add(CoachingContext(user_id=user.id, kind="hr_confound", key="heat"))
+    db.add(CoachNarrative(user_id=user.id, narrative="the story so far"))
+    db.add(RunnerBaseline(user_id=user.id, typical_easy_hr=145.0))
+    db.add(UserMaterial(
+        user_id=user.id, kind="other", title="mine", filename="m.md",
+        raw_text="private", content_hash=f"hash-{hash_suffix}", status="active",
+    ))
+    activity = Activity(
+        user_id=user.id, strava_activity_id=strava_activity_id,
+        start_date=datetime(2026, 5, 27, 10, 0, 0), type="Run", name="run",
+        distance_m=5000, moving_time_s=1500, elapsed_time_s=1500, elev_gain_m=10.0,
+        avg_hr=140, raw_summary={},
+    )
+    db.add(activity)
+    db.commit()
+    db.add(DerivedMetric(
+        activity_id=activity.id, effort="easy", structure="continuous",
+        duration_class="standard", effort_score=50.0, flags=[],
+        confidence="medium", confidence_reasons=[],
+    ))
+    db.add(ActivityStream(activity_id=activity.id, stream_type="heartrate", data=[140, 141]))
+    db.add(CheckIn(activity_id=activity.id, rpe=5))
+    db.add(CoachReport(
+        activity_id=activity.id, report={}, meta={}, context_pack={},
+        prompt_id="x", schema_version="2.0", is_fallback=False,
+    ))
+    db.add(CoachChatMessage(activity_id=activity.id, role="user", content="hi"))
+    block = Block(
+        user_id=user.id, start_date=activity.start_date,
+        end_date=activity.start_date + timedelta(seconds=1500),
+        primary_activity_id=activity.id,
+    )
+    db.add(block)
+    db.commit()
+    # An activity belongs to the block, exercising the activities<->blocks cycle.
+    activity.block_id = block.id
+    db.add(Exchange(user_id=user.id, block_id=block.id, opened_at=datetime.now(timezone.utc)))
+    db.commit()
+    db.refresh(user)
+    db.refresh(activity)
+    # Capture raw ids/email up front: after deletion the ORM instances are gone,
+    # and attribute access on them would trigger a refresh (ObjectDeletedError).
+    return SimpleNamespace(
+        user=user, activity=activity, block=block,
+        user_id=user.id, activity_id=activity.id, email=user.email,
+    )
+
+
+# Every (model, owner-column) pair that must be empty for a deleted user.
+_USER_SCOPED = [
+    (UserProfile, "user_id"), (StravaAccount, "user_id"), (StravaImport, "user_id"),
+    (CoachingRelationship, "user_id"), (CoachingContext, "user_id"),
+    (CoachNarrative, "user_id"), (RunnerBaseline, "user_id"),
+    (UserMaterial, "user_id"), (Activity, "user_id"), (Block, "user_id"),
+    (Exchange, "user_id"),
+]
+_ACTIVITY_SCOPED = [DerivedMetric, ActivityStream, CheckIn, CoachReport, CoachChatMessage]
+
+
+def _residual_rows(db, ctx) -> int:
+    """Count every row still owned by ctx across all tables (uses raw ids so it
+    works after the ORM instances are deleted)."""
+    total = 0
+    for model, col in _USER_SCOPED:
+        total += db.query(model).filter(getattr(model, col) == ctx.user_id).count()
+    for model in _ACTIVITY_SCOPED:
+        total += db.query(model).filter(model.activity_id == ctx.activity_id).count()
+    total += db.query(User).filter(User.id == ctx.user_id).count()
+    return total
+
+
+def _act_as(user):
+    app.dependency_overrides[verify_clerk_session] = lambda: user
+
+
+def test_delete_user_account_removes_every_owned_row(db):
+    a = _seed_full_user(db, email="a@del.dev", athlete_id=1, strava_activity_id=11, hash_suffix="a")
+    b = _seed_full_user(db, email="b@del.dev", athlete_id=2, strava_activity_id=22, hash_suffix="b")
+    assert _residual_rows(db, a) > 10  # the full graph is present
+
+    delete_user_account(db, a.user_id)
+
+    assert _residual_rows(db, a) == 0  # nothing of A's survives, in any table
+    assert _residual_rows(db, b) > 10  # B is completely untouched
+
+
+def test_endpoint_deletes_account_and_calls_clerk(client, db):
+    a = _seed_full_user(db, email="a@del.dev", athlete_id=1, strava_activity_id=11, hash_suffix="a")
+    b = _seed_full_user(db, email="b@del.dev", athlete_id=2, strava_activity_id=22, hash_suffix="b")
+    _act_as(a.user)
+    with patch("app.api.account.delete_clerk_user_by_email", return_value=True) as clerk:
+        resp = client.delete("/api/account")
+    assert resp.status_code == 204
+    clerk.assert_called_once_with(a.email)
+    assert _residual_rows(db, a) == 0
+    assert _residual_rows(db, b) > 10
+
+
+def test_endpoint_aborts_local_cascade_when_clerk_delete_fails(client, db):
+    a = _seed_full_user(db, email="a@del.dev", athlete_id=1, strava_activity_id=11, hash_suffix="a")
+    _act_as(a.user)
+    before = _residual_rows(db, a)
+    with patch("app.api.account.delete_clerk_user_by_email", return_value=False):
+        resp = client.delete("/api/account")
+    assert resp.status_code == 502
+    # Nothing was deleted locally — the operation is all-or-nothing and retryable.
+    assert _residual_rows(db, a) == before


### PR DESCRIPTION
Part of the Phase 2 multi-user epic (#67). Implements **P2.3 — account deletion with full cascade**.

> **Stacked on #471 (P2.1)** — it needs P2.1's `require_current_user` and P2.0's Clerk integration. Base is the P2.1 branch so this diff is P2.3-only; merge order is **#468 → #471 → this**. Built unattended; **do not merge yet.**

## What changed

- **`app/services/account_deletion.py`** (new): `delete_user_account(db, user_id)` deletes every row owned by the user in **FK-safe order** (there is no DB-level `ON DELETE` cascade), nulling `activities.block_id` before deleting blocks to break the `activities`↔`blocks` cycle (`block_id` ↔ `primary_activity_id`). Covers all 17 owned tables — Activity, ActivityStream, DerivedMetric, Block, Exchange, CheckIn, CoachReport, CoachChatMessage, CoachingRelationship, CoachingContext, CoachNarrative, RunnerBaseline, UserMaterial, StravaAccount, StravaImport, UserProfile, User. One commit ⇒ atomic.
- **`app/core/clerk_auth.py`**: `delete_clerk_user_by_email` (Clerk Backend API; best-effort, never raises; returns False on a hard error).
- **`app/api/account.py`** (new): `DELETE /api/account`, scoped to the authenticated user. **Removes the Clerk user first** and **aborts the local cascade (502)** if that fails — so the operation is all-or-nothing and retryable, and a deleted account can't sign back in into an empty shell.

## Decisions made (owner unreachable — recommended option taken)

1. **Clerk-first ordering.** Delete the Clerk user before the local rows; if Clerk removal fails, abort before deleting anything local (502, retryable). This guarantees the "no empty shell" property of ADR 0022 rather than risking a local-deleted-but-still-signed-in state.
2. **Application-level cascade in explicit FK order**, not DB `ON DELETE CASCADE` (the FKs don't declare it, and adding it would be a schema migration across 17 tables). The order is the load-bearing correctness property — see verification.
3. **`StravaImport` included** in the table set (it has a `user_id` FK the plan's list omitted) so deletion never orphans or blocks on it.

## Verification

- **Full suite: 1634 passed**, 0 regressions.
- **Cascade unit test**: after `delete_user_account`, **zero residual rows across all 17 tables**; a second user's data is **completely untouched**.
- **Endpoint tests**: Clerk is called first then the cascade runs (204); a Clerk failure leaves **everything intact** (502).
- **Real-Postgres FK-order validation** (the key check — SQLite doesn't enforce FKs, so the *order* is only testable on Postgres): seeded two full user graphs on a throwaway Postgres DB, ran the cascade — it deleted from **every one of the 17 tables with no IntegrityError**, A's residual = 0, B's = 17.

**Not covered (scoped):** the live Clerk-delete API call is mocked in tests (the helper is best-effort and exercised via mock; the live call is the owner's runtime check against the real Clerk instance); two-real-user e2e (no 2nd real user yet per the phase plan — onboarding one is gated on P2.1 + P2.3 landing).

## Owner note
A Clerk-delete failure returns 502 and deletes nothing, so the user can retry. If Clerk is permanently unreachable, the owner can remove the Clerk user manually; the local data is only deleted once Clerk removal succeeds.

Closes #121 once merged.
