### PR TITLE
refactor(coach): one interface for read-time history-scan signals (#492)

### DIFF
--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -17,7 +17,7 @@ default pack.
 import hashlib
 import json
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
 from sqlalchemy import func
@@ -38,16 +38,15 @@ from app.services.coach.perceived_effort import build_perceived_effort
 from app.services.coach.preference import build_preference_profile
 from app.services.coach.salience import compute_safety_override
 from app.services.coach.corpus import DEFAULT_SCHOOL_ID
+from app.services.coach.prompt_features import PromptFeature
 from app.services.coach.prompts import (
     _describe_dial,
     is_corpus_prompt,
-    is_recent_training_prompt,
     is_stance_prompt,
     is_stream_view_prompt,
-    is_training_load_prompt,
     is_user_materials_prompt,
-    is_volume_prompt,
 )
+from app.services.coach.read_time_signals import ReadTimeSignal, gather
 from app.services.coach.stance import StanceProfile, resolve_stance
 from app.services.coach.volume import build_training_volume
 from app.services.coach.recent_training import build_recent_training
@@ -216,6 +215,11 @@ def build_context_pack(
     # byte-stable (stream_view stays None and is dropped from serialization).
     wc = assemble_working_context(db, activity, deep=is_stream_view_prompt(prompt_id))
     b, f = wc.b_baseline, wc.focus
+    # The read anchor shared across the read-time signal seam (#492). Calibration and
+    # adherence (always-emitted, in the B baseline above) ignore it; the gated
+    # training-load/volume/recent-training signals key on it (each derives the exact
+    # flavour it needs — start_date for readiness, the local calendar day for volume).
+    as_of = activity.start_date
     return CoachContextPack(
         activity=f.activity,
         metrics=f.metrics,
@@ -242,21 +246,21 @@ def build_context_pack(
             school_id=stance.school_id if (stance and is_stance_prompt(prompt_id)) else None,
         ),
         stance=_build_stance_context(prompt_id, stance),
-        # P3 readiness (ADR 0016): emitted ONLY under a training-load-aware prompt id,
-        # computed read-time as of this activity (so the run is in the acute load).
-        training_load=_build_training_load_context(db, activity, prompt_id),
-        # #400 volume-vs-norm: emitted ONLY under a volume-aware prompt id, computed
-        # read-time over the runner's local-day windows so a deliberate easy week reads
-        # as down-vs-norm rather than alarming.
-        training_volume=_build_training_volume_context(db, activity, prompt_id),
+        # The three prompt-gated read-time signals go through the shared seam (#492):
+        # `gather` applies each signal's PromptFeature gate ONCE, returning None
+        # (dropped from serialization, byte-stable) under a prompt that lacks it. The
+        # bounded scan + abstention live inside each adapter's compute.
+        #   - P3 readiness (ADR 0016): as-of this activity, so the run is in the acute load.
+        #   - #400 volume-vs-norm: over the runner's local-day windows.
+        #   - #444 modality-aware recent-training picture.
+        training_load=gather(_TRAINING_LOAD_SIGNAL, db, activity, prompt_id, as_of),
+        training_volume=gather(_TRAINING_VOLUME_SIGNAL, db, activity, prompt_id, as_of),
         # #443 consolidated stream view: present in the DEFAULT pack only under a
         # stream-view-aware prompt (focus.stream_view is None otherwise, dropped from
-        # serialization), so the pack stays byte-stable under v9 and below.
+        # serialization), so the pack stays byte-stable under v9 and below. (Not a
+        # history-scan signal — it rides the focus payload via the deep flag above.)
         stream_view=f.stream_view,
-        # #444 modality-aware recent-training picture: emitted ONLY under a
-        # recent-training-aware prompt (the rich successor to recent_training_summary),
-        # computed read-time over the runner's local-day windows.
-        recent_training=_build_recent_training_context(db, activity, prompt_id),
+        recent_training=gather(_RECENT_TRAINING_SIGNAL, db, activity, prompt_id, as_of),
         safety_rules=b.safety_rules,
     )
 
@@ -351,21 +355,20 @@ def _build_stance_context(
 
 
 def _build_training_load_context(
-    db: Session, activity: Activity, prompt_id: Optional[str]
+    db: Session, activity: Activity, as_of: datetime
 ) -> Optional[TrainingLoadContext]:
     """The P3 training-load readiness pack section (ADR 0016), or None.
 
-    Emitted ONLY under a training-load-aware prompt id (`is_training_load_prompt`), so
-    the pack is byte-stable for every other prompt (AC1) — the section is dropped from
+    A read-time history-scan signal behind the shared `ReadTimeSignal` seam (#492):
+    the `TRAINING_LOAD` gating is applied once in `gather`, so this `compute` is
+    reached ONLY under a training-load-aware prompt — the section is dropped from
     serialization when None, exactly like `corpus`/`stance`/`block`. Computed at read
-    time (mirroring M9 calibration) as of the activity's `start_date`, so this run is
-    in the acute load and a regen of an old activity reproduces the condition as of
-    then. A tier-3 deterministic FACT the coach may cite, but it never overrides the
-    run's re-derived DerivedMetric or the safety floor (prompt rule 27). Degrades to
-    None when no history is available (build_readiness guards)."""
-    if not is_training_load_prompt(prompt_id):
-        return None
-    model = build_readiness(db, activity.user_id, activity.start_date)
+    time (mirroring M9 calibration) as of `as_of` (the activity's `start_date`), so
+    this run is in the acute load and a regen of an old activity reproduces the
+    condition as of then. A tier-3 deterministic FACT the coach may cite, but it never
+    overrides the run's re-derived DerivedMetric or the safety floor (prompt rule 27).
+    Degrades to None when no history is available (build_readiness guards)."""
+    model = build_readiness(db, activity.user_id, as_of)
     if model is None:
         return None
     return TrainingLoadContext(
@@ -382,37 +385,38 @@ def _build_training_load_context(
 
 
 def _build_training_volume_context(
-    db: Session, activity: Activity, prompt_id: Optional[str]
+    db: Session, activity: Activity, as_of: datetime
 ) -> Optional[TrainingVolumeContext]:
     """The #400 frequency-/volume-vs-norm pack section, or None.
 
-    Emitted ONLY under a volume-aware prompt id (`is_volume_prompt`), so the pack is
-    byte-stable for every other prompt — the section is dropped from serialization
-    when None, exactly like `training_load`/`corpus`/`block`. Computed read-time as of
-    this activity's LOCAL day (so the windows match the runner's calendar, #399) over
-    a 91-day fact span (the trailing 7d plus the 12-week norm baseline before it). A
+    A read-time history-scan signal behind the shared `ReadTimeSignal` seam (#492):
+    the `VOLUME` gating is applied once in `gather`, so this `compute` is reached ONLY
+    under a volume-aware prompt — the section is dropped from serialization when None,
+    exactly like `training_load`/`corpus`/`block`. Computed read-time as of this
+    activity's LOCAL day (so the windows match the runner's calendar, #399) over a
+    91-day fact span (the trailing 7d plus the 12-week norm baseline before it). A
     deterministic FACT the coach may cite, but it never overrides the run's re-derived
     DerivedMetric or the safety floor (the volume addendum). Degrades gracefully:
     thin history yields `has_baseline=False` and `no_norm` directions."""
-    if not is_volume_prompt(prompt_id):
-        return None
-    as_of = activity.local_start.date()
+    local_day = activity.local_start.date()
     # _query_activity_facts filters on UTC start_date with an EXCLUSIVE end, so pass
-    # as_of+1 to keep the current local day (today's run) inside the rolling window;
+    # local_day+1 to keep the current local day (today's run) inside the rolling window;
     # the builder partitions the fetched span by local_date. The start is widened to
     # 91 days to cover the trailing 7d plus the 12-week norm baseline before it.
     facts = _query_activity_facts(
-        db, as_of - timedelta(days=91), as_of + timedelta(days=1), user_id=activity.user_id
+        db, local_day - timedelta(days=91), local_day + timedelta(days=1), user_id=activity.user_id
     )
-    return build_training_volume(facts, as_of)
+    return build_training_volume(facts, local_day)
 
 
 def _build_recent_training_context(
-    db: Session, activity: Activity, prompt_id: Optional[str]
+    db: Session, activity: Activity, as_of: datetime
 ) -> Optional[RecentTrainingContext]:
     """The #444 modality-aware recent-training section, or None.
 
-    Emitted ONLY under a recent-training-aware prompt id, so the pack stays byte-stable
+    A read-time history-scan signal behind the shared `ReadTimeSignal` seam (#492):
+    the `RECENT_TRAINING` gating is applied once in `gather`, so this `compute` is
+    reached ONLY under a recent-training-aware prompt — the pack stays byte-stable
     otherwise (the Optional-and-drop idiom). Computed read-time as of this activity's
     LOCAL day over a ~210-day fact span (the 30d window plus its ~6-month vs-typical
     baseline), reusing the Trends per-day-rate core so "typical" has one meaning across
@@ -420,13 +424,11 @@ def _build_recent_training_context(
     run's re-derived DerivedMetric or the safety floor (the recent-training addendum).
     Degrades gracefully: thin history yields `has_baseline=False` and `no_norm`
     directions."""
-    if not is_recent_training_prompt(prompt_id):
-        return None
-    as_of = activity.local_start.date()
+    local_day = activity.local_start.date()
     facts = _query_activity_facts(
-        db, as_of - timedelta(days=210), as_of + timedelta(days=1), user_id=activity.user_id
+        db, local_day - timedelta(days=210), local_day + timedelta(days=1), user_id=activity.user_id
     )
-    return build_recent_training(facts, as_of)
+    return build_recent_training(facts, local_day)
 
 
 def _build_block_context(db: Session, activity: Activity) -> Optional[BlockContext]:
@@ -718,9 +720,13 @@ def build_b_baseline(
             pain_scores=_recent_pain_scores(db, activity),
         ),
         # M7 adherence is gated off pending recalibration (it nagged about prior
-        # next_steps the runner had already moved past); off => the empty form.
+        # next_steps the runner had already moved past); off => the empty form. When
+        # on, it resolves through the shared read-time signal seam (#492) — an
+        # always-emitted signal (no PromptFeature gate), so `gather` runs its compute
+        # on every prompt. (The COACH_ADHERENCE_ENABLED feature-flag is orthogonal to
+        # the prompt-feature gate and stays here, an explicit kill switch.)
         adherence=(
-            _build_adherence_context(db, activity)
+            gather(_ADHERENCE_SIGNAL, db, activity, None, activity.start_date)
             if settings.COACH_ADHERENCE_ENABLED
             else AdherenceContext(prior_report_date=None, outcomes=[])
         ),
@@ -732,7 +738,9 @@ def build_b_baseline(
             if settings.COACH_BELIEFS_ENABLED
             else BelievedFactsContext(facts=[])
         ),
-        calibration=_build_calibration_context(db, activity),
+        # M9 calibration: an always-emitted read-time signal through the shared seam
+        # (#492; no PromptFeature gate, so `gather` runs its compute on every prompt).
+        calibration=gather(_CALIBRATION_SIGNAL, db, activity, None, activity.start_date),
         preference_profile=(
             _build_preference_profile(db, activity)
             if settings.COACH_BELIEFS_ENABLED
@@ -859,7 +867,9 @@ def _matching_baseline_trend(
     )
 
 
-def _build_adherence_context(db: Session, activity: Activity) -> AdherenceContext:
+def _build_adherence_context(
+    db: Session, activity: Activity, as_of: Optional[datetime] = None
+) -> AdherenceContext:
     """Assemble the M7 adherence section: did the runner act on the LAST report's
     next_steps?
 
@@ -871,7 +881,13 @@ def _build_adherence_context(db: Session, activity: Activity) -> AdherenceContex
     re-querying and carrying the full report body. Degrades to empty when there is
     no prior report. All judging lives in the pure `adherence` module; this
     function only gathers rows.
-    """
+
+    An ALWAYS-EMITTED read-time history-scan signal (#492): no `gate_feature`, so it
+    is reached on every prompt and always produces a section (empty when no prior
+    report), never dropped. `as_of` is part of the shared seam signature and is
+    unused here — the scans key on the source report / this run's start_date. This
+    compute-now adapter is exactly the swappable seam #203 turns into a read-stored
+    one without touching `context.py`."""
     prior = fetch_prior_commitments(db, activity)
     if prior is None or not prior.next_steps:
         return AdherenceContext(prior_report_date=None, outcomes=[])
@@ -956,12 +972,19 @@ def _detect_pushback(db: Session, source_activity_id) -> bool:
     return any(phrase in blob for phrase in _PUSHBACK_PHRASES)
 
 
-def _build_calibration_context(db: Session, activity: Activity) -> CalibrationContext:
+def _build_calibration_context(
+    db: Session, activity: Activity, as_of: Optional[datetime] = None
+) -> CalibrationContext:
     """Assemble the M9 calibration section: individualise this run's HR-drift
     reading against the runner's own typical drift for these conditions, and a
     non-diagnostic referral nudge for any computable red-flag pattern. Both are
     computed at read time (the baseline is recomputed after the pipeline) and
-    degrade cleanly. Neither overrides the re-derived DerivedMetric."""
+    degrade cleanly. Neither overrides the re-derived DerivedMetric.
+
+    An ALWAYS-EMITTED read-time history-scan signal (#492): no `gate_feature`, so it
+    is reached on every prompt and always produces a section (empty/degraded when no
+    drift was measured), never dropped. `as_of` is part of the shared seam signature
+    and is unused here — the scans key on the activity's own bucket/window."""
     metrics = activity.metrics
     observed_drift = metrics.hr_drift if metrics else None
     comparable_drifts = _comparable_bucket_drifts(db, activity) if metrics else []
@@ -1110,6 +1133,45 @@ def _build_preference_profile(db: Session, activity: Activity):
         if b.kind == "adherence_pattern"
     ]
     return build_preference_profile(beliefs)
+
+
+# --- The read-time history-scan signal registry (#492) ----------------------
+# The five signals reached through the one `ReadTimeSignal` seam. Each pairs a
+# `_build_*_context` adapter (the bounded scan + thin-history abstention) with its
+# optional prompt-feature gate, so `gather` applies gating + dispatch uniformly and
+# `build_context_pack` / `build_b_baseline` never repeat a private convention.
+#
+# Two are ALWAYS-EMITTED (gate_feature=None — calibration and adherence live in the
+# B baseline and always produce a section, possibly empty/degraded). Three are
+# PROMPT-GATED (the section is dropped from serialization when the active prompt does
+# not carry the feature, keeping the pack byte-stable elsewhere).
+#
+# #203 slots a stored-artifact adapter in by re-registering the same `name` with a
+# read-stored compute of the SAME (db, activity, as_of) shape — no `context.py` change.
+_CALIBRATION_SIGNAL = ReadTimeSignal("calibration", _build_calibration_context)
+_ADHERENCE_SIGNAL = ReadTimeSignal("adherence", _build_adherence_context)
+_TRAINING_LOAD_SIGNAL = ReadTimeSignal(
+    "training_load", _build_training_load_context, PromptFeature.TRAINING_LOAD
+)
+_TRAINING_VOLUME_SIGNAL = ReadTimeSignal(
+    "training_volume", _build_training_volume_context, PromptFeature.VOLUME
+)
+_RECENT_TRAINING_SIGNAL = ReadTimeSignal(
+    "recent_training", _build_recent_training_context, PromptFeature.RECENT_TRAINING
+)
+
+# All five signals, keyed by name — the registry a stored-artifact adapter (#203)
+# would look up and swap an entry in without touching the call sites above.
+READ_TIME_SIGNALS: Dict[str, ReadTimeSignal] = {
+    s.name: s
+    for s in (
+        _CALIBRATION_SIGNAL,
+        _ADHERENCE_SIGNAL,
+        _TRAINING_LOAD_SIGNAL,
+        _TRAINING_VOLUME_SIGNAL,
+        _RECENT_TRAINING_SIGNAL,
+    )
+}
 
 
 def hash_context_pack(pack: Dict[str, Any]) -> str:

--- a/backend/app/services/coach/read_time_signals.py
+++ b/backend/app/services/coach/read_time_signals.py
@@ -1,0 +1,100 @@
+"""One interface for the read-time, history-scan coach-pack signals (#492).
+
+Five coach-pack sections are each a *deterministic signal computed at read time
+from a bounded scan of the runner's recent history, abstaining when history is
+thin*: M9 HR-drift calibration, M7 adherence outcomes, #400 training-volume vs
+norm, P3 training-load readiness, and #444 recent-training. Before this module
+each was wired into the pack by a bespoke ``context._build_*_context`` helper with
+its own scan limit, its own abstention rule, and its own gating clause copy-pasted
+inline — shallow per-signal wiring nearly as complex as the work behind it.
+
+This module is the single seam they share. A signal is a ``ReadTimeSignal``: a
+``compute(db, activity, as_of) -> section | None`` adapter plus an optional
+``gate_feature``. ``gather`` handles the two cross-cutting concerns ONCE:
+
+  - **Prompt gating.** A ``gate_feature`` (a ``PromptFeature``) means the section is
+    emitted ONLY under a prompt that carries that feature; otherwise ``gather``
+    returns ``None`` and the section is dropped from serialization (the
+    Optional-and-drop idiom, byte-stable elsewhere). ``gate_feature=None`` marks an
+    ALWAYS-EMITTED signal (calibration, adherence live in the B baseline and always
+    produce a section, possibly empty/degraded — never dropped).
+  - **Abstention.** The bounded-window scan and the thin-history degrade live inside
+    each adapter's ``compute`` (delegating to the unchanged pure cores and scan
+    helpers), so a caller never re-implements either.
+
+``context.py`` consumes ``gather``, not five private helpers, so a signal's private
+conventions stop leaking into the assembler. The seam is also what #203 needs:
+materialising adherence/calibration as STORED artifacts (read-stored instead of
+compute-now) is a second adapter with the SAME
+``(db, user_id, activity, as_of) -> section | None`` shape registered for the same
+``name`` — swappable with no ``context.py`` change.
+
+The adapter ``compute`` functions themselves live in ``context.py`` (they gather ORM
+rows, which is ``context``'s job); this module owns only the interface and the
+dispatch. Keeping the gathering there avoids an import cycle and keeps the row-reads
+next to the other pack assembly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Callable, Optional, Protocol
+
+from sqlalchemy.orm import Session
+
+from app.services.coach.prompt_features import PromptFeature, has_feature
+
+
+class SignalCompute(Protocol):
+    """A read-time signal adapter: compute one pack section from a bounded history
+    scan as of ``as_of``, or return ``None`` to abstain.
+
+    ``as_of`` is the read anchor (the subject activity's reference instant), part of
+    the seam so a future stored-artifact adapter (#203) keys off the same point in
+    time. Each adapter derives the exact anchor flavour it needs from ``activity``
+    (some read ``start_date``, some the local calendar day); ``as_of`` is passed for
+    the signals that key on it and ignored by the rest, keeping one uniform
+    signature across all adapters.
+    """
+
+    def __call__(self, db: Session, activity: Any, as_of: datetime) -> Optional[Any]:
+        ...
+
+
+@dataclass(frozen=True)
+class ReadTimeSignal:
+    """One read-time history-scan signal behind the shared seam.
+
+    ``name`` identifies the signal (and is the key a stored-artifact adapter would
+    re-register under, #203). ``gate_feature`` is the ``PromptFeature`` that must be
+    present for the section to be emitted, or ``None`` for an always-emitted signal.
+    ``compute`` does the bounded scan + abstention.
+    """
+
+    name: str
+    compute: SignalCompute
+    gate_feature: Optional[PromptFeature] = None
+
+
+def gather(
+    signal: ReadTimeSignal,
+    db: Session,
+    activity: Any,
+    prompt_id: Optional[str],
+    as_of: datetime,
+) -> Optional[Any]:
+    """Resolve one signal into its pack section (or ``None``).
+
+    The two cross-cutting concerns, applied ONCE here so no adapter and no caller
+    repeats them:
+
+      1. Gating: a gated signal whose feature the active prompt does not carry emits
+         ``None`` (dropped from serialization). An ungated signal (``gate_feature``
+         is ``None``) always runs.
+      2. Abstention is delegated to ``compute`` (it owns the bounded scan + thin-history
+         degrade).
+    """
+    if signal.gate_feature is not None and not has_feature(prompt_id, signal.gate_feature):
+        return None
+    return signal.compute(db, activity, as_of)

--- a/backend/tests/test_read_time_signals.py
+++ b/backend/tests/test_read_time_signals.py
@@ -1,0 +1,119 @@
+"""The shared read-time history-scan signal seam (#492).
+
+Pins the deepening's load-bearing contract: the five read-time signals are reached
+through ONE interface, and the two cross-cutting concerns — prompt gating and
+dispatch — are handled ONCE in `gather`, not re-implemented per signal.
+
+  - `gather` dispatches to each signal's `compute` with the uniform
+    `(db, activity, as_of)` signature.
+  - A PROMPT-GATED signal whose feature the active prompt lacks emits None (so the
+    section is dropped from serialization, byte-stable) WITHOUT its `compute` ever
+    running; under a prompt that carries the feature, `compute` runs.
+  - An ALWAYS-EMITTED signal (no `gate_feature`) runs its `compute` on every prompt.
+
+The math/abstention of each signal is covered by the per-signal context tests
+(`test_calibration_context.py`, `test_adherence_context.py`, `test_volume_context.py`,
+`test_training_load_context.py`, `test_recent_training.py`); this file proves only
+that the seam routes/gates them uniformly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.services.coach.context import (
+    READ_TIME_SIGNALS,
+    _ADHERENCE_SIGNAL,
+    _CALIBRATION_SIGNAL,
+    _RECENT_TRAINING_SIGNAL,
+    _TRAINING_LOAD_SIGNAL,
+    _TRAINING_VOLUME_SIGNAL,
+)
+from app.services.coach.prompt_features import PromptFeature
+from app.services.coach.read_time_signals import ReadTimeSignal, gather
+
+_AS_OF = datetime(2026, 3, 20, 8, 0, tzinfo=timezone.utc)
+
+
+# --- registry shape ----------------------------------------------------------
+
+
+def test_all_five_signals_registered_under_one_interface():
+    assert set(READ_TIME_SIGNALS) == {
+        "calibration",
+        "adherence",
+        "training_load",
+        "training_volume",
+        "recent_training",
+    }
+    assert all(isinstance(s, ReadTimeSignal) for s in READ_TIME_SIGNALS.values())
+
+
+def test_always_emitted_vs_gated_split_is_explicit():
+    # Always-emitted (B baseline): no prompt-feature gate.
+    assert _CALIBRATION_SIGNAL.gate_feature is None
+    assert _ADHERENCE_SIGNAL.gate_feature is None
+    # Prompt-gated (Optional-and-drop), each carrying its own feature.
+    assert _TRAINING_LOAD_SIGNAL.gate_feature is PromptFeature.TRAINING_LOAD
+    assert _TRAINING_VOLUME_SIGNAL.gate_feature is PromptFeature.VOLUME
+    assert _RECENT_TRAINING_SIGNAL.gate_feature is PromptFeature.RECENT_TRAINING
+
+
+# --- gather: dispatch + gating handled once ----------------------------------
+
+
+def _spy_signal(name, gate_feature):
+    """A ReadTimeSignal whose compute records that it ran and returns a sentinel."""
+    calls = []
+
+    def compute(db, activity, as_of):
+        calls.append((db, activity, as_of))
+        return f"section::{name}"
+
+    return ReadTimeSignal(name, compute, gate_feature), calls
+
+
+def test_gather_dispatches_to_compute_with_uniform_signature():
+    sig, calls = _spy_signal("x", None)
+    db, activity = object(), object()
+    out = gather(sig, db, activity, prompt_id="anything", as_of=_AS_OF)
+    assert out == "section::x"
+    assert calls == [(db, activity, _AS_OF)]  # exact (db, activity, as_of) seam
+
+
+def test_always_emitted_signal_runs_under_every_prompt():
+    sig, calls = _spy_signal("always", None)
+    for pid in (None, "coach_report_v10", "coach_message_v1", "coach_message_v11"):
+        assert gather(sig, object(), object(), pid, _AS_OF) == "section::always"
+    assert len(calls) == 4  # ran every time — never gated off
+
+
+def test_gated_signal_abstains_without_running_compute_when_feature_absent():
+    sig, calls = _spy_signal("vol", PromptFeature.VOLUME)
+    # v8 carries no VOLUME feature -> dropped, and compute must NOT run.
+    assert gather(sig, object(), object(), "coach_message_v8", _AS_OF) is None
+    # An unknown/None prompt likewise carries nothing.
+    assert gather(sig, object(), object(), None, _AS_OF) is None
+    assert calls == []  # gating short-circuits before the scan
+
+
+def test_gated_signal_runs_compute_when_feature_present():
+    sig, calls = _spy_signal("vol", PromptFeature.VOLUME)
+    # v9 carries VOLUME -> compute runs.
+    assert gather(sig, object(), object(), "coach_message_v9", _AS_OF) == "section::vol"
+    assert len(calls) == 1
+
+
+def test_gating_is_per_feature_not_global():
+    """Each gated signal keys on its OWN feature: v9 (VOLUME, no RECENT_TRAINING)
+    runs volume but drops recent_training; v11 (both) runs both."""
+    vol, vol_calls = _spy_signal("vol", PromptFeature.VOLUME)
+    rec, rec_calls = _spy_signal("rec", PromptFeature.RECENT_TRAINING)
+
+    assert gather(vol, object(), object(), "coach_message_v9", _AS_OF) == "section::vol"
+    assert gather(rec, object(), object(), "coach_message_v9", _AS_OF) is None
+    assert len(vol_calls) == 1 and rec_calls == []
+
+    assert gather(vol, object(), object(), "coach_message_v11", _AS_OF) == "section::vol"
+    assert gather(rec, object(), object(), "coach_message_v11", _AS_OF) == "section::rec"
+    assert len(vol_calls) == 2 and len(rec_calls) == 1


### PR DESCRIPTION
Closes #492.

Behaviour-preserving refactor. Introduces `services/coach/read_time_signals.py` — a `ReadTimeSignal` seam for 'a deterministic signal computed read-time from a bounded history scan, abstaining when history is thin'. The five signals (calibration, adherence, volume, readiness/training_load, recent_training) become adapters; `context.py` consumes the seam, and the prompt-gate + abstention cross-cuts are handled once in `gather`.

This is the seam #203 needs: a stored-artifact adapter re-registers the same signal name with a read-stored `compute` of the identical `(db, activity, as_of)` shape, swappable with no `context.py` change.

## Verification
- `make backend-test`: 1680 passed, 4 deselected, 0 failed (+7 tests).
- Pack proven **byte-identical** via fingerprint across prompts None / v8 / v9 / v11; existing byte-stability + per-signal context tests pass unmodified.
- External call sites untouched (0 diff): `GET /api/trends/volume`, the activity-detail `training_load` projection, and the shared pure cores.
- No DB schema, dependency, or public-API change.

Related: #203, ADR 0008.