### PR TITLE
Trends: distinguish partial edge buckets with faded coverage (#566)

### DIFF
--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -58,7 +58,11 @@ class DailySufferScorePoint(BaseModel):
 
 class WeeklySufferScorePoint(BaseModel):
     week_start: date
-    effort_score: float
+    effort_score: float  # in-period sum
+    # Edge-bucket coverage + out-of-window load (#566); see WeeklyDistancePoint.
+    in_period_days: Optional[int] = None
+    out_of_period_days: int = 0
+    out_of_period_effort_score: float = 0.0
 
 
 class PeriodDistancePoint(BaseModel):
@@ -90,6 +94,9 @@ class PeriodSufferScorePoint(BaseModel):
     """One coarse-granularity bucket of accumulated load (#432)."""
     period_start: date
     effort_score: float
+    in_period_days: Optional[int] = None
+    out_of_period_days: int = 0
+    out_of_period_effort_score: float = 0.0
 
 
 class EfficiencyPoint(BaseModel):

--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -14,10 +14,14 @@ class WeeklyDistancePoint(BaseModel):
     total_distance_m: int
     activity_count: int
     # Edge-bucket coverage (#566): how much of the week falls inside the
-    # selected period, so the chart can fade partial edge weeks. Optional for
+    # selected period, so the chart can split a partial edge week. Optional for
     # back-compat; out_of_period_days == 0 means a full (non-partial) bucket.
     in_period_days: Optional[int] = None
     out_of_period_days: int = 0
+    # Value of the week's days OUTSIDE the window; the chart stacks this as a
+    # faded segment so the bar shows the whole week's total, not just the slice
+    # inside the range. total_distance_m stays the in-period sum.
+    out_of_period_distance_m: int = 0
 
 
 class WeeklyTimePoint(BaseModel):
@@ -26,6 +30,7 @@ class WeeklyTimePoint(BaseModel):
     activity_count: int
     in_period_days: Optional[int] = None
     out_of_period_days: int = 0
+    out_of_period_moving_time_s: int = 0
 
 
 class DailyDistancePoint(BaseModel):
@@ -68,6 +73,7 @@ class PeriodDistancePoint(BaseModel):
     # Edge-bucket coverage (#566); see WeeklyDistancePoint.
     in_period_days: Optional[int] = None
     out_of_period_days: int = 0
+    out_of_period_distance_m: int = 0
 
 
 class PeriodTimePoint(BaseModel):
@@ -77,6 +83,7 @@ class PeriodTimePoint(BaseModel):
     activity_count: int
     in_period_days: Optional[int] = None
     out_of_period_days: int = 0
+    out_of_period_moving_time_s: int = 0
 
 
 class PeriodSufferScorePoint(BaseModel):

--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -13,12 +13,19 @@ class WeeklyDistancePoint(BaseModel):
     week_start: date
     total_distance_m: int
     activity_count: int
+    # Edge-bucket coverage (#566): how much of the week falls inside the
+    # selected period, so the chart can fade partial edge weeks. Optional for
+    # back-compat; out_of_period_days == 0 means a full (non-partial) bucket.
+    in_period_days: Optional[int] = None
+    out_of_period_days: int = 0
 
 
 class WeeklyTimePoint(BaseModel):
     week_start: date
     total_moving_time_s: int
     activity_count: int
+    in_period_days: Optional[int] = None
+    out_of_period_days: int = 0
 
 
 class DailyDistancePoint(BaseModel):
@@ -58,6 +65,9 @@ class PeriodDistancePoint(BaseModel):
     period_start: date
     total_distance_m: int
     activity_count: int
+    # Edge-bucket coverage (#566); see WeeklyDistancePoint.
+    in_period_days: Optional[int] = None
+    out_of_period_days: int = 0
 
 
 class PeriodTimePoint(BaseModel):
@@ -65,6 +75,8 @@ class PeriodTimePoint(BaseModel):
     period_start: date
     total_moving_time_s: int
     activity_count: int
+    in_period_days: Optional[int] = None
+    out_of_period_days: int = 0
 
 
 class PeriodSufferScorePoint(BaseModel):

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -161,6 +161,7 @@ class WeekBucket:
         "week_start", "total_distance_m", "total_moving_time_s",
         "total_effort_score", "activity_count",
         "easy_seconds", "moderate_seconds", "hard_seconds",
+        "in_period_days", "out_of_period_days",
     )
 
     def __init__(self, week_start: date):
@@ -172,6 +173,11 @@ class WeekBucket:
         self.easy_seconds = 0
         self.moderate_seconds = 0
         self.hard_seconds = 0
+        # Edge-bucket coverage (#566): how many of the 7 days fall inside the
+        # selected period. Defaults to a full week; the builder overrides for
+        # buckets that straddle the window boundary.
+        self.in_period_days = 7
+        self.out_of_period_days = 0
 
     def add(self, daily: DailyFact):
         self.total_distance_m += daily.total_distance_m
@@ -216,12 +222,36 @@ def _next_period_start(start: date, period: str) -> date:
     return start + timedelta(days=14)
 
 
+def _coverage_days(
+    span_start: date,
+    span_end: date,
+    period_start: Optional[date],
+    period_end: date,
+) -> tuple[int, int]:
+    """In-period vs out-of-period day counts for a bucket spanning ``[span_start,
+    span_end]`` inclusive against the selected window ``[period_start, period_end]`` (#566).
+
+    A bucket (week / fortnight / month) rarely aligns to the period boundary, so
+    an edge bucket only partially overlaps the window. Returns
+    ``(in_period_days, out_of_period_days)``; when ``period_start`` is ``None``
+    (the ALL range, no window) the bucket is treated as fully in-period.
+    """
+    total_days = (span_end - span_start).days + 1
+    if period_start is None:
+        return total_days, 0
+    lo = max(span_start, period_start)
+    hi = min(span_end, period_end)
+    in_days = (hi - lo).days + 1 if hi >= lo else 0
+    return in_days, total_days - in_days
+
+
 class PeriodBucket:
     """Aggregation bucket for one coarse granularity period (#432)."""
 
     __slots__ = (
         "period_start", "total_distance_m", "total_moving_time_s",
         "total_effort_score", "activity_count",
+        "in_period_days", "out_of_period_days",
     )
 
     def __init__(self, period_start: date):
