### PR TITLE
Fail the web boot when a fail-closed production setting is unset (#480)

### DIFF
--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -146,6 +146,62 @@ def warn_if_coach_prompt_inert() -> None:
     )
 
 
+class ProductionConfigError(RuntimeError):
+    """A setting that fails closed in production is unset at startup."""
+
+
+# Settings whose request-time code FAILS CLOSED in production: an empty value
+# does not stop the process booting, but every application route then returns
+# 503. CLERK_JWKS_URL empty -> verify_clerk_session 503s every app route
+# (clerk_auth.py); BASIC_AUTH_USER/PASSWORD empty -> BasicAuthMiddleware 503s
+# every non-exempt route (auth.py). /api/health is auth-exempt and only checks
+# process + DB, so it stays green and the platform promotes the broken deploy
+# (the Phase 2 outage). Asserting these at boot turns that silent "up but
+# serving errors" deploy into a boot crash, so the platform keeps the previous
+# healthy deploy live instead of cutting over to one that 503s. These are the
+# WEB process's HTTP gate settings only (web-only per docs/deployment/topology.md);
+# the worker serves no HTTP and is intentionally not gated by this (see worker.py).
+_REQUIRED_IN_PRODUCTION = (
+    "CLERK_JWKS_URL",
+    "BASIC_AUTH_USER",
+    "BASIC_AUTH_PASSWORD",
+)
+
+
+def assert_production_config() -> None:
+    """Refuse to boot when a fail-closed production setting is unset.
+
+    No-op unless ``APP_ENV == "production"``: local dev and the test suite run
+    with these unset and degrade to the single local user, so they must not
+    raise. In production a missing (or whitespace-only) value raises
+    ``ProductionConfigError``, which crashes the process before it serves
+    traffic; the hosting platform then keeps the last healthy deploy running
+    rather than promoting one that would 503 every request. The failure
+    direction is safe -- a false positive can only block a new deploy, never
+    take down the running one. Called once per process group right after
+    ``init_logging``.
+    """
+    if settings.APP_ENV != "production":
+        return
+    missing = [
+        name
+        for name in _REQUIRED_IN_PRODUCTION
+        if not str(getattr(settings, name, "") or "").strip()
+    ]
+    if not missing:
+        return
+    logging.getLogger(__name__).critical(
+        "production_config_incomplete",
+        extra={"missing": missing},
+    )
+    raise ProductionConfigError(
+        "Refusing to boot: required production settings are unset: "
+        + ", ".join(missing)
+        + ". The frontend-facing routes would fail closed (503) without them. "
+        "Set them in the deploy environment and redeploy."
+    )
+
+
 def sentry_capture_active() -> bool:
     """True only when Sentry error capture is actually live.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,11 +5,20 @@ from app.api import health, auth, activities, blocks, webhooks, profile, trends,
 from app.core.auth import BasicAuthMiddleware
 from app.core.clerk_auth import verify_clerk_session
 from app.core.config import settings
-from app.core.observability import init_logging, init_sentry, warn_if_coach_prompt_inert
+from app.core.observability import (
+    assert_production_config,
+    init_logging,
+    init_sentry,
+    warn_if_coach_prompt_inert,
+)
 
 init_logging()
 init_sentry("web")
 warn_if_coach_prompt_inert()
+# Crash the boot if a fail-closed production setting is unset, so the platform
+# keeps the last healthy deploy serving instead of promoting one that 503s every
+# route (the Phase 2 deploy-outran-config outage). No-op outside production.
+assert_production_config()
 
 app = FastAPI(
     title="Running Coach",

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -21,6 +21,11 @@ def main() -> None:
     init_logging()
     init_sentry("worker")
     warn_if_coach_prompt_inert()
+    # No assert_production_config() here: the preflight guards the web process's
+    # fail-closed HTTP settings (CLERK_JWKS_URL, BASIC_AUTH_*), which are web-only
+    # (docs/deployment/topology.md). The worker serves no HTTP, so requiring them
+    # would crash a correctly-configured worker. Its hard deps (DATABASE_URL) are
+    # already required by Settings and crash the boot on their own.
     logger.info("Worker booting; listening on %s", ",".join(LISTEN))
     queues = [Queue(name, connection=redis_conn) for name in LISTEN]
     worker = Worker(queues, connection=redis_conn)

--- a/backend/tests/test_production_config.py
+++ b/backend/tests/test_production_config.py
@@ -1,0 +1,107 @@
+"""Production config preflight (#480).
+
+`assert_production_config` crashes the boot when a setting that fails closed in
+production is unset, so the platform keeps the last healthy deploy instead of
+promoting one that 503s every route. These tests pin the exact firing condition:
+it must raise in production with any required setting missing, and stay a no-op
+everywhere else (the test suite and local dev run with these unset).
+"""
+
+import pytest
+
+from app.core.config import settings
+from app.core.observability import ProductionConfigError, assert_production_config
+
+# Clearly-fake test values; never real secrets (aiw-security-testing rule 6).
+_FAKE_JWKS = "https://example-test.clerk.accounts.dev/.well-known/jwks.json"
+_FAKE_USER = "svc-test-do-not-use"
+_FAKE_PASSWORD = "test-secret-do-not-use-in-prod"
+
+
+def _set(monkeypatch, **kwargs):
+    for key, value in kwargs.items():
+        monkeypatch.setattr(settings, key, value)
+
+
+def test_noop_outside_production_even_when_all_unset(monkeypatch):
+    # The degrade path: local dev and the test suite run with every fail-closed
+    # setting unset and fall back to the single local user. The preflight must
+    # stay silent, or it would break every non-production boot.
+    _set(
+        monkeypatch,
+        APP_ENV="local",
+        CLERK_JWKS_URL="",
+        BASIC_AUTH_USER="",
+        BASIC_AUTH_PASSWORD="",
+    )
+    assert_production_config()  # does not raise
+
+
+def test_passes_in_production_when_fully_configured(monkeypatch):
+    _set(
+        monkeypatch,
+        APP_ENV="production",
+        CLERK_JWKS_URL=_FAKE_JWKS,
+        BASIC_AUTH_USER=_FAKE_USER,
+        BASIC_AUTH_PASSWORD=_FAKE_PASSWORD,
+    )
+    assert_production_config()  # does not raise
+
+
+def test_raises_in_production_when_clerk_unset(monkeypatch):
+    # The exact Phase 2 outage: code deployed before CLERK_JWKS_URL was set.
+    _set(
+        monkeypatch,
+        APP_ENV="production",
+        CLERK_JWKS_URL="",
+        BASIC_AUTH_USER=_FAKE_USER,
+        BASIC_AUTH_PASSWORD=_FAKE_PASSWORD,
+    )
+    with pytest.raises(ProductionConfigError) as exc:
+        assert_production_config()
+    assert "CLERK_JWKS_URL" in str(exc.value)
+
+
+def test_raises_in_production_when_basic_auth_unset(monkeypatch):
+    _set(
+        monkeypatch,
+        APP_ENV="production",
+        CLERK_JWKS_URL=_FAKE_JWKS,
+        BASIC_AUTH_USER="",
+        BASIC_AUTH_PASSWORD="",
+    )
+    with pytest.raises(ProductionConfigError) as exc:
+        assert_production_config()
+    msg = str(exc.value)
+    assert "BASIC_AUTH_USER" in msg
+    assert "BASIC_AUTH_PASSWORD" in msg
+
+
+def test_error_lists_every_missing_setting(monkeypatch):
+    _set(
+        monkeypatch,
+        APP_ENV="production",
+        CLERK_JWKS_URL="",
+        BASIC_AUTH_USER="",
+        BASIC_AUTH_PASSWORD="",
+    )
+    with pytest.raises(ProductionConfigError) as exc:
+        assert_production_config()
+    msg = str(exc.value)
+    for name in ("CLERK_JWKS_URL", "BASIC_AUTH_USER", "BASIC_AUTH_PASSWORD"):
+        assert name in msg
+
+
+def test_whitespace_only_value_counts_as_missing(monkeypatch):
+    # A fat-fingered blank secret must be treated as unset, not "present", so it
+    # cannot satisfy the gate (boundary case for the .strip() check).
+    _set(
+        monkeypatch,
+        APP_ENV="production",
+        CLERK_JWKS_URL="   ",
+        BASIC_AUTH_USER=_FAKE_USER,
+        BASIC_AUTH_PASSWORD=_FAKE_PASSWORD,
+    )
+    with pytest.raises(ProductionConfigError) as exc:
+        assert_production_config()
+    assert "CLERK_JWKS_URL" in str(exc.value)

--- a/docs/deployment/topology.md
+++ b/docs/deployment/topology.md
@@ -86,6 +86,13 @@ Clerk production instance, and verification) is **[custom-domain.md](custom-doma
   authenticity is instead checked by `_event_is_authentic` in `app/api/webhooks.py`.
 - In production a missing `BASIC_AUTH_USER`/`BASIC_AUTH_PASSWORD` fails closed with 503. Outside
   production the middleware is a no-op when either is unset, so local dev needs no credentials.
+- Deploy safety (#480): in production the **web** process refuses to boot (crashes with a
+  `production_config_incomplete` CRITICAL log) when `CLERK_JWKS_URL`, `BASIC_AUTH_USER`, or
+  `BASIC_AUTH_PASSWORD` is unset, so a deploy whose env was not applied crash-loops and the platform
+  keeps the previous healthy deploy serving instead of promoting one that 503s every route (the Phase 2
+  outage). If a web deploy crash-loops right after a merge, check these env vars first. The worker is
+  not gated this way (it serves no HTTP). Belt-and-suspenders: set Railway's web Health Check Path to
+  `/api/health` so the cutover also waits on readiness.
 - This whole layer is throwaway: ADR 0005 replaces it with magic-link sessions in Phase 2.
 
 ### Configuration (where each secret lives)


### PR DESCRIPTION
Closes #480.

## Problem
A merge to `main` auto-deploys to Railway. The Phase 2 merge deployed before `CLERK_JWKS_URL` was set in prod: the app booted "successfully" while every application route returned 503 (`verify_clerk_session` fails closed in production when Clerk is unconfigured). `/api/health` is auth-exempt and only checks process + DB, so it stayed green and Railway promoted the broken deploy. The deploy outran its config and nothing caught it.

## Fix
Keep auto-deploy fully on, but make a misconfigured deploy fail *safe* instead of going live. `assert_production_config()` (sibling to `warn_if_coach_prompt_inert` in `observability.py`) runs at web startup and, in production, raises `ProductionConfigError` when `CLERK_JWKS_URL`, `BASIC_AUTH_USER`, or `BASIC_AUTH_PASSWORD` is unset. The process crashes before serving traffic, so Railway marks the new deploy failed and keeps the previous healthy deploy running.

The only behaviour change: a deploy whose config is incomplete cannot replace a working one. The failure direction is safe by construction — a false positive can only block a *new* deploy, never take down the running one. No-op outside production, so local dev and the test suite are unaffected.

## Scope note (deviation from the issue's acceptance)
The issue said "wire into web + worker". While implementing I grounded in `docs/deployment/topology.md`, which documents `BASIC_AUTH` as **web-only** ("gate is web-only"). The worker serves no HTTP and has no fail-closed 503 surface, so requiring those vars on the worker would crash a *correctly-configured* worker. I scoped the preflight to the web process only and documented why in `worker.py` and `topology.md`. The worker's hard deps (`DATABASE_URL`) are already required by `Settings` and crash the boot on their own.

## Verification
- **Unit (6 tests, `test_production_config.py`):** negative path per-setting + all-unset + full enumeration, positive path, the non-production degrade no-op, and the whitespace-only boundary.
- **Runtime boot proof** (`import app.main` at actual boot): local -> no-op boots; production + missing -> crashes `exit=1` with a `production_config_incomplete` CRITICAL log listing all three; production + full -> boots; worker under production with no web-gate vars -> boots (the false positive is avoided).
- **Full regression:** `make backend-test` 1663 passed (1657 baseline + 6 new), 0 failures.

## Owner follow-up (out of scope here)
Set Railway's web **Health Check Path** to `/api/health` as a belt-and-suspenders cutover gate. The boot preflight already gates the deploy; the health-check path makes Railway also wait on readiness at cutover.

## Unrelated drift noticed (not touched)
`topology.md` still says the Basic-auth layer is "throwaway: ADR 0005 replaces it with magic-link sessions in Phase 2." Phase 2 actually shipped Clerk (ADR 0022). Flagging for a separate Phase-2 topology doc refresh.
