### PR TITLE
Repair stale sync integration test + correct owner email in handshake runbook

### DIFF
--- a/backend/tests/test_sync_integration.py
+++ b/backend/tests/test_sync_integration.py
@@ -115,7 +115,10 @@ async def test_sync_upserts_activity_and_streams_and_runs_analysis(
         },
     )
 
-    result = await sync_activities(strava_athlete_id=99999, db=db)
+    # Phase 2 (#473) made sync user-scoped (require_current_user) instead of
+    # athlete-id-keyed: the endpoint resolves the account from the authenticated
+    # user. since_days defaults to the routine 30-day stream-fetch window.
+    result = await sync_activities(db=db, user=user)
 
     assert isinstance(result, SyncResponse)
     assert result.fetched == 1

--- a/docs/testing/deployed-handshake-verification.md
+++ b/docs/testing/deployed-handshake-verification.md
@@ -17,7 +17,8 @@ Telegram link endpoints in `app/api/coach.py`, or the Vercel proxy.
 
 ## Who can run this
 
-The owner of the deployed stack (`philippe@twohourssleep.com`). It needs a real
+The owner of the deployed stack (the `OWNER_EMAIL` identity,
+`philippe.marr@gmail.com`). It needs a real
 Strava account and the live bot, and it WRITES to production (preview deploys
 point at the same backend/Postgres/Redis, so there is no isolated environment;
 see `docs/testing/local-seed.md`). Treat it as a production smoke, not a CI gate.


### PR DESCRIPTION
Two small loose ends noticed while working #542/#543.

## 1. Stale `test_sync_integration.py` (pre-existing failure)
The `@pytest.mark.integration` test called the pre-Phase-2 signature `sync_activities(strava_athlete_id=99999, db=db)`. Phase 2 (#473) made sync **user-scoped** (`require_current_user`), resolving the Strava account from the authenticated user instead of an athlete id. The test already seeds a `user` + linked `account`, so it now calls `sync_activities(db=db, user=user)` (`since_days` defaults to the routine 30-day window).

It's `@pytest.mark.integration`, excluded from `make backend-test`, so it had been failing silently on `main`. The full suite (including integration) now passes: **1801 passed, 0 failed**.

## 2. Stale owner email in the handshake runbook
`docs/testing/deployed-handshake-verification.md` named the deployment owner as `philippe@twohourssleep.com`, but prod `OWNER_EMAIL` (and `NOTIFY_TO`) is `philippe.marr@gmail.com`. Corrected and tied to the `OWNER_EMAIL` identity (the durable Clerk identity that owns the Strava link + the owner-Telegram fallback, relevant to #542).

No production code changes.