### PR TITLE
Multi-user Strava/Telegram follow-ups: per-user status read, /start confirmation, deployed runbook (#532, #533, #534)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -50,17 +50,25 @@ def strava_login(user: User = Depends(require_current_user)):
 
 
 @router.get("/auth/strava/status", response_model=StravaConnectionStatus)
-def strava_status(db: Session = Depends(get_db)) -> StravaConnectionStatus:
-    """Reports whether a Strava account is linked, and surfaces the athlete id and token scope.
+def strava_status(
+    user: User = Depends(require_current_user),
+    db: Session = Depends(get_db),
+) -> StravaConnectionStatus:
+    """Reports whether the signed-in user's Strava account is linked, and surfaces its athlete id and token scope.
 
-    NOTE: login + callback now thread the signed-in user through a signed OAuth
-    `state` so a new account links to the right user (#469), but this status
-    READ stays single-user (the first linked account) -- it is session-exempt
-    (ADR 0022 exempts /api/auth/*) and returns no training data, only the
-    connection's athlete id and scope. A per-user status read is part of the
-    remaining Strava-linking follow-up.
+    Scoped to the authenticated user (#532): the read returns the runner's OWN
+    connection (or "not connected"), never the first account globally, so no
+    cross-tenant athlete id / scope leaks under multi-user. Gated by
+    `require_current_user` like `strava_login`; the route stays session-exempt
+    from BasicAuthMiddleware (ADR 0022 exempts /api/auth/*) but still resolves
+    the Clerk session, degrading to the single local user outside production so
+    the single-owner local/dev path is unchanged.
     """
-    account = db.execute(select(StravaAccount)).scalars().first()
+    account = (
+        db.execute(select(StravaAccount).where(StravaAccount.user_id == user.id))
+        .scalars()
+        .first()
+    )
     if account is None:
         return StravaConnectionStatus(connected=False)
     return StravaConnectionStatus(

--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -21,6 +21,7 @@ from app.services.blocks import remove_activity_from_block
 from app.services.checkins import write_checkin
 from app.services.notifications import get_notifier
 from app.services.notifications import telegram_link_token
+from app.services.notifications.port import Notification
 from app.services.notifications.callback_token import decode as decode_callback_token
 
 logger = logging.getLogger(__name__)
@@ -311,7 +312,41 @@ def _handle_start_link(db: Session, message: _TgMessage) -> dict:
     user.telegram_chat_id = chat_id
     db.commit()
     logger.info("telegram_chat_linked", extra={"user_id": str(user.id)})
+    # Confirm the link in-chat so the runner sees the deep link worked (#533).
+    # Fires only here, on a genuinely successful bind: a one-time token is
+    # consumed above, so a repeat/expired `/start` never reaches this point and
+    # cannot spam. Best-effort and AFTER the commit, so a send failure leaves the
+    # bind intact and the webhook still returns 200.
+    _send_link_confirmation(chat_id)
     return {"status": "processed", "action": "chat_linked"}
+
+
+_LINK_CONFIRMATION_TEXT = (
+    "I'll send your coach messages and check-in prompts here from now on."
+)
+
+
+def _send_link_confirmation(chat_id: str) -> None:
+    """Reply once in the just-bound chat that the link succeeded (#533).
+
+    Best-effort: only the Telegram notifier can send to a chat; any other active
+    channel (email, no-op, in-memory) is skipped. Never raises into the webhook
+    path, so a transport failure never turns the committed bind into a non-200."""
+    notifier = get_notifier()
+    send = getattr(notifier, "send", None)
+    if send is None:
+        return
+    try:
+        send(
+            Notification(
+                to=chat_id,
+                subject="Linked to Running Coach",
+                html="",
+                text=_LINK_CONFIRMATION_TEXT,
+            )
+        )
+    except Exception:
+        logger.exception("failed to send telegram link confirmation to %s", chat_id)
 
 
 def _answer_callback(callback_query_id: str, *, text: str = "") -> None:

--- a/backend/tests/test_basic_auth_middleware.py
+++ b/backend/tests/test_basic_auth_middleware.py
@@ -145,21 +145,33 @@ class TestProductionFailsClosed:
         response = client.get("/api/health")
         assert response.status_code == 200
 
-    def test_production_with_credentials_set_authenticates_normally(self, client, monkeypatch):
-        # Targets /api/auth/strava/status: gated by the basic-auth service-secret
-        # middleware but NOT by the Phase 2 Clerk session dependency (the auth
-        # router is the OAuth handshake surface, ADR-exempt from per-user
-        # sessions). An application route like /api/profile would now also fail
-        # closed (503) under Clerk-unconfigured-in-production, which is the Clerk
-        # layer's job, not the basic middleware's; this test isolates the latter.
-        monkeypatch.setattr(settings, "APP_ENV", "production")
-        monkeypatch.setattr(settings, "BASIC_AUTH_USER", _AUTH_USER)
-        monkeypatch.setattr(settings, "BASIC_AUTH_PASSWORD", _AUTH_PASSWORD)
-        response = client.get(
-            "/api/auth/strava/status",
-            headers={"Authorization": _basic(_AUTH_USER, _AUTH_PASSWORD)},
-        )
-        assert response.status_code == 200
+    def test_production_with_credentials_set_authenticates_normally(self, client, db, monkeypatch):
+        # The basic-auth service-secret middleware authenticates normally in
+        # production with valid creds. /api/auth/strava/status is now a per-user
+        # read (#532), so it also resolves a Clerk session; that layer is the
+        # Clerk dependency's job, not the basic middleware's, so we stub it to
+        # pass. Any non-200 here is then the basic middleware's doing -- the
+        # isolation this test exists for. (No basic-auth-gated, Clerk-free route
+        # remains to target instead.)
+        from app.core.clerk_auth import verify_clerk_session
+        from app.main import app
+        from app.models import User
+
+        user = User(email="basic_auth_probe@example.com")
+        db.add(user)
+        db.commit()
+        app.dependency_overrides[verify_clerk_session] = lambda: user
+        try:
+            monkeypatch.setattr(settings, "APP_ENV", "production")
+            monkeypatch.setattr(settings, "BASIC_AUTH_USER", _AUTH_USER)
+            monkeypatch.setattr(settings, "BASIC_AUTH_PASSWORD", _AUTH_PASSWORD)
+            response = client.get(
+                "/api/auth/strava/status",
+                headers={"Authorization": _basic(_AUTH_USER, _AUTH_PASSWORD)},
+            )
+            assert response.status_code == 200
+        finally:
+            app.dependency_overrides.pop(verify_clerk_session, None)
 
     def test_production_with_credentials_set_rejects_wrong_creds(self, client, monkeypatch):
         monkeypatch.setattr(settings, "APP_ENV", "production")

--- a/backend/tests/test_clerk_auth.py
+++ b/backend/tests/test_clerk_auth.py
@@ -220,9 +220,11 @@ class TestSessionEnforcement:
     def test_health_exempt_without_token(self, client, clerk_env):
         assert client.get("/api/health").status_code == 200
 
-    def test_strava_status_exempt_without_token(self, client, clerk_env):
-        # Auth router is the OAuth handshake surface, exempt from per-user sessions.
-        assert client.get("/api/auth/strava/status").status_code == 200
+    def test_strava_status_requires_session(self, client, clerk_env):
+        # The status read is a per-user read (#532): scoped to the signed-in
+        # runner like strava_login, so it requires the session (401 without a
+        # token). The bare OAuth callback stays the only session-exempt handshake.
+        assert client.get("/api/auth/strava/status").status_code == 401
 
 
 # --- email resolution (claim + Clerk API fallback) -------------------------

--- a/backend/tests/test_strava_auth.py
+++ b/backend/tests/test_strava_auth.py
@@ -92,6 +92,75 @@ def test_strava_status_returns_connected_when_account_linked(client: TestClient,
     }
 
 
+def test_strava_status_is_scoped_to_the_signed_in_user(
+    client: TestClient, db, _as_user
+):
+    # Two runners each have their own Strava account. The status read must
+    # surface the signed-in user's OWN connection, never the first row globally
+    # (#532): no cross-tenant athlete id / scope leak.
+    runner_a = _new_user(db, "runner_a@example.com")
+    runner_b = _new_user(db, "runner_b@example.com")
+    db.add(
+        StravaAccount(
+            user_id=runner_a.id,
+            strava_athlete_id=111,
+            access_token="a",
+            refresh_token="a",
+            expires_at=int(time.time()) + 3600,
+            scope="read,activity:read_all",
+        )
+    )
+    db.add(
+        StravaAccount(
+            user_id=runner_b.id,
+            strava_athlete_id=222,
+            access_token="b",
+            refresh_token="b",
+            expires_at=int(time.time()) + 3600,
+            scope="read",
+        )
+    )
+    db.commit()
+
+    _as_user(runner_b)
+    response = client.get("/api/auth/strava/status")
+
+    assert response.status_code == 200
+    assert response.json()["athlete_id"] == 222
+    assert response.json()["scope"] == "read"
+
+
+def test_strava_status_disconnected_for_user_without_account(
+    client: TestClient, db, _as_user
+):
+    # A signed-in runner with no linked account reads "not connected" even
+    # though another runner's account exists in the table (#532).
+    other = _new_user(db, "linked_other@example.com")
+    db.add(
+        StravaAccount(
+            user_id=other.id,
+            strava_athlete_id=333,
+            access_token="x",
+            refresh_token="x",
+            expires_at=int(time.time()) + 3600,
+            scope="read",
+        )
+    )
+    db.commit()
+    no_account_user = _new_user(db, "no_account@example.com")
+
+    _as_user(no_account_user)
+    response = client.get("/api/auth/strava/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "connected": False,
+        "athlete_id": None,
+        "scope": None,
+        "expires_at": None,
+    }
+
+
 # --- #469: signed-state multi-user OAuth linking ---------------------------
 
 

--- a/backend/tests/test_telegram_callback.py
+++ b/backend/tests/test_telegram_callback.py
@@ -651,6 +651,44 @@ class TestStartLink:
         db.refresh(user)
         assert user.telegram_chat_id == "777"
 
+    def test_start_sends_in_chat_confirmation(
+        self, client, db, configured, isolate_side_effects
+    ):
+        # A successful bind replies once in the chat so the runner sees it worked
+        # (#533): a Notification addressed to the just-bound chat id.
+        user = _seed_user_with_chat(db, None)
+        with patch(
+            "app.api.webhooks.telegram_link_token.consume", return_value=user.id
+        ):
+            client.post(
+                "/api/webhooks/telegram",
+                json=_start_update("/start abc123", chat_id=777),
+                headers={"X-Telegram-Bot-Api-Secret-Token": _SECRET},
+            )
+        send = isolate_side_effects["notifier"].send
+        send.assert_called_once()
+        assert send.call_args.args[0].to == "777"
+
+    def test_start_confirmation_failure_does_not_break_bind(
+        self, client, db, configured, isolate_side_effects
+    ):
+        # The confirmation send is best-effort: a transport failure must leave the
+        # committed bind intact and the webhook still 200 (#533).
+        user = _seed_user_with_chat(db, None)
+        isolate_side_effects["notifier"].send.side_effect = RuntimeError("telegram down")
+        with patch(
+            "app.api.webhooks.telegram_link_token.consume", return_value=user.id
+        ):
+            resp = client.post(
+                "/api/webhooks/telegram",
+                json=_start_update("/start abc123", chat_id=777),
+                headers={"X-Telegram-Bot-Api-Secret-Token": _SECRET},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["action"] == "chat_linked"
+        db.refresh(user)
+        assert user.telegram_chat_id == "777"
+
     def test_start_with_bad_token_is_noop(
         self, client, db, configured, isolate_side_effects
     ):
@@ -665,6 +703,9 @@ class TestStartLink:
         assert resp.json()["reason"] == "bad_link_token"
         db.refresh(user)
         assert user.telegram_chat_id is None
+        # No bind happened, so no confirmation is sent (#533: no spam on a
+        # repeat/expired /start).
+        isolate_side_effects["notifier"].send.assert_not_called()
 
     def test_start_rebind_steals_chat_from_prior_owner(
         self, client, db, configured, isolate_side_effects

--- a/docs/testing/deployed-handshake-verification.md
+++ b/docs/testing/deployed-handshake-verification.md
@@ -1,0 +1,146 @@
+# Deployed handshake verification
+
+How to confirm the two external handshakes that cannot be bootstrapped locally:
+
+1. the Strava OAuth `state` round-trip (connect -> callback -> per-user link, #469/#532), and
+2. the Telegram `/start <token>` chat-bind and inbound tap authorization (#477/#533).
+
+Neither has a dev/local Strava OAuth app or a local bot, so unit and integration
+tests only ever cover the codec + authorization logic, never the real round-trip.
+This runbook is the manual checklist that exercises the live flow so a regression
+in the deployed handshake is caught rather than only the offline logic. An
+automated deployed smoke is a deferred stretch (see "Deferred" at the end).
+
+Run it after any change to `app/api/auth.py`, `app/core/oauth_state.py`,
+`app/api/webhooks.py`, `app/services/notifications/telegram_link_token.py`, the
+Telegram link endpoints in `app/api/coach.py`, or the Vercel proxy.
+
+## Who can run this
+
+The owner of the deployed stack (`philippe@twohourssleep.com`). It needs a real
+Strava account and the live bot, and it WRITES to production (preview deploys
+point at the same backend/Postgres/Redis, so there is no isolated environment;
+see `docs/testing/local-seed.md`). Treat it as a production smoke, not a CI gate.
+
+## Config preflight
+
+These must be set for the handshakes to work. Ownership is per Railway service
+(`docs/deployment/topology.md`); the worker sends outbound, the web service
+authenticates inbound.
+
+| Var | Service | Required? | Notes |
+| --- | --- | --- | --- |
+| `STRAVA_OAUTH_STATE_SECRET` | web | optional | Signs the OAuth `state` (#469). Falls back to `BASIC_AUTH_PASSWORD`, then `CLERK_SECRET_KEY`, so it is secure-by-default without being set. |
+| `STRAVA_REDIRECT_URI` | web | yes | Must match the callback URL registered on the Strava API application. |
+| `STRAVA_WEBHOOK_SUBSCRIPTION_ID` | web | yes (prod) | Inbound Strava events are 403'd unless `owner_id` maps to a connected account and this matches (when non-zero). |
+| `TELEGRAM_BOT_TOKEN` | web + worker | yes | Worker sends; web authenticates inbound and now sends the #533 link confirmation. |
+| `TELEGRAM_CHAT_ID` | web + worker | yes | The global owner chat (single-owner back-compat). |
+| `TELEGRAM_WEBHOOK_SECRET` | web | yes (prod) | The outer gate on `/api/webhooks/telegram`; fails closed in production when unset. |
+| `TELEGRAM_BOT_USERNAME` | web | yes | Builds the `https://t.me/<username>?start=<token>` deep link; the `LinkTelegramButton` is hidden without it (`link-status.configured = false`). |
+
+Quick preflight from a signed-in browser session (DevTools console on the
+deployed frontend, so the Clerk session token is attached by the proxy):
+
+```js
+await fetch('/api/coach/telegram/link-status').then(r => r.json())
+// -> { configured: true, linked: <bool> }   // configured:false => TELEGRAM_BOT_USERNAME missing
+await fetch('/api/auth/strava/status').then(r => r.json())
+// -> { connected: <bool>, athlete_id, scope, expires_at }
+```
+
+## Part A - Strava OAuth state round-trip (#469, #532)
+
+Goal: confirm the connect -> callback flow links the new `StravaAccount` to the
+signed-in user (not the first/owner account), and that the status read is scoped
+to that user.
+
+1. Sign in to the deployed frontend as the test runner (Clerk session).
+2. Read the starting state: `GET /api/auth/strava/status`. Note `connected` and
+   `athlete_id` (so you can tell a re-link from a fresh link).
+3. Start the connect flow (`/api/auth/strava/login`, the profile "Connect Strava"
+   affordance). Confirm the browser navigates to Strava's OAuth consent page and
+   that the `state` query param is present and non-empty on that URL.
+4. Approve on Strava. Confirm the callback returns you to `APP_BASE_URL?connected=true`.
+5. Re-read `GET /api/auth/strava/status`. Expect `connected: true` and the
+   `athlete_id` of the Strava account you just authorized.
+6. Per-user scope check (#532): if a SECOND runner with their own connected
+   Strava account exists, sign in as them and read `GET /api/auth/strava/status`.
+   Each runner must see their OWN `athlete_id`/`scope`, never the other's. This
+   is the cross-tenant-leak regression the status read used to have.
+
+Pass criteria:
+- The OAuth redirect carries a non-empty `state`.
+- After the callback the new account is linked to the signed-in user (verify the
+  status read reflects the just-authorized athlete id).
+- Two runners read two different connection states; neither sees the other's
+  athlete id or scope.
+
+Failure signatures:
+- No `state` on the redirect -> `strava_login` is not gated on the session, or
+  `encode_state` returned empty. Check `STRAVA_OAUTH_STATE_SECRET`/fallbacks.
+- Account links to the wrong (owner) user when a second user exists -> the
+  callback fell back to the single-owner heuristic, meaning the signed `state`
+  was absent/invalid (check the state secret is identical to what minted it).
+- Both runners see the same athlete id -> the status read regressed to the
+  first-row-globally query (#532).
+
+## Part B - Telegram /start chat-bind + tap authorization (#477, #533)
+
+Goal: confirm a deep link binds the chat to the right user, the in-chat
+confirmation (#533) appears, and a bound user's tap acts only on their own
+activity while an unbound/cross-user tap is rejected.
+
+1. Sign in as the test runner. From the profile, use `LinkTelegramButton` (or
+   `POST /api/coach/telegram/link-token`) to mint the deep link. Confirm the
+   response `deep_link` is `https://t.me/<TELEGRAM_BOT_USERNAME>?start=<token>`.
+2. Tap the deep link (or send `/start <token>` to the bot from the test runner's
+   Telegram chat). Confirm:
+   - the bot replies in-chat with the #533 confirmation
+     ("I'll send your coach messages and check-in prompts here from now on");
+   - `GET /api/coach/telegram/link-status` now reads `linked: true`.
+3. Single-use check: tap the SAME deep link again. Expect NO second confirmation
+   (the one-time token was already consumed; the webhook silently 200-acks). This
+   is the no-spam guarantee.
+4. Bound-tap check: trigger a coach receipt/opener for one of the test runner's
+   own activities (a real synced run, or wait for the next ingest). Tap an
+   RPE/pain/done button in Telegram. Confirm the check-in is recorded and the
+   tapped button gets its check mark.
+5. Cross-user rejection: if a second bound runner exists, have them attempt to
+   tap a button whose token references the FIRST runner's activity (e.g. by
+   forwarding/replaying the callback). Expect a silent 200 with no write
+   (`reason: not_owner`). An unbound/unknown chat that is not the global owner
+   chat is likewise a silent no-op.
+
+Pass criteria:
+- The deep link binds the correct user (`link-status.linked` flips to true for
+  that runner only).
+- A successful bind produces exactly one in-chat confirmation; a repeat `/start`
+  produces none.
+- A bound runner's tap writes a check-in only for their own activity; a
+  cross-user or unbound tap writes nothing and returns 200.
+
+Failure signatures:
+- No deep link offered / `link-status.configured: false` -> `TELEGRAM_BOT_USERNAME`
+  unset on the web service.
+- `/start` does nothing and no confirmation -> either the bind failed (check the
+  webhook secret and that the token was minted by the same deployment) or the web
+  service has no `TELEGRAM_BOT_TOKEN` to send the confirmation. The bind can
+  still succeed while the confirmation send fails (best-effort, #533); check the
+  web logs for `telegram_chat_linked` vs `failed to send telegram link confirmation`.
+- A non-Telegram caller is NOT rejected with 403 -> `TELEGRAM_WEBHOOK_SECRET`
+  unset (it must fail closed in production).
+
+## What to capture
+
+Record, per run: the deployment commit/date, which config vars were present, and
+the pass/fail of each numbered step. A regression in the live flow is only caught
+if this is run after the relevant changes and the result is written down.
+
+## Deferred
+
+An automated deployed smoke (a script that mints a state, drives a scripted
+Strava callback, and replays a `/start` + tap against the live stack) is the
+stretch goal in #534. It needs a dedicated test Strava app and a test bot so it
+does not mutate the owner's real account; until those exist this manual checklist
+is the verification path. Related: #488 (local browser-verification blocker keeps
+the frontend affordances from being checked locally).


### PR DESCRIPTION
Finishes three follow-ups from the multi-user Strava/Telegram thread (#469/#477, PRs #527/#529/#530).

## #532 — per-user Strava connection status read
`GET /api/auth/strava/status` returned the first `StravaAccount` in the table, leaking another runner's athlete id + scope under multi-user. It is now gated on the session (`require_current_user`, like `strava_login`) and scoped to the user's id. The bare OAuth callback stays the only session-exempt handshake; degrade mode keeps the single-owner local/dev path working. Updated the two tests that guarded the old exempt contract (the Clerk test now expects 401 without a token; the basic-auth isolation test stubs the Clerk layer since no basic-auth-gated, Clerk-free route remains). Added cross-tenant isolation tests.

## #533 — in-chat confirmation after a Telegram `/start` bind
A successful `/start` bind returned 200 but sent nothing back, so the runner saw Telegram open and nothing happen. The webhook now replies once in the bound chat. Best-effort and after the commit, so a send failure never breaks the bind or the 200; the consumed one-time token means a repeat/expired `/start` never reaches the send, so no spam.

## #534 — deployed handshake verification runbook
`docs/testing/deployed-handshake-verification.md`: a repeatable manual checklist for the Strava OAuth `state` round-trip and the Telegram bind + tap authorization against a real deployment, since neither can be bootstrapped locally. Captures the prod config each needs and the failure signatures. An automated deployed smoke is noted as the deferred stretch.

## Verification
- `make backend-test` green (1794 passed).
- New tests cover the per-user status scoping, the confirmation send / failure-tolerance / no-spam paths.

## Notes
- Discovered (out of scope): `npm run smoke` fails pre-existing on `/activity/42` (`API Error: Unauthorized` from the mock API) on clean `main`. CI's `npm run test` (lint+build) is unaffected.

Closes #532
Closes #533
Closes #534
