### PR TITLE
Strava multi-user resilience: fail-fast 429, per-account refresh lock, deferred first-sync streams, per-call budget gate, prod OAuth-state reject (#596/#597/#599/#601/#602)

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -119,11 +119,11 @@ def update_activity_intent(
     
     return activity
 
-# Sync windows up to this many days fetch streams eagerly (full deep
-# processing). Beyond it, sync is treated as a historical backfill and imports
-# summaries only, because one stream call per activity over a long window would
-# exceed Strava's 100-requests/15-min limit. See #109.
-_STREAM_FETCH_WINDOW_DAYS = 30
+# Default sync window (days). Sync imports summaries for this window in-request
+# and defers all stream fetching to the gated background backfill (#596), so the
+# window size no longer changes whether streams are fetched eagerly — it only
+# bounds how far back the summary import reaches.
+_DEFAULT_SYNC_WINDOW_DAYS = 30
 
 
 @router.post("/sync", response_model=SyncResponse)
@@ -133,21 +133,25 @@ async def sync_activities(
         Query(
             ge=1,
             description=(
-                "How many days back to sync. Windows up to "
-                f"{_STREAM_FETCH_WINDOW_DAYS} days fetch full streams; larger "
-                "windows import activity summaries only (historical backfill)."
+                "How many days back to sync activity summaries. Stream-derived "
+                "analysis is fetched afterwards by the background backfill."
             ),
         ),
-    ] = _STREAM_FETCH_WINDOW_DAYS,
+    ] = _DEFAULT_SYNC_WINDOW_DAYS,
     db: Session = Depends(get_db),
     user: User = Depends(require_current_user),
 ):
     """
     Triggers a manual sync of the last `since_days` days of activities.
 
-    The default window fetches streams and is the routine sync. A larger window
-    backfills summaries only (streams cost one Strava call each and would breach
-    the rate limit over a long window); analysis still runs from the summary.
+    Imports activity summaries in-request (one paginated Strava call) and runs
+    summary-level analysis immediately, then hands stream fetching + stream-derived
+    analysis to the gated background backfill chain (#596). Streams are NOT fetched
+    in-request: one Strava streams call per activity, ungated by the shared rate
+    budget, meant a first sync could fire dozens of calls in-request — blowing
+    Strava's 100/15min ceiling under concurrent onboarding and blocking the request
+    to the gateway timeout. Metrics/coach then populate asynchronously, exactly as
+    the webhook path already does.
     """
     # P2.1: sync only the authenticated user's own Strava account.
     account = db.execute(
@@ -158,9 +162,8 @@ async def sync_activities(
         raise HTTPException(status_code=404, detail="No linked Strava account found. Connect Strava first.")
 
     since = datetime.now() - timedelta(days=since_days)
-    fetch_streams = since_days <= _STREAM_FETCH_WINDOW_DAYS
     activities, stats = await ingest_recent_activities(
-        db, account, get_strava_port(), since=since, fetch_streams=fetch_streams
+        db, account, get_strava_port(), since=since, fetch_streams=False
     )
 
     for activity in activities:
@@ -171,6 +174,14 @@ async def sync_activities(
             stats.errors.append(
                 f"Analysis failed for activity {activity.strava_activity_id}: {exc}"
             )
+
+    # Populate stream-derived analysis in the background, gated by the Strava
+    # budget and self-paced (#601), so concurrent first-syncs cannot overshoot the
+    # shared ceiling. Idempotent + scoped to this user; a no-op when nothing lacks
+    # streams (e.g. a routine re-sync of already-deep-processed activities).
+    from app.jobs.backfill_streams import enqueue_backfill
+
+    enqueue_backfill(db, user.id)
 
     return stats
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
@@ -11,6 +13,8 @@ from app.core.oauth_state import encode_state, decode_state
 from app.db.session import get_db
 from app.models import User, StravaAccount
 from app.services.strava_ingestion import get_strava_port
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -113,15 +117,25 @@ async def strava_callback(
         # the `state` token, so a valid state links the account to exactly that
         # user. This is the fix for mis-linking a second user's Strava account.
         #
-        # Back-compat fallback: when `state` is absent or invalid (a stale link,
-        # a direct callback hit, or single-owner local dev with no state secret)
-        # fall through to the legacy single-owner rule -- attach to the single
-        # existing app user when there is exactly one, else mint a placeholder
-        # email so the non-null constraint holds. The single-owner prod path is
-        # unchanged. (A stricter prod-only reject of an invalid-but-present state
-        # is a possible follow-up; see the PR for #469.)
+        # Multi-user prod (#599): a brand-new athlete MUST arrive with a valid
+        # signed state. If it is absent or invalid (the user lingered on Strava's
+        # consent screen past the state TTL, or hit the callback directly), reject
+        # and send them back to reconnect -- do NOT guess an owner or mint an
+        # orphan `strava-{id}@placeholder.invalid` user that silently loses the
+        # connect while the app still reads as "connected".
+        #
+        # Non-production keeps the legacy single-owner + placeholder fallback so
+        # local/dev without a state secret still links (there is no adversary and
+        # the flow is single-owner).
         new_user = _resolve_user_from_state(db, state)
         if new_user is None:
+            if settings.APP_ENV == "production":
+                logger.warning(
+                    "strava_callback_rejected_no_valid_state athlete=%s", athlete_id
+                )
+                return RedirectResponse(
+                    url=f"{settings.APP_BASE_URL}?strava_error=state_expired"
+                )
             existing_users = db.execute(select(User)).scalars().all()
             if len(existing_users) == 1:
                 new_user = existing_users[0]

--- a/backend/app/core/oauth_state.py
+++ b/backend/app/core/oauth_state.py
@@ -10,8 +10,9 @@ The token is HMAC-SHA256 over ``"{user_id}.{exp}"`` (a Unix expiry), encoded
 base64url so it survives the un-encoded query builder in the Strava adapter. An
 attacker cannot forge a state for a victim's user_id without the signing secret,
 and the short TTL bounds replay. ``decode_state`` never raises: a malformed,
-tampered, or expired token resolves to ``None`` (the caller then falls back to
-the single-owner path), mirroring ``callback_token.decode``.
+tampered, or expired token resolves to ``None``; in production the callback then
+rejects the new-athlete link and prompts a reconnect (#599), while non-production
+falls back to the single-owner path. Mirrors ``callback_token.decode``.
 """
 
 from __future__ import annotations
@@ -26,7 +27,10 @@ from typing import Optional
 
 from app.core.config import settings
 
-_DEFAULT_TTL_SECONDS = 600  # 10 minutes
+# 30 minutes. A runner can linger on Strava's consent screen for several minutes
+# before granting; a too-short TTL expires the state and, in production, forces a
+# reconnect (#599). Long enough to cover a slow consent, short enough to bound replay.
+_DEFAULT_TTL_SECONDS = 1800
 
 
 def _signing_secret() -> bytes:

--- a/backend/app/jobs/backfill_streams.py
+++ b/backend/app/jobs/backfill_streams.py
@@ -39,6 +39,12 @@ logger = logging.getLogger(__name__)
 
 _BACKFILL_JOB_ID = "backfill_streams"
 
+# Best-effort window collapsing rapid re-triggers of a user's backfill into one
+# chain (#596/#601). Short: it only guards against a burst of syncs/taps, not the
+# whole (minutes-to-hours) chain lifetime; the streams_backfilled_at marker keeps
+# any later overlap idempotent.
+_BACKFILL_ENQUEUE_COOLDOWN_S = 120
+
 
 def _eligible_stmt(*, user_id: Optional[str] = None):
     """Activities lacking stream-derived analysis and not yet attempted.
@@ -227,17 +233,45 @@ def backfill_streams_job(user_id: Optional[str] = None) -> None:
         logger.info("Backfill complete: no eligible activities remain")
 
 
+def _acquire_enqueue_slot(user_id: str) -> bool:
+    """Best-effort guard: at most one backfill chain enqueued per user per
+    cooldown, so rapid re-triggers (a double Sync tap, or Sync racing the manual
+    backfill endpoint) don't spawn overlapping chains that double-fetch the same
+    activity's streams against the shared budget. Degrades OPEN on any Redis error
+    so a coordination outage never blocks a legitimate backfill."""
+    try:
+        from app.core.queue import redis_conn
+
+        return bool(
+            redis_conn.set(
+                f"backfill_enqueue:{user_id}",
+                "1",
+                nx=True,
+                ex=_BACKFILL_ENQUEUE_COOLDOWN_S,
+            )
+        )
+    except Exception as exc:  # Redis down / misconfigured: enqueue anyway
+        logger.warning(
+            "backfill_enqueue_guard_unavailable user=%s: %s; enqueuing anyway",
+            user_id,
+            exc,
+        )
+        return True
+
+
 def enqueue_backfill(db: Session, user_id) -> int:
     """Count the runner's eligible activities and enqueue their first backfill batch.
 
-    Returns the eligible count, scoped to `user_id` (#470). A per-user job id
-    keeps a re-trigger from starting a second chain for the same runner while one
-    is in flight, without colliding with another runner's chain; the
-    `streams_backfilled_at` marker makes any overlap idempotent regardless.
-    """
+    Returns the eligible count, scoped to `user_id` (#470). Now called on every
+    `POST /api/sync` (#596), so a best-effort per-user cooldown collapses rapid
+    re-triggers into one chain: `queue.enqueue`'s per-user `job_id` only dedups a
+    still-queued run (not a chain already dequeued and self-rescheduling under a
+    fresh id), so without the cooldown two near-simultaneous syncs could run two
+    chains. The `streams_backfilled_at` marker makes any residual overlap
+    idempotent, and the per-activity budget re-check (#601) bounds the cost."""
     user_id = str(user_id)
     eligible = count_eligible(db, user_id=user_id)
-    if eligible:
+    if eligible and _acquire_enqueue_slot(user_id):
         queue.enqueue(
             backfill_streams_job,
             user_id,

--- a/backend/app/jobs/backfill_streams.py
+++ b/backend/app/jobs/backfill_streams.py
@@ -32,6 +32,8 @@ from app.core.queue import queue
 from app.db.session import SessionLocal
 from app.models import Activity, ActivityStream
 from app.services.analysis import analyze_with_streams
+from app.services.strava_ingestion import strava_budget
+from app.services.strava_ingestion.port import StravaRateLimited
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +78,10 @@ def count_eligible(db: Session, *, user_id: Optional[str] = None) -> int:
 class BackfillBatchResult:
     processed: list[int] = field(default_factory=list)  # strava_activity_ids
     remaining: int = 0
+    # Set when the batch stopped early because the shared Strava budget was
+    # exhausted (or Strava rate-limited us) mid-batch. The job then reschedules
+    # after the budget backoff instead of the normal batch pause (#601).
+    budget_exhausted: bool = False
 
 
 async def backfill_streams_batch(
@@ -83,19 +89,44 @@ async def backfill_streams_batch(
 ) -> BackfillBatchResult:
     """Process up to `limit` eligible activities: fetch streams + re-analyze.
 
-    Marks each attempted activity via `streams_backfilled_at` in a `finally`, so
-    even a hard failure counts as attempted and the job converges (transient
-    Strava errors are already retried inside the HTTP adapter). Commits per
-    activity so progress survives an interruption. Scoped to `user_id` when given
-    (#470). Never notifies.
+    Re-checks the shared Strava budget before EACH activity, not once per batch
+    (#601): a batch of up to BACKFILL_BATCH_SIZE would otherwise fire that many
+    uninterrupted streams calls after a single gate pass, so N concurrent per-user
+    chains could overshoot Strava's 100/15min ceiling. On an exhausted budget — or
+    a StravaRateLimited raised mid-batch (#602) — the loop stops and leaves the
+    remaining activities eligible so they are retried once capacity frees.
+
+    A genuine per-activity failure still marks `streams_backfilled_at` so the job
+    converges (transient Strava errors are retried inside the HTTP adapter, and an
+    activity Strava has no streams for must not be retried forever). Only the
+    budget/rate-limit yield leaves an activity unmarked. Commits per activity so
+    progress survives an interruption. Scoped to `user_id` when given (#470). Never
+    notifies.
     """
     batch = db.execute(_eligible_stmt(user_id=user_id).limit(limit)).scalars().all()
     result = BackfillBatchResult()
 
     for activity in batch:
+        if strava_budget.over_budget():
+            result.budget_exhausted = True
+            logger.info(
+                "Backfill batch yielding mid-batch: Strava budget exhausted "
+                "(%d processed, remaining left eligible)",
+                len(result.processed),
+            )
+            break
         strava_id = activity.strava_activity_id
         try:
             await analyze_with_streams(db, str(activity.id))
+        except StravaRateLimited as exc:
+            # Shared window hit mid-batch: leave this activity eligible (do NOT
+            # mark attempted) and stop so the job reschedules after the backoff.
+            result.budget_exhausted = True
+            logger.info(
+                "Backfill batch yielding: Strava rate limited (retry_after=%s)",
+                exc.retry_after,
+            )
+            break
         except Exception as exc:  # noqa: BLE001 - convergence over completeness
             logger.error(
                 "Backfill failed for activity %s (strava id %s): %s",
@@ -103,11 +134,12 @@ async def backfill_streams_batch(
                 strava_id,
                 exc,
             )
-        finally:
-            activity.streams_backfilled_at = datetime.now(timezone.utc)
-            db.add(activity)
-            db.commit()
-            result.processed.append(strava_id)
+        # Reached only for a genuine attempt (success or terminal-for-this-activity
+        # failure), never the budget/rate-limit break above.
+        activity.streams_backfilled_at = datetime.now(timezone.utc)
+        db.add(activity)
+        db.commit()
+        result.processed.append(strava_id)
 
     result.remaining = count_eligible(db, user_id=user_id)
     logger.info(
@@ -153,14 +185,12 @@ def backfill_streams_job(user_id: Optional[str] = None) -> None:
     `user_id` scopes the eligible set to one runner (#470); the user-triggered
     path always supplies it, while an unscoped call still backfills globally.
 
-    Yields to the shared Strava budget (#544): each batch makes one streams call
-    per activity, the heaviest onboarding cost, so when the global budget is
-    exhausted this defers the whole batch (re-enqueues after the backoff) instead
-    of calling Strava, leaving the shared ceiling for live webhook traffic.
+    Yields to the shared Strava budget (#544/#601): the budget is checked before
+    the batch AND before each activity inside it, so when the global budget is
+    exhausted (up front or mid-batch) this defers (re-enqueues after the backoff)
+    instead of calling Strava, leaving the shared ceiling for live webhook traffic.
     """
-    from app.services.strava_ingestion.strava_budget import over_budget
-
-    if over_budget():
+    if strava_budget.over_budget():
         _reschedule_after_budget(user_id)
         logger.info(
             "Backfill deferred: Strava budget exhausted; retrying in %ds",
@@ -176,7 +206,17 @@ def backfill_streams_job(user_id: Optional[str] = None) -> None:
     finally:
         db.close()
 
-    if result.remaining > 0:
+    if result.budget_exhausted:
+        # Stopped mid-batch on the budget/rate-limit: resume after the budget
+        # backoff (not the short batch pause), so we wait for capacity to free.
+        _reschedule_after_budget(user_id)
+        logger.info(
+            "Backfill deferred mid-batch: Strava budget exhausted; retrying in %ds "
+            "(%d remaining)",
+            settings.STRAVA_BUDGET_BACKOFF_SECONDS,
+            result.remaining,
+        )
+    elif result.remaining > 0:
         _schedule_next_batch(user_id)
         logger.info(
             "Backfill scheduled next batch in %ds (%d remaining)",

--- a/backend/app/jobs/strava_import.py
+++ b/backend/app/jobs/strava_import.py
@@ -53,6 +53,7 @@ from app.services.strava_ingestion.ingestion import (
     _assign_block,
     reconcile_unassigned_activities,
 )
+from app.services.strava_ingestion.port import StravaRateLimited
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,11 @@ async def run_import_batch(
             batch = await port.list_activities_page(
                 access_token, after=after, page=page, per_page=limit
             )
+    except StravaRateLimited:
+        # A rate limit is transient: propagate it so the job reschedules after the
+        # budget backoff (status left "running"), rather than marking the whole
+        # import permanently failed and losing the cursor (#602 / mirrors #601).
+        raise
     except Exception as exc:  # noqa: BLE001 - surface the failure on the row, don't crash the worker
         import_obj.status = "failed"
         import_obj.error = f"Strava list failed: {exc}"
@@ -220,9 +226,22 @@ def strava_import_job(import_id: str) -> None:
                 import_obj.status,
             )
             return
-        result = asyncio.run(
-            run_import_batch(db, import_obj, limit=settings.IMPORT_PAGE_SIZE)
-        )
+        try:
+            result = asyncio.run(
+                run_import_batch(db, import_obj, limit=settings.IMPORT_PAGE_SIZE)
+            )
+        except StravaRateLimited as exc:
+            # Shared window hit mid-walk: defer after the budget backoff, leaving
+            # status "running" so the walk resumes with its cursor intact (#602).
+            _reschedule_after_budget(str(import_id))
+            logger.info(
+                "Historical import %s deferred: Strava rate limited (retry_after=%s); "
+                "retrying in %ds",
+                import_id,
+                exc.retry_after,
+                settings.STRAVA_BUDGET_BACKOFF_SECONDS,
+            )
+            return
     finally:
         db.close()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,10 @@
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from app.api import health, auth, activities, blocks, webhooks, profile, trends, coach, debug, strava_import, materials, account
 from app.core.auth import BasicAuthMiddleware
+from app.services.strava_ingestion.port import StravaRateLimited
 from app.core.clerk_auth import verify_clerk_session
 from app.core.config import settings
 from app.core.observability import (
@@ -31,6 +33,21 @@ app = FastAPI(
     description="Local-first Strava Coach MVP",
     version="0.2.0",
 )
+
+
+@app.exception_handler(StravaRateLimited)
+async def _strava_rate_limited_handler(request: Request, exc: StravaRateLimited):
+    """Surface a Strava rate limit as HTTP 429 on the live request path (#602),
+    so a contended sync returns a clean "retry shortly" instead of a 500. The
+    true Retry-After (when Strava supplied one) rides the standard header."""
+    headers = {}
+    if exc.retry_after is not None:
+        headers["Retry-After"] = str(int(exc.retry_after))
+    return JSONResponse(
+        status_code=429,
+        content={"detail": "Strava is rate-limiting requests right now. Please try again shortly."},
+        headers=headers,
+    )
 
 # BasicAuthMiddleware is REPURPOSED under ADR 0022 as the frontend-to-backend
 # service secret ("proves it is our frontend"), defense in depth beneath the

--- a/backend/app/services/strava_ingestion/__init__.py
+++ b/backend/app/services/strava_ingestion/__init__.py
@@ -7,7 +7,7 @@ from app.services.strava_ingestion.ingestion import (
     refetch_streams,
     upsert_activity,
 )
-from app.services.strava_ingestion.port import StravaPort, Tokens
+from app.services.strava_ingestion.port import StravaPort, StravaRateLimited, Tokens
 
 _default_port: StravaPort | None = None
 
@@ -30,6 +30,7 @@ __all__ = [
     "HTTPStravaAdapter",
     "InMemoryStravaAdapter",
     "StravaPort",
+    "StravaRateLimited",
     "Tokens",
     "ensure_valid_access_token",
     "get_strava_port",

--- a/backend/app/services/strava_ingestion/http_adapter.py
+++ b/backend/app/services/strava_ingestion/http_adapter.py
@@ -6,7 +6,7 @@ from typing import Awaitable, Callable
 import httpx
 
 from app.core.config import settings
-from app.services.strava_ingestion.port import Tokens
+from app.services.strava_ingestion.port import StravaRateLimited, Tokens
 from app.services.strava_ingestion.strava_budget import record as _record_strava_call
 
 logger = logging.getLogger(__name__)
@@ -14,12 +14,20 @@ logger = logging.getLogger(__name__)
 _OAUTH_URL = "https://www.strava.com/oauth/token"
 _BASE_URL = "https://www.strava.com/api/v3"
 
-# Retry tuning. The pipeline job and the polling fallback both flow through
-# this adapter; a single 429 from Strava used to fail the whole pipeline.
+# Retry tuning. The pipeline job, the self-heal check, and the live sync all
+# flow through this adapter.
+#
+# 429 policy (#602): a transient 429 with a short Retry-After is absorbed inline
+# with a bounded retry, but a 429 whose wait exceeds _MAX_INLINE_RETRY_AFTER_S is
+# NOT slept out inline (Strava's window can be up to 15 minutes and holding a
+# worker that long ties up the pool and can still trip the gateway timeout).
+# Instead we raise StravaRateLimited carrying the true Retry-After: the live path
+# turns it into an HTTP 429 "retry shortly", and background jobs let the Strava
+# budget gate (#544) absorb the wait by rescheduling.
 _MAX_RETRIES = 2  # 2 retries after the initial attempt = up to 3 calls total
 _BASE_BACKOFF_S = 1.0
-# Cap an honoured Retry-After so a misbehaving header cannot freeze a worker.
-_MAX_RETRY_AFTER_S = 60.0
+# Longest Retry-After we will absorb with an inline sleep before failing fast.
+_MAX_INLINE_RETRY_AFTER_S = 5.0
 
 # Hard cap on pages walked by list_recent_activities. At per_page=50 this bounds
 # a single call to 2000 activities, enough for a full-history backfill of a
@@ -33,14 +41,17 @@ _MAX_PAGES = 40
 _HTTP_TIMEOUT_S = 30.0
 
 
-def _parse_retry_after(response: httpx.Response, default: float) -> float:
+def _retry_after_seconds(response: httpx.Response) -> float | None:
+    """Return the honoured Retry-After in seconds (uncapped), or None if absent
+    or unparseable. Callers decide whether the wait is short enough to absorb
+    inline or must be surfaced via StravaRateLimited."""
     raw = response.headers.get("Retry-After")
     if raw:
         try:
-            return min(float(raw), _MAX_RETRY_AFTER_S)
+            return float(raw)
         except ValueError:
             pass
-    return min(default, _MAX_RETRY_AFTER_S)
+    return None
 
 
 async def _send_with_retry(
@@ -50,9 +61,11 @@ async def _send_with_retry(
 ) -> httpx.Response:
     """Run request_fn() with bounded retries on 429 + 5xx.
 
-    Returns the final response. Raising is left to the caller via
-    response.raise_for_status() so each method keeps its existing error
-    semantics (e.g. get_activity_streams returns None on failure).
+    On a non-absorbable 429 (Retry-After beyond the inline ceiling, or the
+    bounded retries exhausted) raises StravaRateLimited carrying the true
+    Retry-After (#602). Otherwise returns the final response; raising for other
+    statuses is left to the caller via response.raise_for_status() so each method
+    keeps its existing error semantics (e.g. get_activity_streams returns None).
     """
     response: httpx.Response | None = None
     for attempt in range(_MAX_RETRIES + 1):
@@ -62,14 +75,24 @@ async def _send_with_retry(
         # (#544). This makes the counter honest about ALL metered traffic (webhook
         # ingest included); only the background jobs gate on it, never the live path.
         _record_strava_call()
-        if response.status_code == 429 and attempt < _MAX_RETRIES:
-            wait = _parse_retry_after(response, _BASE_BACKOFF_S * (2 ** attempt))
+        if response.status_code == 429:
+            retry_after = _retry_after_seconds(response)
+            wait = retry_after if retry_after is not None else _BASE_BACKOFF_S * (2 ** attempt)
+            # Absorb a short blip inline; otherwise fail fast so the wait is
+            # handled by the caller (live 429 response, or a background reschedule)
+            # rather than by sleeping a worker for the full window.
+            if attempt < _MAX_RETRIES and wait <= _MAX_INLINE_RETRY_AFTER_S:
+                logger.warning(
+                    "strava_429_retry",
+                    extra={"label": label, "attempt": attempt + 1, "wait_s": wait},
+                )
+                await asyncio.sleep(wait)
+                continue
             logger.warning(
-                "strava_429_retry",
-                extra={"label": label, "attempt": attempt + 1, "wait_s": wait},
+                "strava_429_rate_limited",
+                extra={"label": label, "attempt": attempt + 1, "retry_after_s": retry_after},
             )
-            await asyncio.sleep(wait)
-            continue
+            raise StravaRateLimited(retry_after=retry_after, label=label)
         if 500 <= response.status_code < 600 and attempt < _MAX_RETRIES:
             wait = _BASE_BACKOFF_S * (2 ** attempt)
             logger.warning(
@@ -284,11 +307,11 @@ class HTTPStravaAdapter:
     async def get_athlete_zones(self, access_token: str) -> dict | None:
         headers = {"Authorization": f"Bearer {access_token}"}
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_S) as client:
-            response = await _send_with_retry(
-                lambda: client.get(f"{_BASE_URL}/athlete/zones", headers=headers),
-                label="get_athlete_zones",
-            )
             try:
+                response = await _send_with_retry(
+                    lambda: client.get(f"{_BASE_URL}/athlete/zones", headers=headers),
+                    label="get_athlete_zones",
+                )
                 response.raise_for_status()
                 return response.json()
             except httpx.HTTPStatusError as e:
@@ -296,4 +319,9 @@ class HTTPStravaAdapter:
                 # not a sync prerequisite. A 403 means the profile:read_all scope
                 # was not granted; we log and fall back to the %max scheme.
                 logger.warning("Strava Zones Error: %s", e.response.status_code)
+                return None
+            except StravaRateLimited as e:
+                # Also non-fatal: a rate limit must not fail the whole sync just
+                # for the optional zones refresh; degrade to the %-of-max scheme.
+                logger.warning("Strava Zones rate limited: retry_after=%s", e.retry_after)
                 return None

--- a/backend/app/services/strava_ingestion/ingestion.py
+++ b/backend/app/services/strava_ingestion/ingestion.py
@@ -6,6 +6,7 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.orm import Session, undefer
 
+from app.core.queue import redis_conn
 from app.models import Activity, ActivityStream, StravaAccount, UserProfile
 from app.schemas import SyncResponse
 from app.services.strava_ingestion.port import StravaPort, Tokens
@@ -79,6 +80,21 @@ async def sync_athlete_zones(
 # Buffer in seconds before token expiry we'll trigger a refresh.
 _TOKEN_REFRESH_BUFFER_S = 60
 
+# Per-account refresh serialization (#597). A Strava token refresh ROTATES
+# (invalidates) the refresh token, so two concurrent refreshes for one account
+# race: the second runs with a now-stale refresh token and can permanently
+# unlink the account. We serialize refresh per account with a short Redis lock.
+# TIMEOUT auto-releases if a holder dies mid-refresh (avoids a deadlock); WAIT
+# bounds how long a concurrent caller blocks for the winner (a refresh HTTP call
+# is ~1-2s). If Redis is unavailable we degrade to an unlocked refresh rather
+# than block ingestion — best-effort serialization, never a hard dependency.
+_TOKEN_REFRESH_LOCK_TIMEOUT_S = 15
+_TOKEN_REFRESH_LOCK_WAIT_S = 15
+
+
+def _token_is_fresh(account: StravaAccount) -> bool:
+    return account.expires_at > time.time() + _TOKEN_REFRESH_BUFFER_S
+
 # Stream types pulled during deep ingestion.
 _STREAM_TYPES = [
     "time",
@@ -101,10 +117,74 @@ async def ensure_valid_access_token(
     """Return a valid access token, refreshing and persisting if needed.
 
     Pass force=True to unconditionally refresh (e.g. after a mid-flight 401).
+
+    Refresh is serialized per account behind a Redis lock (#597): a Strava
+    refresh rotates the refresh token, so concurrent refreshes for one account
+    race and the loser can unlink it. The winner refreshes; a loser, on acquiring
+    the lock, RE-READS the row and — if the winner already rotated the token —
+    reuses it instead of refreshing again with a stale refresh token.
     """
-    if not force and account.expires_at > time.time() + _TOKEN_REFRESH_BUFFER_S:
+    if not force and _token_is_fresh(account):
         return account.access_token
 
+    original_access = account.access_token
+    lock = _acquire_refresh_lock(account)
+    if lock is None:
+        # Redis unavailable / not acquired: degrade to an unlocked refresh so a
+        # coordination outage never blocks ingestion.
+        return await _do_refresh(db, account, port)
+    try:
+        # A concurrent caller may have refreshed while we waited. Re-read the row
+        # (READ COMMITTED sees the winner's commit) and, if the access token has
+        # changed, reuse it rather than burning the freshly-rotated refresh token.
+        db.refresh(account)
+        if account.access_token != original_access:
+            return account.access_token
+        if not force and _token_is_fresh(account):
+            return account.access_token
+        return await _do_refresh(db, account, port)
+    finally:
+        _release_refresh_lock(lock)
+
+
+def _acquire_refresh_lock(account: StravaAccount):
+    """Acquire the per-account refresh lock, or None if it can't be taken.
+
+    Returns the held lock (release it via _release_refresh_lock) or None when
+    Redis is unavailable or the wait times out, in which case the caller
+    refreshes unlocked rather than failing."""
+    try:
+        lock = redis_conn.lock(
+            f"strava_token_refresh:{account.id}",
+            timeout=_TOKEN_REFRESH_LOCK_TIMEOUT_S,
+            blocking_timeout=_TOKEN_REFRESH_LOCK_WAIT_S,
+        )
+        if lock.acquire():
+            return lock
+        logger.warning(
+            "strava_token_refresh_lock_timeout account=%s; refreshing unlocked",
+            account.id,
+        )
+        return None
+    except Exception as exc:  # Redis down / misconfigured: degrade, do not block
+        logger.warning(
+            "strava_token_refresh_lock_unavailable account=%s: %s; refreshing unlocked",
+            account.id,
+            exc,
+        )
+        return None
+
+
+def _release_refresh_lock(lock) -> None:
+    try:
+        lock.release()
+    except Exception:  # lock already expired (TTL) or owned by another holder
+        pass
+
+
+async def _do_refresh(
+    db: Session, account: StravaAccount, port: StravaPort
+) -> str:
     tokens = await port.refresh_token(account.refresh_token)
     _apply_tokens(account, tokens)
     db.add(account)

--- a/backend/app/services/strava_ingestion/ingestion.py
+++ b/backend/app/services/strava_ingestion/ingestion.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session, undefer
 from app.core.queue import redis_conn
 from app.models import Activity, ActivityStream, StravaAccount, UserProfile
 from app.schemas import SyncResponse
-from app.services.strava_ingestion.port import StravaPort, Tokens
+from app.services.strava_ingestion.port import StravaPort, StravaRateLimited, Tokens
 
 logger = logging.getLogger(__name__)
 
@@ -84,12 +84,17 @@ _TOKEN_REFRESH_BUFFER_S = 60
 # (invalidates) the refresh token, so two concurrent refreshes for one account
 # race: the second runs with a now-stale refresh token and can permanently
 # unlink the account. We serialize refresh per account with a short Redis lock.
-# TIMEOUT auto-releases if a holder dies mid-refresh (avoids a deadlock); WAIT
-# bounds how long a concurrent caller blocks for the winner (a refresh HTTP call
-# is ~1-2s). If Redis is unavailable we degrade to an unlocked refresh rather
-# than block ingestion — best-effort serialization, never a hard dependency.
-_TOKEN_REFRESH_LOCK_TIMEOUT_S = 15
-_TOKEN_REFRESH_LOCK_WAIT_S = 15
+#
+# TIMEOUT auto-releases the lock if a holder dies mid-refresh (avoids a
+# deadlock). It MUST exceed the worst-case hold — a refresh HTTP call can take up
+# to the adapter's _HTTP_TIMEOUT_S (30s) plus the DB commit — or the lock could
+# expire while the winner is still refreshing and a waiter would double-refresh,
+# defeating the serialization. WAIT bounds how long a concurrent caller blocks
+# for the winner (refreshes are typically ~1-2s); on timeout, or if Redis is
+# unavailable, we degrade to an unlocked refresh rather than block ingestion —
+# best-effort serialization, never a hard dependency.
+_TOKEN_REFRESH_LOCK_TIMEOUT_S = 60
+_TOKEN_REFRESH_LOCK_WAIT_S = 30
 
 
 def _token_is_fresh(account: StravaAccount) -> bool:
@@ -365,6 +370,12 @@ async def ingest_recent_activities(
         # ingest committed but left block-less because its guarded assignment
         # raised (#515).
         reconcile_unassigned_activities(db, account.user_id)
+    except StravaRateLimited:
+        # A rate limit is a "retry shortly" signal, not a per-activity error to
+        # log-and-continue: propagate it so the live path returns HTTP 429 (#602,
+        # via the app-level handler) rather than a 200 with the failure buried in
+        # stats.errors. Background callers let it surface to the job/budget gate.
+        raise
     except Exception as exc:
         msg = f"Ingestion failed globally: {exc}"
         logger.error(msg)

--- a/backend/app/services/strava_ingestion/port.py
+++ b/backend/app/services/strava_ingestion/port.py
@@ -3,6 +3,27 @@ from datetime import datetime
 from typing import Protocol
 
 
+class StravaRateLimited(Exception):
+    """Raised when Strava's rate limit is hit and the wait cannot be absorbed
+    inline (the honoured Retry-After exceeds the small inline ceiling, or the
+    bounded inline retries are exhausted).
+
+    Carries the true Retry-After (uncapped, seconds) when Strava supplied one so
+    callers can decide what to do: the live request path surfaces HTTP 429
+    "retry shortly" (see the app-level handler), while background jobs let the
+    Strava budget gate (#544) absorb the wait by rescheduling rather than
+    sleeping a worker for the full window (#602).
+    """
+
+    def __init__(self, *, retry_after: float | None = None, label: str | None = None):
+        self.retry_after = retry_after
+        self.label = label
+        detail = f"Strava rate limited ({label})" if label else "Strava rate limited"
+        if retry_after is not None:
+            detail += f"; retry after {retry_after:.0f}s"
+        super().__init__(detail)
+
+
 @dataclass(frozen=True)
 class Tokens:
     access_token: str

--- a/backend/tests/test_backfill_streams_job.py
+++ b/backend/tests/test_backfill_streams_job.py
@@ -208,6 +208,83 @@ def test_job_does_not_reschedule_when_drained():
     sched.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_batch_yields_mid_batch_when_budget_exhausted(db, strava_adapter, monkeypatch):
+    """The Strava budget is re-checked before EACH activity, not once per batch
+    (#601): once the shared window crosses the ceiling mid-batch the loop stops,
+    so a batch cannot fire all BACKFILL_BATCH_SIZE calls after a single gate pass."""
+    from app.jobs import backfill_streams as mod
+    from app.services.strava_ingestion import strava_budget
+
+    user, _account = _seed_user_and_account(db)
+    for sid in (7101, 7102, 7103):
+        _seed_summary_activity(db, user, sid)
+        _seed_streams(strava_adapter, sid)
+
+    # Budget: pass the first per-activity check, then read exhausted.
+    checks = {"n": 0}
+
+    def fake_over_budget():
+        checks["n"] += 1
+        return checks["n"] > 1
+
+    monkeypatch.setattr(strava_budget, "over_budget", fake_over_budget)
+
+    result = await mod.backfill_streams_batch(db, limit=settings.BACKFILL_BATCH_SIZE)
+
+    assert len(result.processed) == 1
+    assert result.budget_exhausted is True
+    # The two unprocessed activities stay eligible (never marked attempted).
+    assert result.remaining == 2
+    assert mod.count_eligible(db) == 2
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_activity_is_not_marked_and_stays_eligible(db, monkeypatch):
+    """A StravaRateLimited raised mid-batch (the #602 fail-fast signal) must leave
+    the activity eligible — NOT marked attempted — so it is retried once the
+    window frees, rather than silently skipped by the convergence marker."""
+    from app.jobs import backfill_streams as mod
+    from app.services.strava_ingestion import StravaRateLimited, strava_budget
+
+    user, _account = _seed_user_and_account(db)
+    activity = _seed_summary_activity(db, user, 8201)
+
+    async def _raise_rate_limited(db_, activity_id):
+        raise StravaRateLimited(retry_after=300, label="get_activity_streams")
+
+    monkeypatch.setattr(mod, "analyze_with_streams", _raise_rate_limited)
+    monkeypatch.setattr(strava_budget, "over_budget", lambda: False)
+
+    result = await mod.backfill_streams_batch(db, limit=settings.BACKFILL_BATCH_SIZE)
+
+    db.refresh(activity)
+    assert activity.streams_backfilled_at is None
+    assert 8201 not in result.processed
+    assert result.budget_exhausted is True
+    assert mod.count_eligible(db) == 1
+
+
+def test_job_reschedules_after_budget_when_batch_yields():
+    """When a batch yields mid-way on the budget, the job re-enqueues after the
+    Strava-budget backoff (not the normal batch pause) so it resumes when capacity
+    frees rather than hammering again after the short pause."""
+    from app.jobs import backfill_streams as mod
+
+    from app.services.strava_ingestion import strava_budget
+
+    result = mod.BackfillBatchResult(processed=[1], remaining=3, budget_exhausted=True)
+    with patch.object(mod, "SessionLocal", return_value=MagicMock()), patch.object(
+        mod, "backfill_streams_batch", new=AsyncMock(return_value=result)
+    ), patch.object(strava_budget, "over_budget", return_value=False), patch.object(
+        mod, "_schedule_next_batch"
+    ) as sched, patch.object(mod, "_reschedule_after_budget") as resched:
+        mod.backfill_streams_job()
+
+    resched.assert_called_once()
+    sched.assert_not_called()
+
+
 def test_enqueue_backfill_counts_and_enqueues_first_batch(db):
     from app.jobs import backfill_streams as mod
 

--- a/backend/tests/test_backfill_streams_job.py
+++ b/backend/tests/test_backfill_streams_job.py
@@ -304,6 +304,30 @@ def test_enqueue_backfill_counts_and_enqueues_first_batch(db):
     assert kwargs["job_id"] == f"backfill_streams_{user.id}"
 
 
+def test_enqueue_backfill_collapses_rapid_retriggers_into_one_chain(db):
+    """Called on every sync now (#596): a burst of enqueues for one user must
+    start only ONE chain, so overlapping chains can't double-fetch the same
+    activity's streams against the shared budget."""
+    from app.jobs import backfill_streams as mod
+
+    user, _account = _seed_user_and_account(db)
+    _seed_summary_activity(db, user, 4101)
+
+    fake_queue = MagicMock()
+    fake_redis = MagicMock()
+    fake_redis.set.side_effect = [True, None]  # first acquires the slot, second throttled
+    with patch.object(mod, "queue", fake_queue), patch(
+        "app.core.queue.redis_conn", fake_redis
+    ):
+        first = mod.enqueue_backfill(db, user.id)
+        second = mod.enqueue_backfill(db, user.id)
+
+    # Both report the eligible count, but only one chain is enqueued.
+    assert first == 1
+    assert second == 1
+    fake_queue.enqueue.assert_called_once()
+
+
 def test_enqueue_backfill_is_noop_when_nothing_eligible(db):
     from app.jobs import backfill_streams as mod
 

--- a/backend/tests/test_strava_auth.py
+++ b/backend/tests/test_strava_auth.py
@@ -379,3 +379,68 @@ def test_callback_with_invalid_state_falls_back_to_single_owner(
         db.query(StravaAccount).filter(StravaAccount.strava_athlete_id == 9003).one()
     )
     assert account.user_id == owner.id
+
+
+def test_callback_in_production_rejects_new_athlete_without_valid_state(
+    client: TestClient, db, _inmemory_strava, monkeypatch
+):
+    """#599: in production an absent/invalid state on a NEW athlete is rejected
+    (reconnect), never linked to a guessed owner or an orphan placeholder — even
+    with a single existing user (the old single-owner fallback is prod-disabled)."""
+    monkeypatch.setattr(settings, "APP_ENV", "production")
+    owner = _new_user(db, "prod_owner@example.com")
+    users_before = db.query(User).count()
+    _inmemory_strava.seed_exchange_response(
+        Tokens(
+            access_token="acc",
+            refresh_token="ref",
+            expires_at=int(time.time()) + 3600,
+            athlete={"id": 9101},
+        )
+    )
+
+    response = client.get(
+        "/api/auth/strava/callback",
+        params={"code": "x"},  # no state
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 307)
+    assert "strava_error=state_expired" in response.headers["location"]
+    # No account linked and no orphan placeholder user minted.
+    assert (
+        db.query(StravaAccount).filter(StravaAccount.strava_athlete_id == 9101).first()
+        is None
+    )
+    assert db.query(User).count() == users_before
+    assert owner.email == "prod_owner@example.com"
+
+
+def test_callback_in_production_links_new_athlete_with_valid_state(
+    client: TestClient, db, _inmemory_strava, monkeypatch
+):
+    """A valid signed state still links correctly in production (#599 rejects only
+    the absent/invalid-state path)."""
+    monkeypatch.setattr(settings, "APP_ENV", "production")
+    _new_user(db, "other_prod@example.com")
+    target = _new_user(db, "target_prod@example.com")
+    _inmemory_strava.seed_exchange_response(
+        Tokens(
+            access_token="acc",
+            refresh_token="ref",
+            expires_at=int(time.time()) + 3600,
+            athlete={"id": 9102},
+        )
+    )
+
+    response = client.get(
+        "/api/auth/strava/callback",
+        params={"code": "x", "state": encode_state(target.id)},
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 307)
+    account = (
+        db.query(StravaAccount).filter(StravaAccount.strava_athlete_id == 9102).one()
+    )
+    assert account.user_id == target.id

--- a/backend/tests/test_strava_auth.py
+++ b/backend/tests/test_strava_auth.py
@@ -1,4 +1,5 @@
 import time
+from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -63,6 +64,92 @@ async def test_ensure_valid_access_token_returns_existing_when_valid(db):
 
     assert token == "old_access"
     assert adapter.refresh_calls == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_defers_to_a_concurrent_winner_and_reuses_its_token(db):
+    """#597: if another caller rotated the token while we waited for the
+    per-account lock, reuse that token rather than refreshing again with the now
+    stale refresh token (which Strava would reject / could unlink the account)."""
+    from app.services.strava_ingestion import ingestion
+
+    account = _make_account(db, expires_at=int(time.time()) - 3600)
+    adapter = InMemoryStravaAdapter()
+    adapter.seed_refresh_response(
+        Tokens(access_token="ours", refresh_token="ours_r", expires_at=int(time.time()) + 21600)
+    )
+
+    class _WinnerLock:
+        """Acquiring models the winner having finished a refresh while we waited."""
+
+        def acquire(self):
+            db.query(StravaAccount).filter(StravaAccount.id == account.id).update(
+                {
+                    "access_token": "winner_access",
+                    "refresh_token": "winner_refresh",
+                    "expires_at": int(time.time()) + 21600,
+                }
+            )
+            db.commit()
+            return True
+
+        def release(self):
+            pass
+
+    fake_redis = MagicMock()
+    fake_redis.lock.return_value = _WinnerLock()
+    with patch.object(ingestion, "redis_conn", fake_redis):
+        token = await ensure_valid_access_token(db, account, adapter)
+
+    assert token == "winner_access"
+    assert adapter.refresh_calls == []  # we did NOT burn the stale refresh token
+
+
+@pytest.mark.asyncio
+async def test_refresh_degrades_to_unlocked_when_redis_unavailable(db):
+    """A coordination outage must never block ingestion: with Redis down the
+    refresh still proceeds (unlocked, best effort)."""
+    from app.services.strava_ingestion import ingestion
+
+    account = _make_account(db, expires_at=int(time.time()) - 3600)
+    adapter = InMemoryStravaAdapter()
+    adapter.seed_refresh_response(
+        Tokens(access_token="new_access", refresh_token="new_refresh", expires_at=int(time.time()) + 21600)
+    )
+
+    fake_redis = MagicMock()
+    fake_redis.lock.side_effect = RuntimeError("redis down")
+    with patch.object(ingestion, "redis_conn", fake_redis):
+        token = await ensure_valid_access_token(db, account, adapter)
+
+    assert token == "new_access"
+    assert adapter.refresh_calls == ["old_refresh"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_takes_and_releases_a_per_account_lock(db):
+    """The refresh path acquires and releases the per-account lock, keyed so two
+    accounts never contend (#597)."""
+    from app.services.strava_ingestion import ingestion
+
+    account = _make_account(db, expires_at=int(time.time()) - 3600)
+    adapter = InMemoryStravaAdapter()
+    adapter.seed_refresh_response(
+        Tokens(access_token="new_access", refresh_token="new_refresh", expires_at=int(time.time()) + 21600)
+    )
+
+    lock = MagicMock()
+    lock.acquire.return_value = True
+    fake_redis = MagicMock()
+    fake_redis.lock.return_value = lock
+    with patch.object(ingestion, "redis_conn", fake_redis):
+        token = await ensure_valid_access_token(db, account, adapter)
+
+    assert token == "new_access"
+    assert adapter.refresh_calls == ["old_refresh"]
+    lock.acquire.assert_called_once()
+    lock.release.assert_called_once()
+    assert str(account.id) in fake_redis.lock.call_args.args[0]
 
 
 def test_strava_status_returns_disconnected_when_no_account(client: TestClient):

--- a/backend/tests/test_strava_http_adapter_retries.py
+++ b/backend/tests/test_strava_http_adapter_retries.py
@@ -3,13 +3,18 @@
 The Phase 1 deployment runs ingestion through this adapter. A single 429
 used to fail the pipeline job entirely; the next run for that activity
 would only happen on the next webhook or manual sync. Acceptance:
-- 429 honours Retry-After (capped at a ceiling so a misbehaving header
-  cannot freeze a worker).
-- 5xx retries are bounded with exponential backoff.
+- A transient 429 (short Retry-After) is absorbed inline with a bounded retry.
+- A 429 whose Retry-After exceeds the small inline ceiling fails fast with a
+  typed StravaRateLimited carrying the true Retry-After, rather than sleeping a
+  worker for the full (up to 15-minute) Strava window (#602). The live request
+  path turns that into an HTTP 429 "retry shortly"; background jobs let the
+  Strava budget gate absorb the wait by rescheduling.
+- When the bounded inline 429 retries are exhausted, StravaRateLimited is
+  raised.
+- 5xx retries are bounded with exponential backoff, then the underlying
+  httpx.HTTPStatusError surfaces.
 - 4xx other than 429 propagates immediately (auth / bad request will not
   get better on retry).
-- After retries are exhausted, the underlying httpx.HTTPStatusError
-  surfaces so the polling job's except-Exception still catches it.
 """
 
 from datetime import datetime, timezone
@@ -18,7 +23,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from app.services.strava_ingestion import HTTPStravaAdapter
+from app.services.strava_ingestion import HTTPStravaAdapter, StravaRateLimited
 
 
 class _SeqRecorder:
@@ -97,26 +102,54 @@ class TestListRecentActivitiesRetries:
         assert len(recorder.requests) == 2
 
     @pytest.mark.asyncio
-    async def test_429_is_capped_at_ceiling(self, monkeypatch, _no_real_sleep):
-        """Strava sometimes sends Retry-After hours away. We cap so a single
-        bad header cannot freeze the worker for an hour."""
-        _install_seq_transport(
+    async def test_large_retry_after_fails_fast(self, monkeypatch, _no_real_sleep):
+        """Strava sometimes sends Retry-After minutes/hours away. Rather than
+        sleep a worker for the full window, fail fast with a typed error that
+        carries the true Retry-After so the caller can react (#602)."""
+        recorder = _install_seq_transport(
             monkeypatch,
             [
                 httpx.Response(429, headers={"Retry-After": "3600"}, json={}),
-                httpx.Response(200, json=[]),
+                httpx.Response(200, json=[]),  # must NOT be consumed
             ],
         )
 
-        await HTTPStravaAdapter().list_recent_activities(
-            access_token="abc",
-            since=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        with pytest.raises(StravaRateLimited) as exc_info:
+            await HTTPStravaAdapter().list_recent_activities(
+                access_token="abc",
+                since=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+
+        # True Retry-After surfaced uncapped; no inline sleep; no wasted retry.
+        assert exc_info.value.retry_after == 3600
+        _no_real_sleep.assert_not_called()
+        assert len(recorder.requests) == 1
+
+    @pytest.mark.asyncio
+    async def test_exhausted_429_retries_raise_rate_limited(
+        self, monkeypatch, _no_real_sleep
+    ):
+        """A run of short-Retry-After 429s is retried inline up to the bound,
+        then raises StravaRateLimited once the retries are used up."""
+        recorder = _install_seq_transport(
+            monkeypatch,
+            [
+                httpx.Response(429, headers={"Retry-After": "1"}, json={}),
+                httpx.Response(429, headers={"Retry-After": "1"}, json={}),
+                httpx.Response(429, headers={"Retry-After": "1"}, json={}),
+            ],
         )
 
-        # The sleep call must have been bounded; pull the last call's first arg.
-        _no_real_sleep.assert_called()
-        last_wait = _no_real_sleep.call_args.args[0]
-        assert last_wait <= 120, f"Retry-After cap not honoured (slept {last_wait}s)"
+        with pytest.raises(StravaRateLimited) as exc_info:
+            await HTTPStravaAdapter().list_recent_activities(
+                access_token="abc",
+                since=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+
+        assert exc_info.value.retry_after == 1
+        # initial attempt + 2 bounded retries = 3 requests, 2 inline sleeps.
+        assert len(recorder.requests) == 3
+        assert _no_real_sleep.call_count == 2
 
     @pytest.mark.asyncio
     async def test_raises_after_bounded_5xx_retries(self, monkeypatch, _no_real_sleep):
@@ -229,6 +262,24 @@ class TestGetActivityStreamsRetries:
             activity_id=42,
             stream_types=["time"],
         )
+
+        assert result is None
+
+
+class TestGetAthleteZonesRetries:
+    @pytest.mark.asyncio
+    async def test_rate_limit_is_swallowed_as_none(self, monkeypatch, _no_real_sleep):
+        """Zones are a non-fatal enhancement to time-in-zone, never a sync
+        prerequisite; a rate limit must degrade to None (fall back to %-of-max),
+        not fail the sync."""
+        _install_seq_transport(
+            monkeypatch,
+            [
+                httpx.Response(429, headers={"Retry-After": "3600"}, json={}),
+            ],
+        )
+
+        result = await HTTPStravaAdapter().get_athlete_zones(access_token="abc")
 
         assert result is None
 

--- a/backend/tests/test_strava_import_job.py
+++ b/backend/tests/test_strava_import_job.py
@@ -247,6 +247,48 @@ def test_job_does_not_reschedule_when_done():
     sched.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_batch_propagates_rate_limit_without_marking_failed(db, strava_adapter):
+    """A transient Strava rate limit during the list call must NOT flip the import
+    to `failed` (which would lose the cursor); it propagates for the job to
+    reschedule (#602 / mirrors #601)."""
+    from app.jobs.strava_import import run_import_batch
+    from app.services.strava_ingestion import StravaRateLimited
+
+    user, _account = _seed_user_and_account(db)
+    imp = _make_import(db, user)
+
+    async def _rate_limited(*args, **kwargs):
+        raise StravaRateLimited(retry_after=120, label="list_activities_page")
+
+    strava_adapter.list_activities_page = _rate_limited
+
+    with pytest.raises(StravaRateLimited):
+        await run_import_batch(db, imp, limit=50)
+
+    db.refresh(imp)
+    assert imp.status == "running"
+
+
+def test_job_reschedules_on_rate_limit_and_leaves_running():
+    from app.jobs import strava_import as mod
+    from app.services.strava_ingestion import StravaRateLimited, strava_budget
+
+    fake_db = MagicMock()
+    running = MagicMock()
+    running.status = "running"
+    fake_db.get.return_value = running
+    with patch.object(mod, "SessionLocal", return_value=fake_db), patch.object(
+        mod, "run_import_batch", new=AsyncMock(side_effect=StravaRateLimited(retry_after=120))
+    ), patch.object(strava_budget, "over_budget", return_value=False), patch.object(
+        mod, "_reschedule_after_budget"
+    ) as resched, patch.object(mod, "_schedule_next_batch") as sched:
+        mod.strava_import_job(str(uuid4()))
+
+    resched.assert_called_once()
+    sched.assert_not_called()
+
+
 def test_enqueue_import_creates_row_and_enqueues(db):
     from app.jobs import strava_import as mod
 

--- a/backend/tests/test_strava_ingestion.py
+++ b/backend/tests/test_strava_ingestion.py
@@ -279,3 +279,23 @@ class TestIngestRetryOn401:
         assert activity.strava_activity_id == 700
         assert adapter.refresh_calls == ["fake_refresh"]
         assert adapter._calls == 2
+
+
+@pytest.mark.asyncio
+async def test_ingest_recent_propagates_rate_limit(db):
+    """A StravaRateLimited from list_recent_activities must propagate out of
+    ingest_recent_activities (not be swallowed into stats.errors), so the live
+    sync path can surface HTTP 429 via the app-level handler (#602/#596)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.services.strava_ingestion import StravaRateLimited
+
+    account = _make_account(db, athlete_id=54321)
+    port = MagicMock()
+    port.get_athlete_zones = AsyncMock(return_value=None)
+    port.list_recent_activities = AsyncMock(
+        side_effect=StravaRateLimited(retry_after=120, label="list_recent_activities")
+    )
+
+    with pytest.raises(StravaRateLimited):
+        await ingest_recent_activities(db, account, port, fetch_streams=False)

--- a/backend/tests/test_sync_integration.py
+++ b/backend/tests/test_sync_integration.py
@@ -1,9 +1,10 @@
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from app.api.activities import sync_activities
+from app.core.config import settings
 from app.models import Activity, ActivityStream, StravaAccount, User
 from app.schemas import SyncResponse
 from app.services.strava_ingestion import (
@@ -54,17 +55,19 @@ def _run_sync_capturing_args(client, db, athlete_id, query=""):
     return captured
 
 
-def test_sync_default_window_fetches_streams_over_30_days(client, db):
-    """Default sync: 30-day window, streams fetched (routine deep processing)."""
+def test_sync_default_window_imports_summaries_only(client, db):
+    """Default sync: 30-day window, streams NOT fetched in-request — deferred to
+    the gated background backfill so a first sync cannot overshoot Strava's rate
+    ceiling (#596)."""
     captured = _run_sync_capturing_args(client, db, athlete_id=70001)
 
-    assert captured["fetch_streams"] is True
+    assert captured["fetch_streams"] is False
     expected = datetime.now() - timedelta(days=30)
     assert abs((captured["since"] - expected).total_seconds()) < 5
 
 
 def test_sync_large_window_is_summary_only_backfill(client, db):
-    """A window beyond 30 days imports summaries only (rate-limit-safe backfill)."""
+    """A window beyond 30 days also imports summaries only (rate-limit-safe)."""
     captured = _run_sync_capturing_args(client, db, athlete_id=70002, query="&since_days=3650")
 
     assert captured["fetch_streams"] is False
@@ -91,9 +94,14 @@ def test_sync_returns_429_when_strava_rate_limited(client, db):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_sync_upserts_activity_and_streams_and_runs_analysis(
+async def test_sync_upserts_summary_defers_streams_then_backfill_fills_them(
     db, strava_adapter
 ):
+    """End to end: the in-request sync upserts the summary + runs summary analysis
+    and enqueues the background backfill (no streams fetched in-request, #596);
+    running that backfill batch then fetches and stores the streams."""
+    from app.jobs import backfill_streams as bf
+
     user = User(email="sync_test@example.com")
     db.add(user)
     db.commit()
@@ -132,10 +140,11 @@ async def test_sync_upserts_activity_and_streams_and_runs_analysis(
         },
     )
 
-    # Phase 2 (#473) made sync user-scoped (require_current_user) instead of
-    # athlete-id-keyed: the endpoint resolves the account from the authenticated
-    # user. since_days defaults to the routine 30-day stream-fetch window.
-    result = await sync_activities(db=db, user=user)
+    # Phase 2 (#473) made sync user-scoped (require_current_user). The backfill
+    # enqueue goes through RQ, so stub the queue to keep the test off Redis.
+    fake_queue = MagicMock()
+    with patch.object(bf, "queue", fake_queue):
+        result = await sync_activities(db=db, user=user)
 
     assert isinstance(result, SyncResponse)
     assert result.fetched == 1
@@ -145,8 +154,22 @@ async def test_sync_upserts_activity_and_streams_and_runs_analysis(
     assert activity is not None
     assert activity.name == "Integration Run"
 
+    # Streams are deferred: none fetched in-request, and the gated backfill chain
+    # was enqueued to populate them.
     streams = (
         db.query(ActivityStream).filter(ActivityStream.activity_id == activity.id).all()
     )
-    stream_types = {s.stream_type for s in streams}
+    assert streams == []
+    fake_queue.enqueue.assert_called_once()
+
+    # Running the backfill batch now fetches + stores the streams.
+    await bf.backfill_streams_batch(
+        db, limit=settings.BACKFILL_BATCH_SIZE, user_id=str(user.id)
+    )
+    stream_types = {
+        s.stream_type
+        for s in db.query(ActivityStream)
+        .filter(ActivityStream.activity_id == activity.id)
+        .all()
+    }
     assert stream_types == {"time", "heartrate"}

--- a/backend/tests/test_sync_integration.py
+++ b/backend/tests/test_sync_integration.py
@@ -75,18 +75,22 @@ def test_sync_large_window_is_summary_only_backfill(client, db):
     assert abs((captured["since"] - expected).total_seconds()) < 5
 
 
-def test_sync_returns_429_when_strava_rate_limited(client, db):
-    """A Strava rate limit on the live sync path surfaces as HTTP 429 with the
-    true Retry-After, not a 500 (#602)."""
+def test_sync_returns_429_when_strava_rate_limited(client, db, strava_adapter):
+    """A Strava rate limit surfaces as HTTP 429 with the true Retry-After, not a
+    500 or a 200-with-buried-error, driven end to end through the REAL
+    ingest_recent_activities (which must propagate the rate limit) and the
+    app-level handler (#602/#596)."""
     from app.services.strava_ingestion import StravaRateLimited
 
     _seed_account(db, athlete_id=70003)
 
-    async def _rate_limited(db_, account_, port_, *, since, fetch_streams):
+    async def _rate_limited(*args, **kwargs):
         raise StravaRateLimited(retry_after=42, label="list_recent_activities")
 
-    with patch("app.api.activities.ingest_recent_activities", _rate_limited):
-        resp = client.post("/api/sync?strava_athlete_id=70003")
+    # The live sync makes exactly one Strava call (summary list); make it rate-limit.
+    strava_adapter.list_recent_activities = _rate_limited
+
+    resp = client.post("/api/sync?strava_athlete_id=70003")
 
     assert resp.status_code == 429, resp.text
     assert resp.headers.get("Retry-After") == "42"

--- a/backend/tests/test_sync_integration.py
+++ b/backend/tests/test_sync_integration.py
@@ -72,6 +72,23 @@ def test_sync_large_window_is_summary_only_backfill(client, db):
     assert abs((captured["since"] - expected).total_seconds()) < 5
 
 
+def test_sync_returns_429_when_strava_rate_limited(client, db):
+    """A Strava rate limit on the live sync path surfaces as HTTP 429 with the
+    true Retry-After, not a 500 (#602)."""
+    from app.services.strava_ingestion import StravaRateLimited
+
+    _seed_account(db, athlete_id=70003)
+
+    async def _rate_limited(db_, account_, port_, *, since, fetch_streams):
+        raise StravaRateLimited(retry_after=42, label="list_recent_activities")
+
+    with patch("app.api.activities.ingest_recent_activities", _rate_limited):
+        resp = client.post("/api/sync?strava_athlete_id=70003")
+
+    assert resp.status_code == 429, resp.text
+    assert resp.headers.get("Retry-After") == "42"
+
+
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_sync_upserts_activity_and_streams_and_runs_analysis(


### PR DESCRIPTION
Fixes the five open Strava-labelled issues from the multi-user readiness audit (2026-07-01). All five are one theme — Strava resilience under concurrent multi-user load — and share files (`ingestion.py` is touched by both #596 and #597), so they ride one branch with per-issue commits.

Closes #596, #597, #599, #601, #602.

## Changes

- **#602 — fail fast on 429.** The adapter absorbs only a short inline blip; a longer `Retry-After` (or exhausted retries) raises a typed `StravaRateLimited(retry_after)` instead of sleeping a worker out the up-to-15-minute window. An app-level handler turns it into HTTP 429 + `Retry-After` on the live path; background jobs let the budget gate absorb the wait. `get_athlete_zones` stays non-fatal (rate limit → `None`).
- **#601 — per-call budget gate.** `over_budget()` is re-checked before each activity in the stream backfill (was once per batch, allowing ~20 uninterrupted calls). A mid-batch budget/rate-limit yield leaves the activity eligible (does not set `streams_backfilled_at`) and reschedules after the budget backoff.
- **#597 — serialize token refresh.** `ensure_valid_access_token` takes a per-account Redis lock; a waiter re-reads the row under the lock and reuses a concurrently-rotated token instead of refreshing again with the stale (rotated) refresh token, which could unlink the account. Degrades to an unlocked refresh if Redis is unavailable. Lock TTL (60s) is deliberately above the 30s refresh HTTP timeout so it can't expire mid-refresh.
- **#596 — defer first-sync streams.** `POST /api/sync` imports activity summaries + runs summary analysis in-request, then enqueues the existing gated, self-paced backfill chain for streams — instead of firing one ungated Strava streams call per activity in-request. No API-contract or frontend change (still returns 200 with counts); metrics/coach populate asynchronously exactly as the webhook path does.
- **#599 — reject bad OAuth state in prod.** In production a brand-new athlete must arrive with a valid signed `state`, else the callback redirects back to reconnect (`?strava_error=state_expired`) instead of minting a `strava-{id}@placeholder.invalid` orphan. Non-production keeps the legacy single-owner + placeholder fallback. State TTL raised 10m → 30m to cover a slow consent.

## Interlock + review hardening

The typed rate-limit signal (#602) threads through the background jobs: an adversarial review pass caught that it would otherwise (a) flip the historical-import job to `failed` and (b) be swallowed by `ingest_recent_activities` so `/api/sync` never returned 429. Both are fixed so a rate limit reschedules/surfaces correctly rather than failing hard. `enqueue_backfill` (now called on every sync) also got a best-effort per-user cooldown so rapid re-syncs don't spawn overlapping chains.

## Testing

- TDD throughout; full backend suite green: **1925 passed**, 9 deselected (baseline 1910).
- New coverage: 429 fail-fast + exhaustion + zones-swallow, end-to-end sync 429 through the real ingest path, per-activity budget yield + rate-limit-stays-eligible, per-account refresh lock (concurrent-winner reuse / degrade / lock lifecycle), prod OAuth-state reject + valid-state link, import-job reschedule-not-fail, and the backfill enqueue cooldown.

## Not verified / follow-ups
- #597 real-Redis mutual exclusion under two concurrent workers is not runtime-tested (unit tests use a fake lock; relies on redis-py `Lock`).
- #599 frontend does not yet render `?strava_error=state_expired` (lands on home silently) — frontend follow-up.
- `app/jobs/strava_sync.py::sync_recent_activities_job` is dead (defined, never enqueued) and still calls `ingest_recent_activities(fetch_streams=True)` ungated — left as-is; worth a cleanup issue.
