### PR TITLE
fix(coach): rest-day-aware M7 adherence so recovery windows abstain (#579)

### DIFF
--- a/backend/app/services/coach/adherence.py
+++ b/backend/app/services/coach/adherence.py
@@ -68,6 +68,12 @@ class CandidateActivity:
     is_race: Optional[bool]
     confidence: Optional[str]  # low|medium|high
     user_intent: Optional[str]
+    # True when the pipeline's discount-signals stage fired on this run (heat,
+    # hills, or stimulant use inflated its HR drift). A confounded run is the
+    # runner managing fatigue, not a fair "opportunity" to have added a hard or
+    # long session, so the window themes exclude it (see _is_rest_or_recovery).
+    # Defaulted so existing call sites and fixtures stay valid.
+    discount_signals_fired: Optional[bool] = None
 
 
 # Effort bands the easy-discipline verdict reads as "kept easy" vs "went hard".
@@ -80,6 +86,47 @@ _HARD_EFFORTS = {"tempo", "hard"}
 def _intent_is_easy(intent: Optional[str]) -> bool:
     text = (intent or "").lower()
     return "easy" in text or "recovery" in text
+
+
+# Effort band and intent tokens that mark a run as a DELIBERATE rest / recovery
+# day rather than a training opportunity. A recovery-band effort is the in-data
+# proxy for a deliberate easy/rest day; a recovery/rest intent is the runner
+# saying so explicitly.
+_REST_EFFORTS = {"recovery"}
+_REST_INTENT_TOKENS = ("recovery", "rest")
+
+
+def _intent_is_rest(intent: Optional[str]) -> bool:
+    text = (intent or "").lower()
+    return any(tok in text for tok in _REST_INTENT_TOKENS)
+
+
+def _is_rest_or_recovery(c: CandidateActivity) -> bool:
+    """Is this comparable run a deliberate rest/recovery day or a confounded run,
+    rather than a genuine OPPORTUNITY to have added a quality or long session?
+
+    Mirrors the v13 directional discipline (prompts.py): "a deliberate rest day
+    or a fired discount signal is not non-compliance." A recovery-band effort, a
+    recovery/rest intent, or a fired discount signal (heat/hills/stimulant) all
+    mean the runner was managing fatigue, so the run must not count toward the
+    opportunity quorum that lets a window theme call the advice "ignored" (#579).
+    The strong "acted_on" read is unaffected: a quality session on such a day
+    still counts (those days are only excluded from the negative verdict)."""
+    if (c.effort or "").lower() in _REST_EFFORTS:
+        return True
+    if c.discount_signals_fired:
+        return True
+    return _intent_is_rest(c.user_intent)
+
+
+def _enough_opportunity(comparables: List[CandidateActivity]) -> bool:
+    """True once the runner has had `_MIN_OPPORTUNITY_RUNS` genuine opportunity
+    runs in the window to have acted on a window theme. Deliberate rest/recovery
+    and confounded runs are excluded (#579): a window with no real opportunity
+    (e.g. only rest/recovery days) must ABSTAIN rather than accuse the runner of
+    ignoring advice it was correct to skip."""
+    opportunities = [c for c in comparables if not _is_rest_or_recovery(c)]
+    return len(opportunities) >= _MIN_OPPORTUNITY_RUNS
 
 
 # Intent labels that declare a deliberate hard/structured session. A run the
@@ -153,8 +200,8 @@ def _verdict_add_quality(comparables: List[CandidateActivity]) -> Optional[_Verd
                 "a race" if c.is_race else f"{c.effort} effort"
             )
             return "acted_on", f"a quality session followed on {c.date[:10]} ({descriptor})", c.date
-    if len(comparables) < _MIN_OPPORTUNITY_RUNS:
-        return None  # not enough opportunity yet to call it ignored
+    if not _enough_opportunity(comparables):
+        return None  # not enough genuine opportunity (rest/recovery days excluded)
     return "ignored", "no tempo, interval, or race session followed in the runs since", None
 
 
@@ -164,8 +211,8 @@ def _verdict_add_long_run(comparables: List[CandidateActivity]) -> Optional[_Ver
     for c in comparables:
         if (c.duration_class or "").lower() == "long":
             return "acted_on", f"a long run followed on {c.date[:10]}", c.date
-    if len(comparables) < _MIN_OPPORTUNITY_RUNS:
-        return None
+    if not _enough_opportunity(comparables):
+        return None  # not enough genuine opportunity (rest/recovery days excluded)
     return "ignored", "no long run followed in the runs since", None
 
 

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -1067,6 +1067,10 @@ def _adherence_candidates(
                 is_race=metrics.is_race,
                 confidence=metrics.confidence,
                 user_intent=act.user_intent,
+                # A fired discount-signals annotation marks a confounded run
+                # (heat/hills/stimulant); the adherence window themes treat it as
+                # exculpatory, not a missed opportunity (#579).
+                discount_signals_fired=bool(metrics.discount_signals),
             )
         )
     return candidates

--- a/backend/tests/test_adherence.py
+++ b/backend/tests/test_adherence.py
@@ -378,6 +378,115 @@ def test_caution_in_details_still_abstains_under_action_first():
 
 
 # --------------------------------------------------------------------------- #
+# #579: a deliberate rest/recovery window must abstain, never call "ignored".
+# A recovery-band effort, a recovery/rest intent, or a fired discount signal is
+# the runner managing fatigue, not a missed opportunity to add quality/distance.
+# --------------------------------------------------------------------------- #
+
+def test_add_quality_abstains_when_window_is_all_recovery():
+    """The runner deliberately recovered across the whole window (recovery-band
+    effort). Even at >= _MIN_OPPORTUNITY_RUNS comparable runs, there was no real
+    opportunity to add a quality session -> abstain, not 'ignored'."""
+    ctx = build_adherence(
+        prior_report_date="2026-02-01T10:00:00+00:00",
+        prior_next_steps=[_step("Add a tempo run")],
+        candidates=[
+            _run("2026-02-03T10:00:00+00:00", effort="recovery"),
+            _run("2026-02-05T10:00:00+00:00", effort="recovery"),
+            _run("2026-02-07T10:00:00+00:00", effort="recovery"),
+        ],
+        pushback=False,
+    )
+    assert ctx.outcomes == []
+
+
+def test_add_quality_abstains_when_recovery_intent_leaves_too_few_opportunities():
+    """Two of three comparable runs were declared recovery/rest; only one genuine
+    opportunity remains, below the quorum -> abstain."""
+    ctx = build_adherence(
+        prior_report_date="2026-02-01T10:00:00+00:00",
+        prior_next_steps=[_step("Add a tempo run")],
+        candidates=[
+            _run("2026-02-03T10:00:00+00:00", effort="easy", user_intent="Recovery"),
+            _run("2026-02-05T10:00:00+00:00", effort="easy", user_intent="Rest day jog"),
+            _run("2026-02-07T10:00:00+00:00", effort="easy"),
+        ],
+        pushback=False,
+    )
+    assert ctx.outcomes == []
+
+
+def test_add_quality_abstains_when_window_is_confounded():
+    """Every comparable run fired a discount signal (heat/hills/stimulant). A
+    confounded run is exculpatory, not a missed opportunity -> abstain."""
+    confounded = [
+        CandidateActivity(
+            date=f"2026-02-0{d}T10:00:00+00:00", effort="easy",
+            duration_class="standard", structure="continuous", is_race=False,
+            confidence="high", user_intent=None, discount_signals_fired=True,
+        )
+        for d in (3, 5, 7)
+    ]
+    ctx = build_adherence(
+        prior_report_date="2026-02-01T10:00:00+00:00",
+        prior_next_steps=[_step("Add a tempo run")],
+        candidates=confounded,
+        pushback=False,
+    )
+    assert ctx.outcomes == []
+
+
+def test_add_quality_still_ignored_with_enough_genuine_opportunity():
+    """A rest day in the window does NOT immunise a genuinely-ignored advice: with
+    >= _MIN_OPPORTUNITY_RUNS real (non-recovery, non-confounded) opportunity runs
+    and still no quality, 'ignored' remains the fair read (no regression)."""
+    ctx = build_adherence(
+        prior_report_date="2026-02-01T10:00:00+00:00",
+        prior_next_steps=[_step("Add a tempo run")],
+        candidates=[
+            _run("2026-02-02T10:00:00+00:00", effort="recovery"),  # exculpatory rest
+            _run("2026-02-03T10:00:00+00:00", effort="easy"),
+            _run("2026-02-05T10:00:00+00:00", effort="easy"),
+            _run("2026-02-07T10:00:00+00:00", effort="easy"),
+        ],
+        pushback=False,
+    )
+    assert ctx.outcomes[0].label == "ignored"
+
+
+def test_add_quality_acted_on_survives_confounded_day():
+    """The exculpatory exclusion only suppresses the NEGATIVE verdict: a real
+    quality session, even on a confounded day, still reads 'acted_on'."""
+    ctx = build_adherence(
+        prior_report_date="2026-02-01T10:00:00+00:00",
+        prior_next_steps=[_step("Add a tempo run")],
+        candidates=[
+            CandidateActivity(
+                date="2026-02-03T10:00:00+00:00", effort="tempo",
+                duration_class="standard", structure="continuous", is_race=False,
+                confidence="high", user_intent=None, discount_signals_fired=True,
+            ),
+        ],
+        pushback=False,
+    )
+    assert ctx.outcomes[0].label == "acted_on"
+
+
+def test_add_long_run_abstains_when_window_is_all_recovery():
+    ctx = build_adherence(
+        prior_report_date="2026-02-01T10:00:00+00:00",
+        prior_next_steps=[_step("Add a long run")],
+        candidates=[
+            _run("2026-02-03T10:00:00+00:00", effort="recovery", duration_class="standard"),
+            _run("2026-02-05T10:00:00+00:00", effort="recovery", duration_class="standard"),
+            _run("2026-02-07T10:00:00+00:00", effort="recovery", duration_class="standard"),
+        ],
+        pushback=False,
+    )
+    assert ctx.outcomes == []
+
+
+# --------------------------------------------------------------------------- #
 # abstention: unrecognised, multi-intent, empty
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Autonomous PR (unattended session) — owner review needed.

Closes #579.

## The bug
The M7 adherence loop (`services/coach/adherence.py`) labels a prior report's `next_step` `acted_on` / `ignored` / `contradicted` by scanning the runner's subsequent comparable activities. For the two **window themes** (`add_quality`, `add_long_run`) the verdict called `ignored` whenever the window held `>= _MIN_OPPORTUNITY_RUNS` (3) comparable runs and none added a quality/long session. A **deliberate rest/recovery day** (recovery-band effort, a recovery/rest intent) or a **confounded run** (heat/hills/stimulant) was counted as a missed opportunity, so a runner who correctly rested could be misread as having *ignored* advice to add a hard or long session. This false-`ignored` was one of the inputs the retired belief loop hardened into a standing "ignores guidance" complaint (the incident).

## The fix
Make the opportunity quorum rest-day-aware, reusing the exact exculpatory signals the v13 directional discipline already names in the prompt (`prompts.py`: *"a deliberate rest day or a fired discount signal is not non-compliance"*):

- New `CandidateActivity.discount_signals_fired` flag (defaulted, so existing call sites/fixtures stay valid), populated in `context.py` from `metrics.discount_signals`.
- New `_is_rest_or_recovery(c)` predicate: a comparable run is exculpatory (not a genuine opportunity) when its effort is recovery-band, its intent is recovery/rest, or it fired a discount signal.
- The window verdicts (`_verdict_add_quality`, `_verdict_add_long_run`) now gate `ignored` on `_enough_opportunity(...)`, which counts only genuine opportunity runs. A window with too few real opportunities (e.g. all recovery days) **abstains** instead of accusing.

The change is bounded to `adherence.py`, its `context.py` wiring, and tests, exactly as the issue scoped it. The deterministic policy validator is untouched.

## Design decisions
- **Suppress only the negative verdict.** The `acted_on` early-return scan is unchanged: a real quality/long session, even on a confounded or recovery day, still reads `acted_on`. Only the `ignored` path excludes rest/recovery/confounded days.
- **Conservative, recall-loss-only direction.** Consistent with the module's existing philosophy (abstain under ambiguity), and with the M7 contract that a false abstain only suppresses a note while a false `ignored` fabricates an accusation.
- **`easy` effort still counts as an opportunity.** Only *recovery* effort / *recovery|rest* intent / confounded runs are excluded. An all-easy week when advised to add quality is still a fair `ignored` (that is the genuine drift the coach should note once); the easy-discipline theme is untouched.

## Test evidence
- New unit tests in `tests/test_adherence.py`: an all-recovery window abstains; a recovery-intent-dominated window abstains; an all-confounded window abstains; an all-long-recovery window abstains; **no regression** — a window with >= 3 genuine opportunity runs (plus a rest day) still reads `ignored`, and a quality session on a confounded day still reads `acted_on`.
- `test_adherence.py`: 38 passed.
- Full backend suite (excluding `integration`): **1869 passed, 9 deselected**.

## Real-seed-data validation (house rule)
Ran a throwaway script over the **487-activity production seed** (this runner has 147 recovery-effort runs), building real adherence candidate windows (real effort / intent / discount_signals) against a synthetic `add a tempo run` step and comparing the old gate vs the new gate:

```
OLD gate said 'ignored': 271
NEW gate said 'ignored': 60
FLIPS (old=ignored -> new=abstain because window was rest/recovery/confounded): 211
```

Example flipped windows contained a real `effort=recovery` day, which is exactly the deliberate-rest case the issue describes. The fix removes 211 false-`ignored` reads on real data while leaving 60 genuine-opportunity `ignored` windows intact.

## Notes
- The coach flow diagram (`docs/diagrams/flow-nodes.js`) was regenerated to check impact; the pack content for the seed activity (including the adherence section) is byte-identical apart from the capture-date stamp, so no diagram change is included.
