### PR TITLE
Surface baseline/readiness recompute failures (#513)

### DIFF
--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -214,6 +214,27 @@ def sentry_capture_active() -> bool:
     return _SENTRY_AVAILABLE and bool(settings.SENTRY_DSN)
 
 
+def capture_exception(exc: BaseException) -> None:
+    """Route a caught exception to Sentry. No-op unless capture is active.
+
+    For a best-effort guard that swallows an exception so it never breaks the
+    caller (e.g. the runner-baseline / readiness recomputes), an ERROR-level
+    ``logger.exception`` already reaches Sentry via the ``LoggingIntegration``
+    (``event_level=logging.ERROR``). This helper makes that capture explicit and
+    unconditional at the swallow site so a genuine internal failure is visible as
+    its own event rather than indistinguishable from a normal "not enough data"
+    abstention. It is a no-op when Sentry is not wired up (the optional
+    ``observability`` extra absent or ``SENTRY_DSN`` unset; logs-only by default,
+    see issue #102), so it is safe to call from any code path.
+    """
+    if not sentry_capture_active():
+        return
+    try:
+        sentry_sdk.capture_exception(exc)
+    except Exception:  # pragma: no cover - capture must never break the caller
+        logging.getLogger(__name__).exception("sentry_capture_failed")
+
+
 def init_sentry(component: str) -> None:
     """Initialise the Sentry SDK. No-op unless the SDK is installed and
     SENTRY_DSN is set.

--- a/backend/app/services/analysis/_orchestrator.py
+++ b/backend/app/services/analysis/_orchestrator.py
@@ -134,8 +134,17 @@ def _post_commit_baseline(db: Session, user_id) -> None:
     try:
         from app.services.analysis.baseline import recompute_runner_baseline
         recompute_runner_baseline(db, user_id)
-    except Exception:  # noqa: BLE001 baseline is best-effort, must not break analyze
+    except Exception as exc:  # noqa: BLE001 baseline is best-effort, must not break analyze
+        # Keep the guard (a failure here never breaks analyze), but make a genuine
+        # failure VISIBLE: a legitimate "not enough data" abstention returns cleanly
+        # from recompute_runner_baseline (None) without raising, so reaching here is
+        # always a real fault (a malformed stored bucketed_trends, a bad value type).
+        # Log at ERROR with context and route it to Sentry (a no-op when
+        # unconfigured) so corruption surfaces instead of silently freezing the
+        # baseline at its last good value (#513).
+        from app.core.observability import capture_exception
         logger.exception("runner baseline recompute failed for user %s", user_id)
+        capture_exception(exc)
 
 
 def analyze(db: Session, activity_id: str, skip_baseline: bool = False) -> Optional[DerivedMetric]:

--- a/backend/app/services/readiness.py
+++ b/backend/app/services/readiness.py
@@ -33,6 +33,7 @@ from typing import List, Optional
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.core.observability import capture_exception
 from app.models import Activity, DerivedMetric
 
 logger = logging.getLogger(__name__)
@@ -276,6 +277,14 @@ def build_readiness(db: Session, user_id, as_of) -> Optional[ReadinessModel]:
             history_span_days=history_span_days,
             sample_count=sample_count,
         )
-    except Exception:  # pragma: no cover - defensive guard
+    except Exception as exc:
+        # Best-effort guard: a failure must never break the caller (the coach
+        # pack / activity-detail read), so we still return the safe None. But a
+        # genuine internal failure (a malformed stored value, a bad type) must
+        # NOT be indistinguishable from a legitimate "no history" abstention,
+        # which returns None cleanly above without ever reaching here. Surface it
+        # at ERROR with context and route it to Sentry (a no-op when unconfigured)
+        # so corruption is visible instead of silently freezing the signal (#513).
         logger.exception("readiness computation failed for user %s", user_id)
+        capture_exception(exc)
         return None

--- a/backend/tests/test_readiness.py
+++ b/backend/tests/test_readiness.py
@@ -338,3 +338,63 @@ def test_build_readiness_dst_transition_day_uses_local_wall_clock(db):
 def _d(n):
     """A throwaway as_of date n days into an arbitrary epoch (pure tests don't read it)."""
     return (datetime(2026, 1, 1) + timedelta(days=n)).date()
+
+
+# ---------------------------------------------------------------------------
+# build_readiness — failure VISIBILITY (#513)
+#
+# The broad guard must keep returning the safe None so it never breaks the caller,
+# but a GENUINE internal failure (a malformed stored value, a bad type) must be
+# logged at ERROR and routed to Sentry capture rather than swallowed silently --
+# otherwise corruption is indistinguishable from a normal "no history" abstention
+# and the signal freezes at its last good value with no symptom. The legitimate
+# thin-data path must stay quiet so the new logging does not cry wolf.
+# ---------------------------------------------------------------------------
+
+def test_build_readiness_internal_error_is_visible_but_safe(db, monkeypatch, caplog):
+    import logging
+
+    captured: list[BaseException] = []
+    monkeypatch.setattr(
+        "app.services.readiness.capture_exception",
+        lambda exc: captured.append(exc),
+    )
+    # Force a genuine internal fault deep in the compute, past the abstention
+    # early-returns, so the broad except is the only thing that catches it.
+    def _boom(*args, **kwargs):
+        raise ValueError("malformed stored load")
+
+    monkeypatch.setattr("app.services.readiness.compute_readiness", _boom)
+
+    user = _seed_user(db)
+    _seed_activity(db, user, _BASE, 50.0, idx=0)
+
+    with caplog.at_level(logging.ERROR, logger="app.services.readiness"):
+        model = build_readiness(db, user.id, _BASE + timedelta(hours=2))
+
+    # Contract preserved: caller still gets the safe None.
+    assert model is None
+    # Visible: logged at ERROR and routed to Sentry capture.
+    assert any(r.levelno == logging.ERROR for r in caplog.records)
+    assert "readiness computation failed" in caplog.text
+    assert len(captured) == 1
+    assert isinstance(captured[0], ValueError)
+
+
+def test_build_readiness_thin_data_abstention_stays_quiet(db, monkeypatch, caplog):
+    import logging
+
+    captured: list[BaseException] = []
+    monkeypatch.setattr(
+        "app.services.readiness.capture_exception",
+        lambda exc: captured.append(exc),
+    )
+    user = _seed_user(db)  # no activities -> legitimate abstention
+
+    with caplog.at_level(logging.ERROR, logger="app.services.readiness"):
+        model = build_readiness(db, user.id, _BASE)
+
+    # A normal "not enough data" abstention: safe None, but NOT logged or captured.
+    assert model is None
+    assert not any(r.levelno == logging.ERROR for r in caplog.records)
+    assert captured == []

--- a/backend/tests/test_runner_baseline.py
+++ b/backend/tests/test_runner_baseline.py
@@ -478,3 +478,69 @@ def test_recompute_in_window_history_is_unchanged(db):
     assert row.bucketed_trends[bucket]["abstained"] is False
     # median HR of [140,145,150,155] = 147.5
     assert row.typical_easy_hr == 147.5
+
+
+# ---------------------------------------------------------------------------
+# Baseline recompute failure VISIBILITY (#513)
+#
+# The runner-baseline recompute is best-effort: a failure must never break
+# analyze(), so the orchestrator swallows it and analysis continues. But a GENUINE
+# internal failure (a malformed stored bucketed_trends, a bad value type) must be
+# logged at ERROR and routed to Sentry capture rather than swallowed silently --
+# otherwise corruption is indistinguishable from a normal "not enough data"
+# abstention (which returns None cleanly without raising) and the baseline freezes
+# at its last good value with no symptom. The legitimate thin-data path must stay
+# quiet so the new logging does not cry wolf.
+# ---------------------------------------------------------------------------
+
+def test_post_commit_baseline_internal_error_is_visible_but_safe(db, monkeypatch, caplog):
+    import logging
+
+    from app.services.analysis import _orchestrator
+
+    captured: list[BaseException] = []
+    monkeypatch.setattr(
+        "app.core.observability.capture_exception",
+        lambda exc: captured.append(exc),
+    )
+
+    def _boom(_db, _user_id):
+        raise ValueError("malformed stored bucketed_trends")
+
+    monkeypatch.setattr(
+        "app.services.analysis.baseline.recompute_runner_baseline", _boom
+    )
+
+    user = _seed_user(db)
+
+    with caplog.at_level(logging.ERROR, logger=_orchestrator.__name__):
+        # Best-effort guard: must NOT raise even though the recompute blows up.
+        _orchestrator._post_commit_baseline(db, user.id)
+
+    # Visible: logged at ERROR and routed to Sentry capture.
+    assert any(r.levelno == logging.ERROR for r in caplog.records)
+    assert "runner baseline recompute failed" in caplog.text
+    assert len(captured) == 1
+    assert isinstance(captured[0], ValueError)
+
+
+def test_post_commit_baseline_thin_data_abstention_stays_quiet(db, monkeypatch, caplog):
+    import logging
+
+    from app.services.analysis import _orchestrator
+
+    captured: list[BaseException] = []
+    monkeypatch.setattr(
+        "app.core.observability.capture_exception",
+        lambda exc: captured.append(exc),
+    )
+
+    # No activities -> recompute_runner_baseline returns None cleanly (abstains).
+    user = _seed_user(db)
+
+    with caplog.at_level(logging.ERROR, logger=_orchestrator.__name__):
+        _orchestrator._post_commit_baseline(db, user.id)
+
+    # A normal abstention: no ERROR log, no Sentry capture.
+    assert not any(r.levelno == logging.ERROR for r in caplog.records)
+    assert captured == []


### PR DESCRIPTION
Closes #513

## Problem
The runner-baseline recompute (`analysis/_orchestrator._post_commit_baseline`) and the readiness recompute (`readiness.build_readiness`) each wrap their work in a broad `except Exception` so a failure never breaks the analysis pipeline. That guard is correct and stays. But it swallowed silently, so a genuine data corruption (a malformed stored `bucketed_trends`, a bad value type) looked exactly like a legitimate "not enough data to compute" abstention. The signal then froze at its last good value with no visible symptom.

## Fix (surgical, keeps the pipeline-safety guarantee)
- New shared `observability.capture_exception(exc)` helper: routes a caught exception to Sentry, and is a no-op when Sentry is not wired up (the optional `observability` extra absent or `SENTRY_DSN` unset, the existing logs-only-by-default pattern). Reused at both swallow sites.
- Both swallow sites now log at ERROR with user-id context (already the case for readiness) AND call `capture_exception`. The return contract is unchanged: callers still get the safe `None`/empty on failure, and the guard is not removed.
- A legitimate thin-data abstention returns `None` cleanly BEFORE the except arm, so the normal path never logs or captures.

Audit note: the baseline path's broad swallow lives in the orchestrator caller `_post_commit_baseline`, not inside `recompute_runner_baseline` itself (which has only a narrow `IntegrityError` retry, no broad catch). Hardened the real swallow site.

## Tests
Added to `test_readiness.py` and `test_runner_baseline.py`, mirroring the existing DB-seeded style:
- Inject a genuine internal error (monkeypatch an inner call to raise) -> assert the function still returns the safe `None` (no raise) AND the error is logged at ERROR (caplog) AND routed to capture (patched helper records the exception).
- A legitimate no-history abstention -> safe `None`, and NO error log / NO capture, so the new logging does not cry wolf.

## Verification
`make backend-test`: 1724 passed, 4 deselected (integration), 0 failures.
Unverified: real Sentry delivery (capture is patched in tests; the helper is import-guarded and no-op without SDK/DSN, consistent with the existing init path). The fault is injected at the function boundary rather than via a real malformed DB row, which is sufficient to prove the except arm's behaviour.