### PR TITLE
Stop unbound non-owner users' Telegram notifications leaking to the owner chat (#542)

### DIFF
--- a/backend/app/services/notifications/__init__.py
+++ b/backend/app/services/notifications/__init__.py
@@ -40,25 +40,64 @@ def _recipient_for_channel(channel: str) -> str:
     return settings.NOTIFY_TO
 
 
+def _resolve_to(channel: Optional[str], recipient: Optional[str]) -> Optional[str]:
+    """The address to deliver to, or None to SUPPRESS the notification (#542).
+
+    A per-user `recipient` (from `resolve_recipient`) always wins. With no
+    recipient and the Telegram channel: in MULTI-USER mode (`OWNER_EMAIL` set) this
+    is a non-owner unbound runner that `resolve_recipient` deliberately suppressed,
+    so we return None and never fall back to the global owner chat — defense in
+    depth, so the builder refuses to leak to the owner's chat even if a caller
+    bypassed `resolve_recipient`. In SINGLE-USER mode (`OWNER_EMAIL` unset) there is
+    no owner concept, so the original global fallback is preserved. Email has no
+    per-user routing yet (ADR 0023), so it keeps the global NOTIFY_TO.
+    """
+    if recipient:
+        return recipient
+    if channel == "telegram":
+        from app.core.config import settings
+
+        if (settings.OWNER_EMAIL or "").strip():
+            return None  # multi-user: suppress, never the global owner chat
+        return _recipient_for_channel(channel)  # single-user back-compat
+    return _recipient_for_channel(channel)  # email: global NOTIFY_TO
+
+
 def resolve_recipient(user) -> Optional[str]:
-    """The per-user recipient address for the active channel (P2.4, #120).
+    """The per-user recipient address for the active channel (P2.4, #120, #542).
 
     Telegram routes to the user's bound chat (`telegram_chat_id`) — the decided
-    per-user channel (ADR 0023). Returns None when the user has no bound chat,
-    which the composer turns into the configured global recipient (single-user
-    back-compat) and, if that is also unset, into no notification. Tolerant of a
-    None/partial user so a missing relationship never breaks the pipeline.
+    per-user channel (ADR 0023). When the user has NOT bound a chat, the global
+    `TELEGRAM_CHAT_ID` is used ONLY for the deployment owner (`OWNER_EMAIL`); for a
+    non-owner the resolver returns None, which the composer turns into NO
+    notification rather than delivering to the owner's chat. This closes the
+    multi-user leak where any unbound runner's coach messages were routed to the
+    owner's Telegram (#542). When `OWNER_EMAIL` is unset the deployment is
+    single-user (no multi-user owner concept), so the original global fallback is
+    preserved for everyone. Tolerant of a None/partial user so a missing
+    relationship never breaks the pipeline.
 
     Email is intentionally NOT per-user-routed here: ADR 0023 defers the per-user
     email-API channel, so the email path stays on the global NOTIFY_TO (its
     existing behavior). Routing it to `user.email` would silently change where the
     single-user deployment's email lands.
     """
-    if user is None:
+    if _active_channel() != "telegram":
         return None
-    if _active_channel() == "telegram":
-        return getattr(user, "telegram_chat_id", None)
-    return None
+    from app.core.config import settings
+
+    bound = getattr(user, "telegram_chat_id", None) if user is not None else None
+    if bound:
+        return bound
+    # Unbound: fall back to the global owner chat only for the owner, so a
+    # non-owner who hasn't linked Telegram is never delivered to the owner's chat.
+    owner_email = (settings.OWNER_EMAIL or "").strip().lower()
+    if not owner_email:
+        return str(settings.TELEGRAM_CHAT_ID)  # single-user back-compat
+    user_email = (getattr(user, "email", "") or "").strip().lower()
+    if user_email and user_email == owner_email:
+        return str(settings.TELEGRAM_CHAT_ID)
+    return None  # non-owner, unbound -> suppress (no leak to the owner chat)
 
 
 def _active_channel() -> Optional[str]:
@@ -140,12 +179,19 @@ def build_coach_notification(
     cannot be sniffed from the report shape — it is passed explicitly by the job.
 
     `recipient` (P2.4, #120) is the activity owner's per-user address on the
-    active channel (from `resolve_recipient`). When None it falls back to the
-    configured global recipient, so the single-user path is byte-identical.
+    active channel (from `resolve_recipient`). Returns None (no notification) when
+    `_resolve_to` suppresses — a non-owner unbound Telegram runner in multi-user
+    mode, never delivered to the owner's chat (#542). See `_resolve_to` for the
+    single-user / email fallbacks.
     """
     channel = _active_channel()
     renderer = _renderer_for_channel(channel)
     if renderer is None:
+        return None
+    to = _resolve_to(channel, recipient)
+    if to is None:
+        # Telegram, non-owner runner with no linked chat: suppress rather than
+        # deliver to the global owner chat (#542).
         return None
     return renderer.render_coach_report(
         report=report,
@@ -153,7 +199,7 @@ def build_coach_notification(
         distance_m=distance_m,
         app_base_url=app_base_url,
         stage=stage,
-        to=recipient or _recipient_for_channel(channel),
+        to=to,
     )
 
 
@@ -176,11 +222,18 @@ def build_receipt_notification(
     tap). A thin dispatcher (#333): channel selection here, rendering in the
     adapter.
 
-    `recipient` (P2.4, #120) is the activity owner's per-user address; when None it
-    falls back to the configured global recipient (single-user back-compat)."""
+    `recipient` (P2.4, #120) is the activity owner's per-user address. Returns None
+    (no notification) when `_resolve_to` suppresses — a non-owner unbound Telegram
+    runner in multi-user mode, never delivered to the owner's chat (#542). See
+    `_resolve_to` for the single-user / email fallbacks."""
     channel = _active_channel()
     renderer = _renderer_for_channel(channel)
     if renderer is None:
+        return None
+    to = _resolve_to(channel, recipient)
+    if to is None:
+        # Telegram, non-owner runner with no linked chat: suppress rather than
+        # deliver to the global owner chat (#542).
         return None
     return renderer.render_receipt(
         receipt_text=receipt_text,
@@ -188,7 +241,7 @@ def build_receipt_notification(
         activity_id=activity_id,
         distance_m=distance_m,
         app_base_url=app_base_url,
-        to=recipient or _recipient_for_channel(channel),
+        to=to,
     )
 
 

--- a/backend/tests/test_per_user_notifications.py
+++ b/backend/tests/test_per_user_notifications.py
@@ -18,11 +18,14 @@ from app.services.notifications.port import Notification
 from app.services.notifications.telegram_adapter import TelegramNotifier
 
 
-def _telegram_active(monkeypatch, *, chat_id="GLOBAL"):
+def _telegram_active(monkeypatch, *, chat_id="GLOBAL", owner_email=""):
     monkeypatch.setattr(settings, "TELEGRAM_BOT_TOKEN", "bot-token")
     monkeypatch.setattr(settings, "TELEGRAM_CHAT_ID", chat_id)
     monkeypatch.setattr(settings, "SMTP_HOST", "")
     monkeypatch.setattr(settings, "NOTIFY_TO", "")
+    # Default to single-user mode (no owner concept) unless a test opts in, so the
+    # #542 owner-only fallback is exercised explicitly where it matters.
+    monkeypatch.setattr(settings, "OWNER_EMAIL", owner_email)
 
 
 # --- resolver ------------------------------------------------------------------
@@ -33,10 +36,29 @@ def test_resolve_recipient_returns_bound_telegram_chat(monkeypatch):
     assert resolve_recipient(user) == "USER_CHAT_1"
 
 
-def test_resolve_recipient_unbound_user_returns_none(monkeypatch):
-    # None => the composer falls back to the global recipient (back-compat).
-    _telegram_active(monkeypatch)
-    assert resolve_recipient(SimpleNamespace(telegram_chat_id=None, email="a@x.dev")) is None
+def test_resolve_recipient_unbound_single_user_falls_back_to_global(monkeypatch):
+    # OWNER_EMAIL unset => single-user mode: an unbound user keeps the original
+    # global fallback (back-compat), so the single-owner deployment is unchanged.
+    _telegram_active(monkeypatch, chat_id="GLOBAL", owner_email="")
+    assert resolve_recipient(SimpleNamespace(telegram_chat_id=None, email="a@x.dev")) == "GLOBAL"
+    assert resolve_recipient(None) == "GLOBAL"
+
+
+def test_resolve_recipient_unbound_owner_falls_back_to_global(monkeypatch):
+    # Multi-user (OWNER_EMAIL set): the owner, still unbound, keeps the global chat
+    # so the owner's own notifications are unaffected.
+    _telegram_active(monkeypatch, chat_id="GLOBAL", owner_email="owner@x.dev")
+    owner = SimpleNamespace(telegram_chat_id=None, email="Owner@X.dev")  # case-insensitive
+    assert resolve_recipient(owner) == "GLOBAL"
+
+
+def test_resolve_recipient_unbound_non_owner_is_suppressed(monkeypatch):
+    # The #542 fix: a non-owner runner who has not linked Telegram resolves to
+    # None (suppress), never to the owner's global chat.
+    _telegram_active(monkeypatch, chat_id="GLOBAL", owner_email="owner@x.dev")
+    non_owner = SimpleNamespace(telegram_chat_id=None, email="runner@x.dev")
+    assert resolve_recipient(non_owner) is None
+    # A partial/None user in multi-user mode is also suppressed (no email to match).
     assert resolve_recipient(None) is None
 
 
@@ -61,13 +83,54 @@ def test_receipt_routes_to_per_user_recipient(monkeypatch):
     assert n.to == "USER_CHAT_1"  # the owner's chat, not the global
 
 
-def test_receipt_falls_back_to_global_when_recipient_none(monkeypatch):
-    _telegram_active(monkeypatch, chat_id="GLOBAL")
+def test_receipt_telegram_single_user_falls_back_to_global(monkeypatch):
+    # OWNER_EMAIL unset => single-user mode: a recipientless Telegram build keeps
+    # the original global fallback (back-compat), so single-owner is unchanged.
+    _telegram_active(monkeypatch, chat_id="GLOBAL", owner_email="")
     n = build_receipt_notification(
         receipt_text="Nice run", headline="Easy 5k", activity_id="act-1",
         distance_m=5000, app_base_url="http://app",  # no recipient
     )
-    assert n.to == "GLOBAL"  # single-user back-compat
+    assert n is not None and n.to == "GLOBAL"
+
+
+def test_receipt_telegram_multiuser_suppressed_when_recipient_none(monkeypatch):
+    # OWNER_EMAIL set => multi-user: a recipientless Telegram build is SUPPRESSED,
+    # never routed to the global owner chat (#542). Defense in depth: holds at the
+    # builder even if a caller bypassed resolve_recipient.
+    _telegram_active(monkeypatch, chat_id="OWNER_CHAT", owner_email="owner@x.dev")
+    n = build_receipt_notification(
+        receipt_text="Nice run", headline="Easy 5k", activity_id="act-1",
+        distance_m=5000, app_base_url="http://app",  # no recipient
+    )
+    assert n is None  # suppressed, not routed to OWNER_CHAT
+
+
+def test_receipt_email_falls_back_to_global_notify_to(monkeypatch):
+    # Email has no per-user routing yet (ADR 0023): a None recipient keeps the
+    # global NOTIFY_TO, unchanged by #542 (which is Telegram-only).
+    monkeypatch.setattr(settings, "TELEGRAM_BOT_TOKEN", "")
+    monkeypatch.setattr(settings, "TELEGRAM_CHAT_ID", "")
+    monkeypatch.setattr(settings, "SMTP_HOST", "smtp.example.com")
+    monkeypatch.setattr(settings, "NOTIFY_TO", "global@x.dev")
+    n = build_receipt_notification(
+        receipt_text="Nice run", headline="Easy 5k", activity_id="act-1",
+        distance_m=5000, app_base_url="http://app",  # no recipient
+    )
+    assert n is not None and n.to == "global@x.dev"
+
+
+def test_non_owner_unbound_receipt_is_not_built_end_to_end(monkeypatch):
+    # The full #542 guarantee: a non-owner unbound runner produces NO Telegram
+    # notification (the leak was their receipt going to the owner's chat).
+    _telegram_active(monkeypatch, chat_id="OWNER_CHAT", owner_email="owner@x.dev")
+    non_owner = SimpleNamespace(telegram_chat_id=None, email="runner@x.dev")
+    n = build_receipt_notification(
+        receipt_text="run", headline="h", activity_id="act-1",
+        distance_m=0, app_base_url="http://app",
+        recipient=resolve_recipient(non_owner),
+    )
+    assert n is None
 
 
 # --- adapter honors Notification.to --------------------------------------------


### PR DESCRIPTION
Closes #542.

## Problem
`resolve_recipient` returned `None` for any user with no bound Telegram chat, and the composer turned `None` into the global `TELEGRAM_CHAT_ID` — the owner's chat (single-owner back-compat). Under real multi-user this **leaked**: any signed-up runner who hadn't completed the `/start` Telegram bind had their coach receipts/reports delivered to the **owner**, not themselves. (Found while assessing what happens if ~10 people sign up.)

## Fix
Keyed on the existing **`OWNER_EMAIL`** setting (confirmed set to the real owner — `philippe.marr@gmail.com` — in prod):

- **`resolve_recipient`** falls back to the global owner chat **only for the owner**; a non-owner unbound runner resolves to `None` (suppress). When `OWNER_EMAIL` is unset the deployment is single-user, so the original global fallback is preserved for everyone — **no behaviour change for the single-owner deployment or local dev**.
- **`_resolve_to`** centralises the build-time decision and adds **defense in depth**: in multi-user mode (`OWNER_EMAIL` set) a recipientless Telegram build is suppressed (returns `None`) rather than routed to the owner chat, so the leak can't happen even if a caller bypasses `resolve_recipient`. Email keeps the global `NOTIFY_TO` (per-user email is deferred, ADR 0023).

The pipeline already skips a `None` notification (the receipt path still opens the exchange first — delivery-independent by design), so a non-owner unbound runner simply receives **no Telegram notification until they bind their chat**, which is the intended behaviour.

## Behaviour matrix (Telegram)
| Mode | User | Result |
| --- | --- | --- |
| `OWNER_EMAIL` unset (single-user) | anyone unbound | global chat (back-compat) |
| `OWNER_EMAIL` set | bound runner | their own chat |
| `OWNER_EMAIL` set | owner, unbound | global owner chat (unchanged for the owner) |
| `OWNER_EMAIL` set | **non-owner, unbound** | **suppressed (no leak)** |

## Tests
Rewrote the resolver/builder cases into the owner / non-owner / single-user matrix and added the end-to-end leak-prevention assertion. Full baseline green (`make backend-test`: 1802 passed); the existing notification characterization tests pass unchanged under single-user mode.

## Note (out of scope)
`docs/testing/deployed-handshake-verification.md` still names `philippe@twohourssleep.com` as the deployment owner, but prod `OWNER_EMAIL` is `philippe.marr@gmail.com`. Minor stale doc, flagged for a follow-up.