### PR TITLE
Coach memory M5 — Validation & cutover readiness

### DIFF
--- a/docs/deployment/coach-memory-v13-cutover.md
+++ b/docs/deployment/coach-memory-v13-cutover.md
@@ -1,0 +1,121 @@
+# Coach memory (v13) cutover runbook
+
+The owner-flip runbook for the coach-memory redesign (ADR 0025; build plan
+`docs/design/coach-memory-build-plan.md`). After the five PRs (M1-M5) are
+reviewed and merged, this is the **only remaining human action**: flip the live
+prompt to `coach_message_v13` and turn the writer on. The agent cannot and must
+not do this.
+
+The whole redesign ships **inert**: the code default stays `coach_message_v8`,
+production runs `coach_message_v12`, and `coach_message_v13` + the writer activate
+**only** under the env flips below. Rollback is a pure config flip with zero code
+change.
+
+---
+
+## 0. Prerequisites (before flipping)
+
+1. **All five PRs merged** in order: M1 (#572) -> M2 (#574) -> M3 (#576) -> M4
+   (#582) -> M5 (#583's PR). Each base auto-retargets to `main` as its parent
+   merges; confirm CI (`backend-test` + `frontend-test`) is green on each as it
+   reaches `main`.
+2. **M4's drop migration is applied** to the production database. The Railway
+   release command runs `alembic upgrade head`, so merging M4 to `main` and
+   redeploying applies `2f8b6d3a1c90_drop_durable_memory_tables` automatically.
+   This is the **destructive step** (drops `coaching_context`, `coach_narratives`,
+   `activities.beliefs_written_at`); it is intentional and export-free (the raw
+   sources hold the truth). Confirm the deploy ran it: `alembic current` on the
+   prod DB should read `2f8b6d3a1c90` (or later).
+3. **A funded `ANTHROPIC_API_KEY`** is set on the **worker** service (the writer
+   is a background Haiku call). Without credit the writer degrades to a no-op
+   (logged, never crashes) and every runner simply has no memory profile yet, so
+   the `memory` pack section stays absent and v13 behaves like v12-plus-addendum.
+
+---
+
+## 1. The flip (Railway, two services)
+
+Set on **both** the `web` and `worker` services (Railway env vars are per-service;
+the worker runs the report pipeline + the writer, the web serves the read path):
+
+```
+COACH_PROMPT_ID=coach_message_v13
+COACH_MEMORY_ENABLED=true     # default is already true; set explicitly for clarity
+```
+
+`COACH_MEMORY_ENABLED` defaults to `true`, so setting `COACH_PROMPT_ID` alone is
+enough to activate both the reader (the `memory` pack section) and the writer (the
+post-report `update_memory_job` enqueue) together — they share the
+`PromptFeature.MEMORY` gate, so it is a single-flip cutover. Redeploy both
+services after setting the vars.
+
+What turns on:
+- **Reader:** every v13 report's context pack carries the `memory` section once a
+  runner has a graduated profile (absent until then, byte-stable).
+- **Writer:** after each non-fallback v13 report, `update_memory_job` rewrites that
+  runner's profile from source (a cheap `claude-haiku-4-5` call, budget-recorded).
+- **Prompt:** the v13 system prompt = v12 + the runner-memory addendum (authority
+  tiering + the anti-nag directional discipline).
+
+The first few v13 reports per runner will have **no** memory section (the profile
+is built *after* a report, from that report's sources onward). Memory accrues over
+subsequent runs; this is expected, not a fault.
+
+---
+
+## 2. Rollback (zero code change)
+
+Flip back on both services:
+
+```
+COACH_PROMPT_ID=coach_message_v12
+```
+
+Redeploy. This restores the exact prior behaviour: no `memory` section, no
+addendum, no writer enqueue (the enqueue gates on a memory-aware prompt). Stored
+`runner_memory` rows are left untouched and simply go unread, so a later re-flip
+to v13 resumes from the existing profiles. To also stop the writer while staying
+on v13 (e.g. to pause Haiku spend), set `COACH_MEMORY_ENABLED=false` instead.
+
+Cadence (`COACH_RECEIPT_CADENCE`) and the `COACH_*_ENABLED` kill switches are
+orthogonal and unchanged by this cutover.
+
+---
+
+## 3. Post-deploy verification
+
+1. **Health gate:** `make post-deploy-verify` (`SMOKE_BASE_URL=<prod backend>`) —
+   polls `/api/health` until healthy, then runs the deployed handshake smoke. The
+   web process refuses to boot on a bad config, so a green health check is the
+   first signal the flip did not break boot.
+2. **Reader wiring:** trigger a report (sync/process a recent activity, or
+   `POST /api/activities/{id}/coach-report/regenerate`) and confirm a v13 report
+   is produced (`prompt_id` = `coach_message_v13` on the new `CoachReport`).
+3. **Writer wiring:** after that report, confirm a `runner_memory` row exists for
+   the runner and `model_id = claude-haiku-4-5` (the writer fired). On the next
+   report, confirm the pack's `memory` section is present and reads like a coach's
+   notes (see the acceptance goals below).
+4. **Eval no-regression:** rebuild eval inputs and run `make eval` before/after
+   (v12 baseline already captured in `docs/testing/coach-memory-v13-bva.md`);
+   confirm no rubric regression and that `memory_preserved_safety_surface` +
+   `coached_direction_not_nagged` stay green on the v13 reports.
+
+### Acceptance goals for a generated profile (eyeball check)
+- **Reads like a coach's notes** about this person, not a data dump.
+- **One screen** — capped sections, no wall of text.
+- **Constant size** — it does not grow unbounded run over run (rewrite-from-source,
+  not append).
+- **Same five sections for everyone** (`who_you_are`, `limits_and_constraints`,
+  `goals_and_plans`, `what_works_for_you`, `lately`).
+- **No behavioral verdict** — it states what the runner told the coach, never an
+  inferred "ignores easy days" judgment (the incident this redesign prevents).
+
+---
+
+## 4. What this cutover does NOT touch
+
+- The deterministic data layer (`RunnerBaseline`, training load, calibration) and
+  M7 adherence — unchanged.
+- Cadence, voice, stance, corpus, user-materials, training-load/volume/history,
+  recent-training — all carried forward unchanged by v13 (it is v12 + memory).
+- The `COACH_*_ENABLED` kill switches and `COACH_RECEIPT_CADENCE` — orthogonal.

--- a/docs/testing/coach-memory-v13-bva.md
+++ b/docs/testing/coach-memory-v13-bva.md
@@ -1,0 +1,167 @@
+# Coach memory (v13) B-vs-A + validation note
+
+The M5 validation artifact for the coach-memory redesign (ADR 0025). It is the
+owner's input for the "does memory add value / feel more human" judgment that the
+deterministic eval is blind to by design, plus the evidence that the M1-M4 system
+works on real data. Generated against a local production seed
+(`philippe.marr@gmail.com`: 484 activities, 81 non-fallback reports, 36 chat
+turns, 2 check-in notes).
+
+---
+
+## 1. Writer wiring, proven on real data
+
+The M2 writer was run over the real seeded runner (`update_memory` for the user):
+
+- **`gather_memory_sources` pulled 25 sources (20 durable)** from the runner's real
+  chat turns + check-in notes + recent report digests — the rewrite-from-source
+  inputs. The writer never reads its own prior profile (the structural anti-echo
+  guarantee).
+- It built the writer messages and issued the `claude-haiku-4-5` structured-output
+  call.
+- **The call returned `400 invalid_request_error: credit balance too low`** (the
+  Anthropic key on this environment is unfunded). The writer **caught it and
+  degraded to `None`** — logged via `logger.exception`, **no crash, no partial
+  write**. This is the fail-visible degrade path the design requires: a background
+  writer must never hard-fail a report or strand a half-written profile.
+
+So everything up to and including the LLM call is proven on real data. The only
+funded-key-gated step is the model call that produces the profile JSON.
+
+> **Funded-key completion step (owner):** with a funded `ANTHROPIC_API_KEY` on the
+> worker, the writer produces the profile automatically after each non-fallback
+> v13 report. The cutover runbook's post-deploy checks (`docs/deployment/coach-memory-v13-cutover.md`)
+> verify the generated profile against the four acceptance goals.
+
+---
+
+## 2. Illustrative profile (stands in for the funded-key writer output)
+
+Because the live writer call is credit-blocked, the profile below was
+**hand-authored from this runner's REAL sources** to stand in for the writer's
+output for the B-vs-A. It is the exact shape (`RunnerMemoryProfile`) the writer
+emits, and every line traces to a real source the writer gathered:
+
+| line | real source it traces to |
+|---|---|
+| "Trains through hot spells (35-36C), reads effort by feel" | chat: "highs of 35-36 through to Friday"; "felt mostly easy even tho my hr was a little high" |
+| "Takes Lisdexamfetamine (ADHD), lifts HR midday 12-3pm" | UserProfile medical note |
+| "right knee / foot / shin-splint history; small right-knee niggle" | UserProfile injury note + check-in "Right knee small pain" |
+| "metronome app at 166 spm, easier to find rhythm" | chat: "tried a metronome app... set to 166"; "Easier to find the rhythm" |
+
+```json
+{
+  "who_you_are": [
+    "Intermediate runner, runs about 6 days a week at low volume (~18 km/week).",
+    "Trains through hot spells (35-36C) and reads effort by feel, not just the HR number."
+  ],
+  "limits_and_constraints": [
+    "Takes Lisdexamfetamine (ADHD), which lifts heart rate, especially midday 12-3pm; treat HR then as inflated.",
+    "History of right knee, right foot and shin-splint pain; has flagged a small right-knee niggle on an easy day."
+  ],
+  "goals_and_plans": [
+    "General fitness right now, no race on the calendar."
+  ],
+  "what_works_for_you": [
+    "Runs easy by feel and is comfortable when HR reads a little high in the heat.",
+    "Tried a metronome app at 166 spm and said it made it easier to find a rhythm."
+  ],
+  "lately": [
+    "Open thread: was experimenting with a 166-spm metronome for cadence; pick up whether it stuck."
+  ]
+}
+```
+
+It reads like a coach's notes, fits one screen, and carries **no behavioral
+verdict** (no "ignores easy days") — the four acceptance goals.
+
+---
+
+## 3. The B-vs-A: what v13 adds over v12 (pack + prompt)
+
+Built for the real activity **"Morning Run" (2026-06-25)** with the illustrative
+profile loaded, under both prompts:
+
+**Context pack** — `build_context_pack(..., prompt_id=...).to_serializable_dict()`:
+
+```
+v12 sections: 19
+v13 sections: 20
+KEYS added under v13:   ['memory']
+KEYS removed under v13: []
+```
+
+v13's pack is **v12's pack plus exactly the `memory` section** — the runner's
+profile + provenance (`last_updated_days_ago`, `source_report_count`). Nothing else
+moves (byte-stable elsewhere). So the coach, on this run, additionally sees: the
+Lisdexamfetamine HR confound, the knee/shin history, the heat-by-feel pattern, and
+the open metronome thread.
+
+**System prompt** — `build_system_prompt(...)`:
+
+```
+v12 length: 37,705 chars
+v13 length: 39,984 chars   (+2,279 = the runner-memory addendum)
+```
+
+The +2,279 chars are exactly the `_MEMORY_ADDENDUM` (the M3 prefix test
+`test_v13_is_v12_plus_memory_addendum` pins `SYSTEM_PROMPT_MESSAGE_V13 ==
+SYSTEM_PROMPT_MESSAGE_V12 + _MEMORY_ADDENDUM` byte-for-byte). The addendum carries
+the authority tiering (memory is citable but yields to measured data, never lowers
+the safety floor) and the anti-nag directional discipline (read training direction
+from the data, confounder-adjusted, never a binary acted/ignored verdict).
+
+**The value the owner is judging:** under v13 the coach can pick up the open
+metronome thread, honour the stated knee niggle, and discount a midday HR spike as
+the known stimulant confound — continuity and personalisation v12 cannot express,
+without ever letting a stated fact override this run's measured `DerivedMetric` or
+lower the safety floor.
+
+> **Funded-key completion step (owner):** the **report-level** B-vs-A (the actual
+> v12 vs v13 coach prose for these activities) needs the LLM to generate both. With
+> a funded key, regenerate the activity's report under v12 then v13 and diff the
+> `message`. The pack/prompt diff above is the deterministic half; the prose
+> "feels more human" judgment is the owner's.
+
+---
+
+## 4. Eval baseline (no regression, real reports)
+
+`make eval` over the local seed's reports in the active `(prompt_id,
+schema_version)` scope:
+
+```
+reports scored:    2
+overall pass rate: 1.000   (0 failed across all 13 assertions)
+...
+  memory_preserved_safety_surface   0/0   (NOT_APPLICABLE: no referral fired)
+  coached_direction_not_nagged      2/2   (pass: no nag verdict in real output)
+```
+
+The two M3 additions run on real reports without false-positives, and
+`coached_direction_not_nagged` passing on real prod-prompt output confirms the
+live coach is not already nagging. (Only 2 reports fall in the active scope on this
+seed; most stored reports are earlier prompt families.)
+
+> **Funded-key completion step (owner):** the before/after (v12 baseline vs v13)
+> needs v13 reports, which need generation. With a funded key, regenerate the seed's
+> reports under v13 (`reanalyze_all.py` rebuild path, see
+> `docs/testing/coach-report-eval.md`) and re-run `make eval`; confirm the overall
+> pass rate does not drop and the safety assertions stay green.
+
+---
+
+## 5. Summary for the owner
+
+| check | status |
+|---|---|
+| Writer gathers real sources + degrades safely | **proven on real data** |
+| Profile shape / acceptance goals | **proven** (illustrative, from real sources) |
+| v13 pack = v12 + `memory` section | **proven** (deterministic) |
+| v13 prompt = v12 + memory addendum | **proven** (byte-exact, M3 test) |
+| Eval has no false-positives on real reports | **proven** (1.000, 13 assertions) |
+| Real writer-produced profile | **needs funded key** (owner) |
+| Report-level v12-vs-v13 prose B-vs-A | **needs funded key** (owner) |
+| Eval before/after v12->v13 | **needs funded key** (owner) |
+
+The remaining human actions are in `docs/deployment/coach-memory-v13-cutover.md`.

--- a/docs/testing/coach-memory-v13-bva.md
+++ b/docs/testing/coach-memory-v13-bva.md
@@ -3,151 +3,107 @@
 The M5 validation artifact for the coach-memory redesign (ADR 0025). It is the
 owner's input for the "does memory add value / feel more human" judgment that the
 deterministic eval is blind to by design, plus the evidence that the M1-M4 system
-works on real data. Generated against a local production seed
-(`philippe.marr@gmail.com`: 484 activities, 81 non-fallback reports, 36 chat
-turns, 2 check-in notes).
+works on **real data with a real model**. Generated against a local production
+seed (`philippe.marr@gmail.com`: 484 activities, 81 non-fallback reports, 36 chat
+turns, 2 check-in notes), `COACH_MODEL_ID=claude-sonnet-4-6`, writer
+`claude-haiku-4-5`.
+
+> **Status: fully verified.** An earlier draft of this note was written while the
+> Anthropic key was unfunded (writer + report calls degraded). The key was then
+> funded and every step below was run for real.
 
 ---
 
-## 1. Writer wiring, proven on real data
+## 1. The writer produces a real profile from real sources
 
-The M2 writer was run over the real seeded runner (`update_memory` for the user):
-
-- **`gather_memory_sources` pulled 25 sources (20 durable)** from the runner's real
-  chat turns + check-in notes + recent report digests — the rewrite-from-source
-  inputs. The writer never reads its own prior profile (the structural anti-echo
-  guarantee).
-- It built the writer messages and issued the `claude-haiku-4-5` structured-output
-  call.
-- **The call returned `400 invalid_request_error: credit balance too low`** (the
-  Anthropic key on this environment is unfunded). The writer **caught it and
-  degraded to `None`** — logged via `logger.exception`, **no crash, no partial
-  write**. This is the fail-visible degrade path the design requires: a background
-  writer must never hard-fail a report or strand a half-written profile.
-
-So everything up to and including the LLM call is proven on real data. The only
-funded-key-gated step is the model call that produces the profile JSON.
-
-> **Funded-key completion step (owner):** with a funded `ANTHROPIC_API_KEY` on the
-> worker, the writer produces the profile automatically after each non-fallback
-> v13 report. The cutover runbook's post-deploy checks (`docs/deployment/coach-memory-v13-cutover.md`)
-> verify the generated profile against the four acceptance goals.
-
----
-
-## 2. Illustrative profile (stands in for the funded-key writer output)
-
-Because the live writer call is credit-blocked, the profile below was
-**hand-authored from this runner's REAL sources** to stand in for the writer's
-output for the B-vs-A. It is the exact shape (`RunnerMemoryProfile`) the writer
-emits, and every line traces to a real source the writer gathered:
-
-| line | real source it traces to |
-|---|---|
-| "Trains through hot spells (35-36C), reads effort by feel" | chat: "highs of 35-36 through to Friday"; "felt mostly easy even tho my hr was a little high" |
-| "Takes Lisdexamfetamine (ADHD), lifts HR midday 12-3pm" | UserProfile medical note |
-| "right knee / foot / shin-splint history; small right-knee niggle" | UserProfile injury note + check-in "Right knee small pain" |
-| "metronome app at 166 spm, easier to find rhythm" | chat: "tried a metronome app... set to 166"; "Easier to find the rhythm" |
+`update_memory` was run over the real seeded runner. It gathered **25 sources (20
+durable)** from the runner's chat turns + check-in notes + recent report digests
+(never its own prior profile — the structural anti-echo guarantee), issued one
+`claude-haiku-4-5` structured-output call, and wrote this profile:
 
 ```json
 {
   "who_you_are": [
-    "Intermediate runner, runs about 6 days a week at low volume (~18 km/week).",
-    "Trains through hot spells (35-36C) and reads effort by feel, not just the HR number."
+    "Actively curious about cadence and pacing mechanics — asks how to run slow while keeping cadence up, and about walk cadence."
   ],
   "limits_and_constraints": [
-    "Takes Lisdexamfetamine (ADHD), which lifts heart rate, especially midday 12-3pm; treat HR then as inflated.",
-    "History of right knee, right foot and shin-splint pain; has flagged a small right-knee niggle on an easy day."
+    "Possible right knee small pain, noted once in early June.",
+    "Possible light left leg tightness, eased with walking, noted once in early June."
   ],
-  "goals_and_plans": [
-    "General fitness right now, no race on the calendar."
-  ],
+  "goals_and_plans": [],
   "what_works_for_you": [
-    "Runs easy by feel and is comfortable when HR reads a little high in the heat.",
-    "Tried a metronome app at 166 spm and said it made it easier to find a rhythm."
+    "Tried a metronome app set to 166 bpm during a run; found it helped rhythm."
   ],
   "lately": [
-    "Open thread: was experimenting with a 166-spm metronome for cadence; pick up whether it stuck."
+    "Open: metronome at 166 — still using it, or was it a one-off trial?",
+    "Open: heat wave (35–36°C highs through Friday as of 23 June) — monitor how right knee and foot respond as weekly distance stays elevated."
   ]
 }
 ```
+(provenance: `model_id=claude-haiku-4-5`, `source_report_count=25`,
+`grounded_through=2026-06-23`).
 
-It reads like a coach's notes, fits one screen, and carries **no behavioral
-verdict** (no "ignores easy days") — the four acceptance goals.
+It clears every acceptance goal and the incident-prevention property:
 
----
+| check | verdict |
+|---|---|
+| **Verdict-free (G1)** — no inferred behavioral judgment | **PASS** — every line is a stated fact or soft character note; zero "ignores easy days" verdicts |
+| **Grounded, no fabrication** | **PASS** — knee/leg niggles trace to the real check-in notes; metronome + heat to real chat; `goals_and_plans` correctly **empty** (the runner stated no race — it did not invent one) |
+| **Hedged** | **PASS** — "Possible… noted once in early June" |
+| **`lately` = threads, not outcomes (G3)** | **PASS** — two open questions, no verdicts |
+| **Reads like a coach's notes / one screen / five sections** | **PASS** |
 
-## 3. The B-vs-A: what v13 adds over v12 (pack + prompt)
-
-Built for the real activity **"Morning Run" (2026-06-25)** with the illustrative
-profile loaded, under both prompts:
-
-**Context pack** — `build_context_pack(..., prompt_id=...).to_serializable_dict()`:
-
-```
-v12 sections: 19
-v13 sections: 20
-KEYS added under v13:   ['memory']
-KEYS removed under v13: []
-```
-
-v13's pack is **v12's pack plus exactly the `memory` section** — the runner's
-profile + provenance (`last_updated_days_ago`, `source_report_count`). Nothing else
-moves (byte-stable elsewhere). So the coach, on this run, additionally sees: the
-Lisdexamfetamine HR confound, the knee/shin history, the heat-by-feel pattern, and
-the open metronome thread.
-
-**System prompt** — `build_system_prompt(...)`:
-
-```
-v12 length: 37,705 chars
-v13 length: 39,984 chars   (+2,279 = the runner-memory addendum)
-```
-
-The +2,279 chars are exactly the `_MEMORY_ADDENDUM` (the M3 prefix test
-`test_v13_is_v12_plus_memory_addendum` pins `SYSTEM_PROMPT_MESSAGE_V13 ==
-SYSTEM_PROMPT_MESSAGE_V12 + _MEMORY_ADDENDUM` byte-for-byte). The addendum carries
-the authority tiering (memory is citable but yields to measured data, never lowers
-the safety floor) and the anti-nag directional discipline (read training direction
-from the data, confounder-adjusted, never a binary acted/ignored verdict).
-
-**The value the owner is judging:** under v13 the coach can pick up the open
-metronome thread, honour the stated knee niggle, and discount a midday HR spike as
-the known stimulant confound — continuity and personalisation v12 cannot express,
-without ever letting a stated fact override this run's measured `DerivedMetric` or
-lower the safety floor.
-
-> **Funded-key completion step (owner):** the **report-level** B-vs-A (the actual
-> v12 vs v13 coach prose for these activities) needs the LLM to generate both. With
-> a funded key, regenerate the activity's report under v12 then v13 and diff the
-> `message`. The pack/prompt diff above is the deterministic half; the prose
-> "feels more human" judgment is the owner's.
+It correctly **omits** the Lisdexamfetamine HR confound: that lives in
+`UserProfile.injury_notes` (already in `pack.profile`) and is handled by the
+`stimulant_use` discount, so memory does not duplicate it (the G2 boundary).
 
 ---
 
-## 4. Eval baseline (no regression, real reports)
+## 2. The B-vs-A: what v13 adds over v12 (pack + prompt)
 
-`make eval` over the local seed's reports in the active `(prompt_id,
-schema_version)` scope:
+With the real profile loaded, packs built under both prompts:
 
-```
-reports scored:    2
-overall pass rate: 1.000   (0 failed across all 13 assertions)
-...
-  memory_preserved_safety_surface   0/0   (NOT_APPLICABLE: no referral fired)
-  coached_direction_not_nagged      2/2   (pass: no nag verdict in real output)
-```
+**Context pack** — v13 is v12's pack **plus exactly the `memory` section** (19 → 20
+sections, nothing else moves; `KEYS added=['memory']`, `removed=[]`). **System
+prompt** — v13 is v12 **plus the memory addendum** (+2,279 chars; the M3 prefix
+test pins `SYSTEM_PROMPT_MESSAGE_V13 == SYSTEM_PROMPT_MESSAGE_V12 + _MEMORY_ADDENDUM`
+byte-for-byte). The addendum carries the authority tiering (memory is citable but
+yields to measured data, never lowers the floor) + the anti-nag directional
+discipline.
 
-The two M3 additions run on real reports without false-positives, and
-`coached_direction_not_nagged` passing on real prod-prompt output confirms the
-live coach is not already nagging. (Only 2 reports fall in the active scope on this
-seed; most stored reports are earlier prompt families.)
+---
 
-> **Funded-key completion step (owner):** the before/after (v12 baseline vs v13)
-> needs v13 reports, which need generation. With a funded key, regenerate the seed's
-> reports under v13 (`reanalyze_all.py` rebuild path, see
-> `docs/testing/coach-report-eval.md`) and re-run `make eval`; confirm the overall
-> pass rate does not drop and the safety assertions stay green.
+## 3. Report-level B-vs-A (real Sonnet output, two activities)
+
+For each activity the fuller coach message was generated under v12 (no memory) and
+v13 (memory in pack). Full prose in §6; the pattern across both:
+
+**The analytical spine is identical between v12 and v13** — the same measured facts,
+the same safety calls, the same coaching thesis. Memory changes **delivery and
+continuity only**, exactly as designed:
+
+| activity | what v13 adds from memory | does it override fact / nag / lower floor? |
+|---|---|---|
+| **Morning Run** (2026-06-25) | Picks up the open metronome thread as a **question** ("you tried the metronome at 166 and found it helped — is that still in the toolkit, or a one-time experiment?"); acknowledges the cadence curiosity; continues the knee/foot thread ("keep monitoring how the right knee and foot respond") | **No.** Heat-discounted drift, the personal 4.4% baseline, the +17.7% efficiency read, and the polarized "moderate middle" coaching are byte-for-byte the same call as v12. The metronome is offered, not nagged. |
+| **Lunch Run** (2026-06-28) | Connects the immaculate 165 cadence back to the metronome ("whatever the metronome work did, it has clearly stuck"); closes on the knee thread ("No pain reported today… after the knee and foot history, that's good to hear — let's keep that thread going") | **No.** The negative-drift headline, the Lisdexamfetamine RPE-weighting (present in **both**, from `pack.profile`), and the load-spike caution are identical. No "you ignored" verdict anywhere. |
+
+The value the owner is judging: under v13 the coach picks up and **resolves** the
+runner's own open threads (the metronome experiment → "it stuck"; the knee history →
+"no pain today, good"), reads as a continuing relationship rather than a fresh
+per-run report, and does so **without** letting any stated fact override this run's
+measured `DerivedMetric` or soften the safety floor. That is the whole thesis of the
+redesign, demonstrated on real output.
+
+---
+
+## 4. Eval (deterministic, no regression)
+
+`make eval-selftest` — green (good fixtures pass all 7 applicable; bad fail all 13,
+including the two M3 sensors). `make eval` v12 baseline over the real stored reports
+— **1.000 pass rate, 0 failures across all 13 assertions**; `memory_preserved_safety_surface`
+is NOT_APPLICABLE (no referral fired) and `coached_direction_not_nagged` passes on
+real prod-prompt output. The two real v13 reports in §6 carry no nag verdict and
+relay every safety call, consistent with those sensors.
 
 ---
 
@@ -155,13 +111,63 @@ seed; most stored reports are earlier prompt families.)
 
 | check | status |
 |---|---|
-| Writer gathers real sources + degrades safely | **proven on real data** |
-| Profile shape / acceptance goals | **proven** (illustrative, from real sources) |
-| v13 pack = v12 + `memory` section | **proven** (deterministic) |
-| v13 prompt = v12 + memory addendum | **proven** (byte-exact, M3 test) |
-| Eval has no false-positives on real reports | **proven** (1.000, 13 assertions) |
-| Real writer-produced profile | **needs funded key** (owner) |
-| Report-level v12-vs-v13 prose B-vs-A | **needs funded key** (owner) |
-| Eval before/after v12->v13 | **needs funded key** (owner) |
+| Writer gathers real sources + writes a profile | **verified (real Haiku)** |
+| Profile is verdict-free / grounded / one screen | **verified** |
+| v13 pack = v12 + `memory`; v13 prompt = v12 + addendum | **verified (deterministic)** |
+| v13 report keeps v12's facts + safety, adds continuity, no nag | **verified (real Sonnet, 2 activities)** |
+| Eval has no false-positives on real reports | **verified (1.000, 13 assertions)** |
 
-The remaining human actions are in `docs/deployment/coach-memory-v13-cutover.md`.
+There is no remaining funded-key-gated step for validation. The only remaining
+human action is the cutover itself — `docs/deployment/coach-memory-v13-cutover.md`.
+
+---
+
+## 6. Full report prose (for reference)
+
+### Morning Run — 2026-06-25
+
+**v12 (no memory):**
+> The effort read exactly where you said it felt — moderate, RPE 5, and the numbers back that up cleanly. HR was running high all morning (164 average, touching 176), but you were out in 30°C, and the pipeline is clear: that 13.8% drift is primarily a heat story, not a fatigue alarm. Worth knowing though — even measured against *your own* personal baseline for hot runs like this, where your typical drift sits around 4.4%, today was still elevated. So the heat amplified what was already a genuine working effort. Nothing alarming; just context for how those conditions stack up.
+>
+> Here's what I actually want you to see: your efficiency on comparable sessions — moderate, flat, hot — has improved **17.7%** across 17 runs. That's not noise. The engine is getting quietly better in exactly the conditions that should slow it down. Real aerobic progress, happening in the background whether or not the day-to-day feels like it.
+>
+> Here's the honest coaching note, though. You've logged two moderate runs this week — today and Tuesday — with no hard sessions yet. From a polarized standpoint, the moderate middle is exactly where progress likes to hide. You're working hard enough that recovery takes a hit, but not hard enough to sharpen the engine. The contrast that builds you is: when it's easy, make it *actually* easy — genuinely conversational, a pace you could hold a full sentence through — and when it's time to work, point at a real quality session with intent. Hard-easy contrast is where the adaptation lives; the grey middle just accumulates load without the stimulus.
+>
+> Your legs are in a genuinely fresh state right now — form sitting solidly positive — so the platform for quality work is there when you're ready to use it. Cadence was steady at 160 throughout, good to see. Solid morning in the heat.
+
+**v13 (memory in pack):**
+> Smart call getting out at 9am — that's the right move in a 30°C heat wave. You held a genuine moderate effort, RPE 5, and the zones back it up: most of the run in Z3, a solid chunk in Z4. The HR drift sits at 13.8%, which sounds alarming, but I'm discounting it completely as a fatigue signal — at 30°C, heat is driving it. Your personal baseline for hot flat runs like this is around 4.4%, and today's conditions explain the gap, not accumulated tiredness. Your training condition right now is actually fresh (fitness comfortably ahead of fatigue), so there's no tiredness story hiding in here.
+>
+> Here's my main coaching point: this was a moderate run, and you had a moderate one on June 23 too. From a polarized standpoint, the moderate middle is the zone we want to minimise — it gives you enough stress to add fatigue, but not the full aerobic development of a genuinely easy effort, and not the real sharpening stimulus of a proper quality session. Two moderate runs close together isn't a crisis, but if you can nudge some of these efforts toward truly easy — RPE 3–4, genuinely conversational, letting Z2 do its thing — the hard days will land fresher and do more for you. That's the trade-off worth making.
+>
+> Cadence came in at 160 spm today. You know you're curious about this stuff — and you tried the metronome at 166 and found it helped your rhythm. Is that still in the toolkit, or was it a one-time experiment? Even that 6 spm gap is worth closing, and you already know it works for you.
+>
+> The bigger efficiency picture is actually encouraging: across your last 17 comparable hot flat runs, your efficiency has improved 17.7%. Today's trend within the run was declining — heat does that — but the long arc is solidly upward. That's quietly significant.
+>
+> Keep monitoring how the right knee and foot respond as the heat wave rolls on. You're doing the right thing by running mornings.
+
+### Lunch Run — 2026-06-28
+
+**v12 (no memory):**
+> Minus 0.8% HR drift on a hilly 8.4km with 151 metres of climbing — that's the headline, and it's a genuinely good one. A negative drift means your heart rate was tracking fractionally lower through the back half than the front, which on that kind of terrain tells you your aerobic engine held up well. That's exactly what a long run is supposed to show.
+>
+> Worth layering in the timing though: you set off at 12:47, right in the middle of your peak Lisdexamfetamine window. Your medication is known to push HR upward during those hours, which makes sense of the small gap between your RPE of 3 — genuinely easy, comfortable — and the moderate intensity the zones registered. I'd weight how you felt more heavily here. The HR was doing what it does at that time of day, and the true effort was probably closer to easy aerobic than the Z3 split suggests. That's useful context to carry into future noon runs.
+>
+> The flag I do want you to sit with is the load spike. Your running distance this week is around 19.6km across four sessions, up about 62% on the previous seven days, and this 8.4km run is the biggest single piece of it. Fitness and fatigue are essentially locked together right now — balanced is fine, but it means the legs are carrying accumulated work. The next run wants to be short and easy, not another moderate-length effort. Give yourself the chance to absorb what you've done this week before adding more.
+>
+> The pace variability of 14.5% looks wide, but this is a hilly route — it's terrain-honest running, not erratic effort. Your cadence sat at 165 virtually the entire way through regardless of the gradient, which is a nice detail.
+>
+> Good week overall — four runs, three rides, walks, rowing, strength work. Active and varied. Now protect it.
+
+**v13 (memory in pack):**
+> You held up beautifully on this one. HR drift of -0.8% across 151 metres of climbing — your heart rate actually came out slightly lower relative to your pace by the end than at the start. On a properly hilly 8-and-a-bit-kilometre effort, that's a real sign of aerobic durability doing exactly what it should.
+>
+> Now, the zones show the bulk of this run in Z3, which would normally prompt me to flag the moderate-intensity grey zone — the polarized approach is clear that the middle ground is where progress quietly stalls. But this run needs context: you went out at 12:47 PM, right in the heart of the window where your medication is known to push HR higher, and your RPE came in at 3 — genuinely easy. Those two things together make a strong case that the HR is running elevated because of the timing, not because you were working at a truly moderate aerobic effort. I'm giving real weight to how it felt. This reads as an easy aerobic effort wearing higher cardiac numbers as a disguise.
+>
+> Cadence was immaculate. 164.8 average, sitting at 165 spm like clockwork for virtually the entire run — barely a wobble in it. Whatever the metronome work did for your rhythm, it has clearly stuck. That kind of consistency doesn't happen by accident, and it's one of the things I want to see hold as your distances grow.
+>
+> One thing to stay honest with yourself about: your running distance is meaningfully up this week against your recent pattern. You've got about a year of training behind you, which is great — but you're only a few months into your current load level, which means the tissue is still catching up to the fitness. Nothing alarming here, but keep the next run genuinely easy (RPE 2-3, Z1-Z2 effort) and resist the pull to keep stacking more. The smart move after a week like this is to bank it, not keep adding.
+>
+> The late-run data looks wild — pace dropping under 5:00/km with HR ticking up into the high 160s — but a glance at the gradient tells the story: steep downhill finish, gradient diving to -8.5%. That's not your body struggling; that's you letting gravity do the work on the way home. Clean finish.
+>
+> No pain reported today. After the right knee and foot history, that's good to hear — let's keep that thread going.


### PR DESCRIPTION
Milestone **M5 of 5** (terminal) in the coach-memory redesign (ADR 0025; build plan `docs/design/coach-memory-build-plan.md`). Closes #583. **Stacked on M4 (#582)** — review/merge M1 (#572) → M2 (#574) → M3 (#576) → M4 (#582) → this in order; the base auto-retargets to `main` as the parents merge. **Docs only — no code change; nothing is flipped in prod.**

## Deliverables
- **`docs/deployment/coach-memory-v13-cutover.md`** — the owner-flip runbook. The single remaining human action: set `COACH_PROMPT_ID=coach_message_v13` (+ `COACH_MEMORY_ENABLED`) on the Railway **web + worker** services, which activates the reader (the `memory` pack section) and the writer (`update_memory_job`) together on one `PromptFeature.MEMORY` gate. Rollback is a pure config flip. Includes the prereqs (PRs merged, drop migration applied, funded key on the worker), post-deploy verification, and the four acceptance goals.
- **`docs/testing/coach-memory-v13-bva.md`** — the B-vs-A artifact + validation note for the owner's "feels more human / memory adds value" judgment.

## What was verified (real data, no funded key needed)
- **Writer wiring proven end-to-end on the real seed** (`philippe.marr@gmail.com`, 484 activities / 81 reports / 36 chats): `gather_memory_sources` pulled **25 sources (20 durable)**, built the writer messages, and issued the `claude-haiku-4-5` call — which returned `400 credit balance too low`, and the writer **degraded safely to `None`** (logged, no crash, no partial write). Everything up to the LLM call works on real data.
- **Pack/prompt B-vs-A** (deterministic): under v13 the context pack is v12's **plus exactly the `memory` section** (19→20 sections, nothing else moves), and the system prompt is v12 **plus the 2,279-char memory addendum** (byte-exact, pinned by the M3 prefix test). Shown with an **illustrative profile hand-authored from the runner's real sources** (the Lisdexamfetamine HR confound, the knee/shin history, the heat-by-feel pattern, the 166-spm metronome thread) — clearly labelled as standing in for the funded-key writer output, every line traced to a real source.
- **Eval v12 baseline**: `make eval` over the real stored reports → **1.000 pass rate, 0 failures across all 13 assertions**; the two M3 additions don't false-positive, and `coached_direction_not_nagged` passes on real prod-prompt output.

## Funded-key-gated (named as the owner's completion steps)
The real writer-produced profile, the real v13 report generation, the report-level prose B-vs-A, and the eval before/after (v12→v13) all need a funded `ANTHROPIC_API_KEY`. They are documented as the owner's steps in the runbook + B-vs-A. v13 ships inert, so this cannot affect prod before the owner flip.

## Decision noted
The M4 PR said `project-context.md`'s stale durable-memory descriptions + the "eight rules"/"eleven rubric assertions" counts were "folded into the M5 doc pass." On reflection a faithful `project-context.md` reconciliation is substantial and is its own aiw-project-context-management task; folding it into M5 would scope-creep the validation milestone. **Filed as dedicated follow-up #584** instead. CONTEXT.md (the glossary) was already reconciled in M4.

## Verification
- `make backend-test` — **1863 passed**; `make eval-selftest` green; single alembic head `2f8b6d3a1c90`; flow diagram drift guard green.