### PR TITLE
Make the done-tap an atomic claim (#514)

### DIFF
--- a/backend/app/services/coach/exchange_lifecycle.py
+++ b/backend/app/services/coach/exchange_lifecycle.py
@@ -41,7 +41,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import update
+from sqlalchemy import func, update
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -119,21 +119,40 @@ def record_receipt_sent(db: Session, activity: Activity, *, now: Optional[dateti
 
 
 def mark_done(db: Session, exchange: Exchange, *, now: Optional[datetime] = None) -> bool:
-    """Record the runner's explicit "done" tap (#296). Idempotent: a second tap is a
-    no-op on `done_at`. Defensively opens the exchange if the receipt somehow had not.
-    Returns True if it recorded the completion now.
+    """Atomically record the runner's explicit "done" tap (#296). Idempotent: a second
+    tap is a no-op on `done_at`. Defensively opens the exchange if the receipt somehow
+    had not. Returns True if THIS call recorded the completion now.
 
     The CALLER must already have checked the exchange is open and within window via
-    `can_fire_reply_fuller` (or the equivalent) — this only writes state."""
-    if exchange.done_at is not None:
-        return False
-    now = now or _now()
-    exchange.done_at = now
-    if exchange.opened_at is None:
-        exchange.opened_at = now
-    db.add(exchange)
+    `can_fire_reply_fuller` (or the equivalent) — this only writes state. The caller
+    schedules the full report only when this returns True, so exactly one tap schedules.
+
+    #514: the prior guard was a non-atomic check-then-act (`done_at` read, then the
+    write). The web service is multi-process and the Telegram "done" callback hits it, so
+    two SIMULTANEOUS taps could both read `done_at` null, both transition, and both
+    schedule the full report. This is a conditional UPDATE that sets `done_at` only WHERE
+    it is still NULL and inspects the rowcount, mirroring `claim_fuller`: the database
+    serializes the two taps so exactly one wins (rowcount 1) and the loser (rowcount 0)
+    learns it lost and does NOT schedule. `opened_at` is set in the SAME UPDATE only
+    where it is still null, so the defensive open stays atomic with the claim and never
+    moves an existing reply-window anchor."""
+    stamp = now or _now()
+    result = db.execute(
+        update(Exchange)
+        .where(Exchange.id == exchange.id, Exchange.done_at.is_(None))
+        .values(
+            done_at=stamp,
+            opened_at=func.coalesce(Exchange.opened_at, stamp),
+        )
+    )
     db.commit()
-    return True
+    won = result.rowcount == 1
+    if won:
+        # Keep the in-memory instance consistent with the row the winner just wrote.
+        exchange.done_at = stamp
+        if exchange.opened_at is None:
+            exchange.opened_at = stamp
+    return won
 
 
 # --- the at-most-once notification invariant (one place) ----------------------

--- a/backend/tests/test_claim_concurrency_integration.py
+++ b/backend/tests/test_claim_concurrency_integration.py
@@ -1,0 +1,252 @@
+"""Real-Postgres concurrency proof for the atomic Exchange claim transitions (#506).
+
+`claim_fuller` and `mark_done` in `app/services/coach/exchange_lifecycle.py` are
+the at-most-once guarantees for the fuller turn and the "done" tap. They are
+written as atomic conditional UPDATEs (`... WHERE <sentinel> IS NULL`, then a
+rowcount check) precisely so the DATABASE serializes racing triggers. The default
+unit suite only exercises them against in-memory SQLite on a single connection,
+which cannot exercise true multi-connection row locking.
+
+This integration test runs the REAL `claim_fuller` / `mark_done` (imported from the
+prod module, not reimplemented) against a real local Postgres instance, from many
+separate connections hammering one row at the same instant, and asserts that
+EXACTLY ONE caller wins each race. It is marked `integration` so it stays out of
+the default `make backend-test` run (pyproject addopts uses `-m "not integration"`),
+and it SKIPS gracefully when Postgres is unreachable so it can never break CI.
+
+Threads (not processes) are used, but each thread holds its OWN SQLAlchemy Session
+on its OWN DB connection, so the contention is resolved inside Postgres (row-level
+locking / MVCC), not by the Python GIL. A `threading.Barrier` releases all workers
+at the same instant to maximise the overlap window.
+"""
+
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from app.db.base import Base
+
+# Force every ORM model to register on Base.metadata before create_all.
+import app.models  # noqa: F401
+from app.models import Activity, Block, Exchange, User
+from app.services.coach.exchange_lifecycle import claim_fuller, mark_done
+
+# --- environment -------------------------------------------------------------
+
+_PG_HOST = "localhost"
+_PG_PORT = 5433
+_PG_USER = "coach"
+_PG_PASSWORD = "coach"
+_ADMIN_DB = "coach"  # an existing db to issue CREATE DATABASE from
+_TEST_DB = "coach_concurrency_test"
+
+_ADMIN_URL = (
+    f"postgresql+psycopg://{_PG_USER}:{_PG_PASSWORD}@{_PG_HOST}:{_PG_PORT}/{_ADMIN_DB}"
+)
+_TEST_URL = (
+    f"postgresql+psycopg://{_PG_USER}:{_PG_PASSWORD}@{_PG_HOST}:{_PG_PORT}/{_TEST_DB}"
+)
+
+_TRIALS = 30
+_THREADS = 16
+
+
+def _pg_reachable() -> bool:
+    try:
+        eng = create_engine(_ADMIN_URL, connect_args={"connect_timeout": 3})
+        with eng.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        eng.dispose()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="module")
+def pg_engine():
+    """A dedicated engine against a throwaway database on the local PG instance.
+
+    Creates the database (dropping a stale one first), materializes the full ORM
+    schema, yields a sessionmaker, then drops the database so the dev `coach`
+    database and its seeded data are never touched.
+    """
+    if not _pg_reachable():
+        pytest.skip("local Postgres not reachable at localhost:5433")
+
+    admin = create_engine(_ADMIN_URL, isolation_level="AUTOCOMMIT")
+    with admin.connect() as conn:
+        conn.execute(
+            text(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = :db AND pid <> pg_backend_pid()"
+            ),
+            {"db": _TEST_DB},
+        )
+        conn.execute(text(f'DROP DATABASE IF EXISTS "{_TEST_DB}"'))
+        conn.execute(text(f'CREATE DATABASE "{_TEST_DB}"'))
+    admin.dispose()
+
+    engine = create_engine(_TEST_URL, pool_size=_THREADS + 4, max_overflow=_THREADS)
+    Base.metadata.create_all(engine)
+
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    try:
+        yield engine, Session
+    finally:
+        engine.dispose()
+        admin = create_engine(_ADMIN_URL, isolation_level="AUTOCOMMIT")
+        with admin.connect() as conn:
+            conn.execute(
+                text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = :db AND pid <> pg_backend_pid()"
+                ),
+                {"db": _TEST_DB},
+            )
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{_TEST_DB}"'))
+        admin.dispose()
+
+
+def _seed_exchange(Session) -> tuple[uuid.UUID, uuid.UUID]:
+    """Build a minimal real object graph (User -> Activity -> Block -> Exchange)
+    with both claim sentinels NULL, and return (exchange_id, block_id)."""
+    db = Session()
+    try:
+        now = datetime.now(timezone.utc)
+        user = User(email=f"race-{uuid.uuid4()}@example.test")
+        db.add(user)
+        db.flush()
+
+        activity = Activity(
+            user_id=user.id,
+            strava_activity_id=int(uuid.uuid4().int % 9_000_000_000) + 1,
+            start_date=now,
+            type="Run",
+            name="race seed",
+            distance_m=5000,
+            moving_time_s=1500,
+            elapsed_time_s=1500,
+        )
+        db.add(activity)
+        db.flush()
+
+        block = Block(
+            user_id=user.id,
+            start_date=now,
+            end_date=now + timedelta(minutes=30),
+            primary_activity_id=activity.id,
+        )
+        db.add(block)
+        db.flush()
+
+        activity.block_id = block.id
+        db.add(activity)
+        db.flush()
+
+        exchange = Exchange(
+            user_id=user.id,
+            block_id=block.id,
+            opened_at=now,  # open: replies/done act on an open exchange
+        )
+        db.add(exchange)
+        db.commit()
+        return exchange.id, block.id
+    finally:
+        db.close()
+
+
+def _run_race(Session, claim_fn, exchange_id: uuid.UUID) -> list[bool]:
+    """Launch _THREADS workers, each on its OWN Session/connection, synchronized on
+    a Barrier so they all invoke `claim_fn(db, exchange)` at the same instant.
+    Returns each worker's boolean result."""
+    barrier = threading.Barrier(_THREADS)
+    results: list[bool] = [False] * _THREADS
+    errors: list[BaseException] = []
+
+    def worker(idx: int) -> None:
+        db = Session()
+        try:
+            exchange = db.get(Exchange, exchange_id)
+            barrier.wait()  # release all threads together
+            results[idx] = claim_fn(db, exchange)
+        except BaseException as exc:  # noqa: BLE001 - surface, don't swallow
+            errors.append(exc)
+        finally:
+            db.close()
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(_THREADS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"worker raised: {errors!r}"
+    return results
+
+
+@pytest.mark.integration
+def test_claim_fuller_exactly_one_winner_under_concurrent_pg_connections(pg_engine):
+    _engine, Session = pg_engine
+
+    winners_per_trial = []
+    for trial in range(_TRIALS):
+        exchange_id, _ = _seed_exchange(Session)
+
+        results = _run_race(Session, claim_fuller, exchange_id)
+        wins = sum(results)
+        winners_per_trial.append(wins)
+        assert wins == 1, (
+            f"claim_fuller trial {trial}: expected exactly 1 winner across "
+            f"{_THREADS} concurrent PG connections, got {wins} ({results})"
+        )
+
+        # The row is claimed exactly once: fuller_sent_at is now set (non-null).
+        db = Session()
+        try:
+            ex = db.get(Exchange, exchange_id)
+            assert ex.fuller_sent_at is not None, "winner must have set fuller_sent_at"
+            # A fresh claim AFTER a win must lose (the sentinel is already set).
+            assert claim_fuller(db, ex) is False, "post-win claim must return False"
+        finally:
+            db.close()
+
+    assert all(w == 1 for w in winners_per_trial)
+    print(
+        f"\nclaim_fuller: {sum(1 for w in winners_per_trial if w == 1)}/{_TRIALS} "
+        f"trials had EXACTLY ONE winner across {_THREADS} concurrent PG connections."
+    )
+
+
+@pytest.mark.integration
+def test_mark_done_exactly_one_winner_under_concurrent_pg_connections(pg_engine):
+    _engine, Session = pg_engine
+
+    winners_per_trial = []
+    for trial in range(_TRIALS):
+        exchange_id, _ = _seed_exchange(Session)
+
+        results = _run_race(Session, mark_done, exchange_id)
+        wins = sum(results)
+        winners_per_trial.append(wins)
+        assert wins == 1, (
+            f"mark_done trial {trial}: expected exactly 1 winner across "
+            f"{_THREADS} concurrent PG connections, got {wins} ({results})"
+        )
+
+        db = Session()
+        try:
+            ex = db.get(Exchange, exchange_id)
+            assert ex.done_at is not None, "winner must have set done_at"
+            assert mark_done(db, ex) is False, "post-win mark_done must return False"
+        finally:
+            db.close()
+
+    assert all(w == 1 for w in winners_per_trial)
+    print(
+        f"\nmark_done: {sum(1 for w in winners_per_trial if w == 1)}/{_TRIALS} "
+        f"trials had EXACTLY ONE winner across {_THREADS} concurrent PG connections."
+    )

--- a/backend/tests/test_exchange_lifecycle.py
+++ b/backend/tests/test_exchange_lifecycle.py
@@ -174,6 +174,43 @@ def test_mark_done_is_idempotent(db):
     assert ex.done_at == before
 
 
+def test_mark_done_is_atomic_one_winner(db):
+    # #514 seam-level: the "done" guard is an atomic claim, not a check-then-act. Two
+    # callers marking the same exchange done must yield exactly one winner — the
+    # conditional UPDATE on done_at-IS-NULL serializes the race, so only the first tap
+    # schedules the full report.
+    ex = _exchange(db)
+    assert lifecycle.mark_done(db, ex) is True   # winner
+    assert lifecycle.mark_done(db, ex) is False  # loser: already done
+    db.refresh(ex)
+    assert ex.done_at is not None
+    assert ex.opened_at is not None  # defensively opened, atomically with the claim
+
+
+def test_mark_done_claim_consults_the_row_not_a_stale_instance(db):
+    # #514: simulate two processes that each loaded the exchange with `done_at` still
+    # null (the web service is multi-process) before either committed. The old guard read
+    # the in-memory instance's `done_at` — so a SECOND caller holding its own stale
+    # instance would re-pass the null check and double-win (both scheduling the full
+    # report). The atomic UPDATE's WHERE done_at IS NULL consults the committed ROW, so
+    # the second caller loses regardless of its stale in-memory view. A separate Session
+    # on the same connection gives a genuinely independent identity map (the second
+    # process's view), which a same-session second instance cannot.
+    from sqlalchemy.orm import Session as _Session
+
+    ex = _exchange(db)
+    db.commit()
+    other = _Session(bind=db.connection())
+    stale = other.query(Exchange).filter(Exchange.id == ex.id).one()
+    assert stale.done_at is None  # the second process still sees an unclaimed exchange
+
+    assert lifecycle.mark_done(db, ex) is True        # first process wins the claim
+    assert lifecycle.mark_done(other, stale) is False  # second loses on the committed ROW
+    db.refresh(ex)
+    assert ex.done_at is not None
+    other.close()
+
+
 def test_mark_done_preserves_existing_opened_at(db):
     opened = datetime(2026, 5, 27, 10, 0, 0, tzinfo=timezone.utc)
     ex = _exchange(db, opened_at=opened)

--- a/backend/tests/test_receipt_cadence_pipeline.py
+++ b/backend/tests/test_receipt_cadence_pipeline.py
@@ -243,6 +243,50 @@ async def test_repeated_done_taps_schedule_exactly_one_full_report(db, configure
     assert ex.done_at is not None
 
 
+async def test_concurrent_done_taps_schedule_exactly_one_full_report(db, configured, notifier):
+    # #514: the web service is multi-process and the Telegram "done" callback hits it, so
+    # two SIMULTANEOUS taps land in two PROCESSES that each loaded the exchange with
+    # `done_at` still null before either committed. The old done guard was a non-atomic
+    # check-then-act (`done_at` read on the in-memory instance, then write), so both taps
+    # passed the null check and both scheduled the full report. We model the two processes
+    # as two independent Sessions on the same connection (genuinely separate identity
+    # maps), and INTERLEAVE them: the second tap is fired from inside the first's
+    # mark_done, after BOTH processes have already loaded the still-null exchange but
+    # before either claim has committed. The atomic claim (a conditional UPDATE on
+    # done_at-IS-NULL) must let exactly ONE schedule.
+    from sqlalchemy.orm import Session as _Session
+
+    activity = _seed(db)
+    block = _block_of(db, activity)
+    await _send_receipt(db=db, activity=activity, block=block, notifier=notifier)
+    db.commit()
+
+    second_db = _Session(bind=db.connection())  # the second process's view of the same row
+    racing = {"second": None, "ran": False}
+
+    def race_then_mark(db_, exchange, **kwargs):
+        # The first process has loaded the exchange (done_at null) and is about to claim.
+        # The second process, which ALSO loaded the still-null exchange, now claims first.
+        # Old check-then-act: both pass the null read and both schedule. Atomic UPDATE:
+        # only one rowcount-1 winner schedules.
+        if not racing["ran"]:
+            racing["ran"] = True
+            racing["second"] = mark_done_and_schedule(second_db, activity.id)
+        return real_mark_done(db_, exchange, **kwargs)
+
+    real_mark_done = pna.lifecycle.mark_done
+    with patch.object(pna, "_schedule_block_complete") as sched, \
+         patch.object(pna.lifecycle, "mark_done", side_effect=race_then_mark):
+        first = mark_done_and_schedule(db, activity.id)
+    second_db.close()
+
+    # Exactly one of the two concurrent taps wins the claim and schedules; the other bails.
+    assert {first, racing["second"]} == {True, False}
+    sched.assert_called_once()         # exactly ONE full-report job from concurrent taps
+    ex = _exchange_of(db, activity)
+    assert ex.done_at is not None
+
+
 async def test_done_tap_noops_when_exchange_closed(db, configured, notifier):
     activity = _seed(db)
     ex = _exchange_of(db, activity)


### PR DESCRIPTION
Closes #514

## Summary
Two simultaneous "done" taps on the same exchange could both schedule the full-report (`block_complete`) job. The #505 fix made the done-tap bail when the exchange was already done, but that guard (`mark_done` -> `done_at`) was a non-atomic check-then-act. The web service is multi-process and the Telegram "done" callback hits it, so two concurrent taps could both observe `done_at` null, both transition, and both schedule. Today this is only wasted enqueues (the #506 fuller claim still lets exactly one generation proceed), so it is an efficiency/cleanliness fix, not a correctness hole.

## What changed
- `mark_done` (in `exchange_lifecycle.py`) is now an ATOMIC claim, mirroring #506's `claim_fuller`: a conditional `UPDATE Exchange SET done_at = <now> WHERE id = ... AND done_at IS NULL`, returning `rowcount == 1`. Exactly one concurrent caller wins; the loser learns it lost and does not schedule.
- The defensive open folds into the same UPDATE via `coalesce(opened_at, now)`, so it stays atomic with the claim and never moves an existing reply-window anchor.
- The one caller (`_record_done_and_schedule`) is unchanged: it already schedules only when `mark_done` returns True. Surgical diff scoped to the transition + its existing boolean contract.
- Single-shot / opener / receipt happy paths are untouched.

## Tests
- `test_mark_done_claim_consults_the_row_not_a_stale_instance` (lifecycle seam): two independent Sessions on the same connection (genuinely separate identity maps) model two processes that both loaded the still-null exchange; the second loses on the committed row.
- `test_concurrent_done_taps_schedule_exactly_one_full_report` (job seam): interleaved two-session taps schedule exactly one `block_complete`.
- Both are RED against the prior non-atomic code (old code lets both win -> both schedule) and GREEN after the fix.
- `test_claim_concurrency_integration.py` (NEW, real-Postgres, `integration`-marked, deselected from the default run, skips if PG unreachable): runs the REAL `claim_fuller` and `mark_done` against a throwaway local Postgres database from 16 threads each on its own connection, synchronized on a `threading.Barrier`, across 30 trials, asserting exactly one winner per trial.
- `make backend-test`: 1732 passed, 6 integration deselected.

## Verification
Concurrency simulated with two SQLAlchemy Sessions on one connection, interleaved so both load the null exchange before either commits. The new `integration` test closes the prior real-PG gap: it exercises true multi-connection row locking inside Postgres (threads, but each holds its own Session/connection, so contention is resolved by the DB MVCC/row lock, not the GIL).

### Real-Postgres evidence (new integration test)
Ran on this branch against local Postgres 16:
```
tests/test_claim_concurrency_integration.py::test_claim_fuller_exactly_one_winner_under_concurrent_pg_connections
claim_fuller: 30/30 trials had EXACTLY ONE winner across 16 concurrent PG connections.
PASSED
tests/test_claim_concurrency_integration.py::test_mark_done_exactly_one_winner_under_concurrent_pg_connections
mark_done: 30/30 trials had EXACTLY ONE winner across 16 concurrent PG connections.
PASSED

2 passed in 5.17s
```
This empirically proves the #514 atomic `mark_done` fix under genuinely concurrent Postgres connections: both `claim_fuller` (#506) and the new `mark_done` claim yield exactly one winner per trial. As a control, the same test caught the OLD non-atomic `mark_done` on `main` (all 16 threads won a trial), confirming the test has teeth.

Caveats: this is local Postgres (not Railway prod PG) and multi-thread-with-separate-connections (not multi-process); the contention is still resolved at the DB row-lock level, so the serialization guarantee being tested is the same one prod relies on.

No new dependencies, no distributed lock. This change does not alter the coach context pack or system prompt (no diagram regeneration needed).
