### PR TITLE
Guard Telegram callback against out-of-range tap value (#504)

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -4,7 +4,7 @@ import uuid
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from sqlalchemy.orm import Session
 from sqlalchemy import select, update
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from app.core.config import settings
 from app.db.session import get_db
@@ -354,8 +354,19 @@ def receive_telegram_callback(
         return {"status": "processed", "action": "done_scheduled"}
 
     # RPE/pain: build the validated CheckIn payload from the token (range-checked
-    # the same as the in-app path), then write through the shared helper.
-    checkin_data = CheckInCreate(**{action.field: action.value})
+    # the same as the in-app path), then write through the shared helper. An
+    # authentic-but-forged callback can still carry an out-of-range value (#504),
+    # which CheckInCreate's schema bounds reject; treat that like any other bad
+    # callback — ack and ignore (200, no write) so Telegram does not retry on a 500.
+    try:
+        checkin_data = CheckInCreate(**{action.field: action.value})
+    except ValidationError:
+        logger.warning(
+            "telegram_callback_out_of_range_value",
+            extra={"kind": action.kind, "value": action.value},
+        )
+        _answer_callback(callback.id)
+        return {"status": "ignored", "reason": "bad_value"}
     write_checkin(db, activity_uuid, checkin_data)
 
     label = "RPE" if action.kind == "rpe" else "pain"

--- a/backend/tests/test_telegram_callback.py
+++ b/backend/tests/test_telegram_callback.py
@@ -334,6 +334,55 @@ class TestInboundWrite:
         assert db.query(CheckIn).count() == 0
         isolate_side_effects["answer"].assert_called_once()
 
+    @pytest.mark.parametrize(
+        "kind,value",
+        [
+            ("rpe", 99),    # RPE schema bound is 1-10
+            ("rpe", 0),     # below the RPE floor (ge=1)
+            ("rpe", -3),    # negative
+            ("pain", 99),   # pain_score schema bound is 0-10
+            ("pain", -1),   # below the pain_score floor (ge=0)
+        ],
+    )
+    def test_out_of_range_value_is_ignored_without_write_or_500(
+        self, client, db, configured, isolate_side_effects, kind, value
+    ):
+        # #504: an authentic-but-forged callback carrying an out-of-range value must
+        # not raise an uncaught ValidationError (HTTP 500) — Telegram treats a 500 as
+        # failed delivery and retries, amplifying it. It is acked and ignored (200),
+        # no CheckIn is written, and the bound is the CheckInCreate schema's own.
+        a = _seed_activity(db)
+        token = encode(kind=kind, activity_id=str(a.id), value=value)
+        resp = self._post(client, token)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ignored"
+        assert resp.json()["reason"] == "bad_value"
+        assert db.query(CheckIn).filter(CheckIn.activity_id == a.id).first() is None
+        isolate_side_effects["answer"].assert_called_once()
+
+    def test_in_range_boundary_values_still_write(
+        self, client, db, configured, isolate_side_effects
+    ):
+        # The guard must not over-reject: the schema's RPE 1-10 / pain 0-10 bounds
+        # are inclusive, so the boundaries are the happy path, not forged input.
+        a = _seed_activity(db)
+        token = encode(kind="rpe", activity_id=str(a.id), value=10)
+        resp = self._post(client, token)
+        assert resp.status_code == 200
+        row = db.query(CheckIn).filter(CheckIn.activity_id == a.id).first()
+        assert row is not None and row.rpe == 10
+
+    def test_malformed_token_value_is_ignored_at_handler(
+        self, client, db, configured, isolate_side_effects
+    ):
+        # A non-integer value token never decodes (decode returns None), so the
+        # handler ignores it before any CheckIn construction — no 500, no write.
+        resp = self._post(client, "cb1|rpe|abc|notanint")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ignored"
+        assert db.query(CheckIn).count() == 0
+        isolate_side_effects["answer"].assert_called_once()
+
     def test_non_callback_update_is_ignored(
         self, client, db, configured, isolate_side_effects
     ):


### PR DESCRIPTION
Closes #504

## Problem
An inbound Telegram RPE/pain button tap echoes a token (`rpe`/`pain`/`done`) that the webhook handler turns into a `CheckIn`. For `rpe`/`pain` it built `CheckInCreate(**{field: value})` with no bounds check. An authentic-but-forged callback carrying an out-of-range value (e.g. `rpe=99`, a negative) raised an uncaught Pydantic `ValidationError` and returned HTTP 500. Telegram treats a 500 as failed delivery and retries, amplifying it.

## Fix
Wrap the `CheckInCreate` construction in the handler in a `ValidationError` guard, matching the path's existing bad-callback posture: ack the callback (so the button spinner clears and no retry fires) and return a benign `{"status": "ignored", "reason": "bad_value"}` with HTTP 200, writing no `CheckIn`. The valid range stays the `CheckInCreate` schema's own bounds (RPE 1-10, pain 0-10), not a hardcoded guess, so it cannot drift from the in-app write path. The happy path is untouched. Malformed (non-integer) value tokens were already rejected by `decode()` returning `None`; a regression test now pins that too.

## How verified
- New regression tests in `tests/test_telegram_callback.py`: parametrized out-of-range rpe/pain values (99, 0, -3, -1) each yield an ignored 200 with no CheckIn and an acked callback; an inclusive-boundary value (RPE 10) still writes; a non-integer token is ignored at the handler.
- `make backend-test`: 1709 passed, 4 deselected (integration), 0 failed.