### PR TITLE
fix(blocks): anchor the block report on the run, not a warmup walk, under the receipt cadence (#487)

### DIFF
--- a/backend/app/services/blocks.py
+++ b/backend/app/services/blocks.py
@@ -23,7 +23,7 @@ from typing import Optional, Sequence
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
-from app.models import Activity, Block, Exchange
+from app.models import Activity, Block, CoachReport, Exchange
 
 logger = logging.getLogger(__name__)
 
@@ -259,19 +259,41 @@ def _latest(a: Optional[datetime], b: Optional[datetime]) -> Optional[datetime]:
     return max(a, b)
 
 
+def _primary_has_report(db: Session, block: Block) -> bool:
+    """True once a CoachReport has been written for the block's current primary.
+
+    This is the real invariant behind the freeze: the report row is keyed on the
+    primary, so once it exists a late arrival must not move the anchor out from
+    under it. Under the two-stage LLM exchange the opener writes that row (and
+    sets `opened_at` at the same time, which is why the old `opened_at` proxy
+    held). Under the receipt cadence the first activity's deterministic receipt
+    sets `opened_at` but writes NO report, so the proxy froze the primary to a
+    warmup walk before the run could win it (#487). Gating on the report itself
+    is cadence-agnostic: the primary stays recomputable until a report is keyed
+    to it, so a joining run still wins the anchor under either cadence.
+    """
+    if block.primary_activity_id is None:
+        return False
+    return (
+        db.query(CoachReport.id)
+        .filter(CoachReport.activity_id == block.primary_activity_id)
+        .first()
+        is not None
+    )
+
+
 def _recompute_block(db: Session, block: Block, *, force_primary: bool = False) -> None:
     """Recompute start/end/primary from the block's current members.
 
-    The primary is FROZEN once the block's exchange has opened: the opener
-    spoke about it and the coach report row is keyed on it, so a late arrival
-    may grow the block's bounds but never moves the exchange's anchor. A
-    runner split/merge correction (`force_primary`) recomputes it regardless —
-    an explicit correction outranks the frozen anchor.
+    The primary is FROZEN once a coach report has been keyed to it (see
+    `_primary_has_report`): the report speaks about that activity, so a late
+    arrival may grow the block's bounds but never moves the anchor out from
+    under an existing report. A runner split/merge correction (`force_primary`)
+    recomputes it regardless — an explicit correction outranks the frozen anchor.
     """
     members = db.query(Activity).filter(Activity.block_id == block.id).all()
     block.start_date = min(a.start_date for a in members)
     block.end_date = max(activity_end(a) for a in members)
-    exchange = db.query(Exchange).filter(Exchange.block_id == block.id).first()
-    if force_primary or exchange is None or exchange.opened_at is None:
+    if force_primary or not _primary_has_report(db, block):
         block.primary_activity_id = pick_primary(members).id
     db.add(block)

--- a/backend/tests/test_blocks_service.py
+++ b/backend/tests/test_blocks_service.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from app.models import Activity, Block, Exchange, User
+from app.models import Activity, Block, CoachReport, Exchange, User
 from app.services.blocks import activity_end as activity_end_of
 from app.services.blocks import (
     assign_activity_to_block,
@@ -145,16 +145,25 @@ def test_out_of_order_sync_converges_to_one_block(db):
     assert joined.primary_activity_id == later.id  # still the longest run
 
 
-def test_primary_is_frozen_once_the_exchange_has_opened(db):
-    # The opener spoke about the primary activity and the report row is keyed
-    # on it; a late arrival into the open exchange must not move that anchor,
-    # however long it is.
+def _add_report(db, activity) -> None:
+    """A coach report keyed to an activity — the anchor commitment that freezes
+    the block's primary (the LLM opener writes this row; the receipt does not)."""
+    db.add(CoachReport(activity_id=activity.id, report={}, meta={}, context_pack={}))
+    db.commit()
+
+
+def test_primary_is_frozen_once_a_report_is_keyed_to_it(db):
+    # A report speaks about the primary activity and is keyed on it; a late
+    # arrival into the open exchange must not move that anchor, however long it
+    # is. (Under the LLM exchange the opener writes this report and opens the
+    # exchange together.)
     user = _make_user(db)
     run = _make_activity(db, user, start=T0, elapsed=1500, type="Run")
     block = assign_activity_to_block(db, run, gap_seconds=GAP)
     exchange = db.query(Exchange).filter(Exchange.block_id == block.id).one()
     exchange.opened_at = datetime.now(timezone.utc)
     db.commit()
+    _add_report(db, run)  # the opener's report row, keyed to the primary
 
     longer = _make_activity(
         db, user, start=T0 + timedelta(seconds=1800), elapsed=7200, type="Run"
@@ -166,6 +175,27 @@ def test_primary_is_frozen_once_the_exchange_has_opened(db):
     assert _aware(joined.end_date) == _aware(
         longer.start_date + timedelta(seconds=7200)
     )  # bounds still grow
+
+
+def test_receipt_opened_exchange_does_not_freeze_primary_before_a_report(db):
+    # Under the receipt cadence the first activity's deterministic receipt opens
+    # the exchange (sets opened_at) but writes NO coach report. A run joining the
+    # block afterwards must still win the primary, so the single session report
+    # is about the run and not the warmup walk (#487).
+    user = _make_user(db)
+    walk = _make_activity(db, user, start=T0, elapsed=1200, type="Walk")
+    block = assign_activity_to_block(db, walk, gap_seconds=GAP)
+    exchange = db.query(Exchange).filter(Exchange.block_id == block.id).one()
+    exchange.opened_at = datetime.now(timezone.utc)  # the receipt opened it
+    db.commit()
+    assert block.primary_activity_id == walk.id  # nothing else yet
+
+    run_start = T0 + timedelta(seconds=1800)
+    run = _make_activity(db, user, start=run_start, elapsed=2400, type="Run")
+    joined = assign_activity_to_block(db, run, gap_seconds=GAP)
+
+    assert joined.id == block.id
+    assert joined.primary_activity_id == run.id  # not frozen to the walk
 
 
 def _grouped_pair(db, user):


### PR DESCRIPTION
Closes #487.

## Problem

A morning with a short **walk shortly before a run** produced a single coach report about the **walk**, and the run's activity page rendered that walk report ("Solid recovery walk…"). The walk and run cluster into one Block (intended — the block exists so the coach is aware of the whole session), and the block's one report is keyed to the block **primary** ("the run, else the longest member"). The run should win, but it didn't.

## Root cause

`_recompute_block` froze the primary on `exchange.opened_at`. Under the live receipt cadence (`COACH_RECEIPT_CADENCE`), the **first** activity's instant deterministic receipt sets `opened_at` while writing **no** `CoachReport`. So a walk arriving first opened the exchange and was frozen as primary before the run could join — and the session's full report was generated about the walk. #484's display fallback then surfaced that walk report on the run's page (previously the #482 404-spinner).

The `opened_at` freeze was a correct proxy under the two-stage LLM exchange (the opener sets `opened_at` **and** writes the report together), but it is wrong under the receipt cadence where `opened_at` precedes any report.

## Fix

Freeze the primary on the **real invariant** the freeze was always standing in for: a `CoachReport` is actually keyed to the current primary. The LLM opener writes that row; the deterministic receipt does not — so the predicate is cadence-agnostic and a joining run still wins the anchor under either cadence. One change in `backend/app/services/blocks.py` (new `_primary_has_report`); no schema/migration, no context-pack or prompt change.

## Tests

- New regression test reproduces the receipt-cadence case (walk opens the exchange via receipt, run joins) — **fails before the fix** (frozen to the walk), **passes after** (run wins primary).
- The old `opened_at`-proxy freeze test is corrected to set up its real precondition (a report keyed to the primary), so it still pins the two-stage LLM freeze for the right reason.
- Full backend suite: 1673 passed (the 2 pre-existing `test_models`/`test_sync_integration` Postgres-env failures are unchanged from baseline).

## Verification on real data + browser

Against a `make seed-local` production snapshot: the bug exists on exactly two real blocks (the owner's Jun-25 Morning Walk + Run, and a Jun-14 Lunch Walk + Run). The read-path reproduction matched the reported screenshot verbatim. Replaying the join with the fix on the real Postgres rows makes the **run** the primary on both. Confirmed end-to-end in a real browser: the Morning Run page rendered the walk report before, and a run report ("Moderate run in 30°C heat…") after running the fixed pipeline.

## Scope / follow-ups (not in this PR)

- **Forward-only:** existing already-closed blocks (incl. the owner's Jun-25 run) keep the walk report; they need a one-off re-anchor + regenerate. Deferred per owner.
- **#488:** Phase-2 Clerk auth broke the local seeded-stack browser-verification path; filed to make a fail-closed-in-prod no-auth mode first-class.