### PR TITLE
P2.6: custom-domain readiness — audit + operator cutover runbook (#124)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,11 +9,17 @@ DATABASE_URL=postgresql+psycopg://coach:coach@localhost:5433/coach
 REDIS_URL=redis://localhost:6379/0
 
 # --- Server URLs ---
+# In production these become the custom-domain hostnames. No code is hardcoded to
+# a hostname (#124) — the domain cutover is a pure env/DNS change. See the full
+# operator checklist in docs/deployment/custom-domain.md.
+# APP_BASE_URL is used for the Strava OAuth success redirect and notification links.
 API_BASE_URL=http://localhost:8000
 APP_BASE_URL=http://localhost:3000
 
 # --- CORS ---
-# Comma-separated list of origins allowed to call the API.
+# Comma-separated list of origins allowed to call the API. In prod, add the custom
+# frontend origin (the proxied seam is same-origin so this is mostly defensive —
+# see docs/deployment/custom-domain.md).
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000
 
 # --- Auth: frontend-to-backend service secret (HTTP basic) ---

--- a/docs/deployment/custom-domain.md
+++ b/docs/deployment/custom-domain.md
@@ -1,0 +1,95 @@
+# Custom domain cutover (Phase 2, #124)
+
+Putting a custom domain in front of the frontend (Vercel) and backend (Railway)
+so user-visible URLs are stable for the multi-user rollout.
+
+## The one thing to know: this is a config + DNS change, NOT a code change
+
+The codebase carries **no hardcoded production hostnames**. Every URL on the
+connection seam comes from an environment variable (audited for #124):
+
+| Surface | Variable | Used for |
+|---|---|---|
+| Frontend (Vercel) | `BACKEND_URL` | server components + the `/api/[...path]` proxy reach the backend |
+| Frontend (Vercel) | `NEXT_PUBLIC_API_BASE_URL` | client `fetchFromAPI` base — **empty in prod**, so browser calls go same-origin through the proxy |
+| Backend (Railway) | `APP_BASE_URL` | the Strava OAuth success redirect (`/api/auth/strava/callback` → `${APP_BASE_URL}?connected=true`) and notification deep-links |
+| Backend (Railway) | `API_BASE_URL` | the backend's own public base (informational/links) |
+| Backend (Railway) | `CORS_ALLOWED_ORIGINS` | browsers allowed to call the backend cross-origin |
+| Backend (Railway) | `STRAVA_REDIRECT_URI` | OAuth callback URL registered with Strava |
+| Backend (Railway) | `STRAVA_WEBHOOK_CALLBACK_URL` | the webhook subscription callback URL |
+
+So the cutover is: acquire the domain, point DNS at the platforms, and update the
+env vars below. No deploy of new code is required for the domain itself.
+
+## How the seam works (why CORS is usually not on the hot path)
+
+```
+browser ──> Vercel frontend (custom domain) ──> [server-side proxy: route.ts] ──> Railway backend
+                                   client fetch is SAME-ORIGIN ("/api/*")
+```
+
+Client-side requests hit the frontend's own origin (`/api/*`) and are proxied to
+`${BACKEND_URL}` **server-side**, with the Basic-auth (Phase 1) or Clerk-session
+(Phase 2) credentials attached on the server. The browser never talks to the
+backend directly, so `CORS_ALLOWED_ORIGINS` is **not** required for the normal
+seam — it only matters if a future feature makes a direct browser→backend call.
+Set it to the new frontend origin anyway (defensive + correct).
+
+## Cutover checklist (operator actions, outside the working tree)
+
+Assume the domain is `example.com`, the frontend is `app.example.com`, and
+(optionally) the backend gets `api.example.com`. The backend does **not** need a
+custom public hostname — the frontend reaches it server-side via `BACKEND_URL`,
+which can stay the Railway-generated URL. Give the backend its own subdomain only
+if you want a clean OAuth/webhook URL; the steps below cover both.
+
+### 1. DNS + platform domains
+- [ ] Acquire `example.com`.
+- [ ] Vercel → project → Domains: add `app.example.com` (or the apex). Add the
+      DNS records Vercel shows at the registrar.
+- [ ] (Optional) Railway → backend `web` service → Settings → Networking: add the
+      custom domain `api.example.com`; add the CNAME it shows at the registrar.
+- [ ] (Phase 2 / Clerk) In the **production** Clerk instance, add the Clerk DNS
+      records (CNAMEs for `clerk.example.com` etc.) and add `app.example.com` to
+      the allowed origins / set the production sign-in/up redirect URLs. See the
+      P2.0 notes — the dev instance `fine-octopus-89` does not need this.
+
+### 2. Vercel env (frontend)
+- [ ] `BACKEND_URL` — only change if the backend got a custom hostname
+      (`https://api.example.com`); otherwise leave it on the Railway URL.
+- [ ] Leave `NEXT_PUBLIC_API_BASE_URL` **empty** so client calls stay same-origin
+      through the proxy.
+- [ ] (Phase 2) update the Clerk publishable/secret keys to the **production**
+      instance keys.
+- [ ] Redeploy the frontend so the new env is picked up.
+
+### 3. Railway env (backend `web` AND `worker` — vars are per-service)
+- [ ] `APP_BASE_URL=https://app.example.com` (OAuth success redirect + notification links).
+- [ ] `API_BASE_URL=https://api.example.com` (or the Railway URL if no backend subdomain).
+- [ ] `CORS_ALLOWED_ORIGINS=https://app.example.com` (comma-add any extra origins, e.g. `https://www.example.com`).
+- [ ] `STRAVA_REDIRECT_URI=https://api.example.com/api/auth/strava/callback`
+      (use the backend's public hostname — Railway URL if no subdomain).
+- [ ] `STRAVA_WEBHOOK_CALLBACK_URL=https://api.example.com/api/webhooks/strava`.
+- [ ] (Phase 2) production Clerk `CLERK_*` keys / JWKS URL.
+- [ ] Redeploy both services.
+
+### 4. Strava app settings (external, operator)
+- [ ] Strava API app → set the **Authorization Callback Domain** to the backend's
+      public hostname (`api.example.com` or the Railway host).
+- [ ] Re-register the webhook subscription against the new
+      `STRAVA_WEBHOOK_CALLBACK_URL` (delete the old subscription, create the new
+      one), then set `STRAVA_WEBHOOK_SUBSCRIPTION_ID` to the new id on Railway.
+
+## Verification (after the env is set and both services redeploy)
+- [ ] `GET https://api.example.com/api/health` (or via the frontend) returns 200.
+- [ ] `https://app.example.com` loads the dashboard.
+- [ ] Strava **Connect** round-trips: the OAuth redirect returns to
+      `https://app.example.com?connected=true` and an account links.
+- [ ] A new Strava activity delivers a webhook and a coach report/receipt arrives.
+- [ ] (If any direct browser→backend call exists) a CORS preflight from
+      `app.example.com` is allowed.
+
+## Rollback
+Revert the env vars to the platform-generated URLs and re-register the Strava
+callback domain/webhook to the old host. No code is involved, so rollback is a
+config change on both platforms.

--- a/docs/deployment/topology.md
+++ b/docs/deployment/topology.md
@@ -64,6 +64,20 @@ There are two paths, both adding HTTP Basic credentials server-side so the brows
 `frontend/vercel.json` has a `/api/:path* → /api/:path*` rewrite that keeps `/api` paths handled by the
 app (the route handler) rather than treated as static; the route handler, not the rewrite, is the proxy.
 
+Because client calls are same-origin (the browser only ever talks to the frontend, which proxies
+server-side), the browser never makes a cross-origin call to the backend on the normal path, so
+`CORS_ALLOWED_ORIGINS` is not on the seam's critical path — it only matters if a direct browser→backend
+call is ever added.
+
+### Custom domain (#124)
+
+No hostname is hardcoded in the code — every seam URL is an env var
+(`BACKEND_URL`, `APP_BASE_URL`, `API_BASE_URL`, `CORS_ALLOWED_ORIGINS`,
+`STRAVA_REDIRECT_URI`, `STRAVA_WEBHOOK_CALLBACK_URL`), so putting a custom domain
+in front of both platforms is a config + DNS change, not a code change. The
+turnkey operator checklist (DNS, per-platform env, Strava callback re-registration,
+Clerk production instance, and verification) is **[custom-domain.md](custom-domain.md)**.
+
 ### Auth model (Phase 1)
 
 - The backend gates every route with `BasicAuthMiddleware` (`backend/app/core/auth.py`).

--- a/project-context.md
+++ b/project-context.md
@@ -71,7 +71,7 @@ The Vercel frontend reaches the backend over HTTP: server components call `BACKE
 The backend gates all routes with `BasicAuthMiddleware`, exempting `/api/health`, `/api/webhooks`, and `/api/auth/strava/callback`; this Phase 1 layer is replaced by ADR 0005 magic-link sessions in Phase 2.
 Build and deploy config lives on the platforms rather than in an in-repo deploy manifest; the repo's only committed automation is the CI workflow under `.github/workflows/`.
 Locally `docker compose` provides only Postgres and Redis, while the host runs `uvicorn`, `rq worker --with-scheduler` (the `--with-scheduler` flag is what drains deferred/retry jobs now that the separate rqscheduler process is gone), and `next dev`.
-The full production and local-dev topology, the connection seam, and per-service env var ownership are documented in `docs/deployment/topology.md`.
+The full production and local-dev topology, the connection seam, and per-service env var ownership are documented in `docs/deployment/topology.md`. No production hostname is hardcoded in code — every seam URL (`BACKEND_URL`, `APP_BASE_URL`, `API_BASE_URL`, `CORS_ALLOWED_ORIGINS`, `STRAVA_REDIRECT_URI`, `STRAVA_WEBHOOK_CALLBACK_URL`) is an env var, so a custom domain is a config+DNS change, not a code change (#124); the turnkey operator cutover checklist is `docs/deployment/custom-domain.md`.
 
 ## Important Constraints
 


### PR DESCRIPTION
Part of the Phase 2 multi-user epic (#67). Implements **P2.6 — custom domain code-side**. Branches off `main`. Built unattended; **do not merge yet.**

## The finding: it's already done in code

I audited backend + frontend app code for hostnames that would break the frontend↔backend seam under a custom domain. **There are none.** Every seam URL is an environment variable:

| Variable | Surface | Role |
|---|---|---|
| `BACKEND_URL` | Vercel | server components + `/api/[...path]` proxy reach the backend |
| `NEXT_PUBLIC_API_BASE_URL` | Vercel | client base — empty in prod, so browser calls go same-origin through the proxy |
| `APP_BASE_URL` | Railway | OAuth success redirect + notification deep-links |
| `API_BASE_URL` | Railway | backend public base |
| `CORS_ALLOWED_ORIGINS` | Railway | cross-origin browser allow-list |
| `STRAVA_REDIRECT_URI` | Railway | OAuth callback registered with Strava |
| `STRAVA_WEBHOOK_CALLBACK_URL` | Railway | webhook subscription callback |

The only `https://` literal in non-API code is the **in-memory test adapter's** fake `example.test` URL. So a custom domain is a **config + DNS change, not a code change.**

## What's in this PR (documentation, not code)

- **`docs/deployment/custom-domain.md`** (new) — the turnkey operator cutover checklist: DNS + platform domains, per-platform env (Vercel + Railway, vars are per-service), Strava Authorization-Callback-Domain + webhook re-registration, the Clerk **production** instance, and a verification + rollback section.
- **`docs/deployment/topology.md`** — a "Custom domain" subsection + a clarification that the proxied seam is **same-origin**, so `CORS_ALLOWED_ORIGINS` is defensive, not on the critical path.
- **`backend/.env.example`** + **`project-context.md`** — note the env-driven, no-code-change cutover and point at the runbook.

## Decisions made (owner unreachable — recommended option taken)

1. **No code change** — the audit shows the seam is already hostname-agnostic; inventing a code change would be make-work. The honest deliverable is the audit + a turnkey operator runbook.
2. **The backend does not need its own custom subdomain** — the frontend reaches it server-side via `BACKEND_URL`, which can stay the Railway URL. The runbook covers both options (with/without an `api.example.com`).
3. **`CORS_ALLOWED_ORIGINS` is documented as defensive**, not required, because the client→backend path is same-origin through the Vercel proxy.

## Verification

- **The audit is the oracle** for "no hardcoded hostname": grep sweeps across `backend/app` + `frontend/{app,lib,components}` for `railway.app` / `vercel.app` / the prod hostname / any `https://` literal, plus tracing how `APP_BASE_URL` and `STRAVA_REDIRECT_URI` are consumed (OAuth redirect, notification links, Strava authorize). All env-driven.
- **No code changed**, so the test baseline is unaffected (docs + `.env.example` only).

**Not covered (operator actions, outside the working tree per the issue):** acquiring the domain, DNS, serving the frontend from it. Those are the runbook's job; the code-side AC — the seam keeps working over new hostnames — holds by construction.

Closes #124 once merged (after the operator completes the runbook).
