### PR TITLE
fix(coach): block-aware display fallback for non-primary block members (#482)

### DIFF
--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -22,6 +22,7 @@ from app.schemas.stance import (
 )
 from app.services.coach.chat import get_chat_history, stream_chat_response
 from app.services.coach.service import (
+    get_block_primary_report_row,
     get_displayable_report_row,
     get_or_generate_coach_report,
     report_voice_stale,
@@ -196,6 +197,15 @@ async def get_coach_report(
             # next view). A read-time flag only — the stored report is untouched.
             read.meta.voice_stale = report_voice_stale(db, existing)
             return read
+        # #482: block-aware display fallback. A non-primary member of a multi-
+        # activity block owns no report (the session report is keyed to the block
+        # primary), so show the session's report read-only instead of 404-ing and
+        # leaving the panel spinning. voice_stale is deliberately left False: the
+        # borrowed report belongs to the primary, so it must not auto-trigger a
+        # per-member regeneration here (read-only, no generation).
+        borrowed = get_block_primary_report_row(db, str(activity_id))
+        if borrowed:
+            return _to_read(borrowed)
         if not generate:
             raise HTTPException(status_code=404, detail="No cached report.")
 

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, undefer
 
 from app.core.config import settings
-from app.models import Activity
+from app.models import Activity, Block
 from app.models.coach_report import CoachReport
 from app.models.coaching_relationship import CoachingRelationship
 from app.schemas.coach import (
@@ -276,6 +276,33 @@ def get_displayable_report_row(db: Session, activity_id) -> Optional[CoachReport
         .order_by(CoachReport.created_at.desc())
         .first()
     )
+
+
+def get_block_primary_report_row(db: Session, activity_id) -> Optional[CoachReport]:
+    """Block-aware DISPLAY fallback (#482): the displayable report of this
+    activity's block PRIMARY, when the activity itself owns none.
+
+    The session report is generated once per block, keyed to the primary activity
+    (the run, else the longest member). A non-primary member therefore has zero
+    coach_reports rows, so its page 404s and the panel spins forever. This lets the
+    read path show the session's report on any member instead.
+
+    Read-only, no generation: the M0 versioned-cache identity used for regeneration
+    (get_active_report_row / get_or_generate_coach_report) is unchanged, so the
+    per-activity "Re-run" still mints a member-specific report. Returns None when the
+    activity is not in a block, IS its block's primary (it would have its own report),
+    or the primary has no displayable report yet.
+    """
+    activity_uuid = _coerce_uuid(activity_id)
+    activity = (
+        db.query(Activity).filter(Activity.id == activity_uuid).first()
+    )
+    if activity is None or activity.block_id is None:
+        return None
+    block = db.query(Block).filter(Block.id == activity.block_id).first()
+    if block is None or block.primary_activity_id == activity_uuid:
+        return None
+    return get_displayable_report_row(db, block.primary_activity_id)
 
 
 async def get_or_generate_coach_report(

--- a/backend/tests/test_coach_report_display_fallback.py
+++ b/backend/tests/test_coach_report_display_fallback.py
@@ -16,9 +16,11 @@ from uuid import uuid4
 import pytest
 
 from app.core.config import settings
+from app.models import Activity, Block, DerivedMetric
 from app.models.coach_report import CoachReport
 from app.services.coach.service import (
     get_active_report_row,
+    get_block_primary_report_row,
     get_displayable_report_row,
 )
 
@@ -87,4 +89,90 @@ class TestEndpointDisplaySafe:
         monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
         activity = _seed_activity(db)
         res = client.get(f"/api/activities/{activity.id}/coach-report?generate=false")
+        assert res.status_code == 404
+
+
+def _add_block_member(db, primary) -> Activity:
+    """Add a sibling member to `primary`'s block under the SAME user, with `primary`
+    as the block primary. Returns the non-primary member. Mirrors the prod #482
+    instance: two close-in-time activities grouped into one block, the session
+    report keyed to the primary, the other member owning zero coach_reports rows.
+    """
+    member = Activity(
+        user_id=primary.user_id, strava_activity_id=primary.strava_activity_id + 1,
+        start_date=datetime(2026, 5, 27, 10, 30, 0), type="Walk", name="Cooldown walk",
+        distance_m=800, moving_time_s=600, elapsed_time_s=600, elev_gain_m=2.0,
+        avg_hr=110, raw_summary={},
+    )
+    db.add(member)
+    db.commit()
+    db.add(DerivedMetric(
+        activity_id=member.id, effort="easy", structure="continuous",
+        duration_class="standard", effort_score=10.0, flags=[],
+        confidence="medium", confidence_reasons=[],
+    ))
+    block = Block(
+        user_id=primary.user_id, start_date=primary.start_date,
+        end_date=member.start_date, primary_activity_id=primary.id,
+    )
+    db.add(block)
+    db.commit()
+    primary.block_id = block.id
+    member.block_id = block.id
+    db.commit()
+    db.refresh(member)
+    return member
+
+
+class TestBlockAwareDisplayFallback:
+    """#482: a non-primary block member must display the block's report (the
+    primary's), read-only, instead of 404-ing and spinning forever."""
+
+    def test_helper_returns_primary_report_for_non_primary_member(self, db, monkeypatch):
+        monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
+        primary = _seed_activity(db)
+        member = _add_block_member(db, primary)
+        primary_report = _insert_report(
+            db, primary.id, "coach_message_v3", "2.0", message="the session report"
+        )
+        # The member owns no report of its own ...
+        assert get_displayable_report_row(db, str(member.id)) is None
+        # ... so the block fallback borrows the primary's.
+        got = get_block_primary_report_row(db, str(member.id))
+        assert got is not None and got.id == primary_report.id
+
+    def test_helper_none_for_the_primary_itself(self, db, monkeypatch):
+        # The primary owns its report; the fallback must not loop back to it.
+        monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
+        primary = _seed_activity(db)
+        _add_block_member(db, primary)
+        _insert_report(db, primary.id, "coach_message_v3", "2.0", message="the session report")
+        assert get_block_primary_report_row(db, str(primary.id)) is None
+
+    def test_helper_none_for_activity_without_a_block(self, db, monkeypatch):
+        monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
+        solo = _seed_activity(db)
+        assert get_block_primary_report_row(db, str(solo.id)) is None
+
+    def test_endpoint_serves_block_report_on_non_primary_member(self, client, db, monkeypatch):
+        # The #482 regression: opening a non-primary member returns the session
+        # report (200) rather than 404, without calling the LLM.
+        monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
+        primary = _seed_activity(db)
+        member = _add_block_member(db, primary)
+        _insert_report(db, primary.id, "coach_message_v3", "2.0", message="the session report")
+
+        with patch("app.services.coach.service.AnthropicClient",
+                   side_effect=AssertionError("must not call the LLM on the display path")):
+            res = client.get(f"/api/activities/{member.id}/coach-report?generate=true")
+        assert res.status_code == 200
+        assert res.json()["report"]["message"] == "the session report"
+
+    def test_member_404s_when_primary_has_no_report_yet(self, client, db, monkeypatch):
+        # Nothing to borrow yet: the member still 404s under generate=false rather
+        # than borrowing a non-existent report.
+        monkeypatch.setattr(settings, "COACH_PROMPT_ID", "coach_message_v3")
+        primary = _seed_activity(db)
+        member = _add_block_member(db, primary)
+        res = client.get(f"/api/activities/{member.id}/coach-report?generate=false")
         assert res.status_code == 404


### PR DESCRIPTION
Closes #482.

## Problem

A multi-activity block's coach report is generated once, keyed to the block **primary** (the run, else the longest member). Opening a **non-primary** member's activity-detail page returned **404** from `GET /api/activities/{id}/coach-report` and left the Coach Analysis panel spinning, because that activity owns zero `coach_reports` rows and the read path had no block-aware fallback.

## Fix (read-path only)

- `services/coach/service.py`: new `get_block_primary_report_row` — when an activity owns no displayable report, return its block primary's **displayable** report (read-only, no generation). Returns `None` when the activity is not in a block, IS the primary, or the primary has no report yet.
- `api/coach.py`: the read endpoint tries this fallback before 404-ing. `voice_stale` is left `False` on the borrowed row so a borrowed session report never auto-triggers a per-member regeneration.
- `get_active_report_row` / `get_or_generate_coach_report` are **unchanged**: regeneration identity stays per-activity, so the "Re-run" button still mints a member-specific report.

No schema change, no migration, no change to the context pack or system prompt.

## Tests

`tests/test_coach_report_display_fallback.py` (+5): helper unit cases (non-primary borrows the primary's report; `None` for the primary itself, for a block-less activity) and the endpoint returning the session report (200) on a non-primary member without calling the LLM. Full backend suite green (1668 passed).

## Verified end-to-end on the real prod data snapshot

Drove the full FastAPI stack against the seeded production Postgres, before/after on a real case (block `03f94acb`: primary "Afternoon Walk" with a report; non-primary member "Afternoon Run" with zero reports):

- BEFORE (fallback off): `GET ...?generate=false` → **404** "No cached report."
- AFTER (fix on): same request → **200**, serving the primary's report (`activity_id` = the primary), `voice_stale=False`. Borrowed row == primary's own row.
- Control: the primary member still serves its own report (200).

## Out of scope (split out)

The issue's comment reported a **distinct** second failure mode — a hard **500 on *starting* regeneration** ("Couldn't start regeneration (500)") on a normal run, different root cause and code path. Tracked separately in **#483** (suspected: the cooldown guard degrades open on a Redis error but the subsequent `queue.enqueue` is unguarded). Not addressed here.

The frontend "never an endless spinner" companion from #482 is not needed for the reported bug: `CoachReportPanel`'s polls are already bounded, and once the backend serves the borrowed report the member's mount fetch resolves to `loaded`.