@@ -230,6 +260,10 @@ class PeriodBucket:
         self.total_moving_time_s = 0
         self.total_effort_score = 0.0
         self.activity_count = 0
+        # Edge-bucket coverage (#566): in/out-of-period day counts, set by the
+        # builder from the bucket's full span against the selected window.
+        self.in_period_days = 0
+        self.out_of_period_days = 0
 
     def add(self, daily: DailyFact):
         self.total_distance_m += daily.total_distance_m
@@ -508,6 +542,13 @@ def build_weekly_buckets(
             buckets[cursor] = WeekBucket(cursor)
         cursor += timedelta(weeks=1)
 
+    # Edge-bucket coverage (#566): mark how much of each week falls inside the
+    # selected window [since, end] so the chart can fade partial weeks.
+    for w in buckets.values():
+        w.in_period_days, w.out_of_period_days = _coverage_days(
+            w.week_start, w.week_start + timedelta(days=6), since, end
+        )
+
     return sorted(buckets.values(), key=lambda w: w.week_start)
 
 
@@ -549,6 +590,15 @@ def build_period_buckets(
         if cursor not in buckets:
             buckets[cursor] = PeriodBucket(cursor)
         cursor = _next_period_start(cursor, period)
+
+    # Edge-bucket coverage (#566): the bucket's full span is [period_start,
+    # next_period_start - 1 day] (14 days for biweekly, the calendar month for
+    # monthly); mark how much falls inside the selected window [since, end].
+    for b in buckets.values():
+        span_end = _next_period_start(b.period_start, period) - timedelta(days=1)
+        b.in_period_days, b.out_of_period_days = _coverage_days(
+            b.period_start, span_end, since, end
+        )
 
     return sorted(buckets.values(), key=lambda b: b.period_start)
 
@@ -927,6 +977,8 @@ def get_trends_report(
             week_start=w.week_start,
             total_distance_m=w.total_distance_m,
             activity_count=w.activity_count,
+            in_period_days=w.in_period_days,
+            out_of_period_days=w.out_of_period_days,
         )
         for w in weekly
     ]
@@ -936,6 +988,8 @@ def get_trends_report(
             week_start=w.week_start,
             total_moving_time_s=w.total_moving_time_s,
             activity_count=w.activity_count,
+            in_period_days=w.in_period_days,
+            out_of_period_days=w.out_of_period_days,
         )
         for w in weekly
     ]
@@ -962,6 +1016,8 @@ def get_trends_report(
                 period_start=b.period_start,
                 total_distance_m=b.total_distance_m,
                 activity_count=b.activity_count,
+                in_period_days=b.in_period_days,
+                out_of_period_days=b.out_of_period_days,
             )
             for b in buckets
         ]
@@ -972,6 +1028,8 @@ def get_trends_report(
                 period_start=b.period_start,
                 total_moving_time_s=b.total_moving_time_s,
                 activity_count=b.activity_count,
+                in_period_days=b.in_period_days,
+                out_of_period_days=b.out_of_period_days,
             )
             for b in buckets
         ]

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -162,6 +162,7 @@ class WeekBucket:
         "total_effort_score", "activity_count",
         "easy_seconds", "moderate_seconds", "hard_seconds",
         "in_period_days", "out_of_period_days",
+        "out_of_period_distance_m", "out_of_period_moving_time_s",
     )
 
     def __init__(self, week_start: date):
@@ -178,6 +179,11 @@ class WeekBucket:
         # buckets that straddle the window boundary.
         self.in_period_days = 7
         self.out_of_period_days = 0
+        # Distance/time from the bucket's days OUTSIDE the selected window (the
+        # older days an edge week spans). total_* stays the in-period sum; the
+        # chart stacks this faded segment on top so the bar shows the whole week.
+        self.out_of_period_distance_m = 0
+        self.out_of_period_moving_time_s = 0
 
     def add(self, daily: DailyFact):
         self.total_distance_m += daily.total_distance_m
@@ -245,6 +251,22 @@ def _coverage_days(
     return in_days, total_days - in_days
 
 
+def _add_out_of_period_values(buckets, pre_window_daily, key_fn) -> None:
+    """Fold pre-window (out-of-period) days into the matching displayed bucket's
+    ``out_of_period_*`` totals (#566), so the chart can stack a faded segment for
+    the part of an edge bucket that falls before the window start. Pre-window
+    days whose bucket is not displayed (older than the leading bucket) are
+    ignored. ``key_fn`` maps a date to its bucket's start key.
+    """
+    if not pre_window_daily:
+        return
+    for df in pre_window_daily:
+        bucket = buckets.get(key_fn(df.local_date))
+        if bucket is not None:
+            bucket.out_of_period_distance_m += df.total_distance_m
+            bucket.out_of_period_moving_time_s += df.total_moving_time_s
+
+
 class PeriodBucket:
     """Aggregation bucket for one coarse granularity period (#432)."""
 
@@ -252,6 +274,7 @@ class PeriodBucket:
         "period_start", "total_distance_m", "total_moving_time_s",
         "total_effort_score", "activity_count",
         "in_period_days", "out_of_period_days",
+        "out_of_period_distance_m", "out_of_period_moving_time_s",
     )
 
     def __init__(self, period_start: date):
@@ -264,6 +287,10 @@ class PeriodBucket:
         # builder from the bucket's full span against the selected window.
         self.in_period_days = 0
         self.out_of_period_days = 0
+        # Distance/time from the bucket's days OUTSIDE the selected window; see
+        # WeekBucket. total_* stays the in-period sum.
+        self.out_of_period_distance_m = 0
+        self.out_of_period_moving_time_s = 0
 
     def add(self, daily: DailyFact):
         self.total_distance_m += daily.total_distance_m
