### PR TITLE
Arm the Strava budget by default in production (#544 follow-up)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -164,16 +164,33 @@ class Settings(BaseSettings):
     # Strava's own 15-min + daily reset windows) is recorded on every metered Strava
     # call and CHECKED only by the background jobs (import / stream backfill /
     # self-heal); live webhook ingestion never consults it, so a just-finished run is
-    # always processed ("webhooks always win"). 0 = that window disabled, so the
-    # defaults are a NO-OP until the owner arms it with the deployed Strava app's
-    # CONFIRMED limits, leaving headroom below the real ceiling for the ungated
-    # webhook/live path. See app/services/strava_ingestion/strava_budget.py.
+    # always processed ("webhooks always win"). 0 here = no EXPLICIT ceiling for that
+    # window; in production the safety backstop below still arms a default, so prod is
+    # protected without the owner having to set these. Set either to the deployed
+    # Strava app's CONFIRMED limit (below the real ceiling, to keep live headroom) to
+    # override the backstop. See app/services/strava_ingestion/strava_budget.py.
     STRAVA_BUDGET_GLOBAL_PER_15MIN: int = 0
     STRAVA_BUDGET_GLOBAL_PER_DAY: int = 0
     # How long a background job waits before retrying when the global Strava budget
     # is exhausted: it re-enqueues itself after this delay instead of calling Strava,
     # yielding the shared ceiling to live webhook traffic.
     STRAVA_BUDGET_BACKOFF_SECONDS: int = 60
+    # Production safety backstop (mirrors the LLM budget's #549 pattern). When
+    # APP_ENV=production and the matching explicit ceiling above is 0 (unset) and the
+    # budget is not disabled, the gate falls back to these values, so prod is
+    # protected by DEFAULT without the owner having to arm it. Set BELOW Strava's
+    # standard application limits (~100 req/15min, ~1000/day) so the gap between this
+    # ceiling and Strava's real limit stays reserved for the ungated live webhook
+    # path: once total recorded calls hit this ceiling only the background jobs pause,
+    # leaving the remainder for live ingest. A single backfill paces under this
+    # already (BACKFILL_BATCH_SIZE = ~60/15min), so the default only bites when
+    # MULTIPLE background chains pile up (concurrent onboarding) — exactly the #544
+    # case. Override a window with the confirmed limit, or set STRAVA_BUDGET_DISABLED
+    # to run prod deliberately unthrottled. 0 turns a backstop window off. Outside
+    # production these are inert (local/test never throttle).
+    STRAVA_BUDGET_DISABLED: bool = False
+    STRAVA_BUDGET_PROD_DEFAULT_PER_15MIN: int = 75
+    STRAVA_BUDGET_PROD_DEFAULT_PER_DAY: int = 800
 
     # Receipt cadence (#296, ADR 0010/0011 delta). Orthogonal to COACH_PROMPT_ID:
     # when True AND the active prompt is a two-stage message prompt, the post-activity

--- a/backend/app/services/strava_ingestion/strava_budget.py
+++ b/backend/app/services/strava_ingestion/strava_budget.py
@@ -14,11 +14,13 @@ just-finished run is always processed; only history backfill and the app-open sa
 net yield when the shared budget is tight ("webhooks always win").
 
 Windows are clock-aligned to Strava's accounting: a 15-minute bucket (Strava's short
-window resets on the quarter-hour) and a UTC day. Ceilings are configurable; 0 = that
-window disabled, so this is INERT until the owner arms it with the deployed app's
-CONFIRMED limits (set them BELOW the real ceiling to leave headroom for the ungated
-webhook/live path). Backend: Redis when reachable (cross-process — the worker makes
-the calls), else an in-process dict (local dev + the test suite). The gate degrades
+window resets on the quarter-hour) and a UTC day. An explicit ceiling always wins, but
+in PRODUCTION an unset window falls back to a safety backstop (mirroring the LLM
+budget's #549 pattern), so prod is protected BY DEFAULT without the owner arming it —
+set below Strava's real ceiling to leave headroom for the ungated webhook/live path.
+Outside production an unset window is disabled (0), so local dev and the test suite
+never throttle. Backend: Redis when reachable (cross-process — the worker makes the
+calls), else an in-process dict (local dev + the test suite). The gate degrades
 to permissive (not over budget) on any backend error: a throttle must never become an
 availability risk, and the adapter's 429 backoff remains the hard floor underneath.
 
@@ -63,6 +65,32 @@ def _day_key(d: date) -> str:
     return d.isoformat()
 
 
+def production_default_per_15min() -> int:
+    """The 15-min ceiling the production safety backstop applies, else 0.
+
+    In production, when no explicit 15-min ceiling is set and the budget is not
+    disabled, prod must not run silently unthrottled (the #544 onboarding hazard);
+    the gate falls back to a default below Strava's real limit so prod is protected
+    without an owner action. Returns 0 (backstop inactive) outside production or when
+    the budget is deliberately disabled.
+    """
+    if settings.APP_ENV != "production":
+        return 0
+    if settings.STRAVA_BUDGET_DISABLED:
+        return 0
+    return settings.STRAVA_BUDGET_PROD_DEFAULT_PER_15MIN
+
+
+def production_default_per_day() -> int:
+    """The daily ceiling the production safety backstop applies, else 0. Mirrors
+    ``production_default_per_15min`` for the daily window."""
+    if settings.APP_ENV != "production":
+        return 0
+    if settings.STRAVA_BUDGET_DISABLED:
+        return 0
+    return settings.STRAVA_BUDGET_PROD_DEFAULT_PER_DAY
+
+
 @dataclass
 class _InMemoryBackend:
     """A process-local call accumulator (tests + local dev without Redis)."""
@@ -102,14 +130,17 @@ class StravaBudgetGate:
     def __init__(self, backend) -> None:
         self._backend = backend
 
-    # --- ceilings (read live from settings; 0 = window disabled) ---
+    # --- ceilings (read live from settings) ---
+    # An explicit ceiling always wins; otherwise the production safety backstop may
+    # supply a default so prod is never silently unthrottled. 0 (window off) when
+    # neither applies (outside production, or deliberately disabled).
     @property
     def _per_15min(self) -> int:
-        return settings.STRAVA_BUDGET_GLOBAL_PER_15MIN
+        return settings.STRAVA_BUDGET_GLOBAL_PER_15MIN or production_default_per_15min()
 
     @property
     def _per_day(self) -> int:
-        return settings.STRAVA_BUDGET_GLOBAL_PER_DAY
+        return settings.STRAVA_BUDGET_GLOBAL_PER_DAY or production_default_per_day()
 
     def _key(self, window: str) -> str:
         return f"{self._PREFIX}:global:{window}"

--- a/backend/tests/test_strava_budget.py
+++ b/backend/tests/test_strava_budget.py
@@ -110,6 +110,51 @@ def test_module_wrappers_use_injected_singleton(monkeypatch):
         strava_budget.set_gate(None)
 
 
+# --- production safety backstop ------------------------------------------------
+
+def test_backstop_arms_a_default_in_production_when_unset(gate, monkeypatch):
+    # No explicit ceiling, but APP_ENV=production and not disabled -> the backstop
+    # arms a default below Strava's real limit, so prod is protected with no owner
+    # action. This is what makes #544 deliver without manual arming.
+    monkeypatch.setattr(settings, "APP_ENV", "production")
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_GLOBAL_PER_15MIN", 0)
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_DISABLED", False)
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_PROD_DEFAULT_PER_15MIN", 75)
+
+    assert gate._per_15min == 75
+    gate.record(calls=74)
+    assert gate.over_budget() is False
+    gate.record()
+    assert gate.over_budget() is True
+
+
+def test_backstop_inert_outside_production(gate, monkeypatch):
+    monkeypatch.setattr(settings, "APP_ENV", "local")
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_GLOBAL_PER_15MIN", 0)
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_GLOBAL_PER_DAY", 0)
+    gate.record(calls=10_000)
+    assert gate.over_budget() is False  # local/test never throttle
+
+
+def test_explicit_ceiling_overrides_backstop_in_production(gate, monkeypatch):
+    monkeypatch.setattr(settings, "APP_ENV", "production")
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_GLOBAL_PER_15MIN", 10)
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_PROD_DEFAULT_PER_15MIN", 75)
+    assert gate._per_15min == 10  # the explicit value wins, not the backstop
+
+
+def test_disabled_suppresses_backstop_in_production(gate, monkeypatch):
+    # The deliberate-unthrottled escape hatch: prod runs with no Strava throttle.
+    monkeypatch.setattr(settings, "APP_ENV", "production")
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_GLOBAL_PER_15MIN", 0)
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_GLOBAL_PER_DAY", 0)
+    monkeypatch.setattr(settings, "STRAVA_BUDGET_DISABLED", True)
+    assert gate._per_15min == 0
+    assert gate._per_day == 0
+    gate.record(calls=10_000)
+    assert gate.over_budget() is False
+
+
 # --- recording flows through the HTTP adapter ----------------------------------
 
 def _install_seq_transport(monkeypatch, responses):


### PR DESCRIPTION
Follow-up to #544 (PR #557). Makes the global Strava budget deliver protection **without an owner action**.

## Why
#557 shipped the budget defaulting to `0` = inert, so it protected nothing until the owner confirmed Strava's limits and set the ceilings. That left a pending owner action. This removes it by mirroring the LLM budget's #549 **production safety backstop**.

## What
When `APP_ENV=production`, a window's explicit ceiling is unset (`0`), and the budget is not disabled, the gate falls back to:
- `STRAVA_BUDGET_PROD_DEFAULT_PER_15MIN` = **75**
- `STRAVA_BUDGET_PROD_DEFAULT_PER_DAY` = **800**

Set below Strava's standard application limits (~100/15min, ~1000/day) so the gap stays reserved for the **ungated live webhook path**: once total recorded calls hit the ceiling only background jobs pause; live ingest uses the remainder. An explicit ceiling still wins; `STRAVA_BUDGET_DISABLED` is the deliberate-unthrottled escape hatch. Outside production the backstop is inert (local/test never throttle).

## Behaviour impact
This **does** arm an active throttle in prod by default — but it is effectively inert at the current single-user scale: a single backfill already paces at ~60/15min (under the 75 ceiling), so the default only bites when **multiple** background chains pile up during concurrent onboarding, which is exactly the #544 hazard. No required env, no deploy-ordering risk (self-contained safe defaults).

## Remaining owner option (no longer required)
Confirm the deployed Strava app's actual limits on the dashboard and override `STRAVA_BUDGET_GLOBAL_PER_15MIN`/`PER_DAY` for a tuned ceiling. Until then the backstop protects prod.

## Verification
- `tests/test_strava_budget.py`: backstop arms in production-unconfigured, inert outside production, explicit ceiling overrides it, `DISABLED` suppresses it.
- Full `make backend-test`: 1850 passed, 6 deselected.