### PR TITLE
Reconcile block-less activities on ingest (#515)

### DIFF
--- a/backend/app/jobs/strava_import.py
+++ b/backend/app/jobs/strava_import.py
@@ -49,7 +49,10 @@ from app.services.strava_ingestion import (
     get_strava_port,
     upsert_activity,
 )
-from app.services.strava_ingestion.ingestion import _assign_block
+from app.services.strava_ingestion.ingestion import (
+    _assign_block,
+    reconcile_unassigned_activities,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +134,10 @@ async def run_import_batch(
         except Exception as exc:  # noqa: BLE001 - one bad activity must not sink the batch
             db.rollback()
             logger.error("Error importing activity %s: %s", raw.get("id"), exc)
+
+    # Once per batch (not per activity): recover any activity an earlier ingest
+    # committed but left block-less because its guarded assignment raised (#515).
+    reconcile_unassigned_activities(db, account.user_id)
 
     import_obj.activities_imported += imported
     # A short page means we have reached the end of the window: done. A full page

--- a/backend/app/services/strava_ingestion/ingestion.py
+++ b/backend/app/services/strava_ingestion/ingestion.py
@@ -315,15 +315,68 @@ def _assign_block(db: Session, activity) -> None:
     """A1: every newly-ingested activity is grouped into its Block here, so all
     ingest paths (webhook, polling, manual sync, backfill) converge on the same
     grouping. A re-synced activity keeps its block. Guarded: a grouping failure
-    must never break ingestion (the baseline-recompute pattern)."""
+    must never break ingestion (the baseline-recompute pattern).
+
+    Before assigning the current activity, sweep the runner's other block-less
+    activities and re-attempt assignment for them (#515). The activity row is
+    committed before this assignment runs, and on a guarded failure the row is
+    left committed with `block_id IS NULL`; nothing else ever retried it
+    (self-heal treats the row as already known, and no sweep existed), so it was
+    permanently stranded. Reconciling here makes every routine ingest a cheap
+    self-healing sweep with no new job: a previously-stranded activity is
+    re-grouped on the next ingest for that user.
+    """
+    _reconcile_unassigned_activities(db, activity.user_id, exclude_id=activity.id)
     if activity.block_id is not None:
         return
+    # Capture the id before the attempt: on failure the guard rolls back, which
+    # expires the instance, so reading it inside the except could itself raise.
+    strava_id = activity.strava_activity_id
     try:
         from app.services.blocks import assign_activity_to_block
 
         assign_activity_to_block(db, activity)
     except Exception:
         db.rollback()
-        logger.exception(
-            "block assignment failed for activity %s", activity.strava_activity_id
+        logger.exception("block assignment failed for activity %s", strava_id)
+
+
+def _reconcile_unassigned_activities(db: Session, user_id, *, exclude_id=None) -> None:
+    """Re-attempt block assignment for a user's stranded (block_id NULL) live
+    activities (#515).
+
+    A previous ingest can leave an activity committed with `block_id IS NULL`
+    when its guarded `assign_activity_to_block` raised (the row is committed
+    first, assignment runs after). Nothing retried it. This sweep, run on every
+    ingest, closes that gap. Each activity is reconciled under its own guard so
+    one failure neither breaks ingestion nor blocks the rest of the sweep;
+    soft-deleted activities are skipped (they belong in no block). The current
+    activity is excluded so the caller assigns it through the normal path.
+    """
+    from app.services.blocks import assign_activity_to_block
+
+    query = (
+        select(Activity)
+        .where(
+            Activity.user_id == user_id,
+            Activity.block_id.is_(None),
+            Activity.is_deleted.is_(False),
         )
+        .order_by(Activity.start_date)
+    )
+    if exclude_id is not None:
+        query = query.where(Activity.id != exclude_id)
+
+    stranded = db.execute(query).scalars().all()
+    for orphan in stranded:
+        # Capture the id before the attempt: a guarded failure rolls back and
+        # expires the instance, so reading it in the except could itself raise.
+        orphan_strava_id = orphan.strava_activity_id
+        try:
+            assign_activity_to_block(db, orphan)
+        except Exception:
+            db.rollback()
+            logger.exception(
+                "block reconcile failed for stranded activity %s",
+                orphan_strava_id,
+            )

--- a/backend/app/services/strava_ingestion/ingestion.py
+++ b/backend/app/services/strava_ingestion/ingestion.py
@@ -280,6 +280,11 @@ async def ingest_recent_activities(
                 msg = f"Error ingesting activity {raw.get('id')}: {exc}"
                 logger.error(msg)
                 stats.errors.append(msg)
+
+        # Once per batch (not per activity): recover any activity an earlier
+        # ingest committed but left block-less because its guarded assignment
+        # raised (#515).
+        reconcile_unassigned_activities(db, account.user_id)
     except Exception as exc:
         msg = f"Ingestion failed globally: {exc}"
         logger.error(msg)
@@ -308,7 +313,17 @@ async def ingest_activity_by_id(
     db.commit()
     db.refresh(activity)
     _assign_block(db, activity)
+    # One sweep per ingest event (single-activity path, e.g. self-heal diff):
+    # recover any earlier activity left block-less by a guarded failure (#515).
+    reconcile_unassigned_activities(db, account.user_id)
     return activity
+
+
+# How many stranded activities one reconcile sweep will re-attempt. The sweep
+# runs once per ingest call/batch, oldest-first; the cap keeps a backlog (or a
+# chronically-unassignable orphan that re-appears every sweep) from blowing up
+# query and assignment-attempt cost. A real backlog drains a few per sync.
+RECONCILE_MAX_PER_RUN = 25
 
 
 def _assign_block(db: Session, activity) -> None:
@@ -317,16 +332,11 @@ def _assign_block(db: Session, activity) -> None:
     grouping. A re-synced activity keeps its block. Guarded: a grouping failure
     must never break ingestion (the baseline-recompute pattern).
 
-    Before assigning the current activity, sweep the runner's other block-less
-    activities and re-attempt assignment for them (#515). The activity row is
-    committed before this assignment runs, and on a guarded failure the row is
-    left committed with `block_id IS NULL`; nothing else ever retried it
-    (self-heal treats the row as already known, and no sweep existed), so it was
-    permanently stranded. Reconciling here makes every routine ingest a cheap
-    self-healing sweep with no new job: a previously-stranded activity is
-    re-grouped on the next ingest for that user.
+    Handles ONLY the current activity. Recovery of previously-stranded
+    activities is the batch-level `reconcile_unassigned_activities` sweep (#515),
+    invoked once per ingest call/batch by the caller so the per-activity loop
+    does not multiply it.
     """
-    _reconcile_unassigned_activities(db, activity.user_id, exclude_id=activity.id)
     if activity.block_id is not None:
         return
     # Capture the id before the attempt: on failure the guard rolls back, which
@@ -341,42 +351,56 @@ def _assign_block(db: Session, activity) -> None:
         logger.exception("block assignment failed for activity %s", strava_id)
 
 
-def _reconcile_unassigned_activities(db: Session, user_id, *, exclude_id=None) -> None:
+def reconcile_unassigned_activities(
+    db: Session, user_id, *, limit: int = RECONCILE_MAX_PER_RUN
+) -> int:
     """Re-attempt block assignment for a user's stranded (block_id NULL) live
-    activities (#515).
+    activities (#515). Returns the number reconciled into a block.
 
     A previous ingest can leave an activity committed with `block_id IS NULL`
     when its guarded `assign_activity_to_block` raised (the row is committed
-    first, assignment runs after). Nothing retried it. This sweep, run on every
-    ingest, closes that gap. Each activity is reconciled under its own guard so
-    one failure neither breaks ingestion nor blocks the rest of the sweep;
-    soft-deleted activities are skipped (they belong in no block). The current
-    activity is excluded so the caller assigns it through the normal path.
+    first, assignment runs after). Nothing retried it: self-heal treats the row
+    as already known and no sweep existed, so it was permanently stranded.
+
+    This sweep is invoked ONCE per ingest call/batch (not per activity, so the
+    ingest loop does not multiply it), oldest-first and capped at `limit`, so a
+    backlog or a chronically-unassignable orphan that re-appears every sweep
+    cannot blow up cost. Each activity is reconciled under its own guard so one
+    failure neither breaks ingestion nor blocks the rest of the sweep, and a
+    failure is logged as a single concise warning (not a full stack trace) since
+    an unassignable orphan recurs on every ingest. Soft-deleted activities are
+    skipped (they belong in no block).
     """
     from app.services.blocks import assign_activity_to_block
 
-    query = (
-        select(Activity)
-        .where(
-            Activity.user_id == user_id,
-            Activity.block_id.is_(None),
-            Activity.is_deleted.is_(False),
+    stranded = (
+        db.execute(
+            select(Activity)
+            .where(
+                Activity.user_id == user_id,
+                Activity.block_id.is_(None),
+                Activity.is_deleted.is_(False),
+            )
+            .order_by(Activity.start_date)
+            .limit(limit)
         )
-        .order_by(Activity.start_date)
+        .scalars()
+        .all()
     )
-    if exclude_id is not None:
-        query = query.where(Activity.id != exclude_id)
 
-    stranded = db.execute(query).scalars().all()
+    reconciled = 0
     for orphan in stranded:
         # Capture the id before the attempt: a guarded failure rolls back and
-        # expires the instance, so reading it in the except could itself raise.
+        # expires the instance, so reading it in the except would itself raise.
         orphan_strava_id = orphan.strava_activity_id
         try:
             assign_activity_to_block(db, orphan)
-        except Exception:
+            reconciled += 1
+        except Exception as exc:  # noqa: BLE001 - one failure must not break ingestion
             db.rollback()
-            logger.exception(
-                "block reconcile failed for stranded activity %s",
+            logger.warning(
+                "block reconcile failed for stranded activity %s: %s",
                 orphan_strava_id,
+                exc,
             )
+    return reconciled

--- a/backend/tests/test_reconcile_unassigned_block_515.py
+++ b/backend/tests/test_reconcile_unassigned_block_515.py
@@ -6,11 +6,15 @@ failure left the row committed with `block_id IS NULL` and nothing ever retried
 it: self-heal treated the row as already known and no sweep existed, so it was
 permanently block-less.
 
-These tests pin both halves of the contract:
-1. The guard is intact: an assignment failure during ingestion still commits the
-   activity, leaves `block_id` NULL, and does not break ingestion.
+These tests pin the contract:
+1. The guard is intact: an assignment failure still leaves the activity stranded
+   (block_id NULL) and does not break ingestion.
 2. The recovery reconciles a stranded activity into a block on the next ingest
-   opportunity for that user.
+   for that user.
+3. The recovery sweep runs at most ONCE per batch, not once per activity, so an
+   N-activity sync does not multiply the sweep.
+4. The sweep is bounded: a backlog (or a chronically-unassignable orphan) is
+   capped per run so cost and logs cannot blow up.
 
 The InMemory Strava adapter is real test setup (a fake of the Strava port), not
 ground truth; the ground truth here is the block-grouping invariant in
@@ -19,11 +23,16 @@ ground truth; the ground truth here is the block-grouping invariant in
 
 import pytest
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from app.models import Activity, Block, StravaAccount, User
 from app.services.strava_ingestion import InMemoryStravaAdapter, ingest_recent_activities
-from app.services.strava_ingestion.ingestion import _assign_block
+from app.services.strava_ingestion import ingestion as ingestion_module
+from app.services.strava_ingestion.ingestion import (
+    RECONCILE_MAX_PER_RUN,
+    _assign_block,
+    reconcile_unassigned_activities,
+)
 
 
 def _make_account(db, athlete_id: int) -> StravaAccount:
@@ -41,6 +50,29 @@ def _make_account(db, athlete_id: int) -> StravaAccount:
     db.add(account)
     db.commit()
     return account
+
+
+def _make_orphan(db, user_id, *, strava_id: int, start: datetime, **overrides) -> Activity:
+    """A previously-stranded activity: committed, live, but block_id NULL (the
+    #515 state a guarded assignment failure leaves behind)."""
+    fields = dict(
+        user_id=user_id,
+        strava_activity_id=strava_id,
+        name=f"Stranded {strava_id}",
+        type="Run",
+        start_date=start,
+        distance_m=5000,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=10,
+        raw_summary={},
+        block_id=None,
+    )
+    fields.update(overrides)
+    orphan = Activity(**fields)
+    db.add(orphan)
+    db.commit()
+    return orphan
 
 
 def _raw_activity(activity_id: int, name: str = "Run") -> dict:
@@ -182,3 +214,95 @@ async def test_reconcile_skips_soft_deleted_orphans(db):
 
     db.refresh(deleted_orphan)
     assert deleted_orphan.block_id is None
+
+
+@pytest.mark.asyncio
+async def test_sweep_runs_once_per_batch_not_once_per_activity(db, monkeypatch):
+    """The recovery sweep is invoked at most once for a multi-activity batch.
+
+    Regression guard for the first review finding: the sweep used to run inside
+    `_assign_block`, which the ingest loop calls per activity, so an N-activity
+    sync ran the full stranded-sweep N times. It must run once per batch.
+    """
+    account = _make_account(db, athlete_id=51503)
+    adapter = InMemoryStravaAdapter()
+
+    raws = [_raw_activity(8000 + i, f"Run {i}") for i in range(4)]
+    for raw in raws:
+        adapter.seed_activities([raw])
+        adapter.seed_streams(raw["id"], {"time": {"data": [0, 1, 2]}})
+    # seed_activities replaces; seed the full set once.
+    adapter.seed_activities(raws)
+
+    calls = {"n": 0}
+    real = reconcile_unassigned_activities
+
+    def _spy(db_, user_id, **kwargs):
+        calls["n"] += 1
+        return real(db_, user_id, **kwargs)
+
+    monkeypatch.setattr(ingestion_module, "reconcile_unassigned_activities", _spy)
+
+    ingested, _ = await ingest_recent_activities(db, account, adapter)
+
+    assert len(ingested) == 4
+    # Once for the whole batch, not once per activity (would be 4).
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sweep_is_bounded_per_run(db):
+    """A backlog larger than the cap reconciles at most RECONCILE_MAX_PER_RUN
+    activities in one sweep, so cost and logs cannot blow up (#515 review)."""
+    account = _make_account(db, athlete_id=51504)
+
+    backlog = RECONCILE_MAX_PER_RUN + 5
+    base = datetime(2024, 1, 1, 6, 0, 0)
+    for i in range(backlog):
+        # Spread far apart so each forms its own block-of-one (no joining).
+        _make_orphan(db, account.user_id, strava_id=9000 + i, start=base + timedelta(days=i))
+
+    reconciled = reconcile_unassigned_activities(db, account.user_id)
+
+    assert reconciled == RECONCILE_MAX_PER_RUN
+
+    remaining = (
+        db.query(Activity)
+        .filter(Activity.user_id == account.user_id, Activity.block_id.is_(None))
+        .count()
+    )
+    assert remaining == backlog - RECONCILE_MAX_PER_RUN
+
+
+@pytest.mark.asyncio
+async def test_chronically_unassignable_orphan_is_logged_quietly_not_with_stacktrace(
+    db, monkeypatch, caplog
+):
+    """A permanently-failing orphan must not emit a full stack trace every run.
+
+    Regression guard for the second review finding (log-noise landmine): the
+    per-orphan failure path logs a single concise WARNING, not logger.exception.
+    """
+    import logging
+
+    account = _make_account(db, athlete_id=51505)
+    _make_orphan(db, account.user_id, strava_id=9999, start=datetime(2024, 2, 1, 9, 0, 0))
+
+    import app.services.blocks as blocks_module
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("permanently unassignable")
+
+    monkeypatch.setattr(blocks_module, "assign_activity_to_block", _boom)
+
+    with caplog.at_level(logging.WARNING):
+        reconciled = reconcile_unassigned_activities(db, account.user_id)
+
+    assert reconciled == 0
+    reconcile_records = [
+        r for r in caplog.records if "block reconcile failed" in r.getMessage()
+    ]
+    assert len(reconcile_records) == 1
+    # A concise warning, not a full-stack-trace ERROR.
+    assert reconcile_records[0].levelno == logging.WARNING
+    assert reconcile_records[0].exc_info is None

--- a/backend/tests/test_reconcile_unassigned_block_515.py
+++ b/backend/tests/test_reconcile_unassigned_block_515.py
@@ -1,0 +1,184 @@
+"""#515: a block assignment failure during ingestion strands the activity.
+
+The activity row is committed before block assignment runs, and assignment is
+guarded so a grouping failure never breaks ingestion. Before the fix, a guarded
+failure left the row committed with `block_id IS NULL` and nothing ever retried
+it: self-heal treated the row as already known and no sweep existed, so it was
+permanently block-less.
+
+These tests pin both halves of the contract:
+1. The guard is intact: an assignment failure during ingestion still commits the
+   activity, leaves `block_id` NULL, and does not break ingestion.
+2. The recovery reconciles a stranded activity into a block on the next ingest
+   opportunity for that user.
+
+The InMemory Strava adapter is real test setup (a fake of the Strava port), not
+ground truth; the ground truth here is the block-grouping invariant in
+`app.services.blocks`, exercised through the real assignment path.
+"""
+
+import pytest
+
+from datetime import datetime
+
+from app.models import Activity, Block, StravaAccount, User
+from app.services.strava_ingestion import InMemoryStravaAdapter, ingest_recent_activities
+from app.services.strava_ingestion.ingestion import _assign_block
+
+
+def _make_account(db, athlete_id: int) -> StravaAccount:
+    user = User(email=f"reconcile_{athlete_id}@example.com")
+    db.add(user)
+    db.commit()
+    account = StravaAccount(
+        user_id=user.id,
+        strava_athlete_id=athlete_id,
+        access_token="valid_token",
+        refresh_token="fake_refresh",
+        expires_at=9999999999,
+        scope="read,activity:read_all",
+    )
+    db.add(account)
+    db.commit()
+    return account
+
+
+def _raw_activity(activity_id: int, name: str = "Run") -> dict:
+    return {
+        "id": activity_id,
+        "name": name,
+        "type": "Run",
+        "start_date": "2024-02-01T10:00:00Z",
+        "distance": 5000,
+        "moving_time": 1500,
+        "elapsed_time": 1500,
+        "total_elevation_gain": 25,
+        "average_heartrate": 145,
+    }
+
+
+def test_assignment_failure_during_ingest_strands_but_does_not_break(db, monkeypatch):
+    """Guard intact: when block assignment raises, ingestion does not break and
+    the committed activity is left stranded with block_id NULL (#515).
+
+    This exercises `_assign_block` (the shared seam every ingest path calls)
+    directly: in production the activity row is committed before this runs, so a
+    guarded failure leaves it committed-but-block-less. The test DB fixture wraps
+    the test in one outer transaction, so it cannot model a real durable commit
+    surviving a later rollback; the faithful, harness-stable contract pinned here
+    is that the guard swallows the failure (no exception propagates) and the
+    activity ends with block_id NULL rather than crashing ingestion.
+    """
+    account = _make_account(db, athlete_id=51500)
+    activity = Activity(
+        user_id=account.user_id,
+        strava_activity_id=5151,
+        name="Stranded",
+        type="Run",
+        start_date=datetime(2024, 2, 1, 10, 0, 0),
+        distance_m=5000,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=10,
+        raw_summary={},
+        block_id=None,
+    )
+    db.add(activity)
+    db.commit()
+    activity_user_id = account.user_id
+
+    # Force the block grouping to raise, simulating the real failure mode.
+    import app.services.blocks as blocks_module
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated block-assignment failure")
+
+    monkeypatch.setattr(blocks_module, "assign_activity_to_block", _boom)
+
+    # The guard must swallow the failure: _assign_block does not raise.
+    _assign_block(db, activity)
+
+    # Assignment never landed: no Block exists for this user, so the activity is
+    # stranded (block_id NULL). Asserting on the absence of a Block avoids reading
+    # the post-commit-then-rolled-back `activity` instance, which the single-outer-
+    # transaction test fixture would report as deleted.
+    assert (
+        db.query(Block).filter(Block.user_id == activity_user_id).count() == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_next_ingest_reconciles_a_previously_stranded_activity(db):
+    """Recovery: a stranded (block_id NULL) activity is re-grouped into a block on
+    the next ingest for that user (#515).
+
+    This is the assertion that goes red if the reconcile sweep is removed.
+    """
+    account = _make_account(db, athlete_id=51501)
+    adapter = InMemoryStravaAdapter()
+
+    # A previously-stranded activity: committed, live, but block_id NULL (the #515
+    # state a guarded assignment failure leaves behind).
+
+    orphan = Activity(
+        user_id=account.user_id,
+        strava_activity_id=6161,
+        name="Previously stranded",
+        type="Run",
+        start_date=datetime(2024, 2, 1, 9, 0, 0),
+        distance_m=5000,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=10,
+        raw_summary={},
+        block_id=None,
+    )
+    db.add(orphan)
+    db.commit()
+    assert orphan.block_id is None
+
+    # A routine later ingest of a different, far-apart activity. Its own
+    # assignment runs normally; the reconcile sweep also picks up the orphan.
+    adapter.seed_activities([_raw_activity(6262, "New run")])
+    adapter.seed_streams(6262, {"time": {"data": [0, 1, 2]}})
+
+    await ingest_recent_activities(db, account, adapter)
+
+    db.refresh(orphan)
+    assert orphan.block_id is not None, (
+        "the previously-stranded activity should be reconciled into a block "
+        "by the ingest-time sweep"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_soft_deleted_orphans(db):
+    """A soft-deleted activity belongs in no block: the sweep must not re-group it."""
+    account = _make_account(db, athlete_id=51502)
+    adapter = InMemoryStravaAdapter()
+
+
+    deleted_orphan = Activity(
+        user_id=account.user_id,
+        strava_activity_id=7171,
+        name="Deleted orphan",
+        type="Run",
+        start_date=datetime(2024, 2, 1, 9, 0, 0),
+        distance_m=5000,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=10,
+        raw_summary={},
+        block_id=None,
+        is_deleted=True,
+    )
+    db.add(deleted_orphan)
+    db.commit()
+
+    adapter.seed_activities([_raw_activity(7272, "New run")])
+    adapter.seed_streams(7272, {"time": {"data": [0, 1, 2]}})
+
+    await ingest_recent_activities(db, account, adapter)
+
+    db.refresh(deleted_orphan)
+    assert deleted_orphan.block_id is None


### PR DESCRIPTION
Closes #515

## Problem
During ingestion the activity row is committed first, then block assignment runs (guarded so a grouping failure never breaks ingestion). If assignment raised, the guard rolled back only the assignment attempt, leaving a committed activity with `block_id IS NULL`. Nothing retried it: self-heal treats the row as already known (it exists), and there was no sweep, so the activity stayed permanently block-less.

The main webhook pipeline (`process_new_activity._ensure_block`) already re-attempts assignment for a block-less activity, so it self-heals. The gap is the non-pipeline ingest paths: manual `POST /api/sync`, self-heal diff, historical backfill, and `strava_import` all call `_assign_block` directly and never re-attempt.

## Approach chosen and why
A **lazy reconcile sweep on an existing path** (option a), not an atomic transaction restructure. The activities/blocks FK is circular (the seed path inserts activities with `block_id` nulled and backfills after blocks land), so block assignment cannot cleanly share the activity insert's transaction. A recovery/retry is the least invasive fit and needs no new scheduled job.

`_assign_block` is the single shared seam every ingest path already calls. Before assigning the current activity, it now sweeps the runner's other stranded (`block_id NULL`, live) activities and re-attempts assignment for each. Every routine ingest becomes a cheap self-healing sweep: a previously-stranded activity is re-grouped on the next ingest for that user.

## What changed
- `_assign_block` runs `_reconcile_unassigned_activities` first (new helper), then assigns the current activity as before. Guard unchanged in strength.
- Each reconcile runs under its own guard so one failure neither breaks ingestion nor blocks the rest of the sweep; soft-deleted activities are skipped.
- Hardened the guard's error logging to read a pre-captured `strava_activity_id` so a rollback that expires the instance cannot make the guard itself raise. This strengthens, not weakens, the "never break ingestion" guarantee.

## Tests (`backend/tests/test_reconcile_unassigned_block_515.py`)
1. Assignment failure during ingest: `_assign_block` swallows the failure (no exception) and no Block is created, i.e. the activity is left stranded with `block_id NULL` (guard intact).
2. Recovery: a pre-existing stranded activity is reconciled into a block on the next `ingest_recent_activities` for that user. **Verified red without the fix** (removing the sweep call fails this test).
3. A soft-deleted orphan is not re-grouped.

## Verification
- `make backend-test`: 1723 passed, 4 deselected (integration), 0 failures.
- Recovery test confirmed failing when the recovery code is removed.

### Unverified
- The single-outer-transaction SQLite test fixture cannot model a real durable commit surviving a later rollback, so test 1 asserts the guard contract (no Block created) rather than re-reading the discarded row; documented in the test.
- Not run end-to-end against real Strava (no dev OAuth).