### PR TITLE
Unify Laps and Splits into one view for auto-distance laps (#562)

### DIFF
--- a/frontend/app/activity/[id]/page.tsx
+++ b/frontend/app/activity/[id]/page.tsx
@@ -9,6 +9,7 @@ import RoutePath from '@/components/RoutePath';
 import StreamCharts from '@/components/StreamCharts';
 import { SplitsPanel } from '@/components/SplitsPanel';
 import { LapsPanel } from '@/components/LapsPanel';
+import { lapsAreAutoDistance } from '@/lib/laps';
 import StopsPanel from '@/components/StopsPanel';
 import FeatureDisabledGate from '@/components/FeatureDisabledGate';
 import EfficiencyPanel from '@/components/EfficiencyPanel';
@@ -32,6 +33,15 @@ export default async function ActivityDetail({ params }: { params: { id: string 
   // #522: coach input feature flags drive UI greying (fail open to enabled).
   const coachFlags = (await serverFetch('/api/coach/feature-flags')) || {};
   const stopsEnabled = coachFlags.stops_analysis !== false;
+
+  // #562: when the recorded laps are just per-km auto-distance laps, they
+  // duplicate the per-km splits, so render one unified Laps view (enriched
+  // with the splits' richer columns) instead of two near-identical cards.
+  // Device-meaningful laps (manual button / structured workout) keep both.
+  const hasLaps = !!activity.laps && activity.laps.length > 0;
+  const autoDistanceLaps = lapsAreAutoDistance(activity.laps, activity.splits);
+  const showSplitsPanel =
+    !!activity.splits && activity.splits.length > 0 && !(hasLaps && autoDistanceLaps);
 
   return (
     <div className="space-y-6 relative">
@@ -93,13 +103,18 @@ export default async function ActivityDetail({ params }: { params: { id: string 
              <StreamCharts streams={activity.streams} />
           )}
 
-          {/* Laps Panel: only when the runner recorded laps (#208) */}
-          {activity.laps && activity.laps.length > 0 && (
-              <LapsPanel laps={activity.laps} />
+          {/* Laps Panel: only when the runner recorded laps (#208). When the
+              laps are just per-km auto-distance laps, the aligned splits are
+              passed so this single view carries their richer columns (#562). */}
+          {hasLaps && (
+              <LapsPanel
+                laps={activity.laps}
+                splits={autoDistanceLaps ? activity.splits : undefined}
+              />
           )}
 
-          {/* Splits Panel */}
-          {activity.splits && activity.splits.length > 0 && (
+          {/* Splits Panel: hidden when it would duplicate auto-distance laps (#562) */}
+          {showSplitsPanel && (
               <SplitsPanel splits={activity.splits} />
           )}
 

--- a/frontend/components/LapsPanel.tsx
+++ b/frontend/components/LapsPanel.tsx
@@ -1,11 +1,17 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Lap } from '@/lib/types/activity';
+import { Lap, Split } from '@/lib/types/activity';
 import { formatSplitDuration } from '@/lib/format';
 
 interface LapsPanelProps {
   laps?: Lap[];
+  // When the recorded laps are just per-km auto-distance laps, the page passes
+  // the aligned per-km splits so this single view can carry the richer per-row
+  // columns the splits table shows (grade, elevation, power) without losing
+  // data, instead of rendering a near-identical second card (#562). Aligned by
+  // index; the laps remain the row basis and bar-chart source.
+  splits?: Split[];
 }
 
 type Metric = 'pace' | 'hr';
@@ -43,7 +49,7 @@ function lapMetricValue(lap: Lap, metric: Metric): number | null {
   return lapHasHr(lap) ? lap.avg_hr! : null;
 }
 
-export function LapsPanel({ laps }: LapsPanelProps) {
+export function LapsPanel({ laps, splits }: LapsPanelProps) {
   const hasPace = !!laps?.some(lapHasPace);
   const hasHr = !!laps?.some(lapHasHr);
   // Default to pace when available, otherwise fall back to HR.
@@ -88,6 +94,31 @@ export function LapsPanel({ laps }: LapsPanelProps) {
     activeMetric === 'hr'
       ? `Lap ${lap.lap}: ${lap.avg_hr ? Math.round(lap.avg_hr) + ' bpm' : '-'}`
       : `Lap ${lap.lap}: ${formatLapPace(lap)}`;
+
+  // Enrichment columns sourced from the aligned per-km split (#562). Only the
+  // unified auto-distance case passes splits; each column appears only when
+  // some row has a value, mirroring SplitsPanel so no data is lost when the
+  // separate splits card is collapsed away. Cadence prefers the lap's own.
+  const splitAt = (i: number): Split | undefined => splits?.[i];
+  const cadenceFor = (lap: Lap, i: number): number | null =>
+    lap.avg_cadence ?? splitAt(i)?.avg_cadence ?? null;
+  const showCadence =
+    laps.some((l) => l.avg_cadence != null) || !!splits?.some((s) => s.avg_cadence != null);
+  const showGrade = !!splits?.some((s) => s.avg_grade != null);
+  const showElev = !!splits?.some((s) => s.elev_gain != null);
+  const showPower = !!splits?.some((s) => s.avg_watts != null);
+
+  const columns = [
+    'Lap',
+    'Distance',
+    'Time',
+    'Pace',
+    'Avg HR',
+    ...(showGrade ? ['Avg Grade'] : []),
+    ...(showElev ? ['Elev Gain'] : []),
+    ...(showPower ? ['Avg Power'] : []),
+    ...(showCadence ? ['Avg Cadence'] : []),
+  ];
 
   return (
     <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 mb-6">
@@ -147,7 +178,7 @@ export function LapsPanel({ laps }: LapsPanelProps) {
               below the NavBar (z-30) so the header never paints over it. */}
           <thead className="sticky top-0 z-10 bg-gray-100 dark:bg-gray-700">
             <tr>
-              {['Lap', 'Distance', 'Time', 'Pace', 'Avg HR'].map((label) => (
+              {columns.map((label) => (
                 <th
                   key={label}
                   scope="col"
@@ -159,7 +190,9 @@ export function LapsPanel({ laps }: LapsPanelProps) {
             </tr>
           </thead>
           <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-            {laps.map((lap) => (
+            {laps.map((lap, i) => {
+              const split = splitAt(i);
+              return (
               <tr
                 key={lap.lap}
                 onClick={() => setSelected(selected === lap.lap ? null : lap.lap)}
@@ -174,8 +207,29 @@ export function LapsPanel({ laps }: LapsPanelProps) {
                 <td className="px-6 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                   {lap.avg_hr ? Math.round(lap.avg_hr) : '-'}
                 </td>
+                {showGrade && (
+                  <td className="px-6 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                    {split?.avg_grade != null ? `${split.avg_grade.toFixed(1)}%` : '-'}
+                  </td>
+                )}
+                {showElev && (
+                  <td className="px-6 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                    {split?.elev_gain != null ? `${split.elev_gain} m` : '-'}
+                  </td>
+                )}
+                {showPower && (
+                  <td className="px-6 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                    {split?.avg_watts != null ? `${Math.round(split.avg_watts)} W` : '-'}
+                  </td>
+                )}
+                {showCadence && (
+                  <td className="px-6 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                    {cadenceFor(lap, i) != null ? Math.round(cadenceFor(lap, i)!) : '-'}
+                  </td>
+                )}
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/frontend/lib/laps.ts
+++ b/frontend/lib/laps.ts
@@ -1,0 +1,44 @@
+import { Lap, Split } from "@/lib/types/activity";
+
+// A full auto-lap is treated as "~1 km" within this tolerance. Device
+// distance auto-laps report a clean 1000 m; the band absorbs minor GPS
+// rounding without admitting interval reps (200-500 m) or mile laps.
+const KM_LOW = 940;
+const KM_HIGH = 1060;
+
+/**
+ * Whether the recorded laps are "just" per-kilometre auto-distance laps,
+ * i.e. the same breakdown the per-km splits already show (#562).
+ *
+ * When a device auto-laps every 1 km, the Laps and Splits cards display the
+ * same distances and paces twice. In that case the laps carry no intent the
+ * splits can't reconstruct, so the page collapses to a single view. When the
+ * runner pressed the lap button or ran a structured/planned workout, the laps
+ * diverge from the per-km splits (varied distances, different count) and both
+ * views stay available because the lap structure then carries intent.
+ *
+ * The signal is structural rather than a Strava "manual" flag (which the lap
+ * objects do not reliably carry): the laps must align 1:1 with distance-based
+ * per-km splits (count within 1, to allow a tiny trailing partial the split
+ * builder may merge) and every full lap must be ~1 km. Validated against real
+ * lap data, including interval sessions the backend interval detector does not
+ * tag as recorded_laps.
+ */
+export function lapsAreAutoDistance(
+  laps?: Lap[] | null,
+  splits?: Split[] | null,
+): boolean {
+  if (!laps || laps.length < 2) return false;
+  if (!splits || splits.length === 0) return false;
+  // Only per-km (distance) splits can be the duplicate of distance auto-laps.
+  if (splits[0]?.split_type !== "distance") return false;
+  // Lap count must track the per-km split count (a tiny final partial lap may
+  // be merged into the last split, so allow a difference of one).
+  if (Math.abs(laps.length - splits.length) > 1) return false;
+  // Every lap but the (possibly partial) last must be ~1 km.
+  const fullLaps = laps.slice(0, -1);
+  if (fullLaps.length === 0) return false;
+  return fullLaps.every(
+    (l) => l.distance_m != null && l.distance_m >= KM_LOW && l.distance_m <= KM_HIGH,
+  );
+}


### PR DESCRIPTION
Closes #562.

## What
When a device auto-laps every 1 km, the **Laps** and **Splits (1 km)** cards on the activity page showed the same distances and paces twice. This collapses that duplicate into a single view, while keeping both when the laps actually carry intent.

## Change
- New `lib/laps.ts` `lapsAreAutoDistance(laps, splits)`: laps are "just per-km auto-distance laps" when they align 1:1 with distance-based per-km splits (count within 1, to allow a tiny trailing partial the split builder may merge) and every full lap is ~1 km (940–1060 m).
- `LapsPanel` gains an optional `splits` prop. In the auto-distance case the page passes the aligned splits and the single Laps view carries the richer per-row columns the splits table shows (Avg Grade, Elev Gain, Avg Power, Avg Cadence), sourced from the aligned split by index, so no data is lost. Each column appears only when some row has a value (mirrors SplitsPanel). The bar chart + Pace/HR toggle are unchanged.
- `app/activity/[id]/page.tsx`: renders one enriched Laps view for auto-distance laps and hides the separate Splits card; for device-meaningful laps (manual lap button / structured workout) it keeps both cards; with no laps it shows Splits as before.

## Detection rationale
The signal is **structural**, not the backend `interval_structure.source`. Against real lap data, interval sessions (`laps=18, splits=4`, distances `[1000, 500, 99, 200, …]`) were **not** tagged `recorded_laps`, so relying on that source would wrongly collapse them. The structural check classifies them as device-meaningful and keeps both views.

## Acceptance criteria
- [x] Auto-distance laps equal to per-km splits → a single breakdown, not two near-identical ones.
- [x] The unified view uses the laps bar-chart UX and includes the richer per-row data the splits table shows.
- [x] Manual/structured laps → both lap structure and per-km splits remain available.
- [x] No data currently shown in either card becomes unreachable (verified the unified table renders all 9 columns with values).

## Verification
Real-browser check against a seeded production snapshot (`make verify-local`), validated on real lap data:
- Auto-1km run (9 laps / 9 splits): one Laps card, all columns Lap/Distance/Time/Pace/Avg HR/Avg Grade/Elev Gain/Avg Power/Avg Cadence populated across 9 rows; no separate Splits card.
- Interval run (18 laps / 4 splits): Laps card (18 rows) **and** Splits (1 km) card (4 rows) both present.
- No-laps run: Splits (1 km) only, unchanged.
- `npm run test` (next lint + next build) green.

## Noticed, out of scope
Indoor rides/rows record time-based laps with 0 m distance that visually duplicate the 5-minute splits. That is a different shape from the auto-**distance** case this issue targets, so it is left untouched here; worth a follow-up if the duplication bothers.

Frontend-only; no component-test runner exists, so verification is manual per the repo's convention.