### PR TITLE
Harden the #551 preflight against a silently-disarmed gate (--require-production)

### DIFF
--- a/backend/scripts/preflight_env_check.py
+++ b/backend/scripts/preflight_env_check.py
@@ -13,13 +13,14 @@ in the deploy environment, where the vars live, and Railway fails the deploy and
 keeps the previous one serving when it exits non-zero). Env is per-service on
 Railway, so pass the service scope:
 
-    web service Pre-Deploy Command:    python -m scripts.preflight_env_check --scope web
-    worker service Pre-Deploy Command: python -m scripts.preflight_env_check --scope worker
+    web Pre-Deploy Command:    python -m scripts.preflight_env_check --scope web --require-production
+    worker Pre-Deploy Command: python -m scripts.preflight_env_check --scope worker --require-production
 
 The ``web`` scope checks the fail-closed HTTP gate vars + the DB; the ``worker``
 scope checks only ``DATABASE_URL`` (it serves no HTTP). See
-``docs/deployment/deploy-checklist.md`` for the full wiring and the platform-
-behaviour caveat that must be verified before relying on it.
+``docs/deployment/deploy-checklist.md`` for the full wiring (verified on Railway:
+a failing Pre-Deploy Command marks the deploy FAILED and leaves the previously
+ACTIVE deployment serving).
 
 Checks the canonical per-scope list in ``app.core.required_env`` (the web set is
 the same one the boot guard ``observability.assert_production_config`` enforces),
