### PR TITLE
fix(coach): regeneration start never surfaces a raw 500 (#483)

### DIFF
--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -278,12 +278,33 @@ def regenerate_coach_report(
     # (3 attempts, 60/300/900s backoffs) used by the create/poll paths, so a
     # transient streaming disconnect (httpx.RemoteProtocolError) retries at the
     # RQ level rather than silently leaving the runner with a stale fallback report.
-    queue.enqueue(
-        regenerate_report_job, str(activity_id),
-        job_id=job_id,
-        job_timeout=settings.RQ_JOB_TIMEOUT_SECONDS,
-        retry=PIPELINE_RETRY,
-    )
+    # #483: the cooldown guard above degrades open on a Redis error, so a queue/
+    # Redis blip lands here with the enqueue still to do. Left unguarded, an enqueue
+    # failure propagated as a raw 500 to the runner ("Couldn't start regeneration
+    # (500)"). Guard it: a failed start must never surface a 500. Free the cooldown
+    # key first (best-effort) so the runner's "Try again" can actually re-enqueue
+    # instead of short-circuiting on a key set for a job that never started, then
+    # return an actionable 503.
+    try:
+        queue.enqueue(
+            regenerate_report_job, str(activity_id),
+            job_id=job_id,
+            job_timeout=settings.RQ_JOB_TIMEOUT_SECONDS,
+            retry=PIPELINE_RETRY,
+        )
+    except Exception as exc:  # noqa: BLE001 — a queue failure must not 500 the runner
+        logger.warning(
+            "regenerate_enqueue_failed",
+            extra={"activity_id": str(activity_id), "error": str(exc)},
+        )
+        try:
+            queue.connection.delete(cooldown_key)
+        except Exception:  # noqa: BLE001 — Redis already unreachable; best-effort
+            pass
+        raise HTTPException(
+            status_code=503,
+            detail="Couldn't start the coach analysis just now — please try again in a moment.",
+        )
     return {"status": "regenerating"}
 
 

--- a/backend/tests/test_async_regenerate.py
+++ b/backend/tests/test_async_regenerate.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from tests.test_coach_report_versioning import _seed_activity
 
@@ -76,6 +77,63 @@ class TestRegenerateEndpoint:
                    side_effect=AssertionError("must not call the LLM in the request")):
             res = client.post(f"/api/activities/{activity.id}/coach-report/regenerate")
         assert res.status_code == 202
+
+
+class TestRegenerateEnqueueFailure:
+    """#483: a queue/Redis failure on START must never surface a raw 500.
+
+    The cooldown guard degrades open on a Redis error, so an enqueue failure lands
+    in the request with the job unstarted. Before the fix the unguarded enqueue
+    propagated as a 500 ("Couldn't start regeneration (500)"); now it returns an
+    actionable 503 and frees the cooldown so "Try again" can re-enqueue.
+    """
+
+    def test_enqueue_failure_returns_503_not_500(self, client: TestClient, db):
+        activity = _seed_activity(db)
+        fake_queue = MagicMock()
+        fake_queue.connection.set.return_value = True  # cooldown acquired
+        fake_queue.enqueue.side_effect = RedisConnectionError("redis down")
+        with patch("app.core.queue.queue", fake_queue):
+            res = client.post(f"/api/activities/{activity.id}/coach-report/regenerate")
+        assert res.status_code == 503  # not a raw 500
+        # the runner gets an actionable message, not a stack trace
+        assert "try again" in res.json()["detail"].lower()
+
+    def test_enqueue_failure_frees_cooldown_so_retry_can_reenqueue(self, client: TestClient, db):
+        # The cooldown key was set for a job that never started; it must be cleared
+        # so the next tap is not short-circuited to {"status": "cooldown"}.
+        activity = _seed_activity(db)
+        fake_queue = MagicMock()
+        fake_queue.connection.set.return_value = True
+        fake_queue.enqueue.side_effect = RedisConnectionError("redis down")
+        with patch("app.core.queue.queue", fake_queue):
+            client.post(f"/api/activities/{activity.id}/coach-report/regenerate")
+        fake_queue.connection.delete.assert_called_once_with(
+            f"coach_regen_cooldown:{activity.id}"
+        )
+
+    def test_cooldown_delete_failure_still_returns_503(self, client: TestClient, db):
+        # Redis fully unreachable: even the best-effort cooldown cleanup raises. The
+        # endpoint must still degrade to 503, never a 500.
+        activity = _seed_activity(db)
+        fake_queue = MagicMock()
+        fake_queue.connection.set.return_value = True
+        fake_queue.enqueue.side_effect = RedisConnectionError("redis down")
+        fake_queue.connection.delete.side_effect = RedisConnectionError("redis down")
+        with patch("app.core.queue.queue", fake_queue):
+            res = client.post(f"/api/activities/{activity.id}/coach-report/regenerate")
+        assert res.status_code == 503
+
+    def test_healthy_enqueue_unchanged(self, client: TestClient, db):
+        # Guard must not change the happy path: a healthy queue still enqueues + 202s.
+        activity = _seed_activity(db)
+        fake_queue = MagicMock()
+        with patch("app.core.queue.queue", fake_queue):
+            res = client.post(f"/api/activities/{activity.id}/coach-report/regenerate")
+        assert res.status_code == 202
+        assert res.json() == {"status": "regenerating"}
+        fake_queue.enqueue.assert_called_once()
+        fake_queue.connection.delete.assert_not_called()  # cooldown untouched on success
 
 
 class TestRegenerateJob:

--- a/frontend/components/CoachReportPanel.tsx
+++ b/frontend/components/CoachReportPanel.tsx
@@ -219,7 +219,21 @@ export default function CoachReportPanel({ activityId, hasMetrics, onStartChat }
         `/api/activities/${activityId}/coach-report/regenerate`,
         { method: 'POST' },
       );
-      if (!res.ok) throw new Error(`Couldn't start regeneration (${res.status})`);
+      if (!res.ok) {
+        // #483: surface the server's actionable message (a 503 from a queue blip
+        // carries one) rather than a bare status code. The error state already
+        // renders a working "Try again", so the runner lands on a retry, never a
+        // raw 500.
+        let detail = '';
+        try {
+          detail = ((await res.json())?.detail as string) ?? '';
+        } catch {
+          // non-JSON error body; fall back to the friendly default below
+        }
+        throw new Error(
+          detail || 'Could not start your coach analysis. Please try again in a moment.',
+        );
+      }
     } catch (err: unknown) {
       setErrorMsg(err instanceof Error ? err.message : 'Could not start regeneration.');
       setStatus('error');


### PR DESCRIPTION
Closes #483.

## Problem

Requesting a coach report could show the runner a red banner **"Couldn't start regeneration (500)"** instead of a report. The activity-detail screen otherwise loaded fine — only starting the coach analysis failed with a hard 500.

## Root cause

In `regenerate_coach_report` (`api/coach.py`), the cost-guard cooldown **degrades open** on a Redis error:

```python
try:
    acquired = queue.connection.set(cooldown_key, "1", nx=True, ex=...)
except Exception:        # Redis blip must not block regeneration
    acquired = True
```

but the very next line — the actual enqueue — was **unguarded**, so any enqueue-time exception (`redis.exceptions.ConnectionError` being the most likely) propagated as an unhandled **500**. The guard and the enqueue talk to the same Redis; degrading open on one but hard-failing on the other is the bug.

The exact prod trigger could not be confirmed from a traceback, so this hardens the one structurally-unguarded path and makes **any** enqueue-time failure graceful (covers the Redis hypothesis and any other enqueue exception).

## Fix

- **Backend:** wrap `queue.enqueue`. On failure: log, **best-effort free the cooldown key** (so the runner's "Try again" can actually re-enqueue instead of short-circuiting on `{"status":"cooldown"}` for a job that never started), and raise an actionable **503** — never a raw 500. The healthy path is unchanged (202 / `{"status":"regenerating"}`).
- **Frontend (`CoachReportPanel.tsx`):** the `regenerate` callback surfaced a bare `(${status})`; it now uses the server's `detail` message (friendly fallback otherwise). The error state already renders a working "Try again", so the runner lands on a retry, not a scary raw error.

## Tests (`tests/test_async_regenerate.py`, +4)

Inject the **real** `redis.exceptions.ConnectionError` RQ raises and assert:
- enqueue failure → **503**, not 500, with an actionable detail;
- the cooldown key is **freed** so a retry can re-enqueue;
- a failure even on the best-effort cooldown cleanup still degrades to 503;
- the healthy path still **202**s and leaves the cooldown untouched.

Proven before/after: the 3 failure tests **fail without the fix** (raw `ConnectionError` → 500) and **pass with it**. Coverage gap that let the bug ship: the prior tests mocked the queue with a `MagicMock` whose `.enqueue` never raises, so the unguarded path was never exercised.

Full backend suite green (1672 passed); frontend `tsc --noEmit` + eslint clean. `next build` left to CI (a local `next dev` was running and `next build` corrupts its shared `.next`).

## Context

Split out from #482's comment, where it was reported as a distinct second failure mode (the 404-spinner is fixed in #484). This is the regeneration-**start** path.