### PR TITLE
#549: replace crash-on-boot budget guard with a non-fatal safe default

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -54,10 +54,21 @@ class Settings(BaseSettings):
     LLM_BUDGET_GLOBAL_MONTHLY_USD: float = 0.0
     # The all-zero defaults mean NO cost cap. That is fine for local dev, but in
     # production a silently-uncapped deployment lets one user drain the shared
-    # Anthropic budget (#543). `assert_budget_cap_armed` refuses to boot in
-    # production unless at least one window above is set OR this opt-out is true,
-    # so "no cap in prod" is a conscious, auditable choice rather than a default.
+    # Anthropic budget (#543). Rather than crash the boot when prod is unconfigured
+    # (#549: the #543 boot guard took prod fully DOWN on Railway, since the prior
+    # deploy was REMOVED so a crashed boot left nothing serving — a strictly worse
+    # failure than a missing cost cap), production falls back to the generous
+    # safety ceiling below. Set this opt-out to run prod deliberately uncapped, so
+    # "no cap in prod" stays a conscious, auditable choice.
     LLM_BUDGET_DISABLED: bool = False
+    # The production safety backstop (#549). When APP_ENV=production and no
+    # LLM_BUDGET_*_USD window above is explicitly set and the cap is not disabled,
+    # the budget gate applies this global-daily ceiling so prod is NEVER silently
+    # uncapped — without crashing the boot. Generous by design: it is a catastrophe
+    # backstop, not a tuned cap (set an explicit window for that). 0 turns the
+    # backstop off (prod would then run uncapped when otherwise unconfigured).
+    # See app/services/coach/budget.py.
+    LLM_BUDGET_PROD_DEFAULT_GLOBAL_DAILY_USD: float = 50.0
     # Minimum seconds between on-demand coach-report regenerations for one
     # activity (#122 / going-live landmine 1). The regenerate endpoint is the
     # single most exposed cost lever (it enqueues a full two-stage generation);

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -180,6 +180,17 @@ def assert_production_config() -> None:
     direction is safe -- a false positive can only block a new deploy, never
     take down the running one. Called once per process group right after
     ``init_logging``.
+
+    SCOPE NOTE (#549): the "platform keeps the last healthy deploy serving on a
+    boot crash" assumption above proved FALSE on Railway -- prior deploys were
+    ``REMOVED``, so a crashed boot took prod fully down. The budget guard that
+    shared this pattern was made non-fatal for that reason (see
+    ``log_budget_cap_status``). This guard is left crashing-on-boot deliberately:
+    the settings it guards (Clerk + basic-auth) make EVERY route 503 when unset,
+    so booting anyway just trades a boot crash for a fully-broken-but-"up" deploy
+    -- the tradeoff is defensible here in a way it was not for a cost cap prod
+    runs fine without. Revisiting it (a non-fatal/preflight form) is tracked
+    separately rather than duplicating #549's fix.
     """
     if settings.APP_ENV != "production":
         return
@@ -202,36 +213,61 @@ def assert_production_config() -> None:
     )
 
 
-def assert_budget_cap_armed() -> None:
-    """Refuse to boot when production runs the LLM cost cap silently disabled (#543).
+def log_budget_cap_status() -> None:
+    """Log the effective LLM cost-cap posture at boot. NON-FATAL (#549).
 
-    The four ``LLM_BUDGET_*_USD`` ceilings default to 0 (= cap off), which is fine
-    for local dev but in production lets one user drain the shared Anthropic budget
-    -- the exact failure the budget gate (``budget.py``) exists to prevent. This
-    makes "no cap in prod" a CONSCIOUS choice: it raises unless at least one window
-    is armed OR the cap is explicitly waived via ``LLM_BUDGET_DISABLED=true``.
+    Replaces the #543 crash-on-boot guard (``assert_budget_cap_armed``). That
+    guard refused to boot when production ran with no ``LLM_BUDGET_*_USD`` window
+    set, on the assumption that a boot crash only blocks a NEW deploy while the
+    platform keeps the last healthy one serving. On Railway that did not hold: the
+    prior deploys were ``REMOVED``, so the crashed boot left nothing serving and
+    prod went fully DOWN -- turning a missing cost cap (a setting prod runs FINE
+    without; uncapped means uncapped spend, not a broken app) into a production
+    outage, a strictly worse failure than the thing it guarded.
 
-    No-op unless ``APP_ENV == "production"`` (dev/tests run uncapped and must not
-    raise). Same safe failure direction as ``assert_production_config`` -- a boot
-    crash only blocks a new deploy, never the running one. Unlike that preflight
-    (which guards web-only HTTP settings), spend is incurred on whichever process
-    calls the model, so BOTH the web process (chat) and the worker (reports) call
-    this.
+    Enforcement moved to a non-fatal safe default instead: in production an
+    unconfigured, non-disabled cap falls back to a generous global-daily ceiling
+    (``budget.production_default_ceiling`` / ``LLM_BUDGET_PROD_DEFAULT_GLOBAL_DAILY_USD``),
+    so prod is never silently uncapped AND never crashes on this. This function
+    only makes the resulting posture visible in the logs; it never raises. Called
+    once per process group (web + worker) right after ``init_logging`` -- spend is
+    incurred on whichever process calls the model.
     """
     if settings.APP_ENV != "production":
         return
-    from app.services.coach.budget import cap_is_armed
+    from app.services.coach.budget import (
+        cap_is_armed,
+        production_default_ceiling,
+    )
 
-    if settings.LLM_BUDGET_DISABLED or cap_is_armed():
+    log = logging.getLogger(__name__)
+    if settings.LLM_BUDGET_DISABLED:
+        log.warning(
+            "llm_budget_cap_disabled: LLM_BUDGET_DISABLED=true in production -- "
+            "coach generation runs UNCAPPED. One user can drain the shared "
+            "Anthropic budget. This is a deliberate waiver; set an "
+            "LLM_BUDGET_*_USD window to arm the cap."
+        )
         return
-    logging.getLogger(__name__).critical("llm_budget_cap_unarmed_in_production")
-    raise ProductionConfigError(
-        "Refusing to boot: the LLM cost cap is disabled in production (no "
-        "LLM_BUDGET_*_USD window is set). An uncapped deployment lets one user "
-        "drain the shared Anthropic budget. Set at least one of "
-        "LLM_BUDGET_USER_DAILY_USD / LLM_BUDGET_USER_MONTHLY_USD / "
-        "LLM_BUDGET_GLOBAL_DAILY_USD / LLM_BUDGET_GLOBAL_MONTHLY_USD to a dollar "
-        "amount, or set LLM_BUDGET_DISABLED=true to waive the cap deliberately."
+    backstop = production_default_ceiling()
+    if backstop > 0:
+        log.warning(
+            "llm_budget_cap_default_backstop: no LLM_BUDGET_*_USD window set in "
+            "production; applying the safety backstop of $%.2f global/day "
+            "(LLM_BUDGET_PROD_DEFAULT_GLOBAL_DAILY_USD). Set an explicit window "
+            "for a tuned cap.",
+            backstop,
+        )
+        return
+    if cap_is_armed():
+        log.info("llm_budget_cap_armed: an explicit LLM_BUDGET_*_USD window is set.")
+        return
+    # Reachable only if the backstop default itself is set to 0 in production --
+    # a deliberate "off" with no explicit window. Surface it loudly but never crash.
+    log.warning(
+        "llm_budget_cap_unarmed: production is running UNCAPPED (no window set and "
+        "the safety backstop is 0). Set an LLM_BUDGET_*_USD window or a positive "
+        "LLM_BUDGET_PROD_DEFAULT_GLOBAL_DAILY_USD."
     )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,10 +6,10 @@ from app.core.auth import BasicAuthMiddleware
 from app.core.clerk_auth import verify_clerk_session
 from app.core.config import settings
 from app.core.observability import (
-    assert_budget_cap_armed,
     assert_production_config,
     init_logging,
     init_sentry,
+    log_budget_cap_status,
     warn_if_coach_prompt_inert,
 )
 
@@ -20,9 +20,11 @@ warn_if_coach_prompt_inert()
 # keeps the last healthy deploy serving instead of promoting one that 503s every
 # route (the Phase 2 deploy-outran-config outage). No-op outside production.
 assert_production_config()
-# Crash the boot if the LLM cost cap is silently disabled in production (#543):
-# the web process makes chat LLM calls, so it must not run uncapped either.
-assert_budget_cap_armed()
+# Log the LLM cost-cap posture (#549, NON-FATAL). The web process makes chat LLM
+# calls, so an uncapped web is a spend risk -- but enforcement is a non-fatal
+# safe default in production (budget.production_default_ceiling), not a boot crash
+# (the #543 guard took prod down on Railway, #549).
+log_budget_cap_status()
 
 app = FastAPI(
     title="Running Coach",

--- a/backend/app/services/coach/budget.py
+++ b/backend/app/services/coach/budget.py
@@ -100,6 +100,43 @@ _DAILY_TTL = 60 * 60 * 36          # 36h
 _MONTHLY_TTL = 60 * 60 * 24 * 40   # 40d
 
 
+def _any_window_explicitly_armed() -> bool:
+    """True when at least one budget window has an explicit positive ceiling.
+
+    A window is enabled when its ceiling is > 0 (mirrors `over_budget`'s
+    per-window check). "Explicit" excludes the production safety backstop below;
+    `cap_is_armed` adds that.
+    """
+    return any(
+        ceiling > 0
+        for ceiling in (
+            settings.LLM_BUDGET_USER_DAILY_USD,
+            settings.LLM_BUDGET_USER_MONTHLY_USD,
+            settings.LLM_BUDGET_GLOBAL_DAILY_USD,
+            settings.LLM_BUDGET_GLOBAL_MONTHLY_USD,
+        )
+    )
+
+
+def production_default_ceiling() -> float:
+    """The global-daily ceiling the production safety backstop applies, else 0 (#549).
+
+    In production, when no window is explicitly armed and the cap is not explicitly
+    disabled, prod must not run silently uncapped — but crashing the boot to enforce
+    that took prod fully down on Railway (#549, the #543 guard). Instead the gate
+    falls back to a generous global-daily ceiling here, so an unconfigured prod is
+    capped, not crashed. Returns 0 (backstop inactive) outside production, when an
+    explicit window is set, or when the cap is deliberately disabled.
+    """
+    if settings.APP_ENV != "production":
+        return 0.0
+    if settings.LLM_BUDGET_DISABLED:
+        return 0.0
+    if _any_window_explicitly_armed():
+        return 0.0
+    return settings.LLM_BUDGET_PROD_DEFAULT_GLOBAL_DAILY_USD
+
+
 class BudgetGate:
     """The spend gate. Reads ceilings from settings at call time so a config flip
     (or a test monkeypatch) takes effect without rebuilding the gate."""
@@ -120,7 +157,10 @@ class BudgetGate:
 
     @property
     def _global_daily(self) -> float:
-        return settings.LLM_BUDGET_GLOBAL_DAILY_USD
+        # An explicit ceiling always wins; otherwise the production safety
+        # backstop (#549) may supply a generous default so prod is never silently
+        # uncapped. Returns 0 (window off) when neither applies.
+        return settings.LLM_BUDGET_GLOBAL_DAILY_USD or production_default_ceiling()
 
     @property
     def _global_monthly(self) -> float:
@@ -211,23 +251,17 @@ def new_in_memory_gate() -> BudgetGate:
 
 
 def cap_is_armed() -> bool:
-    """True when at least one budget window has a positive ceiling.
+    """True when some budget window has an effective positive ceiling.
 
     A window is enabled when its ceiling is > 0 (mirrors `over_budget`'s
-    per-window check). All-zero ceilings mean the cost cap is OFF -- no window
-    can ever trip, so generation is never degraded to the fallback on spend. The
-    production boot guard (`assert_budget_cap_armed`) uses this to refuse a
-    silently-uncapped prod deployment (#543).
+    per-window check). This counts both an explicitly-set window AND the #549
+    production safety backstop, so in production an otherwise-unconfigured,
+    non-disabled deployment still reads as armed (the backstop supplies a
+    global-daily ceiling). All-zero ceilings with no backstop mean the cost cap
+    is OFF -- no window can ever trip, so generation is never degraded to the
+    fallback on spend. `log_budget_cap_status` reports this posture at boot.
     """
-    return any(
-        ceiling > 0
-        for ceiling in (
-            settings.LLM_BUDGET_USER_DAILY_USD,
-            settings.LLM_BUDGET_USER_MONTHLY_USD,
-            settings.LLM_BUDGET_GLOBAL_DAILY_USD,
-            settings.LLM_BUDGET_GLOBAL_MONTHLY_USD,
-        )
-    )
+    return _any_window_explicitly_armed() or production_default_ceiling() > 0
 
 
 def over_budget(user_id) -> bool:

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -10,9 +10,9 @@ import logging
 from rq import Queue, Worker
 
 from app.core.observability import (
-    assert_budget_cap_armed,
     init_logging,
     init_sentry,
+    log_budget_cap_status,
     warn_if_coach_prompt_inert,
 )
 from app.core.queue import redis_conn
@@ -32,9 +32,11 @@ def main() -> None:
     # would crash a correctly-configured worker. Its hard deps (DATABASE_URL) are
     # already required by Settings and crash the boot on their own.
     # The budget cap IS a worker concern, though: reports generate here, so an
-    # uncapped prod worker is exactly the spend risk #543 guards. Same safe
-    # failure direction (blocks a new deploy, never the running one).
-    assert_budget_cap_armed()
+    # uncapped prod worker is exactly the spend risk #543/#549 address. Enforcement
+    # is a non-fatal safe default in production (budget.production_default_ceiling),
+    # not a boot crash -- the #543 guard took prod down on Railway (#549). This
+    # only logs the resulting posture.
+    log_budget_cap_status()
     logger.info("Worker booting; listening on %s", ",".join(LISTEN))
     queues = [Queue(name, connection=redis_conn) for name in LISTEN]
     worker = Worker(queues, connection=redis_conn)

--- a/backend/tests/test_budget_cap_guard.py
+++ b/backend/tests/test_budget_cap_guard.py
@@ -1,17 +1,34 @@
-"""Production budget-cap boot guard (#543).
+"""Production LLM cost-cap safety default + non-fatal boot log (#549, supersedes #543).
 
-`assert_budget_cap_armed` crashes the boot when production would run the LLM cost
-cap silently disabled (all `LLM_BUDGET_*_USD` ceilings 0 and no explicit waiver),
-so an uncapped deployment that lets one user drain the shared Anthropic budget is
-never promoted by accident. These tests pin the firing condition: it raises in
-production only when the cap is both unarmed and not waived, and stays a no-op
-everywhere else (the suite and local dev run uncapped and must not raise).
+The #543 boot guard (`assert_budget_cap_armed`) crashed the process when production
+ran with no `LLM_BUDGET_*_USD` window set. On Railway that took prod fully DOWN
+(the prior deploy was REMOVED, so a crashed boot left nothing serving) -- a
+strictly worse failure than the missing cost cap it guarded. #549 replaces it with:
+
+  * a non-fatal safety DEFAULT (`budget.production_default_ceiling`): in production
+    an unconfigured, non-disabled cap falls back to a generous global-daily ceiling,
+    so prod is never silently uncapped without crashing; and
+  * a non-fatal boot LOG (`observability.log_budget_cap_status`) that only surfaces
+    the resulting posture and NEVER raises.
+
+These tests pin both: the default resolution (when it applies, when an explicit
+window or the disable flag overrides it, and that the gate enforces it), and that
+the boot log is silent-safe in every posture.
 """
+
+import logging
 
 import pytest
 
 from app.core.config import settings
-from app.core.observability import ProductionConfigError, assert_budget_cap_armed
+from app.core.observability import log_budget_cap_status
+from app.services.coach import budget
+from app.services.coach.budget import (
+    cap_is_armed,
+    new_in_memory_gate,
+    production_default_ceiling,
+    set_gate,
+)
 
 
 def _set(monkeypatch, **kwargs):
@@ -25,22 +42,35 @@ _ALL_WINDOWS_OFF = dict(
     LLM_BUDGET_GLOBAL_DAILY_USD=0.0,
     LLM_BUDGET_GLOBAL_MONTHLY_USD=0.0,
     LLM_BUDGET_DISABLED=False,
+    LLM_BUDGET_PROD_DEFAULT_GLOBAL_DAILY_USD=50.0,
 )
 
 
-def test_noop_outside_production_even_when_uncapped(monkeypatch):
-    # Local dev and the test suite run with no cost cap; the guard must stay
-    # silent or it would break every non-production boot.
-    _set(monkeypatch, APP_ENV="local", **_ALL_WINDOWS_OFF)
-    assert_budget_cap_armed()  # does not raise
+@pytest.fixture
+def isolated_gate():
+    """A fresh in-process gate for over_budget tests; reset to lazy after."""
+    set_gate(new_in_memory_gate())
+    try:
+        yield
+    finally:
+        set_gate(None)
 
 
-def test_raises_in_production_when_uncapped_and_not_waived(monkeypatch):
-    # The exact #543 risk: prod with no LLM_BUDGET_* window set and no waiver.
+# --- the safety default resolution -----------------------------------------
+
+
+def test_default_applies_in_production_when_uncapped_and_not_disabled(monkeypatch):
+    # The exact #543/#549 case: prod, no window, no waiver -> the backstop arms.
     _set(monkeypatch, APP_ENV="production", **_ALL_WINDOWS_OFF)
-    with pytest.raises(ProductionConfigError) as exc:
-        assert_budget_cap_armed()
-    assert "LLM_BUDGET" in str(exc.value)
+    assert production_default_ceiling() == 50.0
+    assert cap_is_armed() is True
+
+
+def test_default_inactive_outside_production(monkeypatch):
+    # Local dev / the test suite run uncapped and must NOT get the backstop.
+    _set(monkeypatch, APP_ENV="local", **_ALL_WINDOWS_OFF)
+    assert production_default_ceiling() == 0.0
+    assert cap_is_armed() is False
 
 
 @pytest.mark.parametrize(
@@ -52,25 +82,86 @@ def test_raises_in_production_when_uncapped_and_not_waived(monkeypatch):
         "LLM_BUDGET_GLOBAL_MONTHLY_USD",
     ],
 )
-def test_passes_in_production_when_any_single_window_armed(monkeypatch, window):
-    # Any one positive ceiling arms the cap (mirrors over_budget's per-window check).
+def test_explicit_window_overrides_the_default(monkeypatch, window):
+    # An explicit ceiling means the owner tuned the cap; the backstop steps aside.
     _set(monkeypatch, APP_ENV="production", **_ALL_WINDOWS_OFF)
     monkeypatch.setattr(settings, window, 5.0)
-    assert_budget_cap_armed()  # does not raise
+    assert production_default_ceiling() == 0.0
+    assert cap_is_armed() is True
 
 
-def test_passes_in_production_when_explicitly_waived(monkeypatch):
-    # The conscious opt-out: an owner who deliberately wants no cap sets the flag.
+def test_disabled_waiver_suppresses_the_default(monkeypatch):
+    # The conscious opt-out: LLM_BUDGET_DISABLED=true runs prod deliberately uncapped.
     _set(monkeypatch, APP_ENV="production", **_ALL_WINDOWS_OFF)
     monkeypatch.setattr(settings, "LLM_BUDGET_DISABLED", True)
-    assert_budget_cap_armed()  # does not raise
+    assert production_default_ceiling() == 0.0
+    assert cap_is_armed() is False
 
 
-def test_error_names_the_windows_and_the_waiver(monkeypatch):
-    # The message must be actionable: how to arm, and how to waive.
+def test_default_can_be_turned_off_in_production(monkeypatch):
+    # Setting the backstop to 0 in prod is an explicit "no backstop" -> uncapped.
     _set(monkeypatch, APP_ENV="production", **_ALL_WINDOWS_OFF)
-    with pytest.raises(ProductionConfigError) as exc:
-        assert_budget_cap_armed()
-    msg = str(exc.value)
-    assert "LLM_BUDGET_USER_DAILY_USD" in msg
-    assert "LLM_BUDGET_DISABLED" in msg
+    monkeypatch.setattr(settings, "LLM_BUDGET_PROD_DEFAULT_GLOBAL_DAILY_USD", 0.0)
+    assert production_default_ceiling() == 0.0
+    assert cap_is_armed() is False
+
+
+def test_gate_enforces_the_default_ceiling(monkeypatch, isolated_gate):
+    # The backstop is not cosmetic: over_budget must trip at the default global
+    # ceiling. $50 backstop; record exactly $50 of global spend -> over budget.
+    _set(monkeypatch, APP_ENV="production", **_ALL_WINDOWS_OFF)
+    # haiku output is $5/MTok, so 10M output tokens == $50.00 (>= the $50 ceiling).
+    assert budget.over_budget("user-1") is False
+    budget.record("user-1", "claude-haiku-4-5", input_tokens=0, output_tokens=10_000_000)
+    assert budget.over_budget("user-1") is True
+    # A different user shares only the GLOBAL window, which is the one armed here,
+    # so they are over budget too (the backstop is a global catastrophe stop).
+    assert budget.over_budget("user-2") is True
+
+
+def test_gate_uncapped_when_disabled(monkeypatch, isolated_gate):
+    # With the waiver, no window is armed -> spend never trips over_budget.
+    _set(monkeypatch, APP_ENV="production", **_ALL_WINDOWS_OFF)
+    monkeypatch.setattr(settings, "LLM_BUDGET_DISABLED", True)
+    budget.record("user-1", "claude-haiku-4-5", input_tokens=0, output_tokens=10_000_000)
+    assert budget.over_budget("user-1") is False
+
+
+# --- the non-fatal boot log -------------------------------------------------
+
+
+def test_boot_log_never_raises_outside_production(monkeypatch):
+    _set(monkeypatch, APP_ENV="local", **_ALL_WINDOWS_OFF)
+    log_budget_cap_status()  # does not raise
+
+
+def test_boot_log_warns_on_backstop_default(monkeypatch, caplog):
+    _set(monkeypatch, APP_ENV="production", **_ALL_WINDOWS_OFF)
+    with caplog.at_level(logging.WARNING):
+        log_budget_cap_status()  # does not raise
+    assert any("backstop" in r.message for r in caplog.records)
+
+
+def test_boot_log_warns_when_explicitly_disabled(monkeypatch, caplog):
+    _set(monkeypatch, APP_ENV="production", **_ALL_WINDOWS_OFF)
+    monkeypatch.setattr(settings, "LLM_BUDGET_DISABLED", True)
+    with caplog.at_level(logging.WARNING):
+        log_budget_cap_status()  # does not raise
+    assert any("UNCAPPED" in r.message for r in caplog.records)
+
+
+def test_boot_log_info_when_explicit_window_armed(monkeypatch, caplog):
+    _set(monkeypatch, APP_ENV="production", **_ALL_WINDOWS_OFF)
+    monkeypatch.setattr(settings, "LLM_BUDGET_GLOBAL_DAILY_USD", 5.0)
+    with caplog.at_level(logging.INFO):
+        log_budget_cap_status()  # does not raise
+    assert any("armed" in r.message for r in caplog.records)
+
+
+def test_boot_log_warns_when_unarmed_and_backstop_off(monkeypatch, caplog):
+    # Prod, no window, backstop turned off: genuinely uncapped -> loud warning.
+    _set(monkeypatch, APP_ENV="production", **_ALL_WINDOWS_OFF)
+    monkeypatch.setattr(settings, "LLM_BUDGET_PROD_DEFAULT_GLOBAL_DAILY_USD", 0.0)
+    with caplog.at_level(logging.WARNING):
+        log_budget_cap_status()  # does not raise
+    assert any("UNCAPPED" in r.message for r in caplog.records)


### PR DESCRIPTION
Closes #549.

## Problem
The #543 budget boot guard (`assert_budget_cap_armed`) crashed web+worker when prod ran with no `LLM_BUDGET_*_USD` window, assuming the platform keeps the last healthy deploy serving. On Railway that was false (prior deploys were `REMOVED`), so the crashed boot took prod fully DOWN (#546) - turning a missing cost cap (uncapped spend, not a broken app) into an outage, strictly worse than what it guarded.

## Change
- `budget.production_default_ceiling()`: in production, an unconfigured, non-disabled cap falls back to a generous global-daily ceiling (`LLM_BUDGET_PROD_DEFAULT_GLOBAL_DAILY_USD`, default $50/day), so prod is never silently uncapped **and** never crashes. The gate `_global_daily` and `cap_is_armed` honour it; an explicit window or `LLM_BUDGET_DISABLED` suppress it.
- `observability.log_budget_cap_status()` replaces `assert_budget_cap_armed()`: non-fatal, only surfaces the posture (warn on backstop/disabled/unarmed, info when explicitly armed). Wired in `main.py` + `worker.py`.
- `assert_production_config()` left crashing deliberately (its settings 503 every route when absent) with a scope note correcting the now-false Railway assumption; non-fatal/build-time revisit deferred per the #549 comment.
- Tests rewritten for the new behaviour.

## Owner action after merge
Prod currently has `LLM_BUDGET_DISABLED=true` (set during the incident). That waiver **suppresses** the new safe default, so prod stays uncapped until you unset `LLM_BUDGET_DISABLED` on `web` + `worker`. The deploy is safe either way (no boot crash).

## Verification
Full backend suite green (1825 passed). New tests cover the default resolution, the gate enforcing it, and the boot log never raising in any posture.