@@ -503,6 +530,7 @@ def build_weekly_buckets(
     range_key: str = "30D",
     since: Optional[date] = None,
     until: Optional[date] = None,
+    pre_window_daily: Optional[List[DailyFact]] = None,
 ) -> List[WeekBucket]:
     """
     Roll daily facts into ISO-week buckets (Monday start).
@@ -512,6 +540,9 @@ def build_weekly_buckets(
     Pass ``until`` to override the window end (#413): calendar mode passes the
     calendar period's last day so the chart spans the whole period. Defaults to
     today (rolling).
+    Pass ``pre_window_daily`` (days just before ``since``) so a leading edge
+    week carries the value of its out-of-window days for the stacked partial
+    bar (#566); ``total_*`` stays the in-period sum.
     """
     # Build buckets from actual data first
     buckets: dict[date, WeekBucket] = {}
@@ -548,6 +579,10 @@ def build_weekly_buckets(
         w.in_period_days, w.out_of_period_days = _coverage_days(
             w.week_start, w.week_start + timedelta(days=6), since, end
         )
+    # Carry the out-of-window value of a leading edge week's earlier days.
+    _add_out_of_period_values(
+        buckets, pre_window_daily, lambda d: d - timedelta(days=d.weekday())
+    )
 
     return sorted(buckets.values(), key=lambda w: w.week_start)
 
@@ -558,6 +593,7 @@ def build_period_buckets(
     range_key: str = "30D",
     since: Optional[date] = None,
     until: Optional[date] = None,
+    pre_window_daily: Optional[List[DailyFact]] = None,
 ) -> List[PeriodBucket]:
     """Roll daily facts into coarse buckets (#432) for ``biweekly`` or ``monthly``.
 
@@ -599,6 +635,10 @@ def build_period_buckets(
         b.in_period_days, b.out_of_period_days = _coverage_days(
             b.period_start, span_end, since, end
         )
+    # Carry the out-of-window value of a leading edge bucket's earlier days.
+    _add_out_of_period_values(
+        buckets, pre_window_daily, lambda d: _period_start(d, period)
+    )
 
     return sorted(buckets.values(), key=lambda b: b.period_start)
 
@@ -915,6 +955,21 @@ def get_trends_report(
     # 2. Daily facts (sum per local date)
     daily_facts = build_daily_facts(activity_facts)
 
+    # #566: the days just before the window — back to the 1st of `since`'s month,
+    # the earliest leading-bucket start across the week / 2-week / month
+    # granularities — so a leading edge bucket can show the value of its
+    # out-of-window days as a faded stacked segment (the bar then shows the whole
+    # week/period, not just the in-window slice). Kept separate from
+    # daily_facts so the summary/header totals stay strictly in-period.
+    pre_window_daily: List[DailyFact] = []
+    if since is not None:
+        pre_start = _period_start(since, "monthly")
+        if pre_start < since:
+            pre_facts = _query_activity_facts(
+                db, pre_start, since, types=types, user_id=user_id
+            )
+            pre_window_daily = build_daily_facts(pre_facts)
+
     # Summary totals across the entire range
     cur_easy, cur_mod, cur_hard = _zone_minutes(activity_facts)
     summary = TrendsSummary(
@@ -969,7 +1024,8 @@ def get_trends_report(
 
     # 4. Weekly buckets (continuous — includes empty weeks)
     weekly = build_weekly_buckets(
-        daily_facts, range_key=range_upper, since=since, until=until
+        daily_facts, range_key=range_upper, since=since, until=until,
+        pre_window_daily=pre_window_daily,
     )
 
     weekly_distance = [
@@ -979,6 +1035,7 @@ def get_trends_report(
             activity_count=w.activity_count,
             in_period_days=w.in_period_days,
             out_of_period_days=w.out_of_period_days,
+            out_of_period_distance_m=w.out_of_period_distance_m,
         )
         for w in weekly
     ]
@@ -990,6 +1047,7 @@ def get_trends_report(
             activity_count=w.activity_count,
             in_period_days=w.in_period_days,
             out_of_period_days=w.out_of_period_days,
+            out_of_period_moving_time_s=w.out_of_period_moving_time_s,
         )
         for w in weekly
     ]
@@ -1004,10 +1062,12 @@ def get_trends_report(
 
     # 4b. Coarse buckets (#432): 2-week and month rollups of the same daily facts.
     biweekly = build_period_buckets(
-        daily_facts, "biweekly", range_key=range_upper, since=since, until=until
+        daily_facts, "biweekly", range_key=range_upper, since=since, until=until,
+        pre_window_daily=pre_window_daily,
     )
     monthly = build_period_buckets(
-        daily_facts, "monthly", range_key=range_upper, since=since, until=until
+        daily_facts, "monthly", range_key=range_upper, since=since, until=until,
+        pre_window_daily=pre_window_daily,
     )
 
     def _period_distance(buckets: List[PeriodBucket]) -> List[PeriodDistancePoint]:
@@ -1018,6 +1078,7 @@ def get_trends_report(
                 activity_count=b.activity_count,
                 in_period_days=b.in_period_days,
                 out_of_period_days=b.out_of_period_days,
+                out_of_period_distance_m=b.out_of_period_distance_m,
             )
             for b in buckets
         ]
@@ -1030,6 +1091,7 @@ def get_trends_report(
                 activity_count=b.activity_count,
                 in_period_days=b.in_period_days,
                 out_of_period_days=b.out_of_period_days,
+                out_of_period_moving_time_s=b.out_of_period_moving_time_s,
             )
             for b in buckets
         ]

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -163,6 +163,7 @@ class WeekBucket:
         "easy_seconds", "moderate_seconds", "hard_seconds",
         "in_period_days", "out_of_period_days",
         "out_of_period_distance_m", "out_of_period_moving_time_s",
+        "out_of_period_effort_score",
     )
 
     def __init__(self, week_start: date):
@@ -179,11 +180,13 @@ class WeekBucket:
         # buckets that straddle the window boundary.
         self.in_period_days = 7
         self.out_of_period_days = 0
-        # Distance/time from the bucket's days OUTSIDE the selected window (the
-        # older days an edge week spans). total_* stays the in-period sum; the
-        # chart stacks this faded segment on top so the bar shows the whole week.
+        # Distance/time/load from the bucket's days OUTSIDE the selected window
+        # (the older days an edge week spans). total_* stays the in-period sum;
+        # the chart stacks this faded segment on top so the bar shows the whole
+        # week.
         self.out_of_period_distance_m = 0
         self.out_of_period_moving_time_s = 0
+        self.out_of_period_effort_score = 0.0
 
     def add(self, daily: DailyFact):
         self.total_distance_m += daily.total_distance_m
@@ -265,6 +268,7 @@ def _add_out_of_period_values(buckets, pre_window_daily, key_fn) -> None:
         if bucket is not None:
             bucket.out_of_period_distance_m += df.total_distance_m
             bucket.out_of_period_moving_time_s += df.total_moving_time_s
+            bucket.out_of_period_effort_score += df.total_effort_score
 
 
 class PeriodBucket:
@@ -275,6 +279,7 @@ class PeriodBucket:
         "total_effort_score", "activity_count",
         "in_period_days", "out_of_period_days",
         "out_of_period_distance_m", "out_of_period_moving_time_s",
+        "out_of_period_effort_score",
     )
 
     def __init__(self, period_start: date):
@@ -287,10 +292,11 @@ class PeriodBucket:
         # builder from the bucket's full span against the selected window.
         self.in_period_days = 0
         self.out_of_period_days = 0
-        # Distance/time from the bucket's days OUTSIDE the selected window; see
-        # WeekBucket. total_* stays the in-period sum.
+        # Distance/time/load from the bucket's days OUTSIDE the selected window;
+        # see WeekBucket. total_* stays the in-period sum.
         self.out_of_period_distance_m = 0
         self.out_of_period_moving_time_s = 0
+        self.out_of_period_effort_score = 0.0
 
     def add(self, daily: DailyFact):
         self.total_distance_m += daily.total_distance_m
@@ -1056,6 +1062,9 @@ def get_trends_report(
         WeeklySufferScorePoint(
             week_start=w.week_start,
             effort_score=round(w.total_effort_score, 1),
+            in_period_days=w.in_period_days,
+            out_of_period_days=w.out_of_period_days,
+            out_of_period_effort_score=round(w.out_of_period_effort_score, 1),
         )
         for w in weekly
     ]
@@ -1101,6 +1110,9 @@ def get_trends_report(
             PeriodSufferScorePoint(
                 period_start=b.period_start,
                 effort_score=round(b.total_effort_score, 1),
+                in_period_days=b.in_period_days,
+                out_of_period_days=b.out_of_period_days,
+                out_of_period_effort_score=round(b.out_of_period_effort_score, 1),
             )
             for b in buckets
         ]

--- a/backend/tests/test_trends_edge_buckets.py
+++ b/backend/tests/test_trends_edge_buckets.py
@@ -17,9 +17,10 @@ from app.services.trends import (
 )
 
 
-def _df(d: date, dist: int = 0) -> DailyFact:
+def _df(d: date, dist: int = 0, effort: float = 0.0) -> DailyFact:
     f = DailyFact(d)
     f.total_distance_m = dist
+    f.total_effort_score = effort
     return f
 
 
@@ -93,8 +94,8 @@ def test_weekly_leading_edge_carries_out_of_period_value():
     # bucket total; the pre-window Jun 1 (3000) + Jun 2 (2000) are the
     # out-of-period value the chart stacks as a faded segment, so the bar shows
     # the whole week (6000 m) rather than only the in-window slice.
-    in_window = [_df(date(2026, 6, 5), 1000)]
-    pre = [_df(date(2026, 6, 1), 3000), _df(date(2026, 6, 2), 2000)]
+    in_window = [_df(date(2026, 6, 5), 1000, effort=10.0)]
+    pre = [_df(date(2026, 6, 1), 3000, effort=30.0), _df(date(2026, 6, 2), 2000, effort=20.0)]
     weeks = build_weekly_buckets(
         in_window, since=date(2026, 6, 3), until=date(2026, 6, 16),
         pre_window_daily=pre,
@@ -103,6 +104,9 @@ def test_weekly_leading_edge_carries_out_of_period_value():
     lead = by[date(2026, 6, 1)]
     assert lead.total_distance_m == 1000  # in-period sum stays honest
     assert lead.out_of_period_distance_m == 5000  # Jun 1-2 outside the window
+    # Load (effort_score) splits the same way for the Accumulated Load chart.
+    assert lead.total_effort_score == 10.0
+    assert lead.out_of_period_effort_score == 50.0
     # Interior weeks are unaffected.
     assert by[date(2026, 6, 8)].out_of_period_distance_m == 0
 

--- a/backend/tests/test_trends_edge_buckets.py
+++ b/backend/tests/test_trends_edge_buckets.py
@@ -1,0 +1,98 @@
+"""Edge/partial bucket coverage (#566).
+
+When a week / 2-week / month bucket straddles the selected period boundary,
+the builder must report how many of the bucket's days fall inside the period
+(``in_period_days``) versus outside it (``out_of_period_days``), so the chart
+can fade the partial bar rather than letting it read as a genuine low bucket.
+The bucket's aggregated totals are unchanged (still the in-period sum); only
+the coverage is added.
+"""
+
+from datetime import date, timedelta
+
+from app.services.trends import (
+    DailyFact,
+    build_period_buckets,
+    build_weekly_buckets,
+)
+
+
+def _df(d: date, dist: int = 0) -> DailyFact:
+    f = DailyFact(d)
+    f.total_distance_m = dist
+    return f
+
+
+# 2026-06-01 is a Monday; 2026-06-30 is a Tuesday.
+
+
+def test_weekly_trailing_edge_flags_partial_coverage():
+    # Calendar June: weeks anchored Mon at Jun 1, 8, 15, 22, 29. The Jun 29 week
+    # spans Jun 29 - Jul 5, but the period ends Jun 30, so 2 days are in-period
+    # and 5 spill into July.
+    facts = [_df(date(2026, 6, 2), 5000), _df(date(2026, 6, 29), 3000)]
+    weeks = build_weekly_buckets(facts, since=date(2026, 6, 1), until=date(2026, 6, 30))
+    by = {w.week_start: w for w in weeks}
+
+    assert [w.week_start for w in weeks] == [
+        date(2026, 6, 1), date(2026, 6, 8), date(2026, 6, 15),
+        date(2026, 6, 22), date(2026, 6, 29),
+    ]
+    # Full interior weeks carry no spill.
+    assert by[date(2026, 6, 1)].out_of_period_days == 0
+    assert by[date(2026, 6, 1)].in_period_days == 7
+    assert by[date(2026, 6, 8)].out_of_period_days == 0
+    # Trailing edge: Jun 29-30 in, Jul 1-5 out.
+    assert by[date(2026, 6, 29)].in_period_days == 2
+    assert by[date(2026, 6, 29)].out_of_period_days == 5
+    # Totals stay the in-period sum (unchanged behaviour).
+    assert by[date(2026, 6, 29)].total_distance_m == 3000
+
+
+def test_weekly_leading_edge_flags_partial_coverage():
+    # A window starting mid-week (Wed Jun 3): the leading week (Mon Jun 1) has
+    # Jun 1-2 outside the window and Jun 3-7 inside.
+    facts = [_df(date(2026, 6, 5), 1000)]
+    weeks = build_weekly_buckets(facts, since=date(2026, 6, 3), until=date(2026, 6, 16))
+    by = {w.week_start: w for w in weeks}
+
+    assert by[date(2026, 6, 1)].in_period_days == 5
+    assert by[date(2026, 6, 1)].out_of_period_days == 2
+    # Interior week fully covered.
+    assert by[date(2026, 6, 8)].out_of_period_days == 0
+
+
+def test_all_range_has_no_partial_buckets():
+    # ALL (since stays None) frames the whole history, so no bucket is partial.
+    facts = [_df(date(2026, 6, 5), 1000)]
+    weeks = build_weekly_buckets(
+        facts, range_key="ALL", since=None, until=date(2026, 6, 16)
+    )
+    assert all(w.out_of_period_days == 0 for w in weeks)
+    assert all(w.in_period_days == 7 for w in weeks)
+
+
+def test_monthly_leading_edge_flags_partial_coverage():
+    # Window starts mid-May; the May month bucket has May 1-9 outside and
+    # May 10-31 inside. June is fully inside; July ends exactly at the window.
+    facts = [_df(date(2026, 5, 15), 1000)]
+    months = build_period_buckets(
+        facts, "monthly", since=date(2026, 5, 10), until=date(2026, 7, 31)
+    )
+    by = {m.period_start: m for m in months}
+
+    assert by[date(2026, 5, 1)].in_period_days == 22  # May 10-31
+    assert by[date(2026, 5, 1)].out_of_period_days == 9  # May 1-9
+    assert by[date(2026, 6, 1)].out_of_period_days == 0  # full month
+    assert by[date(2026, 7, 1)].out_of_period_days == 0  # ends at window
+
+
+def test_biweekly_bucket_coverage_spans_fourteen_days():
+    # A fortnight bucket straddling the window start splits across 14 days.
+    facts = [_df(date(2026, 6, 10), 1000)]
+    fortnights = build_period_buckets(
+        facts, "biweekly", since=date(2026, 6, 10), until=date(2026, 6, 30)
+    )
+    for fn in fortnights:
+        assert fn.in_period_days + fn.out_of_period_days == 14
+        assert fn.in_period_days >= 0 and fn.out_of_period_days >= 0

--- a/backend/tests/test_trends_edge_buckets.py
+++ b/backend/tests/test_trends_edge_buckets.py
@@ -87,6 +87,39 @@ def test_monthly_leading_edge_flags_partial_coverage():
     assert by[date(2026, 7, 1)].out_of_period_days == 0  # ends at window
 
 
+def test_weekly_leading_edge_carries_out_of_period_value():
+    # Window starts Wed Jun 3. The leading week (Mon Jun 1) spans Jun 1-7;
+    # Jun 1-2 are before the window. The in-window Jun 5 run (1000 m) is the
+    # bucket total; the pre-window Jun 1 (3000) + Jun 2 (2000) are the
+    # out-of-period value the chart stacks as a faded segment, so the bar shows
+    # the whole week (6000 m) rather than only the in-window slice.
+    in_window = [_df(date(2026, 6, 5), 1000)]
+    pre = [_df(date(2026, 6, 1), 3000), _df(date(2026, 6, 2), 2000)]
+    weeks = build_weekly_buckets(
+        in_window, since=date(2026, 6, 3), until=date(2026, 6, 16),
+        pre_window_daily=pre,
+    )
+    by = {w.week_start: w for w in weeks}
+    lead = by[date(2026, 6, 1)]
+    assert lead.total_distance_m == 1000  # in-period sum stays honest
+    assert lead.out_of_period_distance_m == 5000  # Jun 1-2 outside the window
+    # Interior weeks are unaffected.
+    assert by[date(2026, 6, 8)].out_of_period_distance_m == 0
+
+
+def test_monthly_leading_edge_carries_out_of_period_value():
+    # Window starts May 10; the May month bucket's May 1-9 are out-of-period.
+    in_window = [_df(date(2026, 5, 15), 1000)]
+    pre = [_df(date(2026, 5, 3), 4000)]
+    months = build_period_buckets(
+        in_window, "monthly", since=date(2026, 5, 10), until=date(2026, 5, 31),
+        pre_window_daily=pre,
+    )
+    may = {m.period_start: m for m in months}[date(2026, 5, 1)]
+    assert may.total_distance_m == 1000
+    assert may.out_of_period_distance_m == 4000
+
+
 def test_biweekly_bucket_coverage_spans_fourteen_days():
     # A fortnight bucket straddling the window start splits across 14 days.
     facts = [_df(date(2026, 6, 10), 1000)]

--- a/frontend/components/trends/SufferScoreChart.tsx
+++ b/frontend/components/trends/SufferScoreChart.tsx
@@ -38,12 +38,34 @@ interface Props {
 }
 
 export default function SufferScoreChart({ data, granularity, delta, typical }: Props) {
-  const chartData = data.map((d: any) => ({
-    ...d,
-    label: formatDateLabel(bucketKey(d)),
-  }));
+  // #566: an edge bucket straddles the selected period boundary; render the
+  // whole bucket as a stacked bar — in-range load solid, out-of-range load
+  // faded on top — so a partial week/period isn't misread as a low one and the
+  // same bucket reads at the same height across ranges. Daily/per-activity
+  // points carry no out-of-period value, so they render as a single bar.
+  const chartData = data.map((d: any) => {
+    const inRaw = d.effort_score ?? 0;
+    const outRaw = d.out_of_period_effort_score ?? 0;
+    const outDays = d.out_of_period_days ?? 0;
+    const inDays = d.in_period_days ?? null;
+    return {
+      ...d,
+      inValue: inRaw,
+      outValue: outRaw > 0 ? outRaw : null,
+      inRaw,
+      outRaw,
+      label: formatDateLabel(bucketKey(d)),
+      partial: outDays > 0,
+      inDays,
+      totalDays: inDays != null ? inDays + outDays : null,
+    };
+  });
 
-  const title = `Accumulated Load per ${BUCKET_NOUN[granularity]}`;
+  const noun = BUCKET_NOUN[granularity];
+  const title = `Accumulated Load per ${noun}`;
+  const hasOutSegment = chartData.some((d: any) => d.outValue != null);
+  const partialNoun = noun.toLowerCase();
+  const fmtRaw = (raw: number) => Math.round(raw).toLocaleString();
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 shadow-sm p-5">
@@ -77,14 +99,33 @@ export default function SufferScoreChart({ data, granularity, delta, typical }: 
             <Tooltip
               content={
                 <ChartTooltip
-                  formatter={(value) => [(value as number) ?? 0, "Accumulated Load"]}
+                  formatter={(_value, _name, entry) => {
+                    const p: any = entry.payload;
+                    if (entry.dataKey === "outValue") {
+                      return [fmtRaw(p?.outRaw ?? 0), "Outside range"];
+                    }
+                    const inName = p?.partial
+                      ? `In range · ${p.inDays}/${p.totalDays} days`
+                      : "Accumulated Load";
+                    return [fmtRaw(p?.inRaw ?? 0), inName];
+                  }}
                 />
               }
               cursor={{ fill: "rgba(0,0,0,0.05)" }}
             />
+            {/* Stacked: in-range (solid) + out-of-range (faded) = whole bucket. */}
             <Bar
-              dataKey="effort_score"
+              dataKey="inValue"
+              stackId="load"
               fill="#ef4444"
+              radius={[4, 4, 0, 0]}
+              maxBarSize={40}
+            />
+            <Bar
+              dataKey="outValue"
+              stackId="load"
+              fill="#ef4444"
+              fillOpacity={0.32}
               radius={[4, 4, 0, 0]}
               maxBarSize={40}
             />
@@ -97,6 +138,12 @@ export default function SufferScoreChart({ data, granularity, delta, typical }: 
             )}
           </BarChart>
         </ResponsiveContainer>
+      )}
+      {hasOutSegment && (
+        <p className="mt-3 text-xs text-gray-400 dark:text-gray-500">
+          The faded segment is the part of an edge {partialNoun} that falls
+          outside the selected period — the bar shows the whole {partialNoun}.
+        </p>
       )}
     </div>
   );

--- a/frontend/components/trends/TrendBarChart.tsx
+++ b/frontend/components/trends/TrendBarChart.tsx
@@ -3,7 +3,6 @@
 import {
   BarChart,
   Bar,
-  Cell,
   XAxis,
   YAxis,
   Tooltip,
@@ -51,36 +50,46 @@ export default function TrendBarChart({
   const barColor = isDistance ? "#3b82f6" : "#10b981";
   const unitLabel = isDistance ? " km" : " min";
 
-  // Data transformation
-  const chartData = data.map((d) => {
-    const rawValue = isDistance ? d.total_distance_m : d.total_moving_time_s;
-    // For distance: meters -> km
-    // For time: seconds -> minutes (for bar height)
-    const chartValue = isDistance
-      ? +(rawValue / 1000).toFixed(1)
-      : +(rawValue / 60).toFixed(0);
+  // meters -> km / seconds -> minutes for the bar height.
+  const toChart = (raw: number) =>
+    isDistance ? +(raw / 1000).toFixed(1) : +(raw / 60).toFixed(0);
 
-    // #566: an edge bucket straddles the selected period boundary, so part of
-    // its week/fortnight/month falls outside the window. Fade it and annotate
-    // coverage so a partial bucket doesn't read as a genuine low bucket.
+  // Data transformation. #566: an edge bucket straddles the selected period
+  // boundary, so part of its week/fortnight/month falls outside the window.
+  // Render the WHOLE bucket as a stacked bar — the in-range value solid, the
+  // out-of-range value (the bucket's days before the window) as a faded segment
+  // on top — so the bar shows the full week's total and how much is in range,
+  // and the same week reads at the same height across ranges.
+  const chartData = data.map((d) => {
+    const inRaw = isDistance ? d.total_distance_m : d.total_moving_time_s;
+    const outRaw =
+      (isDistance ? d.out_of_period_distance_m : d.out_of_period_moving_time_s) ?? 0;
     const outDays = d.out_of_period_days ?? 0;
     const inDays = d.in_period_days ?? null;
-    const partial = outDays > 0;
 
     return {
       ...d,
-      value: chartValue,
-      rawValue: rawValue, // preserve for tooltip
+      inValue: toChart(inRaw),
+      // null (not 0) so a full bucket renders no faded segment and drops the
+      // "outside range" tooltip row.
+      outValue: outRaw > 0 ? toChart(outRaw) : null,
+      inRaw,
+      outRaw,
       label: formatDateLabel(bucketKey(d)),
-      partial,
+      partial: outDays > 0,
       inDays,
       totalDays: inDays != null ? inDays + outDays : null,
     };
   });
 
   const tooltipPrefix = TOOLTIP_PREFIX[granularity];
-  const hasPartial = chartData.some((d) => d.partial);
+  // A faded segment is only drawn when an edge bucket has real out-of-range
+  // value (a leading week reaching before the window); the trailing in-progress
+  // bucket has none yet.
+  const hasOutSegment = chartData.some((d) => d.outValue != null);
   const partialNoun = noun.toLowerCase();
+  const fmtRaw = (raw: number) =>
+    isDistance ? `${(raw / 1000).toFixed(2)} km` : formatMinutes(raw);
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 shadow-sm p-5">
@@ -114,29 +123,39 @@ export default function TrendBarChart({
                 <ChartTooltip
                   formatter={(_value, _name, entry) => {
                     const p = entry.payload;
-                    const raw = (p?.rawValue as number) ?? 0;
-                    const coverage =
-                      p?.partial && p?.totalDays
-                        ? ` · partial (${p.inDays}/${p.totalDays} days in range)`
-                        : "";
-                    if (isDistance)
-                      return [`${(raw / 1000).toFixed(2)} km`, `Distance${coverage}`];
-                    return [formatMinutes(raw), `Moving Time${coverage}`];
+                    if (entry.dataKey === "outValue") {
+                      return [fmtRaw((p?.outRaw as number) ?? 0), "Outside range"];
+                    }
+                    const inName = p?.partial
+                      ? `In range · ${p.inDays}/${p.totalDays} days`
+                      : isDistance
+                        ? "Distance"
+                        : "Moving Time";
+                    return [fmtRaw((p?.inRaw as number) ?? 0), inName];
                   }}
                   labelFormatter={(label) => `${tooltipPrefix}${label}`}
                 />
               }
               cursor={{ fill: "rgba(0,0,0,0.05)" }}
             />
-            <Bar dataKey="value" radius={[4, 4, 0, 0]} maxBarSize={40}>
-              {chartData.map((d, i) => (
-                <Cell
-                  key={i}
-                  fill={barColor}
-                  fillOpacity={d.partial ? 0.4 : 1}
-                />
-              ))}
-            </Bar>
+            {/* Stacked: in-range (solid) + out-of-range (faded) so the bar is
+                the whole bucket. Full buckets have a null out segment and render
+                exactly as before. */}
+            <Bar
+              dataKey="inValue"
+              stackId="bucket"
+              fill={barColor}
+              radius={[4, 4, 0, 0]}
+              maxBarSize={40}
+            />
+            <Bar
+              dataKey="outValue"
+              stackId="bucket"
+              fill={barColor}
+              fillOpacity={0.32}
+              radius={[4, 4, 0, 0]}
+              maxBarSize={40}
+            />
             {typical != null && typical > 0 && (
               <ReferenceLine
                 y={typical}
@@ -151,10 +170,10 @@ export default function TrendBarChart({
           </BarChart>
         </ResponsiveContainer>
       )}
-      {hasPartial && (
+      {hasOutSegment && (
         <p className="mt-3 text-xs text-gray-400 dark:text-gray-500">
-          Faded bars are partial — only part of the {partialNoun} falls inside the
-          selected period.
+          The faded segment is the part of an edge {partialNoun} that falls
+          outside the selected period — the bar shows the whole {partialNoun}.
         </p>
       )}
     </div>

--- a/frontend/components/trends/TrendBarChart.tsx
+++ b/frontend/components/trends/TrendBarChart.tsx
@@ -3,6 +3,7 @@
 import {
   BarChart,
   Bar,
+  Cell,
   XAxis,
   YAxis,
   Tooltip,
@@ -59,15 +60,27 @@ export default function TrendBarChart({
       ? +(rawValue / 1000).toFixed(1)
       : +(rawValue / 60).toFixed(0);
 
+    // #566: an edge bucket straddles the selected period boundary, so part of
+    // its week/fortnight/month falls outside the window. Fade it and annotate
+    // coverage so a partial bucket doesn't read as a genuine low bucket.
+    const outDays = d.out_of_period_days ?? 0;
+    const inDays = d.in_period_days ?? null;
+    const partial = outDays > 0;
+
     return {
       ...d,
       value: chartValue,
       rawValue: rawValue, // preserve for tooltip
       label: formatDateLabel(bucketKey(d)),
+      partial,
+      inDays,
+      totalDays: inDays != null ? inDays + outDays : null,
     };
   });
 
   const tooltipPrefix = TOOLTIP_PREFIX[granularity];
+  const hasPartial = chartData.some((d) => d.partial);
+  const partialNoun = noun.toLowerCase();
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 shadow-sm p-5">
@@ -100,21 +113,30 @@ export default function TrendBarChart({
               content={
                 <ChartTooltip
                   formatter={(_value, _name, entry) => {
-                    const raw = (entry.payload?.rawValue as number) ?? 0;
-                    if (isDistance) return [`${(raw / 1000).toFixed(2)} km`, "Distance"];
-                    return [formatMinutes(raw), "Moving Time"];
+                    const p = entry.payload;
+                    const raw = (p?.rawValue as number) ?? 0;
+                    const coverage =
+                      p?.partial && p?.totalDays
+                        ? ` · partial (${p.inDays}/${p.totalDays} days in range)`
+                        : "";
+                    if (isDistance)
+                      return [`${(raw / 1000).toFixed(2)} km`, `Distance${coverage}`];
+                    return [formatMinutes(raw), `Moving Time${coverage}`];
                   }}
                   labelFormatter={(label) => `${tooltipPrefix}${label}`}
                 />
               }
               cursor={{ fill: "rgba(0,0,0,0.05)" }}
             />
-            <Bar
-              dataKey="value"
-              fill={barColor}
-              radius={[4, 4, 0, 0]}
-              maxBarSize={40}
-            />
+            <Bar dataKey="value" radius={[4, 4, 0, 0]} maxBarSize={40}>
+              {chartData.map((d, i) => (
+                <Cell
+                  key={i}
+                  fill={barColor}
+                  fillOpacity={d.partial ? 0.4 : 1}
+                />
+              ))}
+            </Bar>
             {typical != null && typical > 0 && (
               <ReferenceLine
                 y={typical}
@@ -128,6 +150,12 @@ export default function TrendBarChart({
             )}
           </BarChart>
         </ResponsiveContainer>
+      )}
+      {hasPartial && (
+        <p className="mt-3 text-xs text-gray-400 dark:text-gray-500">
+          Faded bars are partial — only part of the {partialNoun} falls inside the
+          selected period.
+        </p>
       )}
     </div>
   );

--- a/frontend/lib/types/trends.ts
+++ b/frontend/lib/types/trends.ts
@@ -3,9 +3,12 @@ export interface WeeklyDistancePoint {
   total_distance_m: number;
   activity_count: number;
   // #566: edge-bucket coverage. out_of_period_days > 0 marks a partial week
-  // that straddles the selected period boundary (drawn faded).
+  // straddling the period boundary; out_of_period_distance_m is the value of
+  // its days outside the window, stacked as a faded segment so the bar shows
+  // the whole week.
   in_period_days?: number | null;
   out_of_period_days?: number;
+  out_of_period_distance_m?: number;
 }
 
 export interface WeeklyTimePoint {
@@ -14,6 +17,7 @@ export interface WeeklyTimePoint {
   activity_count: number;
   in_period_days?: number | null;
   out_of_period_days?: number;
+  out_of_period_moving_time_s?: number;
 }
 
 export interface DailyDistancePoint {
@@ -73,6 +77,7 @@ export interface PeriodDistancePoint {
   // #566: edge-bucket coverage; see WeeklyDistancePoint.
   in_period_days?: number | null;
   out_of_period_days?: number;
+  out_of_period_distance_m?: number;
 }
 
 export interface PeriodTimePoint {
@@ -81,6 +86,7 @@ export interface PeriodTimePoint {
   activity_count: number;
   in_period_days?: number | null;
   out_of_period_days?: number;
+  out_of_period_moving_time_s?: number;
 }
 
 export interface PeriodSufferScorePoint {

--- a/frontend/lib/types/trends.ts
+++ b/frontend/lib/types/trends.ts
@@ -46,6 +46,10 @@ export interface DailySufferScorePoint {
 export interface WeeklySufferScorePoint {
   week_start: string;
   effort_score: number;
+  // #566: edge-bucket coverage + out-of-window load; see WeeklyDistancePoint.
+  in_period_days?: number | null;
+  out_of_period_days?: number;
+  out_of_period_effort_score?: number;
 }
 
 export interface EfficiencyPoint {
@@ -92,6 +96,9 @@ export interface PeriodTimePoint {
 export interface PeriodSufferScorePoint {
   period_start: string;
   effort_score: number;
+  in_period_days?: number | null;
+  out_of_period_days?: number;
+  out_of_period_effort_score?: number;
 }
 
 export interface PeriodZoneLoadPoint {

--- a/frontend/lib/types/trends.ts
+++ b/frontend/lib/types/trends.ts
@@ -2,12 +2,18 @@ export interface WeeklyDistancePoint {
   week_start: string;
   total_distance_m: number;
   activity_count: number;
+  // #566: edge-bucket coverage. out_of_period_days > 0 marks a partial week
+  // that straddles the selected period boundary (drawn faded).
+  in_period_days?: number | null;
+  out_of_period_days?: number;
 }
 
 export interface WeeklyTimePoint {
   week_start: string;
   total_moving_time_s: number;
   activity_count: number;
+  in_period_days?: number | null;
+  out_of_period_days?: number;
 }
 
 export interface DailyDistancePoint {
@@ -64,12 +70,17 @@ export interface PeriodDistancePoint {
   period_start: string;
   total_distance_m: number;
   activity_count: number;
+  // #566: edge-bucket coverage; see WeeklyDistancePoint.
+  in_period_days?: number | null;
+  out_of_period_days?: number;
 }
 
 export interface PeriodTimePoint {
   period_start: string;
   total_moving_time_s: number;
   activity_count: number;
+  in_period_days?: number | null;
+  out_of_period_days?: number;
 }
 
 export interface PeriodSufferScorePoint {


### PR DESCRIPTION
Closes #566.

## What
On the Trends bar charts, edge buckets (weeks / 2-week / month buckets straddling the selected period boundary) only counted their in-window days, so the **same week read at different heights across ranges** (e.g. the week of May 25 showed 43.97 km in a 3M view but 12.16 km in a 30D view) — confusing, and a partial bucket looked like a genuine low week.

Now each edge bucket renders as the **whole bucket**: a stacked bar with the in-range part solid and the out-of-range part faded on top. The bar height is the full week/period regardless of range; only the solid/faded split changes.

## Change
**Backend** (`trends.py`, `schemas/trends.py`):
- `_coverage_days` computes each bucket's in/out-of-period **day** counts (for the tooltip).
- `get_trends_report` fetches the days just before the window — back to the 1st of `since`'s month, the earliest leading-bucket start across the week / 2-week / month granularities — and `_add_out_of_period_values` folds their value into each leading bucket's `out_of_period_distance_m` / `out_of_period_moving_time_s`.
- `total_*` stays the **in-period sum**, so the period summary and header deltas are untouched (honest). The pre-window fetch is separate from `daily_facts`.
- Weekly/period distance & time points carry `in_period_days`, `out_of_period_days`, and the out-of-period value.

**Frontend** (`TrendBarChart.tsx`, `types/trends.ts`):
- Two stacked `<Bar>`s: in-range (solid) + out-of-range (faded, same colour at 0.32 opacity). A full bucket has a null out segment and renders exactly as before.
- Tooltip shows **In range · N/M days** and **Outside range** as separate rows; a caption explains the faded segment. The daily chart is a different component, so the day grouping is untouched.

## Acceptance criteria
- [x] Edge/partial buckets are visually distinguishable from full buckets.
- [x] Each edge bar shows the whole bucket with the in-period portion solid and the out-of-period portion faded.
- [x] Consistent across calendar and rolling modes and week / 2-week groupings.
- [x] Period header totals stay honest (`total_*` and the summary are the in-period sum; the chart shows the whole bucket).
- [x] Existing full-bucket rendering and the day grouping are unchanged.

## Verification
TDD on the backend (`tests/test_trends_edge_buckets.py`): day-coverage for leading/trailing weekly edges, monthly + biweekly spans, ALL-range no-partial, plus the **out-of-period value split** (weekly + monthly leading edges with the in-period total staying honest). Full backend suite green (1884 passed).

Real-browser check against a seeded production snapshot (`make verify-local`):
- The week of May 25 totals 43,968 m in both rolling-30D (split 12.16 km solid + 31.81 km faded) and calendar-3M (fully solid) — same bar height, different split.
- Rolling 30D Week and Calendar 3M Week / 2-week render the leading edge as a stacked solid+faded bar on Distance and Time; full weeks unchanged.
- `npm run test` (next lint + next build) green.

## Out of scope
Suffer-score and zone-load charts use different components; this targets the distance & time bar charts (`TrendBarChart`) the issue names. A trailing in-progress bucket whose out-of-window days are in the future has no value to fade (it is genuinely empty so far).