### PR TITLE
Strava #613 follow-ups: remove dead sync job, real-Redis lock test, state_expired reconnect prompt (#614/#615/#616)

### DIFF
--- a/backend/app/jobs/strava_sync.py
+++ b/backend/app/jobs/strava_sync.py
@@ -5,42 +5,12 @@ from sqlalchemy import select
 
 from app.db.session import SessionLocal
 from app.models import StravaAccount
-from app.services import analysis
 from app.services.strava_ingestion import (
     get_strava_port,
     ingest_activity_by_id,
-    ingest_recent_activities,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def sync_recent_activities_job(user_id: str):
-    """RQ Job: Sync recent activities for a user, then analyze each."""
-    db = SessionLocal()
-    try:
-        stmt = select(StravaAccount).where(StravaAccount.user_id == user_id)
-        account = db.execute(stmt).scalars().first()
-
-        if not account:
-            logger.error("Job failed: No Strava account for user_id %s", user_id)
-            return
-
-        activities, _stats = asyncio.run(
-            ingest_recent_activities(db, account, get_strava_port())
-        )
-        for activity in activities:
-            try:
-                analysis.analyze(db, str(activity.id))
-            except Exception as exc:
-                logger.error(
-                    "Analysis failed for activity %s: %s",
-                    activity.strava_activity_id,
-                    exc,
-                )
-        logger.info("Sync complete for user %s", user_id)
-    finally:
-        db.close()
 
 
 def sync_activity_job(strava_athlete_id: int, strava_activity_id: int):

--- a/backend/tests/test_strava_auth.py
+++ b/backend/tests/test_strava_auth.py
@@ -126,6 +126,47 @@ async def test_refresh_degrades_to_unlocked_when_redis_unavailable(db):
     assert adapter.refresh_calls == ["old_refresh"]
 
 
+@pytest.mark.integration
+def test_refresh_lock_mutually_excludes_against_real_redis(monkeypatch):
+    """#614: verify the per-account refresh lock actually serializes holders
+    against a REAL Redis (the other #597 tests use a fake lock). While account X's
+    lock is held, another acquire for X is refused; after release it frees; and a
+    different account never contends. Skips if Redis is unreachable."""
+    from types import SimpleNamespace
+    from uuid import uuid4
+
+    from app.core.queue import redis_conn
+    from app.services.strava_ingestion import ingestion
+
+    try:
+        redis_conn.ping()
+    except Exception:
+        pytest.skip("real Redis not available")
+
+    # Shorten the contended wait so the refused acquire returns promptly.
+    monkeypatch.setattr(ingestion, "_TOKEN_REFRESH_LOCK_WAIT_S", 0.2)
+
+    account_a = SimpleNamespace(id=uuid4())
+    account_b = SimpleNamespace(id=uuid4())
+
+    held = ingestion._acquire_refresh_lock(account_a)
+    assert held is not None
+    try:
+        # Same account: cannot acquire while the lock is held (mutual exclusion).
+        assert ingestion._acquire_refresh_lock(account_a) is None
+        # Different account: never contends (keyed per account).
+        other = ingestion._acquire_refresh_lock(account_b)
+        assert other is not None
+        ingestion._release_refresh_lock(other)
+    finally:
+        ingestion._release_refresh_lock(held)
+
+    # After release the lock is free again.
+    reacquired = ingestion._acquire_refresh_lock(account_a)
+    assert reacquired is not None
+    ingestion._release_refresh_lock(reacquired)
+
+
 @pytest.mark.asyncio
 async def test_refresh_takes_and_releases_a_per_account_lock(db):
     """The refresh path acquires and releases the per-account lock, keyed so two

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -6,6 +6,7 @@ import ActivityList from '@/components/ActivityList';
 import SyncButton from '@/components/SyncButton';
 import SelfHealTrigger from '@/components/SelfHealTrigger';
 import StatDiff from '@/components/StatDiff';
+import StravaConnectNotice from '@/components/StravaConnectNotice';
 
 // Force dynamic since we fetch user data (no static cache for dashboard)
 export const dynamic = 'force-dynamic';
@@ -46,6 +47,7 @@ export default async function Dashboard() {
 
   return (
     <div className="space-y-8">
+      <StravaConnectNotice />
       <header className="flex flex-col gap-4 sm:flex-row sm:justify-between sm:items-start">
         <div>
             <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Weekly Summary</h1>

--- a/frontend/components/StravaConnectNotice.tsx
+++ b/frontend/components/StravaConnectNotice.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { AlertTriangle, ExternalLink, X } from 'lucide-react';
+
+// The Strava OAuth callback redirects here (the app base URL) with
+// ?strava_error=state_expired when the signed state was absent or expired in
+// production (#599/#615) instead of silently minting an orphan account. Surface
+// a clear reconnect prompt at the landing page, then strip the param so a
+// refresh or back-navigation does not resurface the notice.
+export default function StravaConnectNotice() {
+  const [expired, setExpired] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('strava_error') === 'state_expired') {
+      setExpired(true);
+      params.delete('strava_error');
+      const qs = params.toString();
+      window.history.replaceState(
+        {},
+        '',
+        window.location.pathname + (qs ? `?${qs}` : ''),
+      );
+    }
+  }, []);
+
+  if (!expired) return null;
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200"
+    >
+      <AlertTriangle size={18} className="mt-0.5 shrink-0" />
+      <div className="flex-1">
+        <p className="font-medium">Strava connection did not complete</p>
+        <p className="mt-0.5">
+          The secure link expired before you finished authorising. Please connect again.
+        </p>
+        <a
+          href="/api/auth/strava/login"
+          className="mt-2 inline-flex items-center gap-1 font-medium underline"
+        >
+          <ExternalLink size={14} /> Connect with Strava
+        </a>
+      </div>
+      <button
+        type="button"
+        onClick={() => setExpired(false)}
+        aria-label="Dismiss"
+        className="shrink-0 text-amber-700 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
The three follow-ups noted in #613, implemented.

Closes #614, #615, #616.

## Changes

- **#616 — remove dead code.** `app/jobs/strava_sync.py::sync_recent_activities_job` was defined but never enqueued (superseded by the webhook/self-heal `process_new_activity` pipeline and the gated backfill) and called `ingest_recent_activities(fetch_streams=True)` ungated. Deleted, along with its now-unused imports. `sync_activity_job` (used by the webhook update path) is kept.
- **#614 — verify the #597 lock against real Redis.** The per-account refresh lock's mutual exclusion was only unit-tested with a fake lock. Added an `integration`-marked test that, against a real Redis, asserts a second acquire for the same account is refused while the lock is held, a different account never contends, and the lock frees after release (skips cleanly when Redis is unreachable). Confirmed passing against the local Redis.
- **#615 — surface the reconnect prompt.** The prod OAuth callback (#599) redirects to `?strava_error=state_expired`, but the frontend ignored callback params. Added a dismissible client notice (`StravaConnectNotice`) on the home landing page that reads the param, prompts a reconnect, and strips the param so a refresh does not resurface it.

## Testing
- Backend suite green: **1925 passed**, 10 deselected (the new integration test sits in the deselected set; it passed when run explicitly against the local Redis).
- Frontend `next lint` + `next build` clean.
- Visual confirmation of the #615 banner (load `/?strava_error=state_expired`) is a quick human check per the workflow's UI-verification boundary.
