### PR TITLE
#550: automated post-deploy verification as a release gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual trigger so the owner can re-run post-deploy verification on demand,
+  # e.g. after setting an env var the deploy was waiting on (#550).
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,3 +65,50 @@ jobs:
 
       - name: Lint + build
         run: npm run test
+
+  # Post-deploy verification (#550): after a push to main triggers the Railway
+  # deploy, poll the deployed /api/health until healthy then run the deployed
+  # handshake smoke. A crashed or regressed deploy (the #546 outage, where prod
+  # was down and only a human noticing the crash email caught it) now fails this
+  # job, which alerts via GitHub's default failure notification. Does NOT run on
+  # pull_request (no deploy to verify). Skips cleanly when PROD_BACKEND_URL is
+  # unset, so the repo is not broken for anyone without prod access.
+  post-deploy-verify:
+    name: post-deploy-verify
+    needs: [backend-test, frontend-test]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      SMOKE_BASE_URL: ${{ secrets.PROD_BACKEND_URL }}
+      SMOKE_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.PROD_TELEGRAM_WEBHOOK_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check prod URL is configured
+        id: guard
+        run: |
+          if [ -z "${SMOKE_BASE_URL}" ]; then
+            echo "::notice::PROD_BACKEND_URL secret not set; skipping post-deploy verification."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-python@v5
+        if: steps.guard.outputs.configured == 'true'
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      # The verifier imports only httpx (it never imports the app), so the core
+      # backend package is all it needs -- no DATABASE_URL, no test extra.
+      - name: Install backend (for httpx + scripts)
+        if: steps.guard.outputs.configured == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ./backend
+
+      - name: Verify the deploy is healthy
+        if: steps.guard.outputs.configured == 'true'
+        run: make post-deploy-verify

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test seed-local eval eval-selftest diagram-check verify-local deployed-handshake-smoke
+.PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test seed-local eval eval-selftest diagram-check verify-local deployed-handshake-smoke post-deploy-verify
 
 # Prefer the project venv interpreter when it exists, fall back to bare python.
 # Path is relative to backend/ since the targets cd there first. CI has no
@@ -77,3 +77,12 @@ eval-selftest:
 #   make deployed-handshake-smoke SMOKE_BASE_URL=... SMOKE_TELEGRAM_WEBHOOK_SECRET=<secret>
 deployed-handshake-smoke:
 	cd backend && $(BACKEND_PY) -m scripts.deployed_handshake_smoke
+
+# Post-deploy verification (#550): poll the deployed /api/health until it is
+# healthy, then run the deployed handshake smoke as a release smoke. The release
+# gate that catches a crashed/regressed deploy (the #546 outage) automatically
+# instead of waiting for someone to notice the platform's crash email. Run after
+# a deploy (the CI post-deploy-verify job on push to main does this) or by hand.
+#   make post-deploy-verify SMOKE_BASE_URL=https://<deployed-backend>
+post-deploy-verify:
+	cd backend && $(BACKEND_PY) -m scripts.post_deploy_verify

--- a/backend/scripts/deployed_handshake_smoke.py
+++ b/backend/scripts/deployed_handshake_smoke.py
@@ -54,7 +54,6 @@ import os
 import sys
 import time
 from dataclasses import dataclass
-from typing import Callable, Optional
 
 import httpx
 
@@ -242,6 +241,47 @@ def check_telegram_unbound_chat_noop(
     )
 
 
+def run_handshake_checks(
+    client: httpx.Client, base: str, tg_secret: str = ""
+) -> list[CheckResult]:
+    """Run the deployed handshake auth-gate checks and return their results.
+
+    The reusable seam: `main` calls it for the standalone run, and the post-deploy
+    verifier (`scripts.post_deploy_verify`, #550) calls it as the release smoke
+    after the health poll. The optional-secret Telegram no-op check is SKIPped
+    (never FAILed) when `tg_secret` is empty.
+    """
+    results: list[CheckResult] = [
+        check_strava_verify_gate(client, base),
+        check_strava_event_authenticity(client, base),
+        check_telegram_secret_gate(client, base),
+    ]
+    if tg_secret:
+        results.append(check_telegram_unbound_chat_noop(client, base, tg_secret))
+    else:
+        results.append(
+            _skipped(
+                "telegram_unbound_chat_is_noop",
+                "set SMOKE_TELEGRAM_WEBHOOK_SECRET to exercise this",
+            )
+        )
+    return results
+
+
+def report_results(results: list[CheckResult], header: str = "Results") -> int:
+    """Print a results block and return an exit code (0 only when no check FAILed)."""
+    print(f"{header}:")
+    for r in results:
+        print(f"  [{r.status:4}] {r.name}: {r.detail}")
+    failures = [r for r in results if r.status == "FAIL"]
+    skipped = [r for r in results if r.status == "SKIP"]
+    print(
+        f"\n{len(results) - len(failures) - len(skipped)} passed, "
+        f"{len(failures)} failed, {len(skipped)} skipped."
+    )
+    return 1 if failures else 0
+
+
 def main() -> int:
     base = (os.environ.get("SMOKE_BASE_URL") or "").rstrip("/")
     if not base:
@@ -258,45 +298,17 @@ def main() -> int:
 
     print(f"Deployed handshake smoke against: {base}\n")
 
-    results: list[CheckResult] = []
     # `follow_redirects=False`: a 302 to Strava must be observed as a redirect,
     # not silently followed off-host.
     with httpx.Client(timeout=timeout, follow_redirects=False) as client:
-        required: list[Callable[[], CheckResult]] = [
-            lambda: check_strava_verify_gate(client, base),
-            lambda: check_strava_event_authenticity(client, base),
-            lambda: check_telegram_secret_gate(client, base),
-        ]
-        for run in required:
-            results.append(run())
+        results = run_handshake_checks(client, base, tg_secret)
 
-        if tg_secret:
-            results.append(
-                check_telegram_unbound_chat_noop(client, base, tg_secret)
-            )
-        else:
-            results.append(
-                _skipped(
-                    "telegram_unbound_chat_is_noop",
-                    "set SMOKE_TELEGRAM_WEBHOOK_SECRET to exercise this",
-                )
-            )
-
-    print("Results:")
-    for r in results:
-        print(f"  [{r.status:4}] {r.name}: {r.detail}")
-
-    failures = [r for r in results if r.status == "FAIL"]
-    skipped = [r for r in results if r.status == "SKIP"]
-    print(
-        f"\n{len(results) - len(failures) - len(skipped)} passed, "
-        f"{len(failures)} failed, {len(skipped)} skipped."
-    )
-    if failures:
+    code = report_results(results)
+    if code != 0:
         print("\nDEPLOYED HANDSHAKE SMOKE FAILED.", file=sys.stderr)
-        return 1
-    print("\nDeployed handshake smoke passed.")
-    return 0
+    else:
+        print("\nDeployed handshake smoke passed.")
+    return code
 
 
 if __name__ == "__main__":

--- a/backend/scripts/post_deploy_verify.py
+++ b/backend/scripts/post_deploy_verify.py
@@ -1,0 +1,154 @@
+"""Post-deploy verification: confirm a fresh deploy is actually healthy (#550).
+
+When a bad deploy reaches prod, nothing automated caught it. During the #546
+incident the budget boot guard crashed both web and worker and prod was down
+(`/api/health` -> HTTP 000); it was discovered only because the owner saw
+Railway's crash email. This script is the release gate that turns "a human
+noticed the crash email" into "the check caught it".
+
+What it does, against a deployed backend base URL (`SMOKE_BASE_URL`):
+  1. POLLS `GET /api/health` until it returns 200 with ``status == "ok"``, for up
+     to `POST_DEPLOY_HEALTH_TIMEOUT_SECONDS` (default 180). A new Railway deploy
+     takes a minute or two to come up, so this waits rather than checking once.
+     A timeout (the process never became healthy -- the #546 outage) FAILS.
+  2. Runs the deployed handshake auth-gate smoke (`scripts.deployed_handshake_smoke`)
+     as the release smoke, so a regression that opens an auth gate is also caught.
+
+Exit code is 0 only when health came up AND every required handshake check passed.
+This is meant to run on push to `main` (the CI ``post-deploy-verify`` job) after the
+Railway deploy, or by hand. It is non-mutating: health is a read, and the handshake
+smoke only asserts the live gates REJECT unauthentic input (see that script).
+
+Env:
+    SMOKE_BASE_URL                   (required) deployed backend base URL, e.g.
+                                     https://<railway-backend-domain>. No production
+                                     hostname is hardcoded (project principle: every
+                                     seam URL is config).
+    POST_DEPLOY_HEALTH_TIMEOUT_SECONDS (optional, default 180) how long to wait for
+                                     /api/health to become healthy.
+    POST_DEPLOY_HEALTH_POLL_SECONDS  (optional, default 5) seconds between polls.
+    SMOKE_TIMEOUT_SECONDS            (optional, default 15) per-request timeout.
+    SMOKE_TELEGRAM_WEBHOOK_SECRET    (optional) enables the Telegram no-op handshake
+                                     check; skipped (never failed) when absent.
+
+Usage:
+    SMOKE_BASE_URL=https://<deployed-backend> python -m scripts.post_deploy_verify
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import httpx
+
+from scripts.deployed_handshake_smoke import (
+    CheckResult,
+    report_results,
+    run_handshake_checks,
+    _failed,
+    _passed,
+)
+
+
+def poll_health(
+    client: httpx.Client, base: str, timeout_seconds: float, poll_seconds: float
+) -> CheckResult:
+    """Poll GET /api/health until 200 + status ok, or fail after the timeout.
+
+    Returns a PASS once the deploy is healthy (reporting how long it took) or a
+    FAIL describing the last observed state -- a non-200, a non-ok body, a
+    connection refusal (the crashed-boot HTTP-000 case), or never coming up in
+    time. The whole point of #550 is that this FAIL is the signal a crashed or
+    regressed deploy emits, instead of silence.
+    """
+    name = "deploy_health_within_timeout"
+    deadline = time.monotonic() + timeout_seconds
+    attempts = 0
+    last_detail = "no attempt made"
+    while True:
+        attempts += 1
+        try:
+            resp = client.get(f"{base}/api/health")
+            if resp.status_code == 200:
+                body = {}
+                try:
+                    body = resp.json() or {}
+                except ValueError:
+                    body = {}
+                if body.get("status") == "ok":
+                    elapsed = timeout_seconds - max(0.0, deadline - time.monotonic())
+                    db = body.get("database")
+                    detail = (
+                        f"healthy after {attempts} attempt(s), ~{elapsed:.0f}s "
+                        f"(database={db!r})"
+                    )
+                    # A reachable process with a broken DB is "up but degraded".
+                    # Treat it as healthy for the deploy gate (the process booted
+                    # and serves), but make the DB state visible in the detail.
+                    return _passed(name, detail)
+                last_detail = f"200 but body status != ok: {body!r}"
+            else:
+                last_detail = f"HTTP {resp.status_code}: {resp.text[:160]!r}"
+        except httpx.HTTPError as exc:
+            # ConnectError here is the crashed-boot signature: nothing listening.
+            last_detail = f"request error: {exc!r}"
+
+        if time.monotonic() >= deadline:
+            return _failed(
+                name,
+                f"/api/health never became healthy within {timeout_seconds:.0f}s "
+                f"({attempts} attempt(s)). Last: {last_detail}. A crashed or "
+                f"regressed deploy is the likely cause.",
+            )
+        time.sleep(poll_seconds)
+
+
+def main() -> int:
+    base = (os.environ.get("SMOKE_BASE_URL") or "").rstrip("/")
+    if not base:
+        print(
+            "ERROR: SMOKE_BASE_URL is required (the deployed backend base URL).\n"
+            "  e.g. SMOKE_BASE_URL=https://<deployed-backend> "
+            "python -m scripts.post_deploy_verify",
+            file=sys.stderr,
+        )
+        return 2
+
+    health_timeout = float(os.environ.get("POST_DEPLOY_HEALTH_TIMEOUT_SECONDS", "180"))
+    poll_seconds = float(os.environ.get("POST_DEPLOY_HEALTH_POLL_SECONDS", "5"))
+    req_timeout = float(os.environ.get("SMOKE_TIMEOUT_SECONDS", "15"))
+    tg_secret = os.environ.get("SMOKE_TELEGRAM_WEBHOOK_SECRET") or ""
+
+    print(f"Post-deploy verification against: {base}\n")
+
+    results: list[CheckResult] = []
+    # `follow_redirects=False`: a 302 to Strava must be observed as a redirect,
+    # not silently followed off-host (matches the handshake smoke).
+    with httpx.Client(timeout=req_timeout, follow_redirects=False) as client:
+        print(
+            f"Waiting for /api/health (timeout {health_timeout:.0f}s, "
+            f"poll {poll_seconds:.0f}s)...",
+            flush=True,
+        )
+        health = poll_health(client, base, health_timeout, poll_seconds)
+        results.append(health)
+        print(f"  [{health.status:4}] {health.name}: {health.detail}\n", flush=True)
+
+        # Only run the handshake smoke if the deploy is actually up; against a
+        # down deploy the gate checks would just pile redundant connection errors
+        # onto the health failure.
+        if health.ok:
+            results.extend(run_handshake_checks(client, base, tg_secret))
+
+    code = report_results(results, "Post-deploy verification")
+    if code != 0:
+        print("\nPOST-DEPLOY VERIFICATION FAILED.", file=sys.stderr)
+    else:
+        print("\nPost-deploy verification passed.")
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_post_deploy_verify.py
+++ b/backend/tests/test_post_deploy_verify.py
@@ -1,0 +1,129 @@
+"""Post-deploy verification logic (#550).
+
+`scripts.post_deploy_verify` is the release gate that turns "a human noticed the
+crash email" (the #546 outage) into an automated check: it polls the deployed
+`/api/health` until healthy, then runs the deployed handshake auth-gate smoke.
+
+These tests drive the two reusable pieces against an httpx MockTransport (no
+network, no real deploy): the health poll's pass/fail/retry verdicts, and the
+handshake-check seam's pass/skip/fail wiring. The handshake smoke's gate SEMANTICS
+are deployed/production-only (covered by the manual runbook and the auth unit
+tests); here we only verify post_deploy_verify reads the gate verdicts correctly.
+"""
+
+import httpx
+
+from scripts.deployed_handshake_smoke import run_handshake_checks
+from scripts.post_deploy_verify import poll_health
+
+_BASE = "http://testserver"
+
+
+def _client(handler) -> httpx.Client:
+    return httpx.Client(
+        transport=httpx.MockTransport(handler),
+        base_url=_BASE,
+        follow_redirects=False,
+    )
+
+
+# --- health poll ------------------------------------------------------------
+
+
+def test_poll_health_passes_when_healthy():
+    def handler(_request):
+        return httpx.Response(200, json={"status": "ok", "database": "ok"})
+
+    with _client(handler) as client:
+        result = poll_health(client, _BASE, timeout_seconds=2, poll_seconds=0.01)
+    assert result.status == "PASS"
+    assert "healthy" in result.detail
+
+
+def test_poll_health_passes_with_degraded_db_but_reachable():
+    # A reachable process with a broken DB still booted and serves: the deploy
+    # gate is "did the process come up", and the DB state is surfaced in detail.
+    def handler(_request):
+        return httpx.Response(200, json={"status": "ok", "database": "error: boom"})
+
+    with _client(handler) as client:
+        result = poll_health(client, _BASE, timeout_seconds=2, poll_seconds=0.01)
+    assert result.status == "PASS"
+    assert "error: boom" in result.detail
+
+
+def test_poll_health_fails_on_non_200():
+    def handler(_request):
+        return httpx.Response(503, text="nope")
+
+    with _client(handler) as client:
+        result = poll_health(client, _BASE, timeout_seconds=0, poll_seconds=0.01)
+    assert result.status == "FAIL"
+    assert "503" in result.detail
+
+
+def test_poll_health_fails_on_200_but_status_not_ok():
+    def handler(_request):
+        return httpx.Response(200, json={"status": "starting"})
+
+    with _client(handler) as client:
+        result = poll_health(client, _BASE, timeout_seconds=0, poll_seconds=0.01)
+    assert result.status == "FAIL"
+    assert "never became healthy" in result.detail
+
+
+def test_poll_health_fails_on_connection_refused():
+    # The crashed-boot signature: nothing listening -> ConnectError -> FAIL.
+    def handler(_request):
+        raise httpx.ConnectError("connection refused")
+
+    with _client(handler) as client:
+        result = poll_health(client, _BASE, timeout_seconds=0, poll_seconds=0.01)
+    assert result.status == "FAIL"
+    assert "never became healthy" in result.detail
+
+
+def test_poll_health_retries_until_healthy():
+    # The new deploy comes up on the 3rd poll; the poller must wait, not fail once.
+    state = {"calls": 0}
+
+    def handler(_request):
+        state["calls"] += 1
+        if state["calls"] < 3:
+            return httpx.Response(503, text="warming up")
+        return httpx.Response(200, json={"status": "ok", "database": "ok"})
+
+    with _client(handler) as client:
+        result = poll_health(client, _BASE, timeout_seconds=5, poll_seconds=0.01)
+    assert result.status == "PASS"
+    assert state["calls"] >= 3
+
+
+# --- handshake-check seam ---------------------------------------------------
+
+
+def _rejecting_handler(_request):
+    """All webhook gates reject (403) -- the deployed-healthy shape."""
+    return httpx.Response(403, text="forbidden")
+
+
+def test_handshake_checks_pass_when_gates_reject_and_skip_optional():
+    with _client(_rejecting_handler) as client:
+        results = run_handshake_checks(client, _BASE, tg_secret="")
+    by_status = [(r.name, r.status) for r in results]
+    statuses = {s for _, s in by_status}
+    assert "FAIL" not in statuses, by_status
+    # The optional Telegram no-op check is skipped without a secret.
+    assert any(s == "SKIP" for _, s in by_status)
+
+
+def test_handshake_checks_fail_when_a_gate_opens():
+    # A Strava event gate that returns 200 (accepts an unauthentic event) FAILs.
+    def handler(request):
+        if request.url.path == "/api/webhooks/strava" and request.method == "POST":
+            return httpx.Response(200, text="ok")
+        return httpx.Response(403, text="forbidden")
+
+    with _client(handler) as client:
+        results = run_handshake_checks(client, _BASE, tg_secret="")
+    assert any(r.status == "FAIL" for r in results)

--- a/project-context.md
+++ b/project-context.md
@@ -155,7 +155,7 @@ Data flow: Strava API → strava_ingestion → Activity/ActivityStream rows → 
 `frontend/lib/types/` holds domain types (`activity`, `chat`, `coach`, `metrics`, `profile`, `trends`, `voice` the P1.1 voice config + catalog types, `stance` the P1.3 stance config + catalog types, `material` the P4 user-materials read shape + kind/status types, `volume` the #400 volume-vs-norm read shape); `frontend/lib/types.ts` is the barrel.
 `frontend/scripts/smoke.mjs` is the readiness smoke harness that boots a mock API and Next dev server.
 `docker-compose.yml` defines Postgres 16 and Redis 7 services for local development.
-`Makefile` exposes `smoke`, `backend-smoke`, `frontend-smoke`, `test`, `backend-test`, `frontend-test`, `seed-local`, `eval` (run the M5 coach-report eval harness over the local DB, args via `EVAL_ARGS`), and `eval-selftest` (validate the harness against its synthetic fixtures, no DB/key needed).
+`Makefile` exposes `smoke`, `backend-smoke`, `frontend-smoke`, `test`, `backend-test`, `frontend-test`, `seed-local`, `eval` (run the M5 coach-report eval harness over the local DB, args via `EVAL_ARGS`), `eval-selftest` (validate the harness against its synthetic fixtures, no DB/key needed), `deployed-handshake-smoke` (the #540 deployed-only auth-gate smoke, `SMOKE_BASE_URL=...`), and `post-deploy-verify` (the #550 release gate: poll the deployed `/api/health` until healthy via `backend/scripts/post_deploy_verify.py`, then run the handshake smoke; `SMOKE_BASE_URL=...`).
 
 ## Testing Overview
 
@@ -165,7 +165,7 @@ Backend unit and policy coverage exists for analysis, coach context, coach schem
 Integration-tagged tests are excluded from the default regression run because they depend on local services or deeper cross-layer setup.
 Frontend regression runs via `npm run test`, which invokes `next lint` then `next build`; there is no Jest or component test runner configured.
 Frontend smoke runs via `npm run smoke` (`scripts/smoke.mjs`), which boots a mock API on `3001` and a Next dev server on `3100` and verifies core routes load.
-CI runs via `.github/workflows/deploy.yml` (workflow name `ci`) on push and pull requests to `main`, with a `backend-test` job (`make backend-test` on Python 3.12) and a `frontend-test` job (`npm run test` on Node 20); `.github/` also contains `copilot-instructions.md` and a `hooks/` directory.
+CI runs via `.github/workflows/deploy.yml` (workflow name `ci`) on push and pull requests to `main` (plus `workflow_dispatch`), with a `backend-test` job (`make backend-test` on Python 3.12), a `frontend-test` job (`npm run test` on Node 20), and a `post-deploy-verify` job (#550: runs only off PRs — on push to `main` and manual dispatch — after the test jobs; `make post-deploy-verify` against the `PROD_BACKEND_URL` secret to catch a crashed/regressed deploy, skipped cleanly when the secret is unset); `.github/` also contains `copilot-instructions.md` and a `hooks/` directory.
 Major gap: no automated frontend unit or component tests beyond the build-time lint and smoke route checks.
 Major gap: no end-to-end test that exercises a real Strava-to-coach-report flow.
 


### PR DESCRIPTION
Closes #550.

## Problem
A bad deploy reaching prod was caught only by a human noticing Railway`s crash email (#546). Nothing automated confirmed a new release was healthy.

## Change
- `backend/scripts/post_deploy_verify.py`: poll the deployed `/api/health` until 200+`status:ok` (timeout, default 180s - a new Railway deploy takes time to come up), then run the deployed handshake auth-gate smoke. A crashed boot (connection refused / never-healthy) FAILs.
- `deployed_handshake_smoke.py` refactored to expose `run_handshake_checks()` + `report_results()` so the verifier reuses the gate checks (no duplication).
- CI `post-deploy-verify` job: runs off PRs only (push to `main` + `workflow_dispatch`), after the test jobs, via `make post-deploy-verify` against the `PROD_BACKEND_URL` secret; a failure alerts via GitHub`s default notification. Skips cleanly when the secret is unset.
- `make post-deploy-verify` target; tests via httpx `MockTransport`.

## Owner action
Set repo secret `PROD_BACKEND_URL` (and optionally `PROD_TELEGRAM_WEBHOOK_SECRET`) or the job skips every run.

## Verification
New `test_post_deploy_verify.py` covers health-poll pass/fail/retry/connection-refused/non-ok and the handshake seam pass/skip/fail. Failure paths also run live against an unreachable host. CI YAML parses. Full backend suite green.