### PR TITLE
Fix frontend smoke hermeticity and deprecated Pydantic .dict() (#538, #539)

### DIFF
--- a/backend/app/services/checkins.py
+++ b/backend/app/services/checkins.py
@@ -24,11 +24,11 @@ def write_checkin(db: Session, activity_id: UUID, checkin_data: CheckInCreate) -
     (only the fields the caller set, leaving the rest intact). Returns the row."""
     existing = db.query(CheckIn).filter(CheckIn.activity_id == activity_id).first()
     if existing:
-        for k, v in checkin_data.dict(exclude_unset=True).items():
+        for k, v in checkin_data.model_dump(exclude_unset=True).items():
             setattr(existing, k, v)
         db_obj = existing
     else:
-        db_obj = CheckIn(activity_id=activity_id, **checkin_data.dict())
+        db_obj = CheckIn(activity_id=activity_id, **checkin_data.model_dump())
         db.add(db_obj)
 
     db.commit()

--- a/frontend/scripts/smoke.mjs
+++ b/frontend/scripts/smoke.mjs
@@ -248,8 +248,16 @@ async function main() {
   // an empty publishable key makes the middleware/layout pass-through (CI has no
   // .env.local, but a dev machine does, and Next would otherwise inline its key
   // into the build and gate every route behind a sign-in redirect).
+  //
+  // BACKEND_URL must point at the mock too: server components resolve their base
+  // URL as BACKEND_URL || NEXT_PUBLIC_API_BASE_URL || 127.0.0.1:8000 (lib/api.ts),
+  // and a dev machine's .env.local sets BACKEND_URL=http://localhost:8000. Without
+  // overriding it, server-side fetches escape to the real, Clerk-gated backend
+  // (401) instead of the mock, 500-ing /activity/42 (#538). CI has no .env.local
+  // so this is invisible there, but it breaks local `make smoke`.
   const smokeEnv = {
     ...process.env,
+    BACKEND_URL: MOCK_API_BASE_URL,
     NEXT_PUBLIC_API_BASE_URL: MOCK_API_BASE_URL,
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "",
     CLERK_SECRET_KEY: "",


### PR DESCRIPTION
Two small hygiene fixes surfaced while verifying #536/#537.

## #538 — frontend smoke leaked server-fetches to the real backend
`scripts/smoke.mjs` neutralized `NEXT_PUBLIC_*` and Clerk in `smokeEnv` but not `BACKEND_URL`. Server components resolve their base URL as `BACKEND_URL || NEXT_PUBLIC_API_BASE_URL || 127.0.0.1:8000` (`lib/api.ts`), and a dev machine's `.env.local` sets `BACKEND_URL=http://localhost:8000`. So on a dev machine with a backend running on :8000, the smoke's server-side fetches hit the real, Clerk-gated backend (401) instead of the mock and 500-ed `/activity/42`.

**Fix:** point `BACKEND_URL` at the mock in `smokeEnv`, so the smoke is hermetic regardless of `.env.local` or a backend already on :8000. CI is unaffected (no `.env.local`, no backend on :8000).

**Verified** in the exact reproduction environment (backend live on :8000, `.env.local` `BACKEND_URL=http://localhost:8000`):
- without the fix: `npm run smoke` → `Expected 200 for /activity/42, received 500` (the issue's error).
- with the fix: `Frontend smoke checks passed.`

## #539 — deprecated Pydantic `.dict()` in `checkins.write_checkin`
`write_checkin` called the deprecated Pydantic v1 `.dict()` on both the update path (`.dict(exclude_unset=True)`) and the insert path, firing `PydanticDeprecatedSince20` on every test that exercises the check-in write (and slated for removal in Pydantic V3).

**Fix:** switch both calls to `model_dump()`.

**Verified:** `pytest -k checkin` (31 passed) — the `PydanticDeprecatedSince20` warning from `checkins.py` no longer appears in the suite.

Closes #538, closes #539.