### PR TITLE
Show activity-type-appropriate stats; hide distance/pace for indoor (#564)

### DIFF
--- a/frontend/app/activity/[id]/page.tsx
+++ b/frontend/app/activity/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { serverFetch } from '@/lib/serverSession';
 import { format } from 'date-fns';
-import { formatPace, formatDuration, formatDistanceKm, activityStartDate } from '@/lib/format';
+import { formatPace, formatDuration, formatDistanceKm, activityStartDate, hasMeaningfulDistance } from '@/lib/format';
 import CheckInForm from '@/components/CheckInForm';
 import Link from 'next/link';
 import { Activity } from '@/lib/types';
@@ -46,7 +46,9 @@ export default async function ActivityDetail({ params }: { params: { id: string 
                 <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 break-words">{activity.name}</h1>
                 <div className="flex flex-wrap gap-x-4 gap-y-2 mt-2 text-gray-600 dark:text-gray-400 items-center">
                     <span>{format(activityStartDate(activity), 'PPPP p')}</span>
-                    <span>{formatDistanceKm(activity.distance_m)}</span>
+                    {hasMeaningfulDistance(activity.distance_m) && (
+                        <span>{formatDistanceKm(activity.distance_m)}</span>
+                    )}
                     {activity.metrics?.headline && (
                         <span className="inline-block px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 text-sm font-medium">
                             {activity.metrics.headline}
@@ -140,17 +142,21 @@ export default async function ActivityDetail({ params }: { params: { id: string 
                         <dd className="font-medium">{formatDuration(activity.raw_summary.elapsed_time)}</dd>
                     </div>
                 )}
-                <div className="flex justify-between">
-                   <dt className="text-gray-500 dark:text-gray-400">Avg Pace</dt>
-                   <dd className="font-medium">
-                     {formatPace(activity.distance_m, activity.moving_time_s)}
-                   </dd>
-                </div>
-                <div className="flex justify-between">
-                    <dt className="text-gray-500 dark:text-gray-400">Distance</dt>
-                    <dd className="font-medium">{formatDistanceKm(activity.distance_m)}</dd>
-                </div>
-                
+                {hasMeaningfulDistance(activity.distance_m) && (
+                  <>
+                    <div className="flex justify-between">
+                       <dt className="text-gray-500 dark:text-gray-400">Avg Pace</dt>
+                       <dd className="font-medium">
+                         {formatPace(activity.distance_m, activity.moving_time_s)}
+                       </dd>
+                    </div>
+                    <div className="flex justify-between">
+                        <dt className="text-gray-500 dark:text-gray-400">Distance</dt>
+                        <dd className="font-medium">{formatDistanceKm(activity.distance_m)}</dd>
+                    </div>
+                  </>
+                )}
+
                 <div className="border-t border-gray-100 dark:border-gray-700 my-2 pt-2"></div>
                 
                 <div className="flex justify-between">

--- a/frontend/components/ActivityList.tsx
+++ b/frontend/components/ActivityList.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { format } from 'date-fns';
 import { ChevronRight } from 'lucide-react';
 
-import { activityStartDate } from '@/lib/format';
+import { activityStartDate, hasMeaningfulDistance } from '@/lib/format';
 
 interface Activity {
   id: string;
@@ -40,8 +40,12 @@ export default function ActivityList({ activities }: { activities: Activity[] })
               </div>
               <div className="text-sm text-gray-500 dark:text-gray-400 flex flex-wrap gap-x-3 gap-y-1 mt-1">
                 <span>{format(activityStartDate(activity), 'MMM d, yyyy')}</span>
-                <span aria-hidden="true">•</span>
-                <span>{(activity.distance_m / 1000).toFixed(2)} km</span>
+                {hasMeaningfulDistance(activity.distance_m) && (
+                  <>
+                    <span aria-hidden="true">•</span>
+                    <span>{(activity.distance_m / 1000).toFixed(2)} km</span>
+                  </>
+                )}
                 <span aria-hidden="true">•</span>
                 <span>{Math.floor(activity.moving_time_s / 60)} min</span>
               </div>

--- a/frontend/lib/format.ts
+++ b/frontend/lib/format.ts
@@ -67,6 +67,19 @@ export function formatDistanceKm(metres: number): string {
 }
 
 /**
+ * Whether distance and pace are meaningful stats for this activity (#564).
+ *
+ * Indoor modalities (indoor ride, rowing erg, weight training) report a 0
+ * distance, where "0.00 km" / a blank pace reads as missing or broken data
+ * rather than "distance doesn't apply to this activity". Gating the
+ * distance- and pace-derived stats on this keeps each modality's stat set
+ * appropriate without enumerating every activity type.
+ */
+export function hasMeaningfulDistance(metres: number | null | undefined): boolean {
+  return !!metres && metres > 0;
+}
+
+/**
  * Format an ISO date string ("2026-02-08") to "Feb 8" without
  * timezone conversion.  parseISO creates midnight-UTC which shifts
  * the displayed date when the browser is behind UTC.


### PR DESCRIPTION
Closes #564.

## What
Indoor modalities (indoor ride, rowing erg, weight training) report a 0 distance, so the recent-activities cards and the activity detail header + sidebar rendered a meaningless `0.00 km` (and a blank pace) that reads as missing/broken data rather than "distance doesn't apply here".

## Change
- New shared `hasMeaningfulDistance(metres)` helper in `lib/format.ts` (distance > 0).
- `ActivityList.tsx`: the recent-activity card shows the distance chip only when distance is meaningful; duration is always shown.
- `app/activity/[id]/page.tsx`: the detail header distance and the sidebar **Distance** + **Avg Pace** rows are gated on the same helper.
- Power/energy/cadence remain presence-gated as before, so indoor rides still surface power/energy when Strava provides them.

Value-presence gate rather than an enumerated per-type table, so unrecognised modalities degrade correctly too.

## Acceptance criteria
- [x] Indoor activities (indoor ride, row, weight training) no longer show `0.00 km`.
- [x] Each activity type shows a stat set appropriate to its modality.
- [x] Distance-based modalities (run, walk, outdoor ride) are unchanged.
- [x] Rule applied consistently across the recent-activities list and the detail header.

## Verification
Real-browser check against a seeded production snapshot (`make verify-local`):
- Home list: Afternoon Ride / Afternoon Row / Night Ride show date + duration only (no `0.00 km`); runs/walks keep distance.
- Indoor ride detail: header has no distance; Metrics sidebar has no Distance/Avg Pace rows (keeps Duration, HR, Suffer Score, Elevation, Device).
- Run detail unchanged: header `8.37 km`, sidebar Avg Pace `6:14 /km` + Distance `8.37 km`.
- `npm run test` (next lint + next build) green.

Frontend-only; no component-test runner exists, so verification is manual per the repo's convention.