@@ -27,17 +28,26 @@ reading the RAW deploy environment via ``os.environ`` so it needs no ``Settings`
 instantiation (and thus no live ``DATABASE_URL``) just to report what is missing.
 
 Enforcement:
-  - Enforces when ``APP_ENV=production`` (the real release-command case) OR when
-    ``PREFLIGHT_FORCE`` is truthy (a dry run, or the self-test).
+  - Enforces when ``APP_ENV=production``, when ``PREFLIGHT_FORCE`` is truthy, or
+    when ``--require-production`` is passed.
   - Otherwise it is a no-op that exits 0, mirroring the boot guard: local dev and
     the test suite run with these unset and must not fail.
 
-Exit code: 0 = all required vars present (or not enforcing); 1 = a required var is
-missing.
+``--require-production`` is the hardened release-command form: it ALWAYS enforces
+AND additionally FAILS when ``APP_ENV`` is not exactly ``production``. Without it,
+an empty/dropped ``APP_ENV`` would make the gate silently skip (observed: Railway's
+inline variable editor can save an empty value), which disarms not just this gate
+but the boot guard and the production auth path too. Because it is a CLI flag baked
+into the Pre-Deploy Command string, it cannot be dropped the way a separate env var
+can, so the release command stays armed.
+
+Exit code: 0 = all checks pass (or not enforcing); 1 = a required var is missing
+(or, under ``--require-production``, ``APP_ENV`` is not production).
 
 Usage:
     APP_ENV=production python -m scripts.preflight_env_check --scope web
-    PREFLIGHT_FORCE=1 python -m scripts.preflight_env_check   # dry run / self-test
+    python -m scripts.preflight_env_check --scope web --require-production  # release cmd
+    PREFLIGHT_FORCE=1 python -m scripts.preflight_env_check                 # dry run
 """
 
 from __future__ import annotations
@@ -55,17 +65,27 @@ def _is_truthy(value: str | None) -> bool:
     return str(value or "").strip().lower() in _TRUTHY
 
 
-def _parse_scope(argv: Sequence[str]) -> str:
-    """Read ``--scope <value>`` / ``--scope=<value>`` from argv; default ``web``."""
+def _parse_args(argv: Sequence[str]) -> Tuple[str, bool]:
+    """Read ``--scope <value>``/``--scope=<value>`` (default ``web``) and the
+    ``--require-production`` flag from argv."""
+    scope = "web"
+    require_production = False
     for i, arg in enumerate(argv):
         if arg == "--scope" and i + 1 < len(argv):
-            return argv[i + 1].strip().lower()
-        if arg.startswith("--scope="):
-            return arg.split("=", 1)[1].strip().lower()
-    return "web"
+            scope = argv[i + 1].strip().lower()
+        elif arg.startswith("--scope="):
+            scope = arg.split("=", 1)[1].strip().lower()
+        elif arg == "--require-production":
+            require_production = True
+    return scope, require_production
 
 
-def check(env: Mapping[str, str], *, scope: str = "web") -> Tuple[int, str]:
+def check(
+    env: Mapping[str, str],
+    *,
+    scope: str = "web",
+    require_production: bool = False,
+) -> Tuple[int, str]:
     """Pure check: return ``(exit_code, message)`` for the given environment + scope.
 
     Separated from ``main`` so it can be unit-tested against a synthetic env with
@@ -73,22 +93,36 @@ def check(env: Mapping[str, str], *, scope: str = "web") -> Tuple[int, str]:
     """
     app_env = str(env.get("APP_ENV", "") or "").strip().lower()
     force = _is_truthy(env.get("PREFLIGHT_FORCE"))
-    enforcing = force or app_env == "production"
+    enforcing = force or require_production or app_env == "production"
     required = required_for_scope(scope)
 
     if not enforcing:
         return 0, (
             f"preflight[{scope}]: skipped (APP_ENV={app_env or 'unset'!r}, not "
-            "production; set PREFLIGHT_FORCE=1 to check anyway)."
+            "production; pass --require-production or set PREFLIGHT_FORCE=1 to check "
+            "anyway)."
         )
 
+    problems = []
+    # --require-production catches the silent-disarm footgun: an APP_ENV that is not
+    # exactly "production" means this gate (and the boot guard, and the prod auth
+    # path) would otherwise be off. Treat it as a hard failure, not a skip.
+    if require_production and app_env != "production":
+        problems.append(
+            f"APP_ENV is not 'production' (got {app_env or 'unset'!r}) -- production "
+            "hardening (this gate, the boot guard, and the auth path) would be "
+            "disarmed; set APP_ENV=production"
+        )
     missing = missing_env(required, env)
     if missing:
+        problems.append("required env var(s) unset: " + ", ".join(missing))
+
+    if problems:
         return 1, (
-            f"preflight[{scope}] FAILED: required production env var(s) unset: "
-            + ", ".join(missing)
-            + ". A deploy missing these would fail closed (503 every route) or "
-            "crash on boot. Set them on the affected service, then redeploy. "
+            f"preflight[{scope}] FAILED: "
+            + "; ".join(problems)
+            + ". A deploy in this state would fail closed (503 every route) or run "
+            "unhardened. Fix on the affected service, then redeploy. "
             "See docs/deployment/deploy-checklist.md."
         )
     return 0, (
@@ -99,8 +133,10 @@ def check(env: Mapping[str, str], *, scope: str = "web") -> Tuple[int, str]:
 
 
 def main() -> int:
-    scope = _parse_scope(sys.argv[1:])
-    exit_code, message = check(os.environ, scope=scope)
+    scope, require_production = _parse_args(sys.argv[1:])
+    exit_code, message = check(
+        os.environ, scope=scope, require_production=require_production
+    )
     stream = sys.stderr if exit_code != 0 else sys.stdout
     print(message, file=stream)
     return exit_code

--- a/backend/tests/test_preflight_env_check.py
+++ b/backend/tests/test_preflight_env_check.py
@@ -8,7 +8,7 @@ production (or when forced) and fail on any missing var, stay a no-op otherwise.
 """
 
 from app.core.required_env import REQUIRED_FOR_PRODUCTION_DEPLOY, missing_env
-from scripts.preflight_env_check import _parse_scope, check
+from scripts.preflight_env_check import _parse_args, check
 
 # Clearly-fake values; never real secrets (aiw-security-testing rule 6).
 _COMPLETE_PROD_ENV = {
@@ -105,7 +105,48 @@ def test_unknown_scope_falls_back_to_strict_web_set():
     assert code == 1  # treated as web -> the web gates are required
 
 
-def test_parse_scope_reads_both_flag_forms():
-    assert _parse_scope(["--scope", "worker"]) == "worker"
-    assert _parse_scope(["--scope=web"]) == "web"
-    assert _parse_scope([]) == "web"  # default
+def test_parse_args_reads_scope_and_require_production():
+    assert _parse_args(["--scope", "worker"]) == ("worker", False)
+    assert _parse_args(["--scope=web"]) == ("web", False)
+    assert _parse_args([]) == ("web", False)  # defaults
+    assert _parse_args(["--scope", "worker", "--require-production"]) == ("worker", True)
+
+
+# --- --require-production: the hardened release-command form -------------------
+
+def test_require_production_fails_when_app_env_not_production():
+    # The silent-disarm footgun: an empty/dropped APP_ENV would normally make the
+    # gate SKIP. --require-production turns that into a hard failure instead, even
+    # though every required var is present.
+    env = {
+        "DATABASE_URL": "postgresql://test/preflight",
+        "CLERK_JWKS_URL": "https://example-test.clerk.accounts.dev/.well-known/jwks.json",
+        "BASIC_AUTH_USER": "svc-test-do-not-use",
+        "BASIC_AUTH_PASSWORD": "test-secret-do-not-use-in-prod",
+    }  # note: APP_ENV unset
+    code, message = check(env, scope="web", require_production=True)
+    assert code == 1
+    assert "APP_ENV" in message
+
+
+def test_require_production_passes_when_fully_configured():
+    code, message = check(_COMPLETE_PROD_ENV, scope="web", require_production=True)
+    assert code == 0
+    assert "OK" in message
+
+
+def test_require_production_reports_app_env_and_missing_vars_together():
+    code, message = check({}, scope="web", require_production=True)
+    assert code == 1
+    assert "APP_ENV" in message
+    assert "DATABASE_URL" in message  # both problems surfaced in one message
+
+
+def test_require_production_enforces_even_without_app_env_or_force():
+    # Without the flag and with APP_ENV unset, the same env would SKIP (exit 0);
+    # the flag is what makes the release command stay armed.
+    env = {"DATABASE_URL": "postgresql://test/preflight"}  # web gates missing
+    skipped_code, skipped_msg = check(env, scope="web")
+    assert skipped_code == 0 and "skipped" in skipped_msg
+    forced_code, _ = check(env, scope="web", require_production=True)
+    assert forced_code == 1

--- a/docs/deployment/deploy-checklist.md
+++ b/docs/deployment/deploy-checklist.md
@@ -68,7 +68,8 @@ var is unset, *before* the process boots. The required list is the canonical one
 `BASIC_AUTH_PASSWORD` the boot guard `assert_production_config` enforces, plus
 `DATABASE_URL` — so a release missing one fails the deploy instead of crash-looping
 on boot (the #546 failure mode). It is a no-op outside production unless
-`PREFLIGHT_FORCE=1`.
+`--require-production` is passed (the release-command form, below) or
+`PREFLIGHT_FORCE=1` is set.
 
 ### Why it is not a CI gate
 
@@ -80,30 +81,48 @@ anyway. The preflight only has authority where the env actually lives: as the
 gate itself can't silently rot; the post-deploy verification job (#550) remains the
 automated after-the-fact catch.
 
+### Platform assumption — VERIFIED (2026-06-27)
+
+The #546 caveat is resolved. On a throwaway `preflight-test` service (mirroring web:
+same repo, Root Directory `/backend`, Dockerfile builder, Pre-Deploy Command set,
+`APP_ENV=production` + `DATABASE_URL` set but `CLERK_JWKS_URL` left unset), a failing
+Pre-Deploy Command behaved exactly as needed: the deployment was marked **FAILED**
+(during deploy, before traffic), while the previously-successful deployment stayed
+**ACTIVE** and the service stayed **Online**. So unlike a *boot crash* (#546, which
+removed the old deploy and took prod down), a failing **Pre-Deploy Command** does NOT
+disturb the already-serving version — the gate is safe to rely on for blocking.
+
 ### Owner actions to activate (Railway dashboard config, not in-repo)
 
 The script ships inside the runtime image (the Dockerfile copies `scripts/`), so it
-runs as each service's **Pre-Deploy Command** — Railway runs that after the build and
-before the new version takes traffic, and a non-zero exit fails the deploy. Env is
-per-service on Railway, so each service passes its own scope (`web` checks the
-fail-closed HTTP gates + the DB; `worker` checks only `DATABASE_URL`).
+runs as each service's **Pre-Deploy Command** (Railway → service → Settings → Deploy →
+Pre-Deploy Command). Env is per-service on Railway, so each service passes its own
+scope (`web` checks the fail-closed HTTP gates + the DB; `worker` checks only
+`DATABASE_URL`), and `--require-production` keeps the gate armed:
 
-1. **Verify the platform assumption first** (the #546 caveat). On a throwaway/staging
-   service, set the Pre-Deploy Command and deliberately unset one required var, then
-   confirm Railway **fails the deploy and keeps the previous version serving** when
-   the command exits non-zero — rather than removing the old one the way a *boot
-   crash* did in #546. A Pre-Deploy Command failure is documented to halt promotion,
-   but it is the same "platform keeps the old deploy" assumption, so prove it before
-   relying on it.
-2. **Set the Pre-Deploy Command** per service (Railway → service → Settings → Deploy
-   → Pre-Deploy Command):
-   - `web` service:    `python -m scripts.preflight_env_check --scope web`
-   - `worker` service: `python -m scripts.preflight_env_check --scope worker`
+- `web` service:    `python -m scripts.preflight_env_check --scope web --require-production`
+- `worker` service: `python -m scripts.preflight_env_check --scope worker --require-production`
 
-   Put it ahead of (or alongside) `alembic upgrade head` if that also runs as a
-   pre-deploy step; order it first so a missing env fails before any migration runs.
-3. Sanity-check locally any time with `PREFLIGHT_FORCE=1 make preflight-env-check`
-   (forces the check outside production against the current shell env).
+Order it ahead of `alembic upgrade head` if that also runs pre-deploy, so a missing
+env fails before any migration runs:
+`python -m scripts.preflight_env_check --scope web --require-production && alembic upgrade head`.
+
+Sanity-check locally any time with `PREFLIGHT_FORCE=1 make preflight-env-check`.
+
+### Two gotchas found while wiring it (2026-06-27)
+
+- **`--require-production` is not optional, it is the point.** Without it, the gate
+  only enforces when `APP_ENV=production`; an empty/missing `APP_ENV` makes it
+  silently **skip** (exit 0) and provide no protection. That is not hypothetical:
+  Railway's *inline* variable editor was observed saving `APP_ENV` with an **empty
+  value**, which silently disarmed the gate (and would equally disarm the boot guard
+  and the production auth path). `--require-production` turns a non-`production`
+  `APP_ENV` into a hard failure, and being a CLI flag baked into the command string it
+  cannot be dropped the way a separate env var can. Set env values via Railway's
+  **Raw Editor** and re-check them.
+- **A new service defaults to Railpack and scans the repo root.** Stand up any service
+  (including the throwaway test one) with **Root Directory `/backend`** so the
+  Dockerfile is found, matching how `web`/`worker` are configured.
 
 ## Deferred / open
 


### PR DESCRIPTION
Follow-up to #559, prompted by the live Railway verification (thanks for running it).

## The verification result (good news)
Confirmed on a throwaway `preflight-test` service: a failing **Pre-Deploy Command** marks the deployment **FAILED** while the previously-successful deployment stays **ACTIVE** and Online. So unlike a *boot crash* (#546, which removed the old deploy and took prod down), a failing Pre-Deploy Command does **not** disturb the serving version. The #546 caveat is resolved — the gate is safe to rely on for blocking.

## The footgun this fixes
The verification surfaced a real weakness: the preflight only enforces when `APP_ENV=production`, so an **empty/dropped `APP_ENV` makes it silently skip** (exit 0) and protect nothing. Not hypothetical — Railway's *inline* variable editor was observed saving `APP_ENV` with an empty value, which silently disarms this gate **and** the boot guard **and** the production auth path.

`--require-production` is the hardened release-command form: it **always enforces** and additionally **fails when `APP_ENV` is not exactly `production`**. Being a CLI flag baked into the Pre-Deploy Command string, it can't be dropped the way a separate env var can, so the release command stays armed.

## Updated wiring (use these)
- web: `python -m scripts.preflight_env_check --scope web --require-production`
- worker: `python -m scripts.preflight_env_check --scope worker --require-production`

The deploy-checklist now records the verified platform behaviour and the two wiring gotchas found (Root Directory `/backend` for a new service; the inline-editor empty-value trap → use the Raw Editor).

## Env changes
None.

## Verification
- New tests: `--require-production` fails on non-production `APP_ENV` even with all vars set, passes when fully configured, reports APP_ENV + missing vars together, and enforces where the unflagged form would skip; `_parse_args` flag parsing.
- Smoked: `--require-production` with `APP_ENV` unset (all vars set) → exit 1; with `APP_ENV=production` → exit 0.
- Full `make backend-test`: 1858 passed.