### PR TITLE
Add global Strava call budget to protect the shared rate limit (#544)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -155,6 +155,26 @@ class Settings(BaseSettings):
     IMPORT_PAGE_SIZE: int = 50
     IMPORT_BATCH_PAUSE_SECONDS: int = 5
 
+    # Global Strava API call budget (#544). Strava rate-limits per APPLICATION
+    # (~100 req/15min, ~1000/day), shared across every connected athlete — not per
+    # user. The per-call 429 backoff in the HTTP adapter defers a single call but
+    # creates no capacity, so several runners onboarding at once (history backfill
+    # costs one streams call PER ACTIVITY) can exhaust the shared ceiling and starve
+    # everyone's webhook traffic. This Redis-backed global counter (clock-aligned to
+    # Strava's own 15-min + daily reset windows) is recorded on every metered Strava
+    # call and CHECKED only by the background jobs (import / stream backfill /
+    # self-heal); live webhook ingestion never consults it, so a just-finished run is
+    # always processed ("webhooks always win"). 0 = that window disabled, so the
+    # defaults are a NO-OP until the owner arms it with the deployed Strava app's
+    # CONFIRMED limits, leaving headroom below the real ceiling for the ungated
+    # webhook/live path. See app/services/strava_ingestion/strava_budget.py.
+    STRAVA_BUDGET_GLOBAL_PER_15MIN: int = 0
+    STRAVA_BUDGET_GLOBAL_PER_DAY: int = 0
+    # How long a background job waits before retrying when the global Strava budget
+    # is exhausted: it re-enqueues itself after this delay instead of calling Strava,
+    # yielding the shared ceiling to live webhook traffic.
+    STRAVA_BUDGET_BACKOFF_SECONDS: int = 60
+
     # Receipt cadence (#296, ADR 0010/0011 delta). Orthogonal to COACH_PROMPT_ID:
     # when True AND the active prompt is a two-stage message prompt, the post-activity
     # touchpoint becomes an INSTANT deterministic per-activity receipt (RPE/pain +

--- a/backend/app/jobs/backfill_streams.py
+++ b/backend/app/jobs/backfill_streams.py
@@ -134,12 +134,40 @@ def _schedule_next_batch(user_id: Optional[str] = None) -> None:
     )
 
 
+def _reschedule_after_budget(user_id: Optional[str] = None) -> None:
+    """Re-enqueue this batch after the Strava-budget backoff (#544), when the
+    shared budget is exhausted, so the chain resumes once capacity frees rather
+    than dropping the runner's backfill."""
+    from app.core.queue import queue
+
+    queue.enqueue_in(
+        timedelta(seconds=settings.STRAVA_BUDGET_BACKOFF_SECONDS),
+        backfill_streams_job,
+        user_id,
+    )
+
+
 def backfill_streams_job(user_id: Optional[str] = None) -> None:
     """RQ entrypoint. Runs one batch; if work remains, schedules the next.
 
     `user_id` scopes the eligible set to one runner (#470); the user-triggered
     path always supplies it, while an unscoped call still backfills globally.
+
+    Yields to the shared Strava budget (#544): each batch makes one streams call
+    per activity, the heaviest onboarding cost, so when the global budget is
+    exhausted this defers the whole batch (re-enqueues after the backoff) instead
+    of calling Strava, leaving the shared ceiling for live webhook traffic.
     """
+    from app.services.strava_ingestion.strava_budget import over_budget
+
+    if over_budget():
+        _reschedule_after_budget(user_id)
+        logger.info(
+            "Backfill deferred: Strava budget exhausted; retrying in %ds",
+            settings.STRAVA_BUDGET_BACKOFF_SECONDS,
+        )
+        return
+
     db = SessionLocal()
     try:
         result = asyncio.run(

--- a/backend/app/jobs/self_heal.py
+++ b/backend/app/jobs/self_heal.py
@@ -68,6 +68,17 @@ async def _run_self_heal(*, db, user_id) -> list[int]:
     if account is None:
         return []  # no linked Strava account — nothing to heal
 
+    # Yield to the shared Strava budget (#544): the self-heal is a best-effort
+    # safety net, so when the global budget is exhausted skip this check rather than
+    # spend a scarce call — the next app-open re-triggers it, and the live webhook
+    # path (which never gates) still ingests the run. Don't re-enqueue: the
+    # per-user throttle owns re-firing.
+    from app.services.strava_ingestion.strava_budget import over_budget
+
+    if over_budget():
+        logger.info("self_heal skipped for user %s: Strava budget exhausted", user_id)
+        return []
+
     strava_port = get_strava_port()
     since = datetime.now(timezone.utc) - _LOOKBACK
     try:

--- a/backend/app/jobs/strava_import.py
+++ b/backend/app/jobs/strava_import.py
@@ -176,8 +176,37 @@ def _schedule_next_batch(import_id: str) -> None:
     )
 
 
+def _reschedule_after_budget(import_id: str) -> None:
+    """Re-enqueue this import batch after the Strava-budget backoff (#544), when
+    the shared budget is exhausted, so the walk resumes once capacity frees."""
+    from app.core.queue import queue
+
+    queue.enqueue_in(
+        timedelta(seconds=settings.STRAVA_BUDGET_BACKOFF_SECONDS),
+        strava_import_job,
+        import_id,
+    )
+
+
 def strava_import_job(import_id: str) -> None:
-    """RQ entrypoint. Runs one batch; if work remains, schedules the next."""
+    """RQ entrypoint. Runs one batch; if work remains, schedules the next.
+
+    Yields to the shared Strava budget (#544): a runner's full-history walk is the
+    onboarding pressure this protects against, so when the global budget is
+    exhausted the batch defers (re-enqueues after the backoff, status left
+    ``running``) instead of calling Strava and starving live webhook traffic.
+    """
+    from app.services.strava_ingestion.strava_budget import over_budget
+
+    if over_budget():
+        _reschedule_after_budget(str(import_id))
+        logger.info(
+            "Historical import %s deferred: Strava budget exhausted; retrying in %ds",
+            import_id,
+            settings.STRAVA_BUDGET_BACKOFF_SECONDS,
+        )
+        return
+
     db = SessionLocal()
     try:
         import_obj = db.get(StravaImport, UUID(str(import_id)))

--- a/backend/app/services/strava_ingestion/http_adapter.py
+++ b/backend/app/services/strava_ingestion/http_adapter.py
@@ -7,6 +7,7 @@ import httpx
 
 from app.core.config import settings
 from app.services.strava_ingestion.port import Tokens
+from app.services.strava_ingestion.strava_budget import record as _record_strava_call
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,11 @@ async def _send_with_retry(
     response: httpx.Response | None = None
     for attempt in range(_MAX_RETRIES + 1):
         response = await request_fn()
+        # Every actual request — including a retry — counts against Strava's shared
+        # per-application rate limit, so record each one against the global budget
+        # (#544). This makes the counter honest about ALL metered traffic (webhook
+        # ingest included); only the background jobs gate on it, never the live path.
+        _record_strava_call()
         if response.status_code == 429 and attempt < _MAX_RETRIES:
             wait = _parse_retry_after(response, _BASE_BACKOFF_S * (2 ** attempt))
             logger.warning(

--- a/backend/app/services/strava_ingestion/strava_budget.py
+++ b/backend/app/services/strava_ingestion/strava_budget.py
@@ -1,0 +1,208 @@
+"""Global Strava API call budget — protect the shared per-application rate limit (#544).
+
+Strava rate-limits per APPLICATION (~100 req / 15 min, ~1000 / day), shared across
+every connected athlete, NOT per user. The per-call 429/Retry-After backoff in the
+HTTP adapter defers a single call but creates no capacity; with several runners
+onboarding at once (history backfill costs one streams call PER ACTIVITY) the shared
+ceiling can be exhausted, starving steady webhook traffic for everyone.
+
+This is the cross-user throttle the per-user pacing cannot provide: a Redis-backed
+global running call count over Strava's own reset windows, recorded on every metered
+Strava call (in the HTTP adapter) and CHECKED only by the background jobs (historical
+import, stream backfill, self-heal). LIVE webhook ingestion never consults it, so a
+just-finished run is always processed; only history backfill and the app-open safety
+net yield when the shared budget is tight ("webhooks always win").
+
+Windows are clock-aligned to Strava's accounting: a 15-minute bucket (Strava's short
+window resets on the quarter-hour) and a UTC day. Ceilings are configurable; 0 = that
+window disabled, so this is INERT until the owner arms it with the deployed app's
+CONFIRMED limits (set them BELOW the real ceiling to leave headroom for the ungated
+webhook/live path). Backend: Redis when reachable (cross-process — the worker makes
+the calls), else an in-process dict (local dev + the test suite). The gate degrades
+to permissive (not over budget) on any backend error: a throttle must never become an
+availability risk, and the adapter's 429 backoff remains the hard floor underneath.
+
+Deliberately parallel to app/services/coach/budget.py rather than shared: that meters
+USD per user/global for LLM spend, this meters call counts global-only for an external
+rate limit. The two have different units, scopes, and windows; collapsing them would
+couple unrelated concerns.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from typing import Dict, Optional
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Strava's short rate-limit window is a fixed 15 minutes aligned to the clock
+# quarter-hour; bucketing on floor(epoch / 900) tracks the same boundaries Strava
+# resets on, so the local count matches Strava's accounting rather than a private
+# rolling window.
+_WINDOW_15MIN_SECONDS = 900
+# Keep each window's counter alive a little past the window so a call near the
+# boundary still sees the accrued count.
+_15MIN_TTL = _WINDOW_15MIN_SECONDS * 2  # 30m
+_DAILY_TTL = 60 * 60 * 36  # 36h
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _bucket_15min(now: datetime) -> int:
+    return int(now.timestamp()) // _WINDOW_15MIN_SECONDS
+
+
+def _day_key(d: date) -> str:
+    return d.isoformat()
+
+
+@dataclass
+class _InMemoryBackend:
+    """A process-local call accumulator (tests + local dev without Redis)."""
+
+    counts: Dict[str, float] = field(default_factory=dict)
+
+    def incr(self, key: str, amount: int, ttl_seconds: int) -> None:
+        self.counts[key] = self.counts.get(key, 0.0) + amount
+
+    def get(self, key: str) -> float:
+        return self.counts.get(key, 0.0)
+
+
+class _RedisBackend:
+    """Cross-process call accumulator. INCRBY + EXPIRE per window key."""
+
+    def __init__(self, client) -> None:
+        self._r = client
+
+    def incr(self, key: str, amount: int, ttl_seconds: int) -> None:
+        pipe = self._r.pipeline()
+        pipe.incrby(key, amount)
+        pipe.expire(key, ttl_seconds)
+        pipe.execute()
+
+    def get(self, key: str) -> float:
+        raw = self._r.get(key)
+        return float(raw) if raw is not None else 0.0
+
+
+class StravaBudgetGate:
+    """The Strava call-rate gate. Reads ceilings from settings at call time so a
+    config flip (or a test monkeypatch) takes effect without rebuilding the gate."""
+
+    _PREFIX = "strava_budget"
+
+    def __init__(self, backend) -> None:
+        self._backend = backend
+
+    # --- ceilings (read live from settings; 0 = window disabled) ---
+    @property
+    def _per_15min(self) -> int:
+        return settings.STRAVA_BUDGET_GLOBAL_PER_15MIN
+
+    @property
+    def _per_day(self) -> int:
+        return settings.STRAVA_BUDGET_GLOBAL_PER_DAY
+
+    def _key(self, window: str) -> str:
+        return f"{self._PREFIX}:global:{window}"
+
+    def _keys(self, now: datetime) -> tuple[str, str]:
+        return (
+            self._key(f"15m:{_bucket_15min(now)}"),
+            self._key(f"day:{_day_key(now.date())}"),
+        )
+
+    def over_budget(self) -> bool:
+        """True when either enabled window is at or over its ceiling. Errors degrade
+        to False (permissive) so the throttle never becomes an availability risk."""
+        now = _now()
+        key_15m, key_day = self._keys(now)
+        try:
+            checks = (
+                (self._per_15min, key_15m),
+                (self._per_day, key_day),
+            )
+            for ceiling, key in checks:
+                if ceiling > 0 and self._backend.get(key) >= ceiling:
+                    logger.warning(
+                        "strava_budget_exceeded",
+                        extra={"key": key, "ceiling": ceiling},
+                    )
+                    return True
+            return False
+        except Exception as exc:  # noqa: BLE001 — a throttle must not break availability
+            logger.warning("strava_budget_check_failed", extra={"error": str(exc)})
+            return False
+
+    def record(self, calls: int = 1) -> None:
+        """Add ``calls`` (default 1) to both global windows. Never raises."""
+        if calls <= 0:
+            return
+        now = _now()
+        key_15m, key_day = self._keys(now)
+        try:
+            self._backend.incr(key_15m, calls, _15MIN_TTL)
+            self._backend.incr(key_day, calls, _DAILY_TTL)
+        except Exception as exc:  # noqa: BLE001 — recording must never break a call
+            logger.warning("strava_budget_record_failed", extra={"error": str(exc)})
+
+
+# --- module-level gate (lazy, swappable in tests) --------------------------
+
+_gate: Optional[StravaBudgetGate] = None
+_gate_lock = threading.Lock()
+
+
+def _build_gate() -> StravaBudgetGate:
+    """A Redis-backed gate when REDIS_URL is reachable, else an in-process one."""
+    try:
+        import redis
+
+        client = redis.from_url(settings.REDIS_URL, socket_connect_timeout=1)
+        client.ping()
+        return StravaBudgetGate(_RedisBackend(client))
+    except Exception as exc:  # noqa: BLE001 — no Redis -> degrade to in-process
+        logger.info("strava_budget_using_in_memory_backend", extra={"reason": str(exc)})
+        return StravaBudgetGate(_InMemoryBackend())
+
+
+def get_gate() -> StravaBudgetGate:
+    global _gate
+    if _gate is None:
+        with _gate_lock:
+            if _gate is None:
+                _gate = _build_gate()
+    return _gate
+
+
+def set_gate(gate: Optional[StravaBudgetGate]) -> None:
+    """Test seam: inject a controlled gate (None resets to lazy rebuild)."""
+    global _gate
+    with _gate_lock:
+        _gate = gate
+
+
+def new_in_memory_gate() -> StravaBudgetGate:
+    """A fresh in-process gate, for tests that drive the count over a ceiling."""
+    return StravaBudgetGate(_InMemoryBackend())
+
+
+def over_budget() -> bool:
+    """True when the shared Strava call budget is exhausted for the current window.
+
+    Consulted ONLY by background jobs; the live webhook path never calls this.
+    """
+    return get_gate().over_budget()
+
+
+def record(calls: int = 1) -> None:
+    """Record ``calls`` metered Strava request(s) against the global budget."""
+    get_gate().record(calls)

--- a/backend/tests/test_self_heal.py
+++ b/backend/tests/test_self_heal.py
@@ -135,6 +135,26 @@ async def test_self_heal_degrades_when_strava_unreachable(db):
     fake_queue.enqueue.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_self_heal_skips_when_strava_budget_exhausted(db, monkeypatch):
+    """When the shared Strava budget is exhausted (#544), the self-heal yields:
+    it spends no Strava call and enqueues nothing, leaving the scarce shared
+    capacity for the live webhook path. The next app-open re-triggers it."""
+    from app.services.strava_ingestion import strava_budget
+
+    user = _seed_account(db, email="a@heal.dev", athlete_id=1)
+    monkeypatch.setattr(strava_budget, "over_budget", lambda: True)
+    port = _fake_port([900])
+    with patch.object(self_heal, "get_strava_port", return_value=port), \
+         patch.object(self_heal, "ensure_valid_access_token", new=AsyncMock(return_value="tok")), \
+         patch.object(self_heal, "queue", MagicMock()) as fake_queue:
+        new_ids = await _run_self_heal(db=db, user_id=user.id)
+
+    assert new_ids == []
+    port.list_recent_activities.assert_not_called()  # no Strava call spent
+    fake_queue.enqueue.assert_not_called()
+
+
 # --- the endpoint --------------------------------------------------------------
 
 def test_refresh_endpoint_triggers_bounded_check(client, db):

--- a/backend/tests/test_strava_budget.py
+++ b/backend/tests/test_strava_budget.py
@@ -1,0 +1,200 @@
+"""Global Strava API call budget (#544).
+
+Strava rate-limits per APPLICATION, shared across every athlete; with several
+runners onboarding at once the per-activity streams cost can exhaust the shared
+ceiling and starve everyone's webhooks. These tests pin the throttle: a global
+call counter over Strava's reset windows, recorded on every metered call, that the
+background jobs consult and defer on — while the live webhook path never gates and
+the gate degrades permissive (never an availability risk).
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.core.config import settings
+from app.services.strava_ingestion import HTTPStravaAdapter
+from app.services.strava_ingestion import strava_budget
+from app.services.strava_ingestion.strava_budget import (
+    StravaBudgetGate,
+    _InMemoryBackend,
+    new_in_memory_gate,
+)
+
+
+@pytest.fixture
+def gate():
+    return StravaBudgetGate(_InMemoryBackend())
+
+
+def _arm(monkeypatch, *, per_15min=0, per_day=0):
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_GLOBAL_PER_15MIN", per_15min)
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_GLOBAL_PER_DAY", per_day)
+
+
+# --- the gate ------------------------------------------------------------------
+
+def test_inert_when_ceilings_zero(gate, monkeypatch):
+    # Default config: both windows disabled -> never over budget, however many
+    # calls are recorded. This is what makes the PR behaviour-preserving until the
+    # owner arms it with the deployed app's real limits.
+    _arm(monkeypatch, per_15min=0, per_day=0)
+    for _ in range(1000):
+        gate.record()
+    assert gate.over_budget() is False
+
+
+def test_trips_on_15min_ceiling(gate, monkeypatch):
+    _arm(monkeypatch, per_15min=3)
+    gate.record()
+    gate.record()
+    assert gate.over_budget() is False  # 2 < 3
+    gate.record()
+    assert gate.over_budget() is True  # 3 >= 3
+
+
+def test_trips_on_daily_ceiling_independently(gate, monkeypatch):
+    # The daily window trips on its own even when the 15-min window is disabled.
+    _arm(monkeypatch, per_15min=0, per_day=5)
+    gate.record(calls=5)
+    assert gate.over_budget() is True
+
+
+def test_15min_window_is_clock_aligned_and_rolls_over(gate, monkeypatch):
+    _arm(monkeypatch, per_15min=2)
+    t0 = datetime(2026, 6, 27, 10, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(strava_budget, "_now", lambda: t0)
+    gate.record(calls=2)
+    assert gate.over_budget() is True
+    # 16 minutes later is a new clock-aligned 15-min bucket: the count resets.
+    monkeypatch.setattr(
+        strava_budget, "_now", lambda: datetime(2026, 6, 27, 10, 16, 0, tzinfo=timezone.utc)
+    )
+    assert gate.over_budget() is False
+
+
+def test_record_of_zero_or_negative_is_a_noop(gate, monkeypatch):
+    _arm(monkeypatch, per_15min=1)
+    gate.record(calls=0)
+    gate.record(calls=-5)
+    assert gate.over_budget() is False
+
+
+def test_over_budget_is_permissive_on_backend_error(monkeypatch):
+    # A throttle must never become an availability risk: a backend that raises
+    # reads as NOT over budget (the adapter's 429 backoff is the hard floor).
+    failing = MagicMock()
+    failing.get.side_effect = RuntimeError("redis down")
+    g = StravaBudgetGate(failing)
+    _arm(monkeypatch, per_15min=1)
+    assert g.over_budget() is False
+
+
+def test_record_never_raises_on_backend_error(monkeypatch):
+    failing = MagicMock()
+    failing.incr.side_effect = RuntimeError("redis down")
+    g = StravaBudgetGate(failing)
+    g.record()  # must not raise
+
+
+def test_module_wrappers_use_injected_singleton(monkeypatch):
+    _arm(monkeypatch, per_15min=1)
+    strava_budget.set_gate(new_in_memory_gate())
+    try:
+        assert strava_budget.over_budget() is False
+        strava_budget.record()
+        assert strava_budget.over_budget() is True
+    finally:
+        strava_budget.set_gate(None)
+
+
+# --- recording flows through the HTTP adapter ----------------------------------
+
+def _install_seq_transport(monkeypatch, responses):
+    queued = list(responses)
+
+    async def handler(request):
+        return queued.pop(0)
+
+    original_init = httpx.AsyncClient.__init__
+
+    def patched_init(self, *args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+
+
+@pytest.fixture
+def _no_real_sleep():
+    with patch(
+        "app.services.strava_ingestion.http_adapter.asyncio.sleep", new=AsyncMock()
+    ):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_adapter_records_one_call_per_request(monkeypatch):
+    g = new_in_memory_gate()
+    strava_budget.set_gate(g)
+    try:
+        _install_seq_transport(monkeypatch, [httpx.Response(200, json={"id": 1})])
+        await HTTPStravaAdapter().get_activity("token", 1)
+        assert g._backend.get(g._key(f"15m:{strava_budget._bucket_15min(strava_budget._now())}")) == 1
+    finally:
+        strava_budget.set_gate(None)
+
+
+@pytest.mark.asyncio
+async def test_adapter_records_each_retry_against_the_budget(monkeypatch, _no_real_sleep):
+    # Every actual request counts against Strava's limit, so a 429-then-200 records
+    # TWO calls -- the retry is real traffic, not free.
+    g = new_in_memory_gate()
+    strava_budget.set_gate(g)
+    try:
+        _install_seq_transport(
+            monkeypatch,
+            [
+                httpx.Response(429, headers={"Retry-After": "0"}, json={}),
+                httpx.Response(200, json={"id": 1}),
+            ],
+        )
+        await HTTPStravaAdapter().get_activity("token", 1)
+        key = g._key(f"15m:{strava_budget._bucket_15min(strava_budget._now())}")
+        assert g._backend.get(key) == 2
+    finally:
+        strava_budget.set_gate(None)
+
+
+# --- background jobs defer when over budget; the live path never gates ----------
+
+def test_backfill_job_defers_when_over_budget(monkeypatch):
+    import app.jobs.backfill_streams as bf
+
+    monkeypatch.setattr(strava_budget, "over_budget", lambda: True)
+    enqueue_in = MagicMock()
+    monkeypatch.setattr("app.core.queue.queue.enqueue_in", enqueue_in)
+    session_local = MagicMock()
+    monkeypatch.setattr(bf, "SessionLocal", session_local)
+
+    bf.backfill_streams_job("user-1")
+
+    session_local.assert_not_called()  # no batch ran -> no Strava calls
+    enqueue_in.assert_called_once()  # rescheduled after the backoff
+
+
+def test_import_job_defers_when_over_budget(monkeypatch):
+    import app.jobs.strava_import as si
+
+    monkeypatch.setattr(strava_budget, "over_budget", lambda: True)
+    enqueue_in = MagicMock()
+    monkeypatch.setattr("app.core.queue.queue.enqueue_in", enqueue_in)
+    session_local = MagicMock()
+    monkeypatch.setattr(si, "SessionLocal", session_local)
+
+    si.strava_import_job("00000000-0000-0000-0000-000000000000")
+
+    session_local.assert_not_called()
+    enqueue_in.assert_called_once()


### PR DESCRIPTION
Closes #544 (the in-repo mechanism; arming it with the deployed app's real limits is an owner action, see below).

## Problem
Strava rate-limits per **application** (~100 req/15min, ~1000/day), shared across every connected athlete. The per-call 429/Retry-After backoff in `HTTPStravaAdapter` defers a single call but creates no capacity. With several runners onboarding at once — history backfill costs one streams call **per activity** — the shared ceiling can be exhausted, starving steady webhook traffic for everyone. The existing per-user pacing (`BACKFILL_BATCH_SIZE`, self-heal interval) bounds a single user but does not coordinate across users.

## What this adds
A Redis-backed **global** Strava call counter over Strava's own reset windows (a clock-aligned 15-min bucket + a UTC day), mirroring the proven LLM-budget module:

- **Recorded** on every metered Strava call at the single adapter chokepoint (`_send_with_retry`), so the counter is honest about all traffic including webhook ingest (each retry counts — it is real traffic).
- **Checked only by the background jobs** (historical import, stream backfill, self-heal). When the shared budget is exhausted they yield: import/backfill re-enqueue after a backoff; self-heal skips (re-triggered on the next app-open).

## Fairness policy: webhooks always win
The **live webhook path never gates**, so a just-finished run is always processed; only history backfill and the app-open safety net defer when the shared budget is tight. (This was the chosen option.)

## Behaviour-preserving by default
Ceilings default to **0 = window disabled**, so the gate is **inert** until armed — `over_budget()` is always False and there is zero behaviour change. Full backend suite green (1838 passed). The gate degrades **permissive** on a backend error (a throttle must never become an availability risk); the adapter's 429 backoff remains the hard floor underneath.

## Env changes
New settings, all with safe defaults (no required env, no deploy-ordering risk):
- `STRAVA_BUDGET_GLOBAL_PER_15MIN` (default `0` = off)
- `STRAVA_BUDGET_GLOBAL_PER_DAY` (default `0` = off)
- `STRAVA_BUDGET_BACKOFF_SECONDS` (default `60`)

Belongs on the Railway **worker** (where the background jobs run; `web` is harmless to set too).

## Owner action to arm it
Confirm the deployed Strava application's **actual** rate limits + athlete cap on the Strava developer dashboard (the external ceiling to design against, per the issue), then set `STRAVA_BUDGET_GLOBAL_PER_15MIN` / `PER_DAY` **below** the real ceiling so the ungated live webhook path keeps headroom. Until then it is inert.

## Not covered / follow-ups
- Real cross-process Redis behaviour is not exercised here (tests use the in-process backend); the Redis backend mirrors the LLM budget's proven `incrby`/`expire`/`get` path.
- OAuth `exchange_code`/`refresh_token` bypass `_send_with_retry` and are not metered (negligible volume — 1 per onboarding / per token refresh).
- End-to-end onboarding-fairness under real concurrent load is an operational verification once armed.

## Verification
- `tests/test_strava_budget.py` (11 tests): inert-by-default, both ceilings, clock-aligned window rollover, permissive-on-error, no-op record, singleton wrappers, adapter records 1/request and 2/retry, backfill + import defer when over budget.
- `tests/test_self_heal.py`: new skip-when-over-budget branch (no Strava call, no enqueue).
- Full `make backend-test`: 1838 passed, 6 deselected.