### PR TITLE
Bind Strava webhook event to its activity owner (#512)

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -80,6 +80,13 @@ def _event_is_authentic(event: "StravaEvent", db: Session) -> bool:
     2. The event owner must be a connected athlete. Athlete ids are public, so
        this check is weaker on its own, but it is always available from the DB
        and never drifts, so it stays on even when (1) is unconfigured.
+    3. The referenced activity (when one is already stored) must belong to the
+       owner resolved from (2). strava_activity_id is globally unique, so without
+       this bind a connected athlete B passing (1)+(2) could reference athlete
+       A's activity and trigger a side effect (soft-delete, reprocess) on it
+       (#512). A create for a brand-new activity has no stored row to bind, so
+       this check only constrains update/delete and create-when-already-exists;
+       it never blocks the legitimate first sight of a new activity.
     """
     expected_subscription_id = settings.STRAVA_WEBHOOK_SUBSCRIPTION_ID
     if expected_subscription_id and event.subscription_id != expected_subscription_id:
@@ -100,6 +107,22 @@ def _event_is_authentic(event: "StravaEvent", db: Session) -> bool:
     if account is None:
         logger.warning(
             "strava_webhook_rejected_unknown_owner",
+            extra={"owner_id": event.owner_id, "object_id": event.object_id},
+        )
+        return False
+
+    existing_activity = db.execute(
+        select(Activity.user_id).where(
+            Activity.strava_activity_id == event.object_id
+        )
+    ).scalars().first()
+    if existing_activity is not None and existing_activity != account.user_id:
+        # The event references an activity we already store, but it belongs to a
+        # different runner than the event's owner. strava_activity_id is global,
+        # so this is a connected athlete reaching for another athlete's activity
+        # (#512). Reject before the delete/sync/create branches act on it.
+        logger.warning(
+            "strava_webhook_rejected_object_owner_mismatch",
             extra={"owner_id": event.owner_id, "object_id": event.object_id},
         )
         return False

--- a/backend/tests/test_webhook_dispatch.py
+++ b/backend/tests/test_webhook_dispatch.py
@@ -179,3 +179,129 @@ class TestRejectsForgedEvents:
 
         db.refresh(activity)
         assert activity.is_deleted is False
+
+
+# A second connected athlete, distinct from CONNECTED_ATHLETE_ID, used to model
+# the multi-user cross-owner attack: athlete B is fully connected (passes the
+# owner and subscription checks) but references athlete A's activity.
+ATHLETE_B_ID = 888
+
+
+def _seed_user_with_account(db, *, strava_athlete_id: int):
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    account = StravaAccount(
+        user_id=user.id,
+        strava_athlete_id=strava_athlete_id,
+        access_token="test-token-do-not-use-in-prod",
+        refresh_token="test-refresh-do-not-use-in-prod",
+        expires_at=9999999999,
+        scope="read",
+    )
+    db.add(account)
+    db.commit()
+    return user
+
+
+def _seed_activity(db, *, user, strava_activity_id: int):
+    from datetime import datetime
+
+    activity = Activity(
+        user_id=user.id,
+        strava_activity_id=strava_activity_id,
+        start_date=datetime(2026, 5, 27, 10, 0, 0),
+        type="Run",
+        name="Victim run",
+        distance_m=5000,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+    )
+    db.add(activity)
+    db.commit()
+    return activity
+
+
+class TestRejectsCrossOwnerEvents:
+    """Threat model (#512, multi-user): athlete B is a CONNECTED runner, so a
+    forged event from B passes the owner-is-connected and subscription checks.
+    Because strava_activity_id is globally unique, B must still not be able to
+    reference athlete A's activity and trigger a side effect on it (soft-delete
+    or reprocess). The object-to-owner bind in _event_is_authentic enforces this;
+    removing that bind makes every assertion here fail (non-vacuous)."""
+
+    def test_connected_other_owner_delete_does_not_soft_delete(
+        self, client, db, fake_queue
+    ):
+        athlete_a = _seed_user_with_account(db, strava_athlete_id=CONNECTED_ATHLETE_ID)
+        _seed_user_with_account(db, strava_athlete_id=ATHLETE_B_ID)
+        activity = _seed_activity(db, user=athlete_a, strava_activity_id=4242)
+
+        # Athlete B (connected) forges a delete for athlete A's activity.
+        response = _post(
+            client, aspect_type="delete", object_id=4242, owner_id=ATHLETE_B_ID
+        )
+        assert response.status_code == 403
+
+        db.refresh(activity)
+        assert activity.is_deleted is False
+
+    def test_connected_other_owner_update_does_not_enqueue(
+        self, client, db, fake_queue
+    ):
+        athlete_a = _seed_user_with_account(db, strava_athlete_id=CONNECTED_ATHLETE_ID)
+        _seed_user_with_account(db, strava_athlete_id=ATHLETE_B_ID)
+        _seed_activity(db, user=athlete_a, strava_activity_id=4343)
+
+        # Athlete B (connected) forges an update for athlete A's activity: must
+        # not enqueue a re-ingest (sync_activity_job) on A's data.
+        response = _post(
+            client, aspect_type="update", object_id=4343, owner_id=ATHLETE_B_ID
+        )
+        assert response.status_code == 403
+        fake_queue.enqueue.assert_not_called()
+
+    def test_connected_other_owner_create_when_already_exists_does_not_enqueue(
+        self, client, db, fake_queue
+    ):
+        athlete_a = _seed_user_with_account(db, strava_athlete_id=CONNECTED_ATHLETE_ID)
+        _seed_user_with_account(db, strava_athlete_id=ATHLETE_B_ID)
+        _seed_activity(db, user=athlete_a, strava_activity_id=4444)
+
+        # A create referencing an already-stored activity owned by A must not
+        # reprocess it under B's credentials.
+        response = _post(
+            client, aspect_type="create", object_id=4444, owner_id=ATHLETE_B_ID
+        )
+        assert response.status_code == 403
+        fake_queue.enqueue.assert_not_called()
+
+    def test_same_owner_delete_still_soft_deletes(self, client, db, fake_queue):
+        # Non-vacuous guard: the legitimate owner deleting their own activity
+        # must still succeed through the same code path.
+        athlete_a = _seed_user_with_account(db, strava_athlete_id=CONNECTED_ATHLETE_ID)
+        activity = _seed_activity(db, user=athlete_a, strava_activity_id=4545)
+
+        response = _post(
+            client,
+            aspect_type="delete",
+            object_id=4545,
+            owner_id=CONNECTED_ATHLETE_ID,
+        )
+        assert response.status_code == 200
+
+        db.refresh(activity)
+        assert activity.is_deleted is True
+
+    def test_same_owner_update_still_enqueues(self, client, db, fake_queue):
+        athlete_a = _seed_user_with_account(db, strava_athlete_id=CONNECTED_ATHLETE_ID)
+        _seed_activity(db, user=athlete_a, strava_activity_id=4646)
+
+        response = _post(
+            client,
+            aspect_type="update",
+            object_id=4646,
+            owner_id=CONNECTED_ATHLETE_ID,
+        )
+        assert response.status_code == 200
+        fake_queue.enqueue.assert_called_once()


### PR DESCRIPTION
Closes #512

## Summary
The incoming Strava webhook checked that the event owner is a connected athlete (and, when configured, that the subscription id matches), but it never bound the referenced activity (`object_id`) to that owner. Since `strava_activity_id` is globally unique, a *connected* athlete B could POST a forged `delete`/`update`/`create` event referencing athlete A's activity and trigger a side effect on it (soft-delete, or re-ingest/reprocess). Single-user masks this; under the documented multi-user direction it is a cross-tenant authorization gap.

## What changed
- `_event_is_authentic` gains a third check: after resolving the `StravaAccount` from `owner_id` (and thus its `user_id`), if the event references an activity already stored, reject (403) when that activity's `user_id` differs from the owner's. The existing owner-connected and subscription-id checks are kept.
- A brand-new `create` (no stored row) is untouched, so the legitimate first-sight ingestion path still works; the bind only constrains `update`/`delete` and `create-when-already-exists`.

## Verification
- New `TestRejectsCrossOwnerEvents` in `test_webhook_dispatch.py`: a CONNECTED athlete B referencing athlete A's activity is rejected for delete (asserts NOT soft-deleted), update (asserts no enqueue), and create-when-exists (no enqueue); plus same-owner delete/update still succeed (non-vacuous guard).
- Confirmed non-vacuous: neutering the bind makes the 3 cross-owner tests fail red, the 2 same-owner tests stay green.
- Existing unconnected-forger and subscription-mismatch tests still pass.
- `make backend-test`: 1725 passed, 4 deselected (integration).