### PR TITLE
fix: exchange done-tap and fuller-turn at-most-once (#505, #506)

### DIFF
--- a/backend/app/jobs/process_new_activity.py
+++ b/backend/app/jobs/process_new_activity.py
@@ -84,6 +84,7 @@ def _notify(
     sentinel_attr: str,
     notifier: NotifierPort,
     sentinel_obj=None,
+    presend_claimed: bool = False,
 ) -> Optional[Notification]:
     """Send one stage's notification, deduped by its own stage sentinel.
 
@@ -95,9 +96,16 @@ def _notify(
     sentinel. On a send failure the sentinel is left null so the stage stays
     re-sendable, mirroring the prior single-shot behaviour (#114). Returns the
     Notification sent, or None.
+
+    `presend_claimed` (#506, fuller turn only): the caller already atomically
+    claimed the sentinel pre-send via `lifecycle.claim_fuller`, so the sentinel
+    IS the at-most-once claim — skip the already-sent guard (we own it) and do
+    NOT re-mark on success (the claim already set it). On a no-channel or
+    send failure the caller releases the claim, so this path leaves it set; it
+    is the caller's job to release.
     """
     sentinel_obj = sentinel_obj if sentinel_obj is not None else activity
-    if lifecycle.notification_already_sent(sentinel_obj, sentinel_attr):
+    if not presend_claimed and lifecycle.notification_already_sent(sentinel_obj, sentinel_attr):
         logger.info(
             "Skipping %s notification for activity %s: already sent at %s",
             stage, activity.strava_activity_id, getattr(sentinel_obj, sentinel_attr),
@@ -120,6 +128,8 @@ def _notify(
             "Skipping %s notification for activity %s: no channel configured",
             stage, activity.strava_activity_id,
         )
+        if presend_claimed:
+            lifecycle.release_fuller_claim(db, sentinel_obj)
         return None
 
     try:
@@ -129,9 +139,14 @@ def _notify(
             "%s notification send failed for activity %s; sentinel left unset",
             stage, activity.strava_activity_id,
         )
+        if presend_claimed:
+            lifecycle.release_fuller_claim(db, sentinel_obj)
         return None
 
-    lifecycle.mark_notification_sent(db, sentinel_obj, sentinel_attr)
+    # Under the #506 pre-send claim the sentinel was already set atomically by the
+    # caller; do not re-mark (it would just rewrite the same value).
+    if not presend_claimed:
+        lifecycle.mark_notification_sent(db, sentinel_obj, sentinel_attr)
     return notification
 
 
@@ -547,7 +562,16 @@ def _record_done_and_schedule(db: Session, activity_id) -> bool:
 
     # Record the explicit completion signal (idempotent), opening the exchange if
     # the receipt somehow had not (defensive — the receipt opens it on ingest).
-    lifecycle.mark_done(db, exchange)
+    # #505: mark_done returns False when the exchange was ALREADY done, so a second/
+    # rapid "done" tap must NOT schedule another full-report generation — the first
+    # tap already scheduled it. Bail before re-scheduling so repeated taps queue exactly
+    # one generation (the fire-time dedup was the only prior backstop, by which point
+    # concurrent LLM generations could already be running).
+    if not lifecycle.mark_done(db, exchange):
+        logger.info(
+            "Ignoring duplicate done tap for block %s: already done", block.id
+        )
+        return False
 
     last = max(
         db.query(Activity).filter(Activity.block_id == block.id).all(),
@@ -568,12 +592,17 @@ async def process_fuller_turn(
 ) -> Optional[Notification]:
     """A4 stage two: generate (or finalize) the fuller turn and notify it.
 
-    Idempotent on the fuller sentinel (`coach_notification_sent_at`): a reply-fired
-    run and the timer-fired run cannot double-send — the second no-ops. generate_fuller
-    fills the opener's evolving row in place and fires the learning loop on
-    completion; a notify-retry re-sends the cached fuller without re-generating.
-    A fallback fuller is not notified (and leaves the sentinel null), consistent
-    with the single-shot fallback rule."""
+    At-most-once on the fuller sentinel (`fuller_sent_at`): a reply-fired run and the
+    timer-fired run cannot double-send — the loser no-ops. The guard is an ATOMIC claim
+    (#506): the old `is_closed` read was a non-atomic check-then-act with the slow
+    `generate_fuller` sitting between it and the notification sentinel, so under multiple
+    workers both triggers could pass the read, both generate, and both notify. We now
+    claim `fuller_sent_at` via a conditional UPDATE BEFORE generating, so the database
+    serializes the two triggers and only the winner proceeds. generate_fuller fills the
+    opener's evolving row in place and fires the learning loop on completion. A fallback
+    fuller / missing report / no-channel / send failure RELEASES the claim (sentinel back
+    to null) so the stage stays re-sendable, consistent with the single-shot fallback
+    rule (#114)."""
     # #216 / AC6 rollback inertness: a fuller scheduled via enqueue_in before a
     # rollback to a single-shot prompt can still fire up to the stage-two delay
     # after the flip. Gate it like every other two-stage trigger so the stale
@@ -593,15 +622,20 @@ async def process_fuller_turn(
         )
         return None
     db.refresh(exchange)
-    if lifecycle.is_closed(exchange):
+
+    # #506: atomically claim the turn. A non-winning concurrent trigger (or a late
+    # timer after an early reply already closed the exchange) gets rowcount 0 here and
+    # bails BEFORE generating — exactly one generation + one notification per exchange.
+    if not lifecycle.claim_fuller(db, exchange):
         logger.info(
-            "Fuller turn already notified for block %s; no-op", exchange.block_id
+            "Fuller turn already claimed/notified for block %s; no-op", exchange.block_id
         )
         return None
 
     read = await generate_fuller(db, str(activity.id))
     if read is None:
         logger.info("No fuller report for activity %s", activity.strava_activity_id)
+        lifecycle.release_fuller_claim(db, exchange)
         return None
 
     db.refresh(activity)
@@ -611,11 +645,13 @@ async def process_fuller_turn(
             "Skipping fuller notification for activity %s: report is fallback or missing",
             activity.strava_activity_id,
         )
+        lifecycle.release_fuller_claim(db, exchange)
         return None
 
     return _notify(
         db, activity, report=read, stage="fuller",
         sentinel_attr="fuller_sent_at", notifier=notifier, sentinel_obj=exchange,
+        presend_claimed=True,
     )
 
 

--- a/backend/app/jobs/process_new_activity.py
+++ b/backend/app/jobs/process_new_activity.py
@@ -600,9 +600,11 @@ async def process_fuller_turn(
     claim `fuller_sent_at` via a conditional UPDATE BEFORE generating, so the database
     serializes the two triggers and only the winner proceeds. generate_fuller fills the
     opener's evolving row in place and fires the learning loop on completion. A fallback
-    fuller / missing report / no-channel / send failure RELEASES the claim (sentinel back
-    to null) so the stage stays re-sendable, consistent with the single-shot fallback
-    rule (#114)."""
+    fuller / missing report / no-channel / send failure / RAISED exception RELEASES the
+    claim (sentinel back to null) so the stage stays re-sendable, consistent with the
+    single-shot fallback rule (#114) — the claim..send window is a try/finally that
+    releases on any non-send exit, so a crash mid-generation cannot strand the turn
+    CLOSED-but-unsent."""
     # #216 / AC6 rollback inertness: a fuller scheduled via enqueue_in before a
     # rollback to a single-shot prompt can still fire up to the stage-two delay
     # after the flip. Gate it like every other two-stage trigger so the stale
@@ -632,27 +634,44 @@ async def process_fuller_turn(
         )
         return None
 
-    read = await generate_fuller(db, str(activity.id))
-    if read is None:
-        logger.info("No fuller report for activity %s", activity.strava_activity_id)
-        lifecycle.release_fuller_claim(db, exchange)
-        return None
+    # The claim set `fuller_sent_at` (it doubles as the CLOSED / at-most-once sentinel),
+    # so EVERY path between here and a genuinely-successful send must release it — not
+    # only the clean early returns but also a RAISED exception (an RQ JobTimeoutException
+    # over the ~120-360s generation window, a context-build/network error). Otherwise the
+    # exchange exits CLOSED with no notification and RQ retry's claim finds the sentinel
+    # set and bails, stranding the turn — strictly worse than the pre-claim null-on-crash
+    # posture (#114). `release_fuller_claim` is an unconditional set-to-null, so a release
+    # in `finally` after a clean early-return release (or a successful `_notify`) is a
+    # harmless no-op; we only skip it once a send has genuinely succeeded.
+    sent = False
+    try:
+        read = await generate_fuller(db, str(activity.id))
+        if read is None:
+            logger.info("No fuller report for activity %s", activity.strava_activity_id)
+            return None
 
-    db.refresh(activity)
-    coach_row = get_active_report_row(db, activity.id)
-    if coach_row is None or coach_row.is_fallback:
-        logger.info(
-            "Skipping fuller notification for activity %s: report is fallback or missing",
-            activity.strava_activity_id,
+        db.refresh(activity)
+        coach_row = get_active_report_row(db, activity.id)
+        if coach_row is None or coach_row.is_fallback:
+            logger.info(
+                "Skipping fuller notification for activity %s: report is fallback or missing",
+                activity.strava_activity_id,
+            )
+            return None
+
+        notification = _notify(
+            db, activity, report=read, stage="fuller",
+            sentinel_attr="fuller_sent_at", notifier=notifier, sentinel_obj=exchange,
+            presend_claimed=True,
         )
-        lifecycle.release_fuller_claim(db, exchange)
-        return None
-
-    return _notify(
-        db, activity, report=read, stage="fuller",
-        sentinel_attr="fuller_sent_at", notifier=notifier, sentinel_obj=exchange,
-        presend_claimed=True,
-    )
+        sent = notification is not None
+        return notification
+    finally:
+        # Released on EVERY non-send exit: a None read, a fallback/missing report, a
+        # no-channel/send-failure `_notify` return, OR a raised exception. Left SET only
+        # after a real successful send, so the happy path stays CLOSED and never re-sends.
+        if not sent:
+            lifecycle.release_fuller_claim(db, exchange)
 
 
 def process_new_activity_job(

--- a/backend/app/services/coach/exchange_lifecycle.py
+++ b/backend/app/services/coach/exchange_lifecycle.py
@@ -41,6 +41,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Optional
 
+from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -167,3 +168,51 @@ def mark_notification_sent(
     setattr(sentinel_obj, sentinel_attr, now or _now())
     db.add(sentinel_obj)
     db.commit()
+
+
+# --- the atomic fuller-turn claim (#506) --------------------------------------
+
+
+def claim_fuller(db: Session, exchange: Exchange, *, now: Optional[datetime] = None) -> bool:
+    """Atomically CLAIM the fuller turn for this exchange, so exactly one of a racing
+    timer-fired and reply-fired trigger proceeds to generate + notify (#506).
+
+    The prior guard was a non-atomic check-then-act (`is_closed` read, then a long
+    `generate_fuller`, then the notification sentinel set). Under multiple workers both
+    triggers could pass the read, both generate, and both notify — two notifications and
+    a wasted second generation. This is a conditional UPDATE that sets `fuller_sent_at`
+    only WHERE it is still NULL and inspects the rowcount, so the database serializes the
+    two triggers: the winner gets rowcount 1 and owns the turn, the loser gets 0 and
+    bails BEFORE generating.
+
+    The claim doubles as the at-most-once notification sentinel (`fuller_sent_at` set =
+    CLOSED), so the winner does NOT re-mark it after the send. To preserve the
+    re-sendable-on-failure posture (#114), the caller MUST `release_fuller_claim` if the
+    generation falls back, produces no report, or the send fails — leaving the sentinel
+    null so the stage can be retried. Returns True if this caller won the claim."""
+    stamp = now or _now()
+    result = db.execute(
+        update(Exchange)
+        .where(Exchange.id == exchange.id, Exchange.fuller_sent_at.is_(None))
+        .values(fuller_sent_at=stamp)
+    )
+    db.commit()
+    won = result.rowcount == 1
+    if won:
+        # Keep the in-memory instance consistent with the row the winner just claimed.
+        exchange.fuller_sent_at = stamp
+    return won
+
+
+def release_fuller_claim(db: Session, exchange: Exchange) -> None:
+    """Release a fuller-turn claim taken by `claim_fuller` when the turn did not complete
+    (a fallback/empty generation, missing report, or a send failure), so the stage stays
+    re-sendable (#114). Only ever clears a sentinel this same caller set; never called on
+    a legitimately-closed exchange. The mirror of `claim_fuller`'s pre-send set."""
+    db.execute(
+        update(Exchange)
+        .where(Exchange.id == exchange.id)
+        .values(fuller_sent_at=None)
+    )
+    db.commit()
+    exchange.fuller_sent_at = None

--- a/backend/tests/test_receipt_cadence_pipeline.py
+++ b/backend/tests/test_receipt_cadence_pipeline.py
@@ -223,6 +223,26 @@ async def test_done_tap_records_and_schedules(db, configured, notifier):
     assert ex.done_at is not None
 
 
+async def test_repeated_done_taps_schedule_exactly_one_full_report(db, configured, notifier):
+    # #505: a second "done" tap on an already-done exchange must NOT schedule another
+    # full-report generation. mark_done is idempotent (done_at set once), but the caller
+    # previously discarded its return and scheduled unconditionally, so rapid/repeat taps
+    # queued redundant generations (deduped only at fire time, after spend may be live).
+    activity = _seed(db)
+    block = _block_of(db, activity)
+    await _send_receipt(db=db, activity=activity, block=block, notifier=notifier)
+    with patch.object(pna, "_schedule_block_complete") as sched:
+        first = mark_done_and_schedule(db, activity.id)
+        second = mark_done_and_schedule(db, activity.id)
+        third = mark_done_and_schedule(db, activity.id)
+    assert first is True               # the first tap schedules
+    assert second is False             # the duplicate taps are scheduling no-ops
+    assert third is False
+    sched.assert_called_once()         # exactly ONE full-report job from repeated taps
+    ex = _exchange_of(db, activity)
+    assert ex.done_at is not None
+
+
 async def test_done_tap_noops_when_exchange_closed(db, configured, notifier):
     activity = _seed(db)
     ex = _exchange_of(db, activity)

--- a/backend/tests/test_two_stage_pipeline.py
+++ b/backend/tests/test_two_stage_pipeline.py
@@ -239,6 +239,68 @@ async def test_fuller_turn_idempotent_racing_timer_noops(db, configured, notifie
     assert len(notifier.sent) == 1  # exactly one fuller notification
 
 
+async def test_concurrent_timer_and_reply_fuller_yields_one_notify_one_report(
+    db, configured, notifier
+):
+    # #506: a timer-fired and a reply-fired fuller can race past the closed-check. The
+    # old guard was a non-atomic is_closed READ followed by the slow generate_fuller and
+    # only THEN the notification sentinel, so under concurrency both triggers could pass
+    # the read, both generate, and both notify. We simulate the race at the seam: the
+    # SECOND (racing) trigger is fired from INSIDE the first's generation, i.e. after the
+    # first has entered process_fuller_turn but before it has finished. The atomic claim
+    # (a conditional UPDATE on fuller_sent_at taken BEFORE generation) must let exactly
+    # ONE through: one notification and one stored non-fallback report.
+    activity = _seed(db)
+    exchange = _exchange_of(db, activity)
+
+    racing = {"second": None, "ran": False}
+
+    real_generate_fuller = pna.generate_fuller
+
+    async def generate_then_race(db_, activity_id, *args, **kwargs):
+        # While the winner is "generating", a concurrent trigger arrives. With the
+        # atomic claim already taken, this racing call must bail BEFORE generating.
+        if not racing["ran"]:
+            racing["ran"] = True
+            racing["second"] = await pna.process_fuller_turn(
+                db=db_, activity=activity, notifier=notifier
+            )
+        return await real_generate_fuller(db_, activity_id, *args, **kwargs)
+
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_fuller_blocks()), _result(_fuller_blocks()))), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"), \
+         patch.object(pna, "generate_fuller", side_effect=generate_then_race):
+        first = await pna.process_fuller_turn(db=db, activity=activity, notifier=notifier)
+
+    assert first is not None            # the winner generated + notified
+    assert racing["second"] is None     # the racer bailed before generating (claim lost)
+    assert len(notifier.sent) == 1      # exactly ONE fuller notification
+    db.refresh(exchange)
+    assert exchange.fuller_sent_at is not None
+    row = get_active_report_row(db, activity.id)
+    assert row is not None and row.is_fallback is False  # one stored non-fallback report
+
+
+async def test_fuller_claim_is_atomic_one_winner(db, configured, notifier):
+    # #506 seam-level: the at-most-once fuller guard is an atomic claim, not a
+    # check-then-act. Two callers claiming the same exchange must yield exactly one
+    # winner — the conditional UPDATE on fuller_sent_at-IS-NULL serializes the race.
+    from app.services.coach import exchange_lifecycle as lifecycle
+
+    exchange = _exchange_of(db, _seed(db))
+    assert lifecycle.claim_fuller(db, exchange) is True   # winner
+    assert lifecycle.claim_fuller(db, exchange) is False  # loser: already claimed
+    db.refresh(exchange)
+    assert exchange.fuller_sent_at is not None
+    # Releasing re-arms the stage (the #114 re-sendable posture on a failed turn).
+    lifecycle.release_fuller_claim(db, exchange)
+    db.refresh(exchange)
+    assert exchange.fuller_sent_at is None
+    assert lifecycle.claim_fuller(db, exchange) is True   # claimable again
+
+
 async def test_safety_forced_fuller_fallback_stays_recoverable(db, configured, notifier):
     # #217: a red-flag run forces a fuller turn. If that forced fuller's LLM call
     # falls back persistently (both prose attempts empty), the turn must NOT be

--- a/backend/tests/test_two_stage_pipeline.py
+++ b/backend/tests/test_two_stage_pipeline.py
@@ -301,6 +301,39 @@ async def test_fuller_claim_is_atomic_one_winner(db, configured, notifier):
     assert lifecycle.claim_fuller(db, exchange) is True   # claimable again
 
 
+async def test_fuller_raised_exception_releases_claim_and_stays_recoverable(
+    db, configured, notifier
+):
+    # #506 regression: the atomic claim sets `fuller_sent_at` (the CLOSED / at-most-once
+    # sentinel) BEFORE the slow `generate_fuller` runs. If generation RAISES mid-turn (an
+    # RQ JobTimeoutException over the ~120-360s window, a context-build/network error),
+    # the claim must be RELEASED — otherwise the exchange exits CLOSED-but-unsent and RQ
+    # retry's claim finds the sentinel set and bails, stranding the turn (strictly worse
+    # than the pre-claim null-on-crash posture, #114).
+    activity = _seed(db)
+    exchange = _exchange_of(db, activity)
+
+    boom = RuntimeError("simulated JobTimeout / network error mid-fuller")
+    with patch.object(pna, "generate_fuller", new=AsyncMock(side_effect=boom)):
+        with pytest.raises(RuntimeError):
+            await process_fuller_turn(db=db, activity=activity, notifier=notifier)
+
+    db.refresh(exchange)
+    assert exchange.fuller_sent_at is None  # claim released despite the raise
+    assert len(notifier.sent) == 0          # nothing was notified
+
+    # The turn is re-sendable: a retry re-claims and the real fuller lands + notifies.
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client(_result(_fuller_blocks()))), \
+         patch("app.services.coach.service.write_back_beliefs"), \
+         patch("app.services.coach.service.enqueue_consolidation"):
+        recovered = await process_fuller_turn(db=db, activity=activity, notifier=notifier)
+    assert recovered is not None
+    assert len(notifier.sent) == 1
+    db.refresh(exchange)
+    assert exchange.fuller_sent_at is not None
+
+
 async def test_safety_forced_fuller_fallback_stays_recoverable(db, configured, notifier):
     # #217: a red-flag run forces a fuller turn. If that forced fuller's LLM call
     # falls back persistently (both prose attempts empty), the turn must NOT be


### PR DESCRIPTION
Closes #505
Closes #506

Two exchange at-most-once / dedup correctness fixes in the same two files.

## #505 — repeated "done" tap scheduled duplicate full reports
Under the receipt cadence, every "done" tap scheduled a full-report (block-complete) job. The lifecycle's `mark_done` is idempotent and returns `False` when the exchange was already done, but `_record_done_and_schedule` discarded that return and scheduled unconditionally. So rapid/repeat taps queued redundant LLM generations, deduped only at fire time (by which point concurrent generations could already be running and spending). Fix: bail when `mark_done` reports already-done.

## #506 — timer + reply fuller could race past the closed-check and double-notify
The two-stage fuller turn can be triggered by both a timer and a runner reply. The "is this exchange already closed?" guard was a non-atomic check-then-act: an `is_closed` read, then the slow `generate_fuller`, then the notification sentinel. Under multiple workers both triggers could pass the read, both generate, and both notify (two notifications, a wasted second generation). Fix: an atomic claim. `claim_fuller` is a conditional `UPDATE ... SET fuller_sent_at = now WHERE id = :id AND fuller_sent_at IS NULL` that inspects rowcount, so the database serializes the two triggers — the winner (rowcount 1) generates + notifies, the loser (rowcount 0) bails BEFORE generating. The claim is taken pre-generation and released (`release_fuller_claim`) on a fallback/missing report/no-channel/send failure, preserving the re-sendable-on-failure posture (#114). The claim lives in `exchange_lifecycle.py`, the module that already owns every legal Exchange transition.

No new dependency, no distributed lock; the single-worker happy path and the single-shot/opener paths are unchanged.

## Verification
- `make backend-test`: 1705 passed, 0 failed (1702 baseline + 3 new).
- New tests confirmed to FAIL against the pre-fix code (the #506 one fails with "already sent", proving the old path generated twice and only deduped at the final notify step).
- #505: three sequential done taps -> first schedules, 2nd/3rd are no-ops, `_schedule_block_complete` called exactly once.
- #506: concurrency simulated at the seam by firing the racing `process_fuller_turn` from inside the winner's `generate_fuller` (both in flight before either finishes) -> racer bails, exactly one notification + one stored non-fallback report. Plus a seam-level `claim_fuller`/`release_fuller_claim` test.

### Residual risk
The test baseline runs on in-memory SQLite over one connection, so a true multi-worker / multi-connection race against production Postgres is not exercised in CI. The claim is correct by construction (single-row conditional UPDATE + rowcount, atomic in Postgres) and verified by the single-connection seam test + the mid-generation interleave; cross-connection concurrency is reasoned, not integration-tested.