### PR TITLE
Add pre-deploy required-env preflight (#551)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test seed-local eval eval-selftest diagram-check verify-local deployed-handshake-smoke post-deploy-verify
+.PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test seed-local eval eval-selftest diagram-check verify-local deployed-handshake-smoke post-deploy-verify preflight-env-check
 
 # Prefer the project venv interpreter when it exists, fall back to bare python.
 # Path is relative to backend/ since the targets cd there first. CI has no
@@ -86,3 +86,14 @@ deployed-handshake-smoke:
 #   make post-deploy-verify SMOKE_BASE_URL=https://<deployed-backend>
 post-deploy-verify:
 	cd backend && $(BACKEND_PY) -m scripts.post_deploy_verify
+
+# Pre-deploy required-env preflight (#551): exit non-zero when a production deploy
+# is missing a required env var, BEFORE the process boots. Meant to run as the
+# Railway release command (in the deploy environment, where the vars live) so a
+# misconfigured release fails the deploy instead of crash-looping on boot and
+# taking prod down (the #546 failure mode). A no-op outside production unless
+# PREFLIGHT_FORCE=1. See docs/deployment/deploy-checklist.md for the wiring.
+#   APP_ENV=production make preflight-env-check          # the release-command form
+#   PREFLIGHT_FORCE=1 make preflight-env-check           # dry run against this env
+preflight-env-check:
+	cd backend && $(BACKEND_PY) -m scripts.preflight_env_check

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -27,6 +27,7 @@ except ImportError:
     _SENTRY_AVAILABLE = False
 
 from app.core.config import settings
+from app.core.required_env import REQUIRED_PRODUCTION_ENV
 
 
 _STANDARD_LOG_RECORD_FIELDS = frozenset(
@@ -161,11 +162,9 @@ class ProductionConfigError(RuntimeError):
 # healthy deploy live instead of cutting over to one that 503s. These are the
 # WEB process's HTTP gate settings only (web-only per docs/deployment/topology.md);
 # the worker serves no HTTP and is intentionally not gated by this (see worker.py).
-_REQUIRED_IN_PRODUCTION = (
-    "CLERK_JWKS_URL",
-    "BASIC_AUTH_USER",
-    "BASIC_AUTH_PASSWORD",
-)
+# The list itself lives in ``app.core.required_env`` so the pre-deploy preflight
+# (scripts.preflight_env_check, #551) shares one source of truth with this guard.
+_REQUIRED_IN_PRODUCTION = REQUIRED_PRODUCTION_ENV
 
 
 def assert_production_config() -> None:

--- a/backend/app/core/required_env.py
+++ b/backend/app/core/required_env.py
@@ -1,0 +1,49 @@
+"""Canonical list of env vars a production deploy needs, and a pure presence check.
+
+Single source of truth shared by two enforcers so they never drift:
+  - the boot guard ``observability.assert_production_config`` (reads resolved
+    ``Settings`` values, crashes the WEB boot when one is unset), and
+  - the pre-deploy preflight ``scripts.preflight_env_check`` (reads the raw deploy
+    environment, exits non-zero so a release command can block cutover BEFORE the
+    process boots -- #551).
+
+This module deliberately imports nothing heavy (no ``Settings``, no DB): the
+preflight must be able to read the required list and check ``os.environ`` without
+instantiating ``Settings`` (which requires ``DATABASE_URL``), so it runs as a thin
+release command and is trivially unit-testable against a synthetic environment.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Mapping
+
+# Env vars whose absence makes a production WEB deploy FAIL CLOSED (every route
+# 503s) WITHOUT crashing the boot -- the silent "up but broken" deploy that the
+# boot guard turns into a crash. CLERK_JWKS_URL empty -> every authenticated route
+# 503s; BASIC_AUTH_USER/PASSWORD empty -> every non-exempt route 503s. Web-only
+# (the worker serves no HTTP). Keep in sync with the guard's scope note in
+# ``observability.assert_production_config``.
+REQUIRED_PRODUCTION_ENV = (
+    "CLERK_JWKS_URL",
+    "BASIC_AUTH_USER",
+    "BASIC_AUTH_PASSWORD",
+)
+
+# Env vars BOTH the web and worker processes need to boot at all: ``DATABASE_URL``
+# is a required ``Settings`` field with no default, so its absence is a loud
+# pydantic crash rather than a silent 503. The preflight checks it too so a release
+# missing it is blocked before cutover rather than crash-looping on boot.
+REQUIRED_BASE_ENV = ("DATABASE_URL",)
+
+# The full set the pre-deploy preflight validates for a production release.
+REQUIRED_FOR_PRODUCTION_DEPLOY = REQUIRED_BASE_ENV + REQUIRED_PRODUCTION_ENV
+
+
+def missing_env(names: Iterable[str], env: Mapping[str, str]) -> List[str]:
+    """Return the names whose value in ``env`` is absent or whitespace-only.
+
+    A whitespace-only value (a fat-fingered blank secret) counts as missing, the
+    same boundary the boot guard's ``.strip()`` check applies, so a blank can never
+    satisfy the gate.
+    """
+    return [name for name in names if not str(env.get(name, "") or "").strip()]

--- a/backend/scripts/preflight_env_check.py
+++ b/backend/scripts/preflight_env_check.py
@@ -1,0 +1,91 @@
+"""Pre-deploy required-env preflight (#551).
+
+Validates that the env vars a production deploy needs are present BEFORE the
+process boots, so a release that is missing one is blocked at the release command
+rather than crash-looping on boot. The motivation is the #546 incident: a change
+needed an env set first, merged before it was set, and on Railway a crashed boot
+does NOT keep the prior healthy deploy serving (the old deploys were ``REMOVED``),
+so prod went fully down. A release command that exits non-zero BEFORE cutover is
+the stronger gate -- it fails the deploy while the old one keeps serving.
+
+Intended use: wire as the Railway *release command* on both the ``web`` and
+``worker`` services (it runs in the deploy environment, where the vars live),
+ahead of ``alembic upgrade head`` and the app start. See
+``docs/deployment/deploy-checklist.md`` for the wiring and the platform-behaviour
+caveat that must be verified before relying on it.
+
+Checks the canonical list in ``app.core.required_env`` (the same one the boot
+guard ``observability.assert_production_config`` enforces), reading the RAW deploy
+environment via ``os.environ`` so it needs no ``Settings`` instantiation (and thus
+no live ``DATABASE_URL``) just to report what is missing.
+
+Enforcement:
+  - Enforces when ``APP_ENV=production`` (the real release-command case) OR when
+    ``PREFLIGHT_FORCE`` is truthy (a dry run, or the self-test).
+  - Otherwise it is a no-op that exits 0, mirroring the boot guard: local dev and
+    the test suite run with these unset and must not fail.
+
+Exit code: 0 = all required vars present (or not enforcing); 1 = a required var is
+missing.
+
+Usage:
+    APP_ENV=production python -m scripts.preflight_env_check
+    PREFLIGHT_FORCE=1 python -m scripts.preflight_env_check   # dry run / self-test
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Mapping, Tuple
+
+from app.core.required_env import REQUIRED_FOR_PRODUCTION_DEPLOY, missing_env
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _is_truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in _TRUTHY
+
+
+def check(env: Mapping[str, str]) -> Tuple[int, str]:
+    """Pure check: return ``(exit_code, message)`` for the given environment.
+
+    Separated from ``main`` so it can be unit-tested against a synthetic env with
+    no process exit and no stdout coupling.
+    """
+    app_env = str(env.get("APP_ENV", "") or "").strip().lower()
+    force = _is_truthy(env.get("PREFLIGHT_FORCE"))
+    enforcing = force or app_env == "production"
+
+    if not enforcing:
+        return 0, (
+            f"preflight: skipped (APP_ENV={app_env or 'unset'!r}, not production; "
+            "set PREFLIGHT_FORCE=1 to check anyway)."
+        )
+
+    missing = missing_env(REQUIRED_FOR_PRODUCTION_DEPLOY, env)
+    if missing:
+        return 1, (
+            "preflight FAILED: required production env var(s) unset: "
+            + ", ".join(missing)
+            + ". A deploy missing these would fail closed (503 every route) or "
+            "crash on boot. Set them on every affected service, then redeploy. "
+            "See docs/deployment/deploy-checklist.md."
+        )
+    return 0, (
+        "preflight OK: all required production env vars are present ("
+        + ", ".join(REQUIRED_FOR_PRODUCTION_DEPLOY)
+        + ")."
+    )
+
+
+def main() -> int:
+    exit_code, message = check(os.environ)
+    stream = sys.stderr if exit_code != 0 else sys.stdout
+    print(message, file=stream)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_preflight_env_check.py
+++ b/backend/tests/test_preflight_env_check.py
@@ -1,0 +1,79 @@
+"""Pre-deploy required-env preflight (#551).
+
+The preflight is the release-command gate that exits non-zero BEFORE cutover when
+a production deploy is missing a required env var, so the deploy fails while the
+old one keeps serving instead of crash-looping on boot (the #546 failure mode).
+These tests pin the firing condition against a synthetic environment: enforce in
+production (or when forced) and fail on any missing var, stay a no-op otherwise.
+"""
+
+from app.core.required_env import REQUIRED_FOR_PRODUCTION_DEPLOY, missing_env
+from scripts.preflight_env_check import check
+
+# Clearly-fake values; never real secrets (aiw-security-testing rule 6).
+_COMPLETE_PROD_ENV = {
+    "APP_ENV": "production",
+    "DATABASE_URL": "postgresql://test-do-not-use/preflight",
+    "CLERK_JWKS_URL": "https://example-test.clerk.accounts.dev/.well-known/jwks.json",
+    "BASIC_AUTH_USER": "svc-test-do-not-use",
+    "BASIC_AUTH_PASSWORD": "test-secret-do-not-use-in-prod",
+}
+
+
+def test_noop_outside_production_even_when_all_unset():
+    # Local dev and the test suite run with every required var unset and degrade;
+    # the preflight must stay silent there, or it would block every non-prod run.
+    code, message = check({"APP_ENV": "local"})
+    assert code == 0
+    assert "skipped" in message
+
+
+def test_passes_in_production_when_fully_configured():
+    code, message = check(_COMPLETE_PROD_ENV)
+    assert code == 0
+    assert "OK" in message
+
+
+def test_forced_check_enforces_outside_production():
+    # PREFLIGHT_FORCE makes the check run even when APP_ENV is not production, so a
+    # dry run / self-test can exercise the failing path.
+    code, message = check({"APP_ENV": "local", "PREFLIGHT_FORCE": "1"})
+    assert code == 1
+    assert "FAILED" in message
+
+
+def test_fails_in_production_when_clerk_unset():
+    env = dict(_COMPLETE_PROD_ENV)
+    env["CLERK_JWKS_URL"] = ""
+    code, message = check(env)
+    assert code == 1
+    assert "CLERK_JWKS_URL" in message
+
+
+def test_fails_in_production_when_database_url_unset():
+    env = dict(_COMPLETE_PROD_ENV)
+    del env["DATABASE_URL"]
+    code, message = check(env)
+    assert code == 1
+    assert "DATABASE_URL" in message
+
+
+def test_error_lists_every_missing_var():
+    code, message = check({"APP_ENV": "production"})
+    assert code == 1
+    for name in REQUIRED_FOR_PRODUCTION_DEPLOY:
+        assert name in message
+
+
+def test_whitespace_only_value_counts_as_missing():
+    # A fat-fingered blank secret must be treated as unset (boundary on .strip()).
+    env = dict(_COMPLETE_PROD_ENV)
+    env["BASIC_AUTH_PASSWORD"] = "   "
+    code, message = check(env)
+    assert code == 1
+    assert "BASIC_AUTH_PASSWORD" in message
+
+
+def test_missing_env_helper_treats_blank_and_absent_alike():
+    env = {"A": "x", "B": "", "C": "   "}
+    assert missing_env(["A", "B", "C", "D"], env) == ["B", "C", "D"]

--- a/docs/deployment/deploy-checklist.md
+++ b/docs/deployment/deploy-checklist.md
@@ -59,15 +59,39 @@ config:
   that on Railway it means an outage, not a blocked promotion. See
   `assert_production_config`'s scope note.
 
+## Build-time required-env preflight (#551)
+
+`scripts/preflight_env_check.py` (`make preflight-env-check`) is the release-command
+gate: run in the deploy environment it exits non-zero when a required production env
+var is unset, *before* the process boots. The required list is the canonical one in
+`app/core/required_env.py` — the same `CLERK_JWKS_URL` / `BASIC_AUTH_USER` /
+`BASIC_AUTH_PASSWORD` the boot guard `assert_production_config` enforces, plus
+`DATABASE_URL` — so a release missing one fails the deploy instead of crash-looping
+on boot (the #546 failure mode). It is a no-op outside production unless
+`PREFLIGHT_FORCE=1`.
+
+### Why it is not a CI gate
+
+CI in GitHub cannot block the Railway deploy (Railway auto-deploys on the merge
+commit, independent of GitHub Actions) and cannot see Railway's per-service env
+anyway. The preflight only has authority where the env actually lives: as the
+**Railway release command**. The script's logic is covered by
+`backend/tests/test_preflight_env_check.py` in the normal `backend-test` run, so the
+gate itself can't silently rot; the post-deploy verification job (#550) remains the
+automated after-the-fact catch.
+
+### Owner actions to activate (platform config, not in-repo)
+
+1. **Verify the platform assumption first.** Wire `make preflight-env-check` (or
+   `python -m scripts.preflight_env_check`) as the Railway release command on the
+   `web` and `worker` services, then deliberately unset one required var on a
+   throwaway test service and confirm Railway **keeps the previous deploy serving**
+   when the release command exits non-zero — rather than removing it the way it did
+   for the boot crash in #546. Only rely on this gate once that holds.
+2. Once verified, leave it as the release command ahead of `alembic upgrade head`
+   and the app start, so a misconfigured release is blocked at deploy time.
+
 ## Deferred / open
 
-- **A build-time required-env preflight** (a release command that fails the
-  *deploy* before cutover, so the old deploy keeps serving) is the stronger
-  enforcement #551 floats, but it is deferred: it depends on Railway actually
-  preserving the previous deploy when a *release command* fails (distinct from a
-  boot crash), which is the same "platform keeps the old deploy" assumption #546
-  proved false for boot crashes and must be verified on the platform before we
-  rely on it. Wiring it (and the Railway release-command config) is tracked on
-  #551.
 - **A real staging environment** (its own backend + DB, not sharing prod) is the
   longer-term fix for the no-isolation gap and is out of scope here.


### PR DESCRIPTION
Closes #551 (the in-repo half; activation is an owner action, see below).

## Problem
Merging to `main` auto-deploys to prod. A change that needs an env var set *first* has no gate: in #546 the budget boot guard needed `LLM_BUDGET_*` set before it deployed, the merge auto-deployed first, both services crash-looped, and Railway did **not** keep the prior healthy deploy serving — so prod went fully down rather than the deploy being blocked.

## What this adds
`scripts/preflight_env_check.py` (`make preflight-env-check`): run in the deploy environment it exits non-zero when a required production env var is unset, **before** the process boots — so it can be wired as the Railway **release command** to fail the deploy instead of crash-looping.

- The canonical required list moves to `app/core/required_env.py` as one source of truth shared with the boot guard `assert_production_config` (the existing `CLERK_JWKS_URL` / `BASIC_AUTH_USER` / `BASIC_AUTH_PASSWORD`), extended with `DATABASE_URL`.
- No-op outside production unless `PREFLIGHT_FORCE=1`, mirroring the boot guard so local/dev/test runs are unaffected.

## Why it is not a CI gate
CI in GitHub cannot block Railway's auto-deploy (platform-triggered on the merge commit) and cannot see Railway's per-service env. The check only has authority where the env lives: the Railway release command. Its logic is covered by `backend-test`, and the post-deploy verification job (#550) stays the automated after-the-fact catch.

## Env changes
None. No new or changed env var is required by this PR.

## Owner actions to activate (platform config, documented in the deploy checklist)
1. **Verify the platform assumption first** — wire the preflight as the Railway release command on `web` + `worker`, then deliberately unset a required var on a throwaway service and confirm Railway keeps the previous deploy serving when the release command exits non-zero (the assumption #546 disproved for *boot* crashes; must hold for *release-command* failures before we rely on it).
2. Once verified, leave it as the release command ahead of `alembic upgrade head` + app start.

## Verification
- New `tests/test_preflight_env_check.py` (8 tests) + existing `tests/test_production_config.py` (refactor regression) — 14 passed.
- Script smoked end-to-end: skip outside prod (exit 0), missing var (exit 1, lists all), complete env (exit 0).
- `app.main` imports cleanly after the constant refactor.