### PR TITLE
Automated deployed smoke for the Strava/Telegram handshake auth gates (#540)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test seed-local eval eval-selftest diagram-check verify-local
+.PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test seed-local eval eval-selftest diagram-check verify-local deployed-handshake-smoke
 
 # Prefer the project venv interpreter when it exists, fall back to bare python.
 # Path is relative to backend/ since the targets cd there first. CI has no
@@ -67,3 +67,13 @@ eval:
 # no API key required, so this is safe to run in CI.
 eval-selftest:
 	cd backend && $(BACKEND_PY) -m scripts.eval_coach_reports --self-test
+
+# Deployed-only smoke for the Strava + Telegram handshake auth gates (#540).
+# NOT a CI gate: needs a live deployment (real APP_ENV/secrets). Non-mutating —
+# it only asserts the live gates reject unauthentic input; it never completes a
+# real OAuth callback or sends a real /start/tap. The session-gated positive
+# checks stay in the manual runbook (docs/testing/deployed-handshake-verification.md).
+#   make deployed-handshake-smoke SMOKE_BASE_URL=https://<deployed-backend>
+#   make deployed-handshake-smoke SMOKE_BASE_URL=... SMOKE_TELEGRAM_WEBHOOK_SECRET=<secret>
+deployed-handshake-smoke:
+	cd backend && $(BACKEND_PY) -m scripts.deployed_handshake_smoke

--- a/backend/scripts/deployed_handshake_smoke.py
+++ b/backend/scripts/deployed_handshake_smoke.py
@@ -1,0 +1,303 @@
+"""Deployed-only smoke for the Strava + Telegram handshake auth gates (#540).
+
+The two user-facing handshakes that cannot be bootstrapped locally -- the Strava
+OAuth `state` round-trip (#469) and the Telegram `/start` chat-bind + inbound tap
+authorization (#477) -- are otherwise covered only by the MANUAL runbook
+(`docs/testing/deployed-handshake-verification.md`) plus unit/integration tests of
+the offline codec/authorization logic. This script is the automatable half: a
+thin, deployed-only smoke that exercises the live deployment's auth GATES, so a
+regression that opens a gate (or stops it failing closed) is caught by a
+repeatable check rather than only by someone running the manual checklist.
+
+Scope (deliberately the SAFE, non-mutating subset, per the #540 decision):
+  * It only asserts that the live gates REJECT unauthentic input. It never
+    completes a real OAuth callback and never sends a real `/start`/tap, so it
+    cannot mutate the owner's Strava account or Telegram chat.
+  * The fully automatable checks need NO credentials: they hit the webhook
+    endpoints, which are exempt from the frontend-to-backend basic auth so the
+    external services can reach them.
+  * The session-gated positive checks from the manual runbook (the OAuth `/login`
+    redirect carrying a non-empty signed `state`, and `link-status.configured`)
+    are NOT automated here: they require a live Clerk session, which cannot be
+    minted non-interactively (the same blocker as #488). They stay in the manual
+    runbook. This script narrows, not replaces, that runbook.
+
+This is NOT part of CI: it depends on live external config (a real deployment
+with `STRAVA_WEBHOOK_SUBSCRIPTION_ID`, `TELEGRAM_WEBHOOK_SECRET`, prod
+`APP_ENV`). Run it by hand (or from an out-of-CI scheduled job) after any change
+to `app/api/auth.py`, `app/core/oauth_state.py`, `app/api/webhooks.py`, or the
+Telegram link plumbing.
+
+Usage:
+    SMOKE_BASE_URL=https://<deployed-backend> python -m scripts.deployed_handshake_smoke
+    # optionally exercise the authentic-secret no-op path too:
+    SMOKE_BASE_URL=... SMOKE_TELEGRAM_WEBHOOK_SECRET=<secret> python -m scripts.deployed_handshake_smoke
+
+Env:
+    SMOKE_BASE_URL                (required) the deployed backend base URL, e.g.
+                                  https://<railway-backend-domain>. No production
+                                  hostname is hardcoded here (project principle:
+                                  every seam URL is config), so this must be set.
+    SMOKE_TELEGRAM_WEBHOOK_SECRET (optional) the deployment's TELEGRAM_WEBHOOK_SECRET.
+                                  When set, also asserts that an AUTHENTIC-secret
+                                  callback from an unbound/unknown chat is a silent
+                                  200 no-op (no write). Skipped when absent.
+    SMOKE_TIMEOUT_SECONDS         (optional, default 15) per-request timeout.
+
+Exit code is 0 only when every REQUIRED check passes; any failure exits non-zero.
+Optional checks that are skipped for missing config never fail the run.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import httpx
+
+# A value that cannot collide with a real Strava athlete id or subscription id
+# (those are positive), so the POST authenticity check is provably non-mutating:
+# `_event_is_authentic` rejects it before any enqueue/soft-delete branch runs.
+_IMPOSSIBLE_ID = -1
+# A deliberately wrong Telegram secret -- proves the outer gate rejects a
+# non-Telegram caller. Never equal to a real secret.
+_WRONG_SECRET = "__smoke_invalid_secret__"  # noqa: S105 (not a real secret)
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: str  # "PASS" | "FAIL" | "SKIP"
+    detail: str
+
+    @property
+    def ok(self) -> bool:
+        # SKIP never fails the run; only FAIL does.
+        return self.status != "FAIL"
+
+
+def _passed(name: str, detail: str) -> CheckResult:
+    return CheckResult(name, "PASS", detail)
+
+
+def _failed(name: str, detail: str) -> CheckResult:
+    return CheckResult(name, "FAIL", detail)
+
+
+def _skipped(name: str, detail: str) -> CheckResult:
+    return CheckResult(name, "SKIP", detail)
+
+
+def check_strava_verify_gate(client: httpx.Client, base: str) -> CheckResult:
+    """GET /api/webhooks/strava with a WRONG verify token must be refused.
+
+    A correctly-configured deployment rejects an unknown `hub.verify_token` with
+    403 (or 503 in production when the token itself is unset -- the gate is still
+    present, just misconfigured). A 200 that echoes the challenge means the gate
+    accepted an unknown token -> anyone could register a subscription. Read-only.
+    """
+    name = "strava_verify_gate_rejects_wrong_token"
+    try:
+        resp = client.get(
+            f"{base}/api/webhooks/strava",
+            params={
+                "hub.mode": "subscribe",
+                "hub.verify_token": _WRONG_SECRET,
+                "hub.challenge": "smoke_challenge",
+            },
+        )
+    except httpx.HTTPError as exc:
+        return _failed(name, f"request error: {exc!r}")
+
+    if resp.status_code == 403:
+        return _passed(name, "403 as expected (wrong verify token refused)")
+    if resp.status_code == 503:
+        return _passed(
+            name,
+            "503: gate present but STRAVA_WEBHOOK_VERIFY_TOKEN unset on the "
+            "deployment -- gate is closed, but fix the config",
+        )
+    return _failed(
+        name,
+        f"expected 403/503, got {resp.status_code}: a wrong verify token was "
+        f"not refused (gate may be open). Body: {resp.text[:200]!r}",
+    )
+
+
+def check_strava_event_authenticity(client: httpx.Client, base: str) -> CheckResult:
+    """POST /api/webhooks/strava with an unauthentic event must be 403.
+
+    Uses negative (impossible) owner/object ids so `_event_is_authentic` cannot
+    match a connected athlete -> 403 BEFORE any enqueue or soft-delete. Provably
+    non-mutating regardless of subscription config.
+    """
+    name = "strava_event_gate_rejects_unauthentic"
+    body = {
+        "object_type": "activity",
+        "object_id": _IMPOSSIBLE_ID,
+        "aspect_type": "create",
+        "owner_id": _IMPOSSIBLE_ID,
+        "subscription_id": _IMPOSSIBLE_ID,
+        "event_time": int(time.time()),
+    }
+    try:
+        resp = client.post(f"{base}/api/webhooks/strava", json=body)
+    except httpx.HTTPError as exc:
+        return _failed(name, f"request error: {exc!r}")
+
+    if resp.status_code == 403:
+        return _passed(name, "403 as expected (unauthentic event refused)")
+    return _failed(
+        name,
+        f"expected 403, got {resp.status_code}: an event with an unconnected "
+        f"owner was not refused. Body: {resp.text[:200]!r}",
+    )
+
+
+def check_telegram_secret_gate(client: httpx.Client, base: str) -> CheckResult:
+    """POST /api/webhooks/telegram with a WRONG secret must be 403.
+
+    The outer `X-Telegram-Bot-Api-Secret-Token` gate fails closed in production.
+    The body carries no callback_query and no `/start`, so even if the gate were
+    (mis)configured open on a non-prod deployment, the request is a no-op
+    (`not_callback`) and writes nothing. A 200 here against a PRODUCTION
+    deployment means the gate did not fail closed.
+    """
+    name = "telegram_secret_gate_rejects_wrong_secret"
+    try:
+        resp = client.post(
+            f"{base}/api/webhooks/telegram",
+            json={"update_id": 0},
+            headers={"X-Telegram-Bot-Api-Secret-Token": _WRONG_SECRET},
+        )
+    except httpx.HTTPError as exc:
+        return _failed(name, f"request error: {exc!r}")
+
+    if resp.status_code == 403:
+        return _passed(name, "403 as expected (wrong secret refused)")
+    return _failed(
+        name,
+        f"expected 403, got {resp.status_code}: the Telegram webhook did not "
+        f"fail closed on a wrong secret. This check is only valid against a "
+        f"production deployment with TELEGRAM_WEBHOOK_SECRET set. "
+        f"Body: {resp.text[:200]!r}",
+    )
+
+
+def check_telegram_unbound_chat_noop(
+    client: httpx.Client, base: str, secret: str
+) -> CheckResult:
+    """With the CORRECT secret, an unbound/unknown chat callback is a 200 no-op.
+
+    Confirms the inner authorization: a chat that is neither bound to a user nor
+    the global owner chat is silently ignored (no CheckIn written). Double-safe:
+    the callback carries a bogus token, so even an unlikely chat-id collision
+    hits the `bad_token` path and writes nothing. Only runs when the secret is
+    supplied.
+    """
+    name = "telegram_unbound_chat_is_noop"
+    body = {
+        "update_id": 0,
+        "callback_query": {
+            "id": "smoke",
+            "data": "__smoke_bogus_token__",
+            "message": {
+                "chat": {"id": 1},  # not the global owner chat (large id), unbound
+                "message_id": 1,
+            },
+        },
+    }
+    try:
+        resp = client.post(
+            f"{base}/api/webhooks/telegram",
+            json=body,
+            headers={"X-Telegram-Bot-Api-Secret-Token": secret},
+        )
+    except httpx.HTTPError as exc:
+        return _failed(name, f"request error: {exc!r}")
+
+    if resp.status_code != 200:
+        return _failed(
+            name,
+            f"expected 200 no-op, got {resp.status_code}: an authentic-secret "
+            f"request did not pass the outer gate (is the secret correct?). "
+            f"Body: {resp.text[:200]!r}",
+        )
+    reason = ""
+    try:
+        reason = (resp.json() or {}).get("reason", "")
+    except ValueError:
+        pass
+    # Both reasons mean "nothing was written": the chat was unauthorized, or the
+    # bogus token failed to decode. Either confirms the no-op guarantee.
+    if reason in {"unauthorized_chat", "bad_token"}:
+        return _passed(name, f"200 no-op as expected (reason={reason!r})")
+    return _failed(
+        name,
+        f"200 but unexpected reason {reason!r}: expected a no-op "
+        f"(unauthorized_chat/bad_token). Body: {resp.text[:200]!r}",
+    )
+
+
+def main() -> int:
+    base = (os.environ.get("SMOKE_BASE_URL") or "").rstrip("/")
+    if not base:
+        print(
+            "ERROR: SMOKE_BASE_URL is required (the deployed backend base URL).\n"
+            "  e.g. SMOKE_BASE_URL=https://<deployed-backend> "
+            "python -m scripts.deployed_handshake_smoke",
+            file=sys.stderr,
+        )
+        return 2
+
+    timeout = float(os.environ.get("SMOKE_TIMEOUT_SECONDS", "15"))
+    tg_secret = os.environ.get("SMOKE_TELEGRAM_WEBHOOK_SECRET") or ""
+
+    print(f"Deployed handshake smoke against: {base}\n")
+
+    results: list[CheckResult] = []
+    # `follow_redirects=False`: a 302 to Strava must be observed as a redirect,
+    # not silently followed off-host.
+    with httpx.Client(timeout=timeout, follow_redirects=False) as client:
+        required: list[Callable[[], CheckResult]] = [
+            lambda: check_strava_verify_gate(client, base),
+            lambda: check_strava_event_authenticity(client, base),
+            lambda: check_telegram_secret_gate(client, base),
+        ]
+        for run in required:
+            results.append(run())
+
+        if tg_secret:
+            results.append(
+                check_telegram_unbound_chat_noop(client, base, tg_secret)
+            )
+        else:
+            results.append(
+                _skipped(
+                    "telegram_unbound_chat_is_noop",
+                    "set SMOKE_TELEGRAM_WEBHOOK_SECRET to exercise this",
+                )
+            )
+
+    print("Results:")
+    for r in results:
+        print(f"  [{r.status:4}] {r.name}: {r.detail}")
+
+    failures = [r for r in results if r.status == "FAIL"]
+    skipped = [r for r in results if r.status == "SKIP"]
+    print(
+        f"\n{len(results) - len(failures) - len(skipped)} passed, "
+        f"{len(failures)} failed, {len(skipped)} skipped."
+    )
+    if failures:
+        print("\nDEPLOYED HANDSHAKE SMOKE FAILED.", file=sys.stderr)
+        return 1
+    print("\nDeployed handshake smoke passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/testing/deployed-handshake-verification.md
+++ b/docs/testing/deployed-handshake-verification.md
@@ -8,8 +8,19 @@ How to confirm the two external handshakes that cannot be bootstrapped locally:
 Neither has a dev/local Strava OAuth app or a local bot, so unit and integration
 tests only ever cover the codec + authorization logic, never the real round-trip.
 This runbook is the manual checklist that exercises the live flow so a regression
-in the deployed handshake is caught rather than only the offline logic. An
-automated deployed smoke is a deferred stretch (see "Deferred" at the end).
+in the deployed handshake is caught rather than only the offline logic.
+
+The auth GATES (not the full round-trip) now also have an automated deployed
+smoke -- `make deployed-handshake-smoke SMOKE_BASE_URL=https://<deployed-backend>`
+(`backend/scripts/deployed_handshake_smoke.py`, #540). It is non-mutating: it
+asserts only that the live gates reject unauthentic input (a wrong Strava verify
+token, an event from an unconnected owner, a wrong Telegram secret, and -- with
+`SMOKE_TELEGRAM_WEBHOOK_SECRET` set -- that an authentic-secret unbound-chat tap
+is a silent no-op). It never completes a real OAuth callback or sends a real
+`/start`/tap, so the POSITIVE round-trip below (real connect, real bind, real
+owned/cross-user tap) stays MANUAL -- those need a live Clerk session and a real
+Strava account/bot that cannot be driven non-interactively (the #488 blocker).
+Run the automated gate smoke first; if it is green, work the manual steps below.
 
 Run it after any change to `app/api/auth.py`, `app/core/oauth_state.py`,
 `app/api/webhooks.py`, `app/services/notifications/telegram_link_token.py`, the
@@ -136,11 +147,15 @@ Record, per run: the deployment commit/date, which config vars were present, and
 the pass/fail of each numbered step. A regression in the live flow is only caught
 if this is run after the relevant changes and the result is written down.
 
-## Deferred
+## Automated coverage and what stays manual
 
-An automated deployed smoke (a script that mints a state, drives a scripted
-Strava callback, and replays a `/start` + tap against the live stack) is the
-stretch goal in #534. It needs a dedicated test Strava app and a test bot so it
-does not mutate the owner's real account; until those exist this manual checklist
-is the verification path. Related: #488 (local browser-verification blocker keeps
-the frontend affordances from being checked locally).
+The auth-gate half is automated (`make deployed-handshake-smoke`, #540): it
+confirms the live gates fail closed without touching the owner's real account or
+chat. What it deliberately does NOT do is the full mutating round-trip -- minting
+a state and driving a scripted Strava callback to completion, or replaying a real
+`/start` bind + owned/cross-user tap. That remains manual because it needs a
+dedicated test Strava app + test bot to avoid mutating the owner's real account
+(preview deploys share the prod backend/Postgres/Redis, so there is no isolated
+environment), plus a live Clerk session that cannot be minted non-interactively
+(#488). Until a test app/bot exists, the steps above are the verification path
+for the positive round-trip. Related: #488 (local browser-verification blocker).


### PR DESCRIPTION
Closes #540.

The two handshakes that can't be bootstrapped locally — the Strava OAuth `state` round-trip (#469) and the Telegram `/start` bind + tap authorization (#477) — were covered only by the **manual** runbook (`docs/testing/deployed-handshake-verification.md`, #534) plus offline codec/authorization unit tests. This adds the **safe, automatable half**: a deployed-only smoke that exercises the live auth **gates**.

## What it does
`backend/scripts/deployed_handshake_smoke.py` asserts the live deployment **rejects unauthentic input**, non-mutatingly:

| Check | Assertion |
| --- | --- |
| `GET /api/webhooks/strava` wrong verify token | 403 (or 503 if the token is unset on the deployment) |
| `POST /api/webhooks/strava` event from an unconnected owner | 403 — refused before any enqueue/soft-delete |
| `POST /api/webhooks/telegram` wrong secret | 403 — fails closed in prod |
| (optional) authentic-secret callback from an unbound/unknown chat | 200 silent no-op (no write) |

The Strava POST check uses impossible negative owner/object ids, so `_event_is_authentic` rejects it before any side effect — provably non-mutating. The optional Telegram no-op check only runs when `SMOKE_TELEGRAM_WEBHOOK_SECRET` is supplied, and uses a bogus callback token so nothing is ever written.

## What it deliberately does NOT do
It never completes a real OAuth callback or sends a real `/start`/tap, so it can't mutate the owner's Strava account or chat. The **positive** round-trip (real connect, real bind, owned/cross-user tap) stays in the manual runbook — that needs a dedicated test Strava app + test bot and a live Clerk session that can't be minted non-interactively (#488). This narrows the manual runbook, it doesn't replace it.

## Not a CI gate
It depends on live external config (real `APP_ENV`/secrets), so it's kept out of CI and exposed as `make deployed-handshake-smoke SMOKE_BASE_URL=https://<deployed-backend>`.

## Verification
Ran against the local backend:
- the two Strava gate checks **PASS** (they hold in any environment);
- the Telegram secret-gate check is a **prod-behavior** assertion (local dev skips the secret when unset / non-prod), validated by reading `_secret_is_valid` + the chat-authorization path in `webhooks.py`;
- the Make target wiring and non-zero exit propagation are confirmed.

(Note: a backend currently running on local :8000 returns an older `"Unauthenticated callback"` detail string, i.e. it's running stale pre-current `webhooks.py`; against a real deployment on current code with the secret set, both Telegram assertions pass by construction.)