### PR TITLE
Fix readiness day-bucketing to use the runner's local calendar day (#507)

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -257,7 +257,9 @@ def read_activity(
     # P3 readiness (ADR 0016): the current-condition read as of this activity,
     # computed read-time from the user's windowed history. Shown regardless of the
     # active coach prompt; None (card hidden) when there is no history.
-    readiness = build_readiness(db, activity.user_id, activity.start_date)
+    # #507: anchor on the runner's LOCAL day so readiness and the volume signal agree
+    # on the calendar-day boundary (the daily-load series is bucketed by local day).
+    readiness = build_readiness(db, activity.user_id, activity.local_start)
     if readiness is not None:
         response.training_load = TrainingLoadRead(
             fitness=readiness.fitness,

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -363,12 +363,16 @@ def _build_training_load_context(
     the `TRAINING_LOAD` gating is applied once in `gather`, so this `compute` is
     reached ONLY under a training-load-aware prompt — the section is dropped from
     serialization when None, exactly like `corpus`/`stance`/`block`. Computed at read
-    time (mirroring M9 calibration) as of `as_of` (the activity's `start_date`), so
-    this run is in the acute load and a regen of an old activity reproduces the
-    condition as of then. A tier-3 deterministic FACT the coach may cite, but it never
+    time (mirroring M9 calibration) as of this activity's LOCAL day (#507, the
+    `local_start` convention the volume signal uses), so this run is in the acute load,
+    the daily series agrees with the volume signal on the day boundary, and a regen of
+    an old activity reproduces the condition as of then. A tier-3 deterministic FACT the coach may cite, but it never
     overrides the run's re-derived DerivedMetric or the safety floor (prompt rule 27).
     Degrades to None when no history is available (build_readiness guards)."""
-    model = build_readiness(db, activity.user_id, as_of)
+    # #507: anchor on the runner's LOCAL day so the daily-load series buckets by local
+    # calendar day, agreeing with the volume signal on the day boundary (a late-evening
+    # run that rolled to the next UTC day stays on its local day across both signals).
+    model = build_readiness(db, activity.user_id, activity.local_start)
     if model is None:
         return None
     return TrainingLoadContext(

--- a/backend/app/services/readiness.py
+++ b/backend/app/services/readiness.py
@@ -180,13 +180,28 @@ def compute_readiness(
     )
 
 
+def _local_day(start_date, start_date_local) -> date:
+    """The runner's LOCAL calendar day for an activity, the ``Activity.local_start``
+    convention (#507): ``start_date_local`` when present, else the UTC ``start_date``.
+
+    Identical to the day-bucketing the volume / recent-training signals use (via
+    ``ActivityFact.local_date``), so readiness and volume agree on the day boundary
+    — a late-evening local run that has rolled to the next UTC day, and a same-local-
+    day double session, land on ONE day across both signals.
+    """
+    chosen = start_date_local if start_date_local is not None else start_date
+    return chosen.date() if isinstance(chosen, datetime) else chosen
+
+
 def build_readiness(db: Session, user_id, as_of) -> Optional[ReadinessModel]:
     """Read-time readiness from the user's windowed activity history up to ``as_of``.
 
     ``as_of`` is the reference instant — for a coach report this is the activity's
-    ``start_date``, so the read includes that run in the acute load and a regen of an
-    old activity reproduces the condition as of *then*. Activities strictly after
-    ``as_of`` are excluded; same-day loads are summed. The series is bounded to
+    ``local_start`` (the runner's local wall-clock start, #507), so the daily series
+    is keyed to the runner's local calendar and agrees with the volume signal on the
+    day boundary. The read includes that run in the acute load and a regen of an old
+    activity reproduces the condition as of *then*. Activities after ``as_of``'s local
+    day are excluded; same-local-day loads are summed. The series is bounded to
     ``READINESS_WINDOW_DAYS`` so per-read cost stays flat as history grows (#167).
 
     Guarded: returns ``None`` on no history or on any failure, so it never breaks the
@@ -196,44 +211,62 @@ def build_readiness(db: Session, user_id, as_of) -> Optional[ReadinessModel]:
         if not isinstance(user_id, uuid.UUID):
             user_id = uuid.UUID(str(user_id))
 
-        # The runner's first activity on or before as_of — a cheap aggregate that
-        # gives the true history span without materialising rows.
-        first_dt = db.execute(
-            select(func.min(Activity.start_date))
+        as_of_date = as_of.date() if isinstance(as_of, datetime) else as_of
+
+        # The runner's first activity day on or before as_of, by LOCAL day (#507).
+        # Fetch the earliest candidate cheaply (UTC min is a safe lower bound), then
+        # resolve its local day; widen the <= filter by a day so a local day that
+        # straddles the UTC boundary is never clipped at the edge.
+        first_row = db.execute(
+            select(Activity.start_date, Activity.start_date_local)
             .where(Activity.user_id == user_id)
             .where(Activity.is_deleted == False)  # noqa: E712
-            .where(Activity.start_date <= as_of)
-        ).scalar()
-        if first_dt is None:
+            .order_by(Activity.start_date)
+            .limit(1)
+        ).first()
+        if first_row is None:
             return None
-
-        as_of_date = as_of.date() if isinstance(as_of, datetime) else as_of
-        first_date = first_dt.date() if isinstance(first_dt, datetime) else first_dt
+        first_date = _local_day(first_row[0], first_row[1])
+        if first_date > as_of_date:
+            return None
         history_span_days = (as_of_date - first_date).days
 
-        window_start_dt = as_of - timedelta(days=READINESS_WINDOW_DAYS)
+        # The UTC window filter is a coarse perf bound (#167): widen both edges by a
+        # day so no local-vs-UTC boundary activity is dropped, then bucket precisely
+        # by local day below.
+        window_start_dt = as_of - timedelta(days=READINESS_WINDOW_DAYS + 1)
+        as_of_upper_dt = as_of + timedelta(days=1)
         rows = db.execute(
-            select(Activity.start_date, DerivedMetric.effort_score)
+            select(
+                Activity.start_date,
+                Activity.start_date_local,
+                DerivedMetric.effort_score,
+            )
             .join(DerivedMetric, DerivedMetric.activity_id == Activity.id)
             .where(Activity.user_id == user_id)
             .where(Activity.is_deleted == False)  # noqa: E712
             .where(Activity.start_date >= window_start_dt)
-            .where(Activity.start_date <= as_of)
+            .where(Activity.start_date <= as_of_upper_dt)
         ).all()
-
-        by_day: dict[date, float] = {}
-        sample_count = 0
-        for start, effort in rows:
-            if effort is None:
-                continue
-            d = start.date() if isinstance(start, datetime) else start
-            by_day[d] = by_day.get(d, 0.0) + float(effort)
-            sample_count += 1
 
         window_start_date = (
             window_start_dt.date() if isinstance(window_start_dt, datetime) else window_start_dt
         )
         series_start = max(window_start_date, first_date)
+
+        by_day: dict[date, float] = {}
+        sample_count = 0
+        for start, start_local, effort in rows:
+            if effort is None:
+                continue
+            d = _local_day(start, start_local)
+            # Bucket by LOCAL day, excluding anything after as_of's local day or
+            # before the series window (the widened UTC filter may admit a few).
+            if d > as_of_date or d < series_start:
+                continue
+            by_day[d] = by_day.get(d, 0.0) + float(effort)
+            sample_count += 1
+
         n_days = max((as_of_date - series_start).days + 1, 1)
         daily = [by_day.get(series_start + timedelta(days=i), 0.0) for i in range(n_days)]
 

--- a/backend/tests/test_readiness.py
+++ b/backend/tests/test_readiness.py
@@ -128,11 +128,12 @@ def _seed_user(db):
     return user
 
 
-def _seed_activity(db, user, when, effort, *, idx=0):
+def _seed_activity(db, user, when, effort, *, idx=0, local=None):
     act = Activity(
         user_id=user.id,
         strava_activity_id=int(when.timestamp()) + idx,
         start_date=when,
+        start_date_local=local,   # naive local wall-clock; None => local_start falls back to UTC
         type="Run",
         name="Run",
         distance_m=5000,
@@ -235,6 +236,103 @@ def test_build_readiness_skips_activities_without_metrics(db):
     model = build_readiness(db, user.id, _BASE + timedelta(days=1, hours=2))
     assert model is not None
     assert model.sample_count == 1           # the metric-less activity is not counted
+
+
+# ---------------------------------------------------------------------------
+# build_readiness — LOCAL-day bucketing (#507)
+#
+# Readiness must key its daily-load series to the runner's LOCAL calendar day (the
+# `Activity.local_start` convention: start_date_local when present, else UTC
+# start_date), consistent with the volume vs-norm signal. Otherwise a late-evening
+# local run whose UTC instant has rolled to the next day, and a same-local-day double
+# session straddling the UTC midnight, split across two days and understate the acute
+# (fatigue) load spike the coach reads.
+#
+# The real callers now pass `activity.local_start` as `as_of`; these tests mirror that.
+# ---------------------------------------------------------------------------
+
+def test_build_readiness_buckets_late_evening_run_on_local_day(db):
+    # A run at 23:00 local in a UTC-2 zone => UTC instant is 01:00 the NEXT calendar
+    # day. Its local day is the EARLIER day; readiness must agree with volume and use
+    # the local day. Two such runs on the SAME local day (but different UTC days) must
+    # sum into ONE day's load, not split across two.
+    user = _seed_user(db)
+    local_day = datetime(2026, 6, 1)  # the runner's local calendar day
+
+    # Morning: 09:00 local (UTC 11:00, same UTC day) and evening: 23:00 local (UTC
+    # 01:00 the next UTC day). Both share local day 2026-06-01.
+    morning_local = local_day.replace(hour=9)
+    morning_utc = datetime(2026, 6, 1, 11, 0, tzinfo=timezone.utc)
+    evening_local = local_day.replace(hour=23)
+    evening_utc = datetime(2026, 6, 2, 1, 0, tzinfo=timezone.utc)  # rolled to next UTC day
+
+    _seed_activity(db, user, morning_utc, 30.0, idx=0, local=morning_local)
+    _seed_activity(db, user, evening_utc, 40.0, idx=1, local=evening_local)
+
+    # As-of the runner's local wall-clock end of the evening run (the real call site).
+    model = build_readiness(db, user.id, evening_local.replace(hour=23, minute=30))
+    assert model is not None
+    assert model.sample_count == 2
+    # One day of history seeded at 0 with summed load 30+40=70:
+    #   fitness = a_ctl * 70 = 0.0235284 * 70 = 1.6470 -> 1.6.
+    # If the two runs had split across two UTC days the series would be [70-ish split],
+    # giving a different (lower) fatigue spike; 1.6 confirms they summed into ONE day.
+    assert model.fitness == 1.6
+    assert model.history_span_days == 0   # both runs land on the single local day
+
+
+def test_build_readiness_double_session_one_acute_spike_not_split(db):
+    # The acute-fatigue point of the bug: a same-local-day double session must register
+    # as one day's load (a bigger fatigue spike), not two half-loads across two days.
+    user = _seed_user(db)
+    # Establish a flat baseline of one run/day for 60 prior local days at load 20, in a
+    # UTC-5 zone (so evening runs roll to the next UTC day but stay on their local day).
+    offset = timedelta(hours=5)  # local = UTC - 5h
+    base_local = datetime(2026, 4, 1, 18, 0)  # 18:00 local
+    last_local = None
+    for i in range(60):
+        d_local = base_local + timedelta(days=i)
+        d_utc = (d_local + offset).replace(tzinfo=timezone.utc)
+        _seed_activity(db, user, d_utc, 20.0, idx=i, local=d_local)
+        last_local = d_local
+
+    # The final local day gets a SECOND session in the evening that crosses UTC midnight.
+    second_local = last_local.replace(hour=23)          # 23:00 local, same local day
+    second_utc = (second_local + offset).replace(tzinfo=timezone.utc)  # 04:00 next UTC day
+    _seed_activity(db, user, second_utc, 60.0, idx=999, local=second_local)
+
+    model = build_readiness(db, user.id, second_local.replace(minute=30))
+    assert model is not None
+    # The final local day carries 20 + 60 = 80 of load summed into ONE series day, so
+    # the acute (fatigue) EWMA spikes above the steady ~20 baseline rather than being
+    # diluted across two UTC days.
+    assert model.fatigue > 25.0
+    assert model.sample_count == 61   # 60 baseline + the second session, all counted
+
+
+def test_build_readiness_dst_transition_day_uses_local_wall_clock(db):
+    # On a DST "spring forward" day the local wall-clock day is unambiguous (Strava
+    # supplies start_date_local already shifted), so _local_day just takes its date.
+    # A run on the DST day must bucket on its local day regardless of the UTC instant.
+    user = _seed_user(db)
+    # US spring-forward 2026: 2026-03-08, clocks jump 02:00->03:00 (UTC-5 -> UTC-4).
+    # An evening run at 22:00 local on the DST day, UTC-4 after the shift => UTC 02:00
+    # on 2026-03-09 (rolled to the next UTC day).
+    dst_local = datetime(2026, 3, 8, 22, 0)
+    dst_utc = datetime(2026, 3, 9, 2, 0, tzinfo=timezone.utc)
+    # A few prior days to give a non-trivial series, all UTC-4 evenings.
+    for i in range(1, 6):
+        prior_local = dst_local - timedelta(days=i)
+        prior_utc = dst_utc - timedelta(days=i)
+        _seed_activity(db, user, prior_utc, 25.0, idx=i, local=prior_local)
+    _seed_activity(db, user, dst_utc, 25.0, idx=0, local=dst_local)
+
+    model = build_readiness(db, user.id, dst_local.replace(minute=30))
+    assert model is not None
+    assert model.sample_count == 6
+    # History spans the 5 prior local days to the DST local day inclusive -> 5 days.
+    # (If the DST run were bucketed on its UTC day 2026-03-09 it would read 6.)
+    assert model.history_span_days == 5
 
 
 def _d(n):


### PR DESCRIPTION
Closes #507

## What was wrong
The readiness / training-load signal bucketed its EWMA daily-load series by the **UTC** date of each activity's start, while the volume vs-norm signal buckets by the runner's **local** day. Two consequences:

- A late-evening local run whose UTC instant has rolled into the next calendar day landed on a different day across the two signals (they disagreed on the day boundary).
- A same-local-day double session straddling UTC midnight split across two UTC days, understating the acute (fatigue) load spike the coach reads.

## The fix
`build_readiness` now keys its daily series to the runner's **local calendar day**, using the exact same `local_start` convention the volume signal already uses (`start_date_local` when present, else UTC `start_date`). The two call sites (the coach `training_load` pack section in `context.py` and the activity-detail `/load` card in `activities.py`) now anchor the as-of day on `activity.local_start`. The UTC window query stays as a coarse perf bound, widened a day each edge so no boundary-crossing activity is clipped, and rows are then bucketed precisely by local day.

No new dependencies; `volume.py` is untouched (it is the reference convention).

## Intended behavior change
This is a derived-signal correction. **Readiness values will shift for runs near the local/UTC midnight boundary** — that shift is the intended fix (both signals now agree on the day, and same-local-day double sessions register as one acute spike rather than two diluted half-loads).

## No migration needed
Readiness is recomputed read-time and is never persisted, so there is nothing to backfill. No stored value needs recompute.

## Tests
Three new `build_readiness` DB tests (mirroring the existing readiness suite):
- a 23:00-local run that rolled to the next UTC day buckets on its local day, and a same-local-day morning+evening pair sums to one day's load (fitness hand-computed from the EWMA);
- a same-local-day double session crossing UTC midnight registers as one acute fatigue spike rather than splitting;
- a DST spring-forward evening run buckets on its local wall-clock day.

All three fail against the old UTC bucketing and pass after the fix. No existing test expectations changed (prior readiness tests seed without `start_date_local`, so local day equals UTC day for them).

## Verification
`make backend-test`: **1705 passed, 4 deselected** (integration, excluded). New tests verified to fail on the pre-fix code (confirming they exercise the bug). Unverified: no real-data run against production/seeded Postgres (in-memory SQLite test harness).