### PR TITLE
docs(diagram): distinct Runner color, value-first chips, linkable fate chips

### DIFF
--- a/docs/diagrams/ai-flow-graph.html
+++ b/docs/diagrams/ai-flow-graph.html
@@ -8,7 +8,7 @@
   :root {
     --bg:#0f1115; --panel:#181b22; --ink:#e6e9ef; --muted:#9aa3b2; --line:#2c313c;
     --source:#3b82f6; --code:#10b981; --store:#a78bfa; --llm:#f59e0b;
-    --gate:#ef4444; --runner:#14b8a6; --memory:#a78bfa;
+    --gate:#ef4444; --runner:#ec4899; --memory:#a78bfa;
     --up:#22d3ee; --down:#f59e0b;
   }
   * { box-sizing:border-box; }
@@ -78,7 +78,7 @@
     padding:1px 6px; border-radius:4px; }
   .tag.source{background:rgba(59,130,246,.18);color:#93c5fd;} .tag.code{background:rgba(16,185,129,.18);color:#6ee7b7;}
   .tag.store{background:rgba(167,139,250,.18);color:#c4b5fd;} .tag.llm{background:rgba(245,158,11,.2);color:#fcd34d;}
-  .tag.gate{background:rgba(239,68,68,.2);color:#fca5a5;} .tag.runner{background:rgba(20,184,166,.2);color:#5eead4;}
+  .tag.gate{background:rgba(239,68,68,.2);color:#fca5a5;} .tag.runner{background:rgba(236,72,153,.2);color:#f9a8d4;}
   .tag.memory{background:rgba(167,139,250,.18);color:#c4b5fd;}
   .drawer .body { padding:16px 22px 50px; overflow-y:auto; }
   .drawer .desc { margin:0 0 8px; font-size:12.5px; color:var(--muted); }
@@ -139,6 +139,9 @@
   .kv .k { color:#7dd3fc; }
   .kv .meta { color:#5b6472; font-size:10px; }
   .kv .vline { flex:1 1 auto; min-width:0; color:#e6e9ef; word-break:break-word; }
+  /* basis 0 keeps value+trailing chips on the '=' line; only the chips wrap when tight */
+  .kv .rw > .vline { flex:1 1 0; }
+  .kv .rowchips { margin-top:3px; }
   .kv .sep { color:#525a68; }
   .kv .v.vnum{ color:#f0abfc; } .kv .v.vstr{ color:#fcd34d; } .kv .v.vbool{ color:#86efac; } .kv .v.vnull{ color:#6ee7b7; }
   .kv .nest { border-left:1px solid var(--line); margin:3px 0 4px 4px; padding-left:12px; }
@@ -159,6 +162,8 @@
     display:inline-block; font-weight:700; font-size:11px; border-radius:4px; padding:0 4px;
     vertical-align:middle; white-space:nowrap; }
   .kv .fatetag { font-size:9px; letter-spacing:.3px; margin-left:5px; padding:0 5px; cursor:default; }
+  .kv .fatetag.fatelink { cursor:pointer; }
+  .kv .fatetag.fatelink:hover { filter:brightness(1.25); }
   .legend .fchip { font-size:11px; padding:0 5px; }
   .fate-forwarded   { color:#fcd34d; background:rgba(252,211,77,.12); border:1px solid rgba(252,211,77,.34); }
   .fate-transformed { color:#c4b5fd; background:rgba(167,139,250,.15); border:1px solid rgba(167,139,250,.38); }
@@ -308,7 +313,7 @@ const worldW = LEFT + (totalCols-1)*COLPITCH + (CATS.length-1)*CATGAP + NW + 60;
 const worldH = PADTOP + maxStack + 60;
 
 const shortLabel = n => n.title.split('—')[0].split('(')[0].trim();
-const KCOL = { source:'#3b82f6', code:'#10b981', store:'#a78bfa', llm:'#f59e0b', gate:'#ef4444', runner:'#14b8a6', memory:'#a78bfa' };
+const KCOL = { source:'#3b82f6', code:'#10b981', store:'#a78bfa', llm:'#f59e0b', gate:'#ef4444', runner:'#ec4899', memory:'#a78bfa' };
 
 /* ----- category headers (one per category, at its leftmost sub-column) ----- */
 CATS.forEach(cat=>{
@@ -428,7 +433,7 @@ function openDrawer(id, up, down){
        : '<div class="grp end"><span class="lbl end">■ end of chain</span> nothing consumes this — it is the final output</div>');
   document.getElementById('dBody').innerHTML=n.body();
   document.querySelectorAll('#dRel .chip').forEach(c=>c.addEventListener('click',()=>select(c.dataset.go)));
-  document.querySelectorAll('#dBody .srctag').forEach(c=>c.addEventListener('click', e=>{ e.stopPropagation(); select(c.dataset.go); }));
+  document.querySelectorAll('#dBody .srctag, #dBody .fatetag[data-go]').forEach(c=>c.addEventListener('click', e=>{ e.stopPropagation(); select(c.dataset.go); }));
   drawer.classList.add('open');
 }
 function closeDrawer(){ drawer.classList.remove('open'); }

--- a/docs/diagrams/flow-nodes.js
+++ b/docs/diagrams/flow-nodes.js
@@ -70,14 +70,40 @@ function _fateWord(f){
   if(f.f==='gated') return 'gated:'+(f.passed===false?'blocked':'passed');
   return f.f;
 }
+// Resolve a fate's destination LABEL to a node id so the chip can link to where the field
+// went (symmetric with the source chip linking to where it was written). "the model" maps to
+// the LLM node; a "pack.activity.avg_hr"-style label resolves to its owning pack node by
+// stripping trailing field segments. Descriptive non-node targets ("(not in pack.activity)",
+// "RunnerBaseline + Trends") resolve to null and stay unlinked. Resolved lazily at render
+// time, when the inline-script globals (NODES/byId/shortLabel) exist.
+let _fateLabelMap = null;
+function _fateGo(to){
+  if(!to) return null;
+  if(to==='the model') return (typeof byId!=='undefined' && byId['llm']) ? 'llm' : null;
+  if(!_fateLabelMap){
+    _fateLabelMap = {};
+    if(typeof NODES!=='undefined') NODES.forEach(n=>{ _fateLabelMap[shortLabel(n)] = n.id; });
+  }
+  if(_fateLabelMap[to]) return _fateLabelMap[to];
+  let t = to;
+  while(t.includes('.')){
+    t = t.slice(0, t.lastIndexOf('.'));
+    if(_fateLabelMap[t]) return _fateLabelMap[t];
+  }
+  return null;
+}
 // A fate chip carries the fate GLYPH + WORD (what happened on the next hop) and \u2014 when
-// known \u2014 the DESTINATION it reached (the "where it went" label the field gets).
+// known \u2014 the DESTINATION it reached (the "where it went" label the field gets). When that
+// destination resolves to a node, the chip is a link (data-go) like the source chip.
 function _fateChip(f){
   const blocked = f.f==='gated' && f.passed===false;
   const cls = 'fate-'+(blocked?'gated-blocked':f.f);
   const word = _fateWord(f);
   const to = f.to ? ' <span class="fate-to">'+esc(f.to)+'</span>' : '';
-  return ' <span class="fatetag '+cls+'" title="'+esc(f.note||word)+'">'+_FATE_GLYPH[f.f]+' '+esc(word)+to+'</span>';
+  const go = _fateGo(f.to);
+  const goCls = go ? ' fatelink' : '';
+  const goAttr = go ? ' data-go="'+go+'"' : '';
+  return ' <span class="fatetag '+cls+goCls+'"'+goAttr+' title="'+esc(f.note||word)+'">'+_FATE_GLYPH[f.f]+' '+esc(word)+to+'</span>';
 }
 // DerivedMetric row \u2192 pack.metrics (context.build_focus_payload, context.py:593-627). MOST columns are
 // forwarded, but the hop is NOT uniformly verbatim: efficiency_analysis is reshaped and the scalar
@@ -175,27 +201,31 @@ function _rows(obj, depth, sources, fates){
     const _tag=_src ? ' <span class="srctag" data-go="'+_src.id+'" title="written by the '+esc(_src.label)+' stage">\u21a4 '+esc(_src.label)+'</span>' : '';
     const _fate=(depth===0 && fates && fates[k]) ? fates[k] : null;
     const _ftag=_fate ? _fateChip(_fate) : '';
-    const key='<span class="k">'+esc(k)+'</span>'+_tag+_ftag;
+    // the source/fate chips ride AFTER the value, not the field name: inline for scalar
+    // rows, on a trailing line (cblock) for multi-line block rows.
+    const name='<span class="k">'+esc(k)+'</span>';
+    const chips=_tag+_ftag;
+    const cblock=chips ? '<div class="rowchips">'+chips+'</div>' : '';
     if(Array.isArray(v)){
       if(_allNum(v) && v.length>10){
-        h+='<div class="rw col"><div class="kline">'+key+' <span class="meta">'+v.length+' points</span></div>'+_sparkline(v)+'</div>';
+        h+='<div class="rw col"><div class="kline">'+name+' <span class="meta">'+v.length+' points</span></div>'+_sparkline(v)+cblock+'</div>';
       } else if(v.length===0){
-        h+='<div class="rw"><div class="kline">'+key+'</div><span class="eq">=</span><div class="vline"><span class="v vnull">[ ]</span></div></div>';
+        h+='<div class="rw"><div class="kline">'+name+'</div><span class="eq">=</span><div class="vline"><span class="v vnull">[ ]</span>'+chips+'</div></div>';
       } else if(_allNum(v) || (_allPrim(v) && v.every(x=>typeof x!=='string'))){
-        h+='<div class="rw"><div class="kline">'+key+' <span class="meta">'+v.length+'</span></div><span class="eq">=</span><div class="vline">'
-          +v.map(x=>_valHTML(x)).join('<span class="sep">, </span>')+'</div></div>';
+        h+='<div class="rw"><div class="kline">'+name+' <span class="meta">'+v.length+'</span></div><span class="eq">=</span><div class="vline">'
+          +v.map(x=>_valHTML(x)).join('<span class="sep">, </span>')+chips+'</div></div>';
       } else if(v.every(x=>typeof x==='string')){
-        h+='<div class="rw col"><div class="kline">'+key+' <span class="meta">'+v.length+' items</span></div>'
-          +'<div class="strlist">'+v.map(x=>'<span class="si">'+esc(x)+'</span>').join('')+'</div></div>';
+        h+='<div class="rw col"><div class="kline">'+name+' <span class="meta">'+v.length+' items</span></div>'
+          +'<div class="strlist">'+v.map(x=>'<span class="si">'+esc(x)+'</span>').join('')+'</div>'+cblock+'</div>';
       } else {
         const show=v.slice(0,10), more=v.length>10?' (first 10 of '+v.length+')':'';
-        h+='<div class="rw col"><div class="kline">'+key+' <span class="meta">'+v.length+' items'+more+'</span></div>'
-          +'<div class="nest">'+_rows(show, depth+1, sources, fates)+'</div></div>';
+        h+='<div class="rw col"><div class="kline">'+name+' <span class="meta">'+v.length+' items'+more+'</span></div>'
+          +'<div class="nest">'+_rows(show, depth+1, sources, fates)+'</div>'+cblock+'</div>';
       }
     } else if(v && typeof v==='object'){
-      h+='<div class="rw col"><div class="kline">'+key+'</div><div class="nest">'+_rows(v)+'</div></div>';
+      h+='<div class="rw col"><div class="kline">'+name+'</div><div class="nest">'+_rows(v)+'</div>'+cblock+'</div>';
     } else {
-      h+='<div class="rw"><div class="kline">'+key+'</div><span class="eq">=</span><div class="vline">'+_valHTML(v)+'</div></div>';
+      h+='<div class="rw"><div class="kline">'+name+'</div><span class="eq">=</span><div class="vline">'+_valHTML(v)+chips+'</div></div>';
     }
   }
   return h;


### PR DESCRIPTION
Readability tweaks to the data-flow diagram (`docs/diagrams/ai-flow-graph.html` + the static render helpers in `flow-nodes.js`), all requested from looking at the rendered drawer.

## Changes
- **Runner color**: recolor the `Runner` node kind teal → pink (`#ec4899`) so it no longer reads near-identical to the green `Code / fact` kind. Updated in the CSS var, the `.tag.runner` chip, and the `KCOL` map.
- **Chips after the value**: each field's source/fate provenance chips (`↤ source`, `→ forwarded → the model`) now ride after the *value* (`field = value [↤ source] [→ fate]`) instead of crowding the field name. Scalar rows keep the chips inline; multi-line block rows (objects, lists) trail them on their own line. Value cell uses `flex-basis:0` so value+chips stay on the `=` line and only the fate chip wraps when tight.
- **Linkable fate chips**: the forward (fate) chip is now a link like the source chip. `_fateGo()` resolves a fate's destination label to a node id (`the model` → the LLM node; `pack.x.y` → its owning pack node by stripping field segments) and the chip gets `data-go` + navigates on click. Terminal/descriptive fates (`✕ dropped …`, `↝ transformed RunnerBaseline + Trends`) have no destination node and correctly stay unlinked.

## Verification
Rendered in a real browser (Chrome DevTools) against the saved files:
- Runner pink is clearly distinct from Code/fact green.
- Chip-after-value layout renders correctly, including the worst case (the long `injury_notes` paragraph).
- All fate chips on `pack.metrics` link to the model; clicking one navigates to the Anthropic node; a `pack.activity.name` fate on the Activity row resolves to the `pack.activity` node; the four descriptive/dropped fates stay unlinked.

Docs-only; no backend/frontend code touched.