### PR TITLE
refactor(coach): extract ExchangeLifecycle state-machine module (#494)

### DIFF
--- a/backend/app/jobs/process_new_activity.py
+++ b/backend/app/jobs/process_new_activity.py
@@ -25,7 +25,7 @@ per-activity store.
 import asyncio
 import logging
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Optional
 
 from rq import Retry
@@ -39,6 +39,7 @@ from app.models.coaching_relationship import CoachingRelationship
 from app.services.analysis import analyze_with_streams
 from app.services.analysis.classifier import Classification, compose_headline
 from app.services.blocks import activity_end, assign_activity_to_block
+from app.services.coach import exchange_lifecycle as lifecycle
 from app.services.coach.receipt import build_receipt
 from app.services.coach.service import (
     generate_fuller,
@@ -96,7 +97,7 @@ def _notify(
     Notification sent, or None.
     """
     sentinel_obj = sentinel_obj if sentinel_obj is not None else activity
-    if getattr(sentinel_obj, sentinel_attr) is not None:
+    if lifecycle.notification_already_sent(sentinel_obj, sentinel_attr):
         logger.info(
             "Skipping %s notification for activity %s: already sent at %s",
             stage, activity.strava_activity_id, getattr(sentinel_obj, sentinel_attr),
@@ -130,9 +131,7 @@ def _notify(
         )
         return None
 
-    setattr(sentinel_obj, sentinel_attr, datetime.now(timezone.utc))
-    db.add(sentinel_obj)
-    db.commit()
+    lifecycle.mark_notification_sent(db, sentinel_obj, sentinel_attr)
     return notification
 
 
@@ -254,10 +253,8 @@ async def _send_receipt(
     # Open the exchange on the first receipt, independent of delivery (A4 posture):
     # the reply window anchors here and must work even for a NoOp local notifier.
     exchange = db.query(Exchange).filter(Exchange.block_id == block.id).first()
-    if exchange is not None and exchange.opened_at is None:
-        exchange.opened_at = datetime.now(timezone.utc)
-        db.add(exchange)
-        db.commit()
+    if exchange is not None:
+        lifecycle.open_exchange(db, exchange)
 
     if notification is None:
         logger.info(
@@ -275,9 +272,7 @@ async def _send_receipt(
         )
         return None
 
-    activity.receipt_sent_at = datetime.now(timezone.utc)
-    db.add(activity)
-    db.commit()
+    lifecycle.record_receipt_sent(db, activity)
     return notification
 
 
@@ -376,7 +371,7 @@ async def _run_opener_stage(
     marks generation so a late arrival knows the exchange has spoken even if
     delivery failed or no channel is configured."""
     db.refresh(exchange)
-    if exchange.opener_sent_at is not None:
+    if lifecycle.notification_already_sent(exchange, "opener_sent_at"):
         logger.info(
             "Opener already sent for block %s; skipping", exchange.block_id
         )
@@ -387,10 +382,7 @@ async def _run_opener_stage(
         logger.info("No opener generated for activity %s", activity.strava_activity_id)
         return None
 
-    if exchange.opened_at is None:
-        exchange.opened_at = datetime.now(timezone.utc)
-        db.add(exchange)
-        db.commit()
+    lifecycle.open_exchange(db, exchange)
 
     # Schedule the conditional fuller turn FIRST, on the salience decision (the
     # opener LLM's judgment OR-ed with the deterministic safety override; a fallback
@@ -499,16 +491,11 @@ def _enqueue_reply_fuller(db: Session, activity_id) -> bool:
     exchange = db.query(Exchange).filter(Exchange.block_id == activity.block_id).first()
     if block is None or exchange is None:
         return False
-    if exchange.fuller_sent_at is not None:
-        return False  # closed: never re-fires
-    if exchange.opened_at is None:
-        return False  # not yet opened: a reply cannot spin up the exchange
-
-    opened = exchange.opened_at
-    opened_aware = opened if opened.tzinfo else opened.replace(tzinfo=timezone.utc)
-    age = (datetime.now(timezone.utc) - opened_aware).total_seconds()
-    if age > settings.EXCHANGE_REPLY_WINDOW_SECONDS:
-        return False  # opener too old: a reply on a stale exchange (AC4)
+    # Open (opener generated, not closed) and within the reply window: a closed or
+    # stale or never-opened exchange never re-fires / spins up (AC3/AC4). The state
+    # is owned by exchange_lifecycle, so the "never re-fire" guarantee lives once.
+    if not lifecycle.can_fire_reply_fuller(exchange):
+        return False
 
     primary_id = block.primary_activity_id
     try:
@@ -551,24 +538,16 @@ def _record_done_and_schedule(db: Session, activity_id) -> bool:
     exchange = db.query(Exchange).filter(Exchange.block_id == activity.block_id).first()
     if block is None or exchange is None:
         return False
-    if exchange.fuller_sent_at is not None:
+    if lifecycle.is_closed(exchange):
         return False  # closed: the full report already went
-
-    now = datetime.now(timezone.utc)
-    opened = exchange.opened_at
-    if opened is not None:
-        opened_aware = opened if opened.tzinfo else opened.replace(tzinfo=timezone.utc)
-        if (now - opened_aware).total_seconds() > settings.EXCHANGE_REPLY_WINDOW_SECONDS:
-            return False  # stale exchange: a "done" tap cannot resurrect it
+    # A "done" tap cannot resurrect a stale exchange (an unopened one is allowed —
+    # the receipt opens it on ingest, but a defensive mark_done opens it anyway).
+    if exchange.opened_at is not None and not lifecycle.within_reply_window(exchange):
+        return False
 
     # Record the explicit completion signal (idempotent), opening the exchange if
     # the receipt somehow had not (defensive — the receipt opens it on ingest).
-    if exchange.done_at is None:
-        exchange.done_at = now
-        if exchange.opened_at is None:
-            exchange.opened_at = now
-        db.add(exchange)
-        db.commit()
+    lifecycle.mark_done(db, exchange)
 
     last = max(
         db.query(Activity).filter(Activity.block_id == block.id).all(),
@@ -614,7 +593,7 @@ async def process_fuller_turn(
         )
         return None
     db.refresh(exchange)
-    if exchange.fuller_sent_at is not None:
+    if lifecycle.is_closed(exchange):
         logger.info(
             "Fuller turn already notified for block %s; no-op", exchange.block_id
         )

--- a/backend/app/services/coach/exchange_lifecycle.py
+++ b/backend/app/services/coach/exchange_lifecycle.py
@@ -1,0 +1,169 @@
+"""ExchangeLifecycle — the single owner of legal Exchange state transitions (#494).
+
+The `Exchange` row is a first-class two-stage lifecycle (A1/A4, ADR 0010) with a
+receipt-cadence variant (#296, ADR 0018). Its state lives in five sentinels:
+
+- `opened_at`     — the exchange has opened (the LLM opener generated under A4, or
+                    the first deterministic receipt under #296). Anchors the reply
+                    window, independent of notification delivery.
+- `opener_sent_at`— the opener notification went out (at most once). Unused under
+                    the receipt cadence (there is no LLM opener).
+- `fuller_sent_at`— the fuller/full-report notification went out (at most once).
+                    Set means the exchange is CLOSED and never re-fires.
+- `done_at`       — the runner tapped "done" on a receipt (#296), the explicit
+                    "session finished" signal that schedules the full report.
+
+Plus a per-activity receipt dedup sentinel that lives on the Activity, not the
+exchange, because the receipt is per-activity:
+
+- `Activity.receipt_sent_at` — this activity's instant receipt has been sent.
+
+Before this module the transitions were scattered across five helpers in
+`jobs/process_new_activity.py`, each re-asserting the "never re-fire" guarantee and
+the reply/done open-window guards. The recent prod bugs (#487, #482, #490) all
+landed in that scattered lifecycle. This module concentrates every transition and
+its guard in one place, so the at-most-once invariant is enforced — and tested —
+once, and a new bug surfaces at the interface rather than in prod.
+
+Boundary: this module owns ROW STATE only. SCHEDULING (RQ enqueue) and NOTIFICATION
+(building/sending the channel message, and reading the report row) stay in the job
+layer. A transition function never sends, never schedules, never generates; it reads
+and mutates the Exchange/Activity sentinels under the at-most-once invariant and
+commits.
+
+Sentinel posture mirrors A4 exactly: a notification sentinel is set only on a
+successful send (the job calls `mark_notification_sent` AFTER the send returns), left
+null on failure so the stage stays re-sendable, and never reset by a `force=true`
+regeneration (no transition here ever clears a sentinel).
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models import Activity, Exchange
+
+logger = logging.getLogger(__name__)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _aware(dt: datetime) -> datetime:
+    """A datetime guaranteed tz-aware (naive reads from the DB are treated UTC)."""
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+# --- state reads --------------------------------------------------------------
+
+
+def is_closed(exchange: Exchange) -> bool:
+    """The exchange is CLOSED: the fuller/full report has been sent. A closed
+    exchange never re-fires and never re-opens (a late activity starts a new
+    block)."""
+    return exchange.fuller_sent_at is not None
+
+
+def is_open(exchange: Exchange) -> bool:
+    """The exchange is OPEN: it has opened (`opened_at` set, independent of delivery)
+    and is not yet closed. Replies and "done" taps act only on an open exchange."""
+    return exchange.opened_at is not None and not is_closed(exchange)
+
+
+def within_reply_window(exchange: Exchange, *, now: Optional[datetime] = None) -> bool:
+    """The opener is recent enough that a reply/done may still act on the exchange.
+    A reply on a stale exchange (opener older than EXCHANGE_REPLY_WINDOW_SECONDS)
+    must never spin one up (AC4). An unopened exchange has no window."""
+    if exchange.opened_at is None:
+        return False
+    now = now or _now()
+    age = (now - _aware(exchange.opened_at)).total_seconds()
+    return age <= settings.EXCHANGE_REPLY_WINDOW_SECONDS
+
+
+def can_fire_reply_fuller(exchange: Exchange, *, now: Optional[datetime] = None) -> bool:
+    """Whether a runner reply may early-fire the fuller turn: the exchange is open,
+    not closed, and within the reply window (A4 reply path)."""
+    return is_open(exchange) and within_reply_window(exchange, now=now)
+
+
+# --- state transitions (each guarded, idempotent, committing) -----------------
+
+
+def open_exchange(db: Session, exchange: Exchange, *, now: Optional[datetime] = None) -> bool:
+    """Open the exchange (set `opened_at`) if not already open. Idempotent: a second
+    call on an already-opened exchange is a no-op. Returns True if it opened it now.
+
+    Opening is independent of notification delivery (A4 posture), so the reply window
+    anchors even under a NoOp local notifier."""
+    if exchange.opened_at is not None:
+        return False
+    exchange.opened_at = now or _now()
+    db.add(exchange)
+    db.commit()
+    return True
+
+
+def record_receipt_sent(db: Session, activity: Activity, *, now: Optional[datetime] = None) -> None:
+    """Mark this activity's instant receipt as sent (#296). The per-activity dedup
+    sentinel; set only after a successful send so the receipt stays re-sendable on a
+    pipeline retry. The caller has already confirmed `receipt_sent_at` was null."""
+    activity.receipt_sent_at = now or _now()
+    db.add(activity)
+    db.commit()
+
+
+def mark_done(db: Session, exchange: Exchange, *, now: Optional[datetime] = None) -> bool:
+    """Record the runner's explicit "done" tap (#296). Idempotent: a second tap is a
+    no-op on `done_at`. Defensively opens the exchange if the receipt somehow had not.
+    Returns True if it recorded the completion now.
+
+    The CALLER must already have checked the exchange is open and within window via
+    `can_fire_reply_fuller` (or the equivalent) — this only writes state."""
+    if exchange.done_at is not None:
+        return False
+    now = now or _now()
+    exchange.done_at = now
+    if exchange.opened_at is None:
+        exchange.opened_at = now
+    db.add(exchange)
+    db.commit()
+    return True
+
+
+# --- the at-most-once notification invariant (one place) ----------------------
+
+#: The notification sentinels and the row they live on. The opener/fuller stages
+#: dedup on the block's Exchange row (A1); the single-shot rollback path dedups on
+#: the Activity itself (per-activity dedup needs a per-activity store).
+NOTIFICATION_SENTINELS = frozenset(
+    {"opener_sent_at", "fuller_sent_at", "coach_notification_sent_at"}
+)
+
+
+def notification_already_sent(sentinel_obj, sentinel_attr: str) -> bool:
+    """Whether this stage's notification has already gone out (the at-most-once read).
+
+    `sentinel_obj` is the Exchange (two-stage) or the Activity (single-shot rollback);
+    `sentinel_attr` names the dedup sentinel. The job checks this BEFORE building and
+    sending, so a stage sends at most once per exchange (A4 AC5)."""
+    if sentinel_attr not in NOTIFICATION_SENTINELS:
+        raise ValueError(f"unknown notification sentinel {sentinel_attr!r}")
+    return getattr(sentinel_obj, sentinel_attr) is not None
+
+
+def mark_notification_sent(
+    db: Session, sentinel_obj, sentinel_attr: str, *, now: Optional[datetime] = None
+) -> None:
+    """Set this stage's notification sentinel AFTER a successful send (the at-most-once
+    write). Set only on success so a send failure leaves the stage re-sendable (#114).
+    Never clears a sentinel, so a `force=true` regeneration never re-arms a stage."""
+    if sentinel_attr not in NOTIFICATION_SENTINELS:
+        raise ValueError(f"unknown notification sentinel {sentinel_attr!r}")
+    setattr(sentinel_obj, sentinel_attr, now or _now())
+    db.add(sentinel_obj)
+    db.commit()

--- a/backend/tests/test_exchange_lifecycle.py
+++ b/backend/tests/test_exchange_lifecycle.py
@@ -1,0 +1,233 @@
+"""Unit tests for the ExchangeLifecycle state-machine module (#494).
+
+This is the single owner of legal Exchange transitions and the at-most-once
+notification invariant, extracted from the five scattered helpers in
+process_new_activity.py. These tests pin each transition's guard and idempotency
+directly at the interface, so the "never re-fire" guarantee is tested in ONE place
+(the invariant the issue calls out), rather than re-asserted at each call site.
+"""
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.core.config import settings
+from app.models import Activity, DerivedMetric, Exchange, User
+from app.services.blocks import assign_activity_to_block
+from app.services.coach import exchange_lifecycle as lifecycle
+
+
+# --- fixtures -----------------------------------------------------------------
+
+
+def _user(db) -> User:
+    u = User(id=uuid4(), email=f"u-{uuid4()}@example.com")
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _activity(db, *, receipt_sent_at=None) -> Activity:
+    user = _user(db)
+    a = Activity(id=uuid4(), user_id=user.id,
+                 strava_activity_id=abs(hash(str(uuid4()))) % 10**9,
+                 start_date=datetime(2026, 5, 27, 10, 0, 0), type="Run", name="Run",
+                 distance_m=5000, moving_time_s=1500, elapsed_time_s=1500,
+                 elev_gain_m=10.0, avg_hr=140, raw_summary={},
+                 receipt_sent_at=receipt_sent_at)
+    db.add(a)
+    db.flush()
+    db.add(DerivedMetric(id=uuid4(), activity_id=a.id, effort="easy",
+                         structure="continuous", duration_class="standard",
+                         effort_score=50.0, flags=[], confidence="medium",
+                         confidence_reasons=[]))
+    db.flush()
+    return a
+
+
+def _exchange(db, *, opened_at=None, opener_sent_at=None,
+              fuller_sent_at=None, done_at=None) -> Exchange:
+    """A real Exchange (via block assignment, since blocks carry a NOT NULL primary)
+    put directly into the given lifecycle state."""
+    activity = _activity(db)
+    block = assign_activity_to_block(db, activity)
+    ex = db.query(Exchange).filter(Exchange.block_id == block.id).one()
+    ex.opened_at = opened_at
+    ex.opener_sent_at = opener_sent_at
+    ex.fuller_sent_at = fuller_sent_at
+    ex.done_at = done_at
+    db.flush()
+    return ex
+
+
+@pytest.fixture
+def window(monkeypatch):
+    monkeypatch.setattr(settings, "EXCHANGE_REPLY_WINDOW_SECONDS", 86400)  # 24h
+
+
+# --- state reads --------------------------------------------------------------
+
+
+def test_unopened_exchange_is_not_open_not_closed(db):
+    ex = _exchange(db)
+    assert lifecycle.is_open(ex) is False
+    assert lifecycle.is_closed(ex) is False
+
+
+def test_opened_unclosed_exchange_is_open(db):
+    ex = _exchange(db, opened_at=datetime.now(timezone.utc))
+    assert lifecycle.is_open(ex) is True
+    assert lifecycle.is_closed(ex) is False
+
+
+def test_fuller_sent_is_closed_and_not_open(db):
+    ex = _exchange(db, opened_at=datetime.now(timezone.utc),
+                   fuller_sent_at=datetime.now(timezone.utc))
+    assert lifecycle.is_closed(ex) is True
+    assert lifecycle.is_open(ex) is False
+
+
+def test_within_reply_window_true_for_recent_opener(db, window):
+    ex = _exchange(db, opened_at=datetime.now(timezone.utc) - timedelta(hours=1))
+    assert lifecycle.within_reply_window(ex) is True
+
+
+def test_within_reply_window_false_for_stale_opener(db, window):
+    ex = _exchange(db, opened_at=datetime.now(timezone.utc) - timedelta(days=3))
+    assert lifecycle.within_reply_window(ex) is False
+
+
+def test_within_reply_window_false_when_unopened(db, window):
+    ex = _exchange(db)
+    assert lifecycle.within_reply_window(ex) is False
+
+
+def test_within_reply_window_treats_naive_db_read_as_utc(db, window):
+    # A naive datetime (some DB drivers strip tz) must be read as UTC, not crash.
+    ex = _exchange(db, opened_at=datetime.utcnow() - timedelta(hours=1))
+    assert lifecycle.within_reply_window(ex) is True
+
+
+def test_can_fire_reply_fuller_requires_open_and_in_window(db, window):
+    now = datetime.now(timezone.utc)
+    assert lifecycle.can_fire_reply_fuller(
+        _exchange(db, opened_at=now - timedelta(hours=1))) is True
+    assert lifecycle.can_fire_reply_fuller(_exchange(db)) is False  # unopened
+    assert lifecycle.can_fire_reply_fuller(
+        _exchange(db, opened_at=now, fuller_sent_at=now)) is False  # closed
+    assert lifecycle.can_fire_reply_fuller(
+        _exchange(db, opened_at=now - timedelta(days=3))) is False  # stale
+
+
+# --- open transition ----------------------------------------------------------
+
+
+def test_open_exchange_sets_opened_at_once(db):
+    ex = _exchange(db)
+    assert lifecycle.open_exchange(db, ex) is True
+    db.refresh(ex)
+    assert ex.opened_at is not None
+
+
+def test_open_exchange_is_idempotent(db):
+    first = datetime(2026, 5, 27, 10, 0, 0, tzinfo=timezone.utc)
+    ex = _exchange(db, opened_at=first)
+    db.refresh(ex)
+    before = ex.opened_at
+    # a second open is a no-op and never moves the anchor (the reply window must
+    # not slide when a later receipt arrives)
+    assert lifecycle.open_exchange(db, ex) is False
+    db.refresh(ex)
+    assert ex.opened_at == before
+
+
+# --- receipt-sent transition --------------------------------------------------
+
+
+def test_record_receipt_sent_sets_sentinel(db):
+    a = _activity(db)
+    assert a.receipt_sent_at is None
+    lifecycle.record_receipt_sent(db, a)
+    db.refresh(a)
+    assert a.receipt_sent_at is not None
+
+
+# --- done transition ----------------------------------------------------------
+
+
+def test_mark_done_records_and_opens_defensively(db):
+    ex = _exchange(db)  # unopened (defensive: receipt should have opened it)
+    assert lifecycle.mark_done(db, ex) is True
+    db.refresh(ex)
+    assert ex.done_at is not None
+    assert ex.opened_at is not None  # defensively opened
+
+
+def test_mark_done_is_idempotent(db):
+    first = datetime(2026, 5, 27, 10, 0, 0, tzinfo=timezone.utc)
+    ex = _exchange(db, opened_at=first, done_at=first)
+    db.refresh(ex)
+    before = ex.done_at
+    assert lifecycle.mark_done(db, ex) is False  # already done -> no-op
+    db.refresh(ex)
+    assert ex.done_at == before
+
+
+def test_mark_done_preserves_existing_opened_at(db):
+    opened = datetime(2026, 5, 27, 10, 0, 0, tzinfo=timezone.utc)
+    ex = _exchange(db, opened_at=opened)
+    db.refresh(ex)
+    before = ex.opened_at
+    lifecycle.mark_done(db, ex)
+    db.refresh(ex)
+    assert ex.opened_at == before  # done does not move the reply-window anchor
+
+
+# --- the at-most-once notification invariant (the issue's core invariant) -----
+
+
+def test_notification_already_sent_reads_the_sentinel(db):
+    ex = _exchange(db)
+    assert lifecycle.notification_already_sent(ex, "opener_sent_at") is False
+    ex.opener_sent_at = datetime.now(timezone.utc)
+    assert lifecycle.notification_already_sent(ex, "opener_sent_at") is True
+
+
+def test_mark_notification_sent_then_already_sent_is_true(db):
+    # The at-most-once contract end-to-end: marking sent makes the read True, so a
+    # second stage attempt is suppressed. One place owns "a stage sends at most once".
+    ex = _exchange(db)
+    lifecycle.mark_notification_sent(db, ex, "fuller_sent_at")
+    db.refresh(ex)
+    assert ex.fuller_sent_at is not None
+    assert lifecycle.notification_already_sent(ex, "fuller_sent_at") is True
+
+
+def test_mark_notification_sent_never_clears(db):
+    # No transition ever re-arms a stage: a second mark does not move the sentinel
+    # backward (a force=true regen must never re-enable a sent notification).
+    first = datetime(2026, 5, 27, 10, 0, 0, tzinfo=timezone.utc)
+    ex = _exchange(db, opener_sent_at=first)
+    # mark again would overwrite to "now"; the invariant relies on the CALLER
+    # checking already_sent first — confirm the guard catches it.
+    assert lifecycle.notification_already_sent(ex, "opener_sent_at") is True
+
+
+def test_single_shot_sentinel_lives_on_activity(db):
+    # The single-shot rollback path dedups on the Activity, not an Exchange row.
+    a = _activity(db)
+    assert lifecycle.notification_already_sent(a, "coach_notification_sent_at") is False
+    lifecycle.mark_notification_sent(db, a, "coach_notification_sent_at")
+    db.refresh(a)
+    assert a.coach_notification_sent_at is not None
+
+
+def test_unknown_sentinel_is_rejected(db):
+    # receipt_sent_at and opened_at/done_at are NOT notification sentinels (they have
+    # their own transitions); routing them through the notification path is a bug.
+    ex = _exchange(db)
+    with pytest.raises(ValueError):
+        lifecycle.notification_already_sent(ex, "receipt_sent_at")
+    with pytest.raises(ValueError):
+        lifecycle.mark_notification_sent(db, ex, "opened_at")


### PR DESCRIPTION
Closes #494.

Behaviour-preserving refactor. Extracts `services/coach/exchange_lifecycle.py` as the single owner of every legal Exchange transition (open, opener-sent, fuller-sent, done, receipt-sent) and the at-most-once notification invariant. The job layer (`process_new_activity.py`) keeps scheduling + notification + dispatch; no direct sentinel writes remain in the job helpers (grep-verified). The at-most-once invariant lives in one place behind a `NOTIFICATION_SENTINELS` whitelist that raises on an unknown sentinel.

This is where the recent prod bugs landed (#487, #482, #490); concentrating the invariant moves the next such bug to the interface instead of prod.

## Verification
- `make backend-test`: 1692 passed, 4 deselected, 0 failed (+19 new lifecycle tests).
- Existing exchange / reply / receipt / pipeline suites pass unmodified (the behaviour oracle).
- No DB schema, dependency, or public-API change.

## ADRs
0010 (two-stage exchange), 0018 (receipt cadence), 0019 (cadence seam).