### PR TITLE
Make the #551 preflight runnable as a Railway Pre-Deploy Command

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -43,6 +43,11 @@ COPY --chown=app:app app ./app
 COPY --chown=app:app alembic ./alembic
 COPY --chown=app:app alembic.ini ./alembic.ini
 COPY --chown=app:app pyproject.toml ./pyproject.toml
+# Ops scripts run inside the image as Railway commands: the #551 pre-deploy
+# env preflight (python -m scripts.preflight_env_check) is wired as the service
+# Pre-Deploy Command, so the deploy fails before cutover when a required env is
+# unset. See docs/deployment/deploy-checklist.md.
+COPY --chown=app:app scripts ./scripts
 
 USER app
 

--- a/backend/app/core/required_env.py
+++ b/backend/app/core/required_env.py
@@ -35,8 +35,28 @@ REQUIRED_PRODUCTION_ENV = (
 # missing it is blocked before cutover rather than crash-looping on boot.
 REQUIRED_BASE_ENV = ("DATABASE_URL",)
 
-# The full set the pre-deploy preflight validates for a production release.
+# The full set the pre-deploy preflight validates for a production WEB release.
 REQUIRED_FOR_PRODUCTION_DEPLOY = REQUIRED_BASE_ENV + REQUIRED_PRODUCTION_ENV
+
+# Per-service required sets for the pre-deploy preflight, since env is per-service
+# on Railway. The ``web`` process needs the full set (the fail-closed HTTP gates +
+# the DB); the ``worker`` serves no HTTP, so it needs only the base (``DATABASE_URL``).
+# Running the web set on the worker would wrongly require the Clerk/basic-auth gates
+# there. ``web`` is the strict default for any unknown scope, so a typo never
+# under-checks.
+REQUIRED_BY_SCOPE = {
+    "web": REQUIRED_FOR_PRODUCTION_DEPLOY,
+    "worker": REQUIRED_BASE_ENV,
+}
+
+
+def required_for_scope(scope: str) -> tuple[str, ...]:
+    """The required env names for a service ``scope`` (web | worker).
+
+    An unknown scope falls back to the strict ``web`` set, so a mistyped flag fails
+    safe (over-checks) rather than silently passing an under-checked deploy.
+    """
+    return REQUIRED_BY_SCOPE.get(scope, REQUIRED_FOR_PRODUCTION_DEPLOY)
 
 
 def missing_env(names: Iterable[str], env: Mapping[str, str]) -> List[str]:

--- a/backend/scripts/preflight_env_check.py
+++ b/backend/scripts/preflight_env_check.py
@@ -8,16 +8,23 @@ does NOT keep the prior healthy deploy serving (the old deploys were ``REMOVED``
 so prod went fully down. A release command that exits non-zero BEFORE cutover is
 the stronger gate -- it fails the deploy while the old one keeps serving.
 
-Intended use: wire as the Railway *release command* on both the ``web`` and
-``worker`` services (it runs in the deploy environment, where the vars live),
-ahead of ``alembic upgrade head`` and the app start. See
-``docs/deployment/deploy-checklist.md`` for the wiring and the platform-behaviour
-caveat that must be verified before relying on it.
+Intended use: wire as the Railway **Pre-Deploy Command** on each service (it runs
+in the deploy environment, where the vars live, and Railway fails the deploy and
+keeps the previous one serving when it exits non-zero). Env is per-service on
+Railway, so pass the service scope:
 
-Checks the canonical list in ``app.core.required_env`` (the same one the boot
-guard ``observability.assert_production_config`` enforces), reading the RAW deploy
-environment via ``os.environ`` so it needs no ``Settings`` instantiation (and thus
-no live ``DATABASE_URL``) just to report what is missing.
+    web service Pre-Deploy Command:    python -m scripts.preflight_env_check --scope web
+    worker service Pre-Deploy Command: python -m scripts.preflight_env_check --scope worker
+
+The ``web`` scope checks the fail-closed HTTP gate vars + the DB; the ``worker``
+scope checks only ``DATABASE_URL`` (it serves no HTTP). See
+``docs/deployment/deploy-checklist.md`` for the full wiring and the platform-
+behaviour caveat that must be verified before relying on it.
+
+Checks the canonical per-scope list in ``app.core.required_env`` (the web set is
+the same one the boot guard ``observability.assert_production_config`` enforces),
+reading the RAW deploy environment via ``os.environ`` so it needs no ``Settings``
+instantiation (and thus no live ``DATABASE_URL``) just to report what is missing.
 
 Enforcement:
   - Enforces when ``APP_ENV=production`` (the real release-command case) OR when
@@ -29,7 +36,7 @@ Exit code: 0 = all required vars present (or not enforcing); 1 = a required var 
 missing.
 
 Usage:
-    APP_ENV=production python -m scripts.preflight_env_check
+    APP_ENV=production python -m scripts.preflight_env_check --scope web
     PREFLIGHT_FORCE=1 python -m scripts.preflight_env_check   # dry run / self-test
 """
 
@@ -37,9 +44,9 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Mapping, Tuple
+from typing import Mapping, Sequence, Tuple
 
-from app.core.required_env import REQUIRED_FOR_PRODUCTION_DEPLOY, missing_env
+from app.core.required_env import missing_env, required_for_scope
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
@@ -48,8 +55,18 @@ def _is_truthy(value: str | None) -> bool:
     return str(value or "").strip().lower() in _TRUTHY
 
 
-def check(env: Mapping[str, str]) -> Tuple[int, str]:
-    """Pure check: return ``(exit_code, message)`` for the given environment.
+def _parse_scope(argv: Sequence[str]) -> str:
+    """Read ``--scope <value>`` / ``--scope=<value>`` from argv; default ``web``."""
+    for i, arg in enumerate(argv):
+        if arg == "--scope" and i + 1 < len(argv):
+            return argv[i + 1].strip().lower()
+        if arg.startswith("--scope="):
+            return arg.split("=", 1)[1].strip().lower()
+    return "web"
+
+
+def check(env: Mapping[str, str], *, scope: str = "web") -> Tuple[int, str]:
+    """Pure check: return ``(exit_code, message)`` for the given environment + scope.
 
     Separated from ``main`` so it can be unit-tested against a synthetic env with
     no process exit and no stdout coupling.
@@ -57,31 +74,33 @@ def check(env: Mapping[str, str]) -> Tuple[int, str]:
     app_env = str(env.get("APP_ENV", "") or "").strip().lower()
     force = _is_truthy(env.get("PREFLIGHT_FORCE"))
     enforcing = force or app_env == "production"
+    required = required_for_scope(scope)
 
     if not enforcing:
         return 0, (
-            f"preflight: skipped (APP_ENV={app_env or 'unset'!r}, not production; "
-            "set PREFLIGHT_FORCE=1 to check anyway)."
+            f"preflight[{scope}]: skipped (APP_ENV={app_env or 'unset'!r}, not "
+            "production; set PREFLIGHT_FORCE=1 to check anyway)."
         )
 
-    missing = missing_env(REQUIRED_FOR_PRODUCTION_DEPLOY, env)
+    missing = missing_env(required, env)
     if missing:
         return 1, (
-            "preflight FAILED: required production env var(s) unset: "
+            f"preflight[{scope}] FAILED: required production env var(s) unset: "
             + ", ".join(missing)
             + ". A deploy missing these would fail closed (503 every route) or "
-            "crash on boot. Set them on every affected service, then redeploy. "
+            "crash on boot. Set them on the affected service, then redeploy. "
             "See docs/deployment/deploy-checklist.md."
         )
     return 0, (
-        "preflight OK: all required production env vars are present ("
-        + ", ".join(REQUIRED_FOR_PRODUCTION_DEPLOY)
+        f"preflight[{scope}] OK: all required env vars are present ("
+        + ", ".join(required)
         + ")."
     )
 
 
 def main() -> int:
-    exit_code, message = check(os.environ)
+    scope = _parse_scope(sys.argv[1:])
+    exit_code, message = check(os.environ, scope=scope)
     stream = sys.stderr if exit_code != 0 else sys.stdout
     print(message, file=stream)
     return exit_code

--- a/backend/tests/test_preflight_env_check.py
+++ b/backend/tests/test_preflight_env_check.py
@@ -8,7 +8,7 @@ production (or when forced) and fail on any missing var, stay a no-op otherwise.
 """
 
 from app.core.required_env import REQUIRED_FOR_PRODUCTION_DEPLOY, missing_env
-from scripts.preflight_env_check import check
+from scripts.preflight_env_check import _parse_scope, check
 
 # Clearly-fake values; never real secrets (aiw-security-testing rule 6).
 _COMPLETE_PROD_ENV = {
@@ -77,3 +77,35 @@ def test_whitespace_only_value_counts_as_missing():
 def test_missing_env_helper_treats_blank_and_absent_alike():
     env = {"A": "x", "B": "", "C": "   "}
     assert missing_env(["A", "B", "C", "D"], env) == ["B", "C", "D"]
+
+
+# --- per-service scope (env is per-service on Railway) -------------------------
+
+def test_worker_scope_requires_only_database_url():
+    # The worker serves no HTTP, so the fail-closed web gates are irrelevant there:
+    # with only DATABASE_URL set, the worker scope passes while the web scope fails.
+    env = {"APP_ENV": "production", "DATABASE_URL": "postgresql://test/preflight"}
+    worker_code, _ = check(env, scope="worker")
+    web_code, web_msg = check(env, scope="web")
+    assert worker_code == 0
+    assert web_code == 1
+    assert "CLERK_JWKS_URL" in web_msg
+
+
+def test_worker_scope_still_fails_without_database_url():
+    code, message = check({"APP_ENV": "production"}, scope="worker")
+    assert code == 1
+    assert "DATABASE_URL" in message
+
+
+def test_unknown_scope_falls_back_to_strict_web_set():
+    # A mistyped scope must over-check (fail safe), never under-check.
+    env = {"APP_ENV": "production", "DATABASE_URL": "postgresql://test/preflight"}
+    code, _ = check(env, scope="wrkr")
+    assert code == 1  # treated as web -> the web gates are required
+
+
+def test_parse_scope_reads_both_flag_forms():
+    assert _parse_scope(["--scope", "worker"]) == "worker"
+    assert _parse_scope(["--scope=web"]) == "web"
+    assert _parse_scope([]) == "web"  # default

--- a/docs/deployment/deploy-checklist.md
+++ b/docs/deployment/deploy-checklist.md
@@ -80,16 +80,30 @@ anyway. The preflight only has authority where the env actually lives: as the
 gate itself can't silently rot; the post-deploy verification job (#550) remains the
 automated after-the-fact catch.
 
-### Owner actions to activate (platform config, not in-repo)
+### Owner actions to activate (Railway dashboard config, not in-repo)
 
-1. **Verify the platform assumption first.** Wire `make preflight-env-check` (or
-   `python -m scripts.preflight_env_check`) as the Railway release command on the
-   `web` and `worker` services, then deliberately unset one required var on a
-   throwaway test service and confirm Railway **keeps the previous deploy serving**
-   when the release command exits non-zero — rather than removing it the way it did
-   for the boot crash in #546. Only rely on this gate once that holds.
-2. Once verified, leave it as the release command ahead of `alembic upgrade head`
-   and the app start, so a misconfigured release is blocked at deploy time.
+The script ships inside the runtime image (the Dockerfile copies `scripts/`), so it
+runs as each service's **Pre-Deploy Command** — Railway runs that after the build and
+before the new version takes traffic, and a non-zero exit fails the deploy. Env is
+per-service on Railway, so each service passes its own scope (`web` checks the
+fail-closed HTTP gates + the DB; `worker` checks only `DATABASE_URL`).
+
+1. **Verify the platform assumption first** (the #546 caveat). On a throwaway/staging
+   service, set the Pre-Deploy Command and deliberately unset one required var, then
+   confirm Railway **fails the deploy and keeps the previous version serving** when
+   the command exits non-zero — rather than removing the old one the way a *boot
+   crash* did in #546. A Pre-Deploy Command failure is documented to halt promotion,
+   but it is the same "platform keeps the old deploy" assumption, so prove it before
+   relying on it.
+2. **Set the Pre-Deploy Command** per service (Railway → service → Settings → Deploy
+   → Pre-Deploy Command):
+   - `web` service:    `python -m scripts.preflight_env_check --scope web`
+   - `worker` service: `python -m scripts.preflight_env_check --scope worker`
+
+   Put it ahead of (or alongside) `alembic upgrade head` if that also runs as a
+   pre-deploy step; order it first so a missing env fails before any migration runs.
+3. Sanity-check locally any time with `PREFLIGHT_FORCE=1 make preflight-env-check`
+   (forces the check outside production against the current shell env).
 
 ## Deferred / open
 


### PR DESCRIPTION
Follow-up to #551 (PR #556). The preflight could not actually gate a deploy as merged — this makes the Railway wiring work.

## Two gaps fixed
1. **The script was not in the runtime image.** The Dockerfile copies `app`/`alembic`/`alembic.ini`/`pyproject.toml` but **not `scripts/`**, so `python -m scripts.preflight_env_check` would fail as a Railway command. Now `COPY scripts ./scripts`.
2. **The required list is web-scoped.** Clerk/basic-auth are web HTTP gates; running the full set on the worker would wrongly require them there. Added per-service scope: `web` checks the fail-closed gates + DB, `worker` checks only `DATABASE_URL`. Unknown scope falls back to the strict web set (fail safe).

## How to wire it (Railway dashboard, owner action)
Railway runs a service's **Pre-Deploy Command** after build, before the new version takes traffic; a non-zero exit fails the deploy. Per service → Settings → Deploy → Pre-Deploy Command:
- **web**: `python -m scripts.preflight_env_check --scope web`
- **worker**: `python -m scripts.preflight_env_check --scope worker`

Order it ahead of `alembic upgrade head` so a missing env fails before any migration runs.

## Verify the platform behaviour first (#546 caveat)
On a throwaway/staging service, set the command and unset one required var, then confirm Railway **fails the deploy and keeps the previous version serving** on the non-zero exit — the same 'platform keeps the old deploy' assumption that was false for a *boot crash* in #546, so prove it for a *Pre-Deploy Command* failure before relying on it.

## Env changes
None.

## Verification
- `tests/test_preflight_env_check.py`: worker-vs-web scope, worker still needs DATABASE_URL, unknown-scope fail-safe, `--scope` flag parsing.
- Script smoked: `--scope worker` passes with only DATABASE_URL set; `--scope web` fails listing the missing gates.
- Full `make backend-test`: 1854 passed.

Note: I could not build the Docker image here (no docker in this environment), so the `COPY scripts` line is verified by inspection against the existing COPY lines, not by an image build. Worth a local `docker build` before relying on it.