### PR TITLE
Fix: retry Anthropic 429 with backoff before coach-report fallback (#603)

### DIFF
--- a/backend/app/services/coach/llm.py
+++ b/backend/app/services/coach/llm.py
@@ -30,6 +30,49 @@ _COACH_EFFORT = "high"
 # Initial backoff before the single retry on transient failures.
 _RETRY_BACKOFF_SECONDS = 1.0
 
+# Transient (timeout / connection / 5xx) retry budget: initial attempt + this
+# many retries. Kept at 1 to preserve the file's prior "initial + one retry".
+_MAX_TRANSIENT_RETRIES = 1
+
+# 429 / rate-limit retry budget (#603). A burst of concurrent generations
+# (worker fuller turns + web-process chat) can trip Anthropic's per-minute
+# limit; a 429 is retriable (unlike a 4xx bug) because capacity frees up. We
+# honor the Retry-After header when present, else fall back to exponential
+# backoff, and cap both so a single report generation stays well under the RQ
+# ~600s death penalty. Worst case: _MAX_RATE_LIMIT_RETRIES * cap seconds of
+# sleep before propagating to the caller's deterministic fallback.
+_MAX_RATE_LIMIT_RETRIES = 2
+_RATE_LIMIT_BACKOFF_BASE_SECONDS = 1.0
+_RATE_LIMIT_BACKOFF_CAP_SECONDS = 30.0
+
+
+def _retry_after_header_seconds(exc: Any) -> Optional[float]:
+    """Parse the Retry-After header (a count of seconds) off a RateLimitError,
+    or None when it is absent, non-numeric (e.g. an HTTP-date form we don't
+    honor), or negative."""
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None)
+    if not headers:
+        return None
+    raw = headers.get("retry-after")
+    if raw is None:
+        return None
+    try:
+        seconds = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return seconds if seconds >= 0 else None
+
+
+def _rate_limit_backoff_seconds(exc: Any, retry_index: int) -> float:
+    """Seconds to sleep before the next 429 retry: honor Retry-After when the
+    server sent it, else exponential backoff on the retry index; both capped."""
+    retry_after = _retry_after_header_seconds(exc)
+    if retry_after is not None:
+        return min(retry_after, _RATE_LIMIT_BACKOFF_CAP_SECONDS)
+    backoff = _RATE_LIMIT_BACKOFF_BASE_SECONDS * (2 ** retry_index)
+    return min(backoff, _RATE_LIMIT_BACKOFF_CAP_SECONDS)
+
 
 @dataclass
 class Usage:
@@ -91,9 +134,9 @@ class AnthropicClient:
         """`generate_json` that also returns token usage for the budget gate (#472)."""
         import anthropic
 
-        max_attempts = 2  # initial + one retry
-        last_exc: Exception | None = None
-        for attempt in range(max_attempts):
+        transient_retries = 0
+        rate_limit_retries = 0
+        while True:
             try:
                 response = await self.client.messages.create(
                     model=self.model,
@@ -105,30 +148,39 @@ class AnthropicClient:
                 )
                 return response.content[0].text, _usage_from_response(response)
             except (anthropic.APITimeoutError, anthropic.APIConnectionError) as exc:
-                last_exc = exc
-                logger.warning(
-                    "anthropic_transient_failure",
-                    extra={"attempt": attempt + 1, "kind": type(exc).__name__},
-                )
-                if attempt + 1 < max_attempts:
-                    await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
-                    continue
-                raise
-            except anthropic.APIStatusError as exc:
-                # Retry only on 5xx; 4xx (bad request, auth, etc.) is a caller
-                # bug and won't get better on retry.
-                if exc.status_code >= 500 and attempt + 1 < max_attempts:
-                    last_exc = exc
+                if transient_retries < _MAX_TRANSIENT_RETRIES:
+                    transient_retries += 1
                     logger.warning(
-                        "anthropic_5xx_retry",
-                        extra={"attempt": attempt + 1, "status": exc.status_code},
+                        "anthropic_transient_failure",
+                        extra={"attempt": transient_retries, "kind": type(exc).__name__},
                     )
                     await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
                     continue
                 raise
-        # Defensive: loop only exits via return or raise above.
-        assert last_exc is not None
-        raise last_exc
+            except anthropic.RateLimitError as exc:
+                # 429: capacity, not a caller bug — retry honoring Retry-After (#603).
+                if rate_limit_retries < _MAX_RATE_LIMIT_RETRIES:
+                    delay = _rate_limit_backoff_seconds(exc, rate_limit_retries)
+                    rate_limit_retries += 1
+                    logger.warning(
+                        "anthropic_rate_limit_retry",
+                        extra={"attempt": rate_limit_retries, "sleep": delay},
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                raise
+            except anthropic.APIStatusError as exc:
+                # Retry only on 5xx; other 4xx (bad request, auth, etc.) is a
+                # caller bug and won't get better on retry.
+                if exc.status_code >= 500 and transient_retries < _MAX_TRANSIENT_RETRIES:
+                    transient_retries += 1
+                    logger.warning(
+                        "anthropic_5xx_retry",
+                        extra={"attempt": transient_retries, "status": exc.status_code},
+                    )
+                    await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
+                    continue
+                raise
 
     async def generate_text(
         self, system: str, user: str, max_tokens: int = 512
@@ -186,9 +238,9 @@ class AnthropicClient:
         import anthropic
 
         tool_name = tool["name"]
-        max_attempts = 2  # initial + one retry on transient transport failure
-        last_exc: Exception | None = None
-        for attempt in range(max_attempts):
+        transient_retries = 0
+        rate_limit_retries = 0
+        while True:
             try:
                 response = await self.client.messages.create(
                     model=self.model,
@@ -219,27 +271,36 @@ class AnthropicClient:
                         return result, usage
                 raise ValueError(f"no {tool_name} tool_use block in response")
             except (anthropic.APITimeoutError, anthropic.APIConnectionError) as exc:
-                last_exc = exc
-                logger.warning(
-                    "anthropic_structured_transient_failure",
-                    extra={"attempt": attempt + 1, "kind": type(exc).__name__},
-                )
-                if attempt + 1 < max_attempts:
-                    await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
-                    continue
-                raise
-            except anthropic.APIStatusError as exc:
-                if exc.status_code >= 500 and attempt + 1 < max_attempts:
-                    last_exc = exc
+                if transient_retries < _MAX_TRANSIENT_RETRIES:
+                    transient_retries += 1
                     logger.warning(
-                        "anthropic_structured_5xx_retry",
-                        extra={"attempt": attempt + 1, "status": exc.status_code},
+                        "anthropic_structured_transient_failure",
+                        extra={"attempt": transient_retries, "kind": type(exc).__name__},
                     )
                     await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
                     continue
                 raise
-        assert last_exc is not None
-        raise last_exc
+            except anthropic.RateLimitError as exc:
+                if rate_limit_retries < _MAX_RATE_LIMIT_RETRIES:
+                    delay = _rate_limit_backoff_seconds(exc, rate_limit_retries)
+                    rate_limit_retries += 1
+                    logger.warning(
+                        "anthropic_structured_rate_limit_retry",
+                        extra={"attempt": rate_limit_retries, "sleep": delay},
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                raise
+            except anthropic.APIStatusError as exc:
+                if exc.status_code >= 500 and transient_retries < _MAX_TRANSIENT_RETRIES:
+                    transient_retries += 1
+                    logger.warning(
+                        "anthropic_structured_5xx_retry",
+                        extra={"attempt": transient_retries, "status": exc.status_code},
+                    )
+                    await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
+                    continue
+                raise
 
     async def generate_coach_message(
         self,
@@ -262,9 +323,9 @@ class AnthropicClient:
         """
         import anthropic
 
-        max_attempts = 2  # initial + one retry on transient transport failure
-        last_exc: Exception | None = None
-        for attempt in range(max_attempts):
+        transient_retries = 0
+        rate_limit_retries = 0
+        while True:
             try:
                 async with self.client.messages.stream(
                     model=self.model,
@@ -298,27 +359,38 @@ class AnthropicClient:
                 # so they follow the same retry-then-propagate path (#302).
                 httpx.RemoteProtocolError,
             ) as exc:
-                last_exc = exc
-                logger.warning(
-                    "anthropic_message_transient_failure",
-                    extra={"attempt": attempt + 1, "kind": type(exc).__name__},
-                )
-                if attempt + 1 < max_attempts:
-                    await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
-                    continue
-                raise
-            except anthropic.APIStatusError as exc:
-                if exc.status_code >= 500 and attempt + 1 < max_attempts:
-                    last_exc = exc
+                if transient_retries < _MAX_TRANSIENT_RETRIES:
+                    transient_retries += 1
                     logger.warning(
-                        "anthropic_message_5xx_retry",
-                        extra={"attempt": attempt + 1, "status": exc.status_code},
+                        "anthropic_message_transient_failure",
+                        extra={"attempt": transient_retries, "kind": type(exc).__name__},
                     )
                     await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
                     continue
                 raise
-        assert last_exc is not None
-        raise last_exc
+            except anthropic.RateLimitError as exc:
+                # 429 under concurrent-generation load: retry honoring
+                # Retry-After before the caller's fallback fires (#603).
+                if rate_limit_retries < _MAX_RATE_LIMIT_RETRIES:
+                    delay = _rate_limit_backoff_seconds(exc, rate_limit_retries)
+                    rate_limit_retries += 1
+                    logger.warning(
+                        "anthropic_message_rate_limit_retry",
+                        extra={"attempt": rate_limit_retries, "sleep": delay},
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                raise
+            except anthropic.APIStatusError as exc:
+                if exc.status_code >= 500 and transient_retries < _MAX_TRANSIENT_RETRIES:
+                    transient_retries += 1
+                    logger.warning(
+                        "anthropic_message_5xx_retry",
+                        extra={"attempt": transient_retries, "status": exc.status_code},
+                    )
+                    await asyncio.sleep(_RETRY_BACKOFF_SECONDS)
+                    continue
+                raise
 
     async def stream_chat(
         self,

--- a/backend/tests/test_coach_llm_timeout_retry.py
+++ b/backend/tests/test_coach_llm_timeout_retry.py
@@ -259,3 +259,143 @@ async def test_generate_coach_message_logs_warning_on_remote_protocol_error(capl
             )
 
     assert any("transient" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic 429 / RateLimitError (#603)
+#
+# RateLimitError is a subclass of APIStatusError with status_code 429. Because
+# 429 < 500, the old code raised it immediately and the coach report silently
+# degraded to the deterministic fallback (is_fallback=True). The fix retries a
+# 429 with exponential backoff, honoring the Retry-After header (capped) before
+# giving up and propagating so the caller's fallback still fires as a last
+# resort.
+# ---------------------------------------------------------------------------
+
+from app.services.coach import llm as _llm_mod  # noqa: E402
+
+
+def _make_rate_limit_error(retry_after=None) -> anthropic.RateLimitError:
+    """Build a real anthropic.RateLimitError (429), optionally carrying a
+    Retry-After header (a string count of seconds, as the API sends it)."""
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    headers = {}
+    if retry_after is not None:
+        headers["retry-after"] = str(retry_after)
+    response = httpx.Response(status_code=429, request=request, headers=headers)
+    return anthropic.RateLimitError("rate limited", response=response, body=None)
+
+
+@pytest.mark.asyncio
+async def test_retries_on_429_then_succeeds():
+    client = AnthropicClient(api_key="k", model="m")
+    rate_limited = _make_rate_limit_error(retry_after=2)
+    fake_create = AsyncMock(side_effect=[rate_limited, _ok_response("ok")])
+    client.client.messages.create = fake_create
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        result = await client.generate_json("sys", "user")
+
+    assert result == "ok"
+    assert fake_create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_429_honors_retry_after_header():
+    client = AnthropicClient(api_key="k", model="m")
+    rate_limited = _make_rate_limit_error(retry_after=7)
+    fake_create = AsyncMock(side_effect=[rate_limited, _ok_response("ok")])
+    client.client.messages.create = fake_create
+
+    sleep_mock = AsyncMock()
+    with patch("asyncio.sleep", new=sleep_mock):
+        await client.generate_json("sys", "user")
+
+    # The single backoff before the retry honored the Retry-After value.
+    assert sleep_mock.await_args_list[0].args[0] == pytest.approx(7.0)
+
+
+@pytest.mark.asyncio
+async def test_429_caps_absurd_retry_after():
+    client = AnthropicClient(api_key="k", model="m")
+    rate_limited = _make_rate_limit_error(retry_after=100000)
+    fake_create = AsyncMock(side_effect=[rate_limited, _ok_response("ok")])
+    client.client.messages.create = fake_create
+
+    sleep_mock = AsyncMock()
+    with patch("asyncio.sleep", new=sleep_mock):
+        await client.generate_json("sys", "user")
+
+    slept = sleep_mock.await_args_list[0].args[0]
+    assert slept == pytest.approx(_llm_mod._RATE_LIMIT_BACKOFF_CAP_SECONDS)
+
+
+@pytest.mark.asyncio
+async def test_429_uses_exponential_backoff_when_no_retry_after():
+    client = AnthropicClient(api_key="k", model="m")
+    # Two 429s (no header) then success — exercises retry indices 0 then 1.
+    fake_create = AsyncMock(
+        side_effect=[
+            _make_rate_limit_error(),
+            _make_rate_limit_error(),
+            _ok_response("ok"),
+        ]
+    )
+    client.client.messages.create = fake_create
+
+    sleep_mock = AsyncMock()
+    with patch("asyncio.sleep", new=sleep_mock):
+        result = await client.generate_json("sys", "user")
+
+    assert result == "ok"
+    base = _llm_mod._RATE_LIMIT_BACKOFF_BASE_SECONDS
+    first = sleep_mock.await_args_list[0].args[0]
+    second = sleep_mock.await_args_list[1].args[0]
+    assert first == pytest.approx(base)
+    assert second == pytest.approx(base * 2)
+
+
+@pytest.mark.asyncio
+async def test_propagates_429_after_retries_exhausted():
+    client = AnthropicClient(api_key="k", model="m")
+    n = _llm_mod._MAX_RATE_LIMIT_RETRIES
+    fake_create = AsyncMock(side_effect=[_make_rate_limit_error() for _ in range(n + 1)])
+    client.client.messages.create = fake_create
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(anthropic.RateLimitError):
+            await client.generate_json("sys", "user")
+
+    # initial attempt + n retries
+    assert fake_create.call_count == n + 1
+
+
+@pytest.mark.asyncio
+async def test_structured_retries_on_429_then_succeeds():
+    client = AnthropicClient(api_key="k", model="m")
+    tool = {"name": "record", "input_schema": {"type": "object"}}
+    ok = SimpleNamespace(
+        content=[SimpleNamespace(type="tool_use", name="record", input={"a": 1})],
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+    )
+    fake_create = AsyncMock(side_effect=[_make_rate_limit_error(retry_after=1), ok])
+    client.client.messages.create = fake_create
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        result = await client.generate_structured(system="s", user="u", tool=tool)
+
+    assert result == {"a": 1}
+    assert fake_create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_coach_message_retries_on_429_then_succeeds():
+    client = AnthropicClient(api_key="k", model="m")
+    ok = _make_ok_message_result()
+    err = _make_rate_limit_error(retry_after=1)
+    client.client.messages.stream = _make_streaming_ctx([err, ok])
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        result = await client.generate_coach_message(system="sys", user="user", tools=[])
+
+    assert result.stop_reason == "end_turn"


### PR DESCRIPTION
## Summary
The Anthropic client (`backend/app/services/coach/llm.py`) retried only on `status_code >= 500`. A 429 (`anthropic.RateLimitError`, a subclass of `APIStatusError` with status 429) is `< 500`, so it fell through the `>= 500` guard and raised immediately. The coach report was then stored as `is_fallback=True` and the runner silently got a deterministic template. Under concurrent-generation load (worker fuller turns + web-process chat streams) a burst can trip Anthropic's per-minute limit.

This adds a bounded, backoff-aware 429 retry to the three retry loops in the client (`generate_json_with_usage`, `generate_structured_with_usage`, `generate_coach_message`) before the caller's fallback fires as a last resort.

## Decisions
- **New `RateLimitError` branch ordered before `APIStatusError`.** Since `RateLimitError` subclasses `APIStatusError`, the 429 branch must come first or it would be swallowed by the `>= 500` clause.
- **Honor `Retry-After`, else exponential backoff.** `_rate_limit_backoff_seconds` reads the `Retry-After` header (seconds) when present, otherwise `base * 2**retry_index`. A non-numeric (HTTP-date) or negative header degrades to the exponential path.
- **Caps to stay under the RQ ~600s death penalty.** `_MAX_RATE_LIMIT_RETRIES = 2` (initial + 2), `_RATE_LIMIT_BACKOFF_BASE_SECONDS = 1.0`, `_RATE_LIMIT_BACKOFF_CAP_SECONDS = 30.0` — so a single generation sleeps at most ~60s across retries even if the server sends an absurd `Retry-After`. After exhaustion the 429 propagates so the existing fallback path is preserved.
- **Transient behaviour unchanged.** Timeout/connection/5xx still get initial + one retry (`_MAX_TRANSIENT_RETRIES = 1`); 4xx-non-429 still raises immediately. The loops moved from `for … range(2)` to a `while` loop so the 429 budget is tracked independently of the transient budget (the two share one loop but separate counters). No public interfaces changed; no new dependency (`anthropic` already provides `RateLimitError`).

This change is transport-only and does not alter the context pack or system prompt, so no coach flow diagram regeneration was needed.

## Testing
- Added 7 tests to `backend/tests/test_coach_llm_timeout_retry.py` (all mocked, no network; `asyncio.sleep` patched): 429-then-success on `generate_json`, `generate_structured`, and streaming `generate_coach_message`; `Retry-After` honored; absurd `Retry-After` capped; exponential fallback with no header; and propagation after exhaustion (call count = initial + max retries).
- `make backend-test`: **1948 passed, 10 deselected** (integration marker). The 11 pre-existing transient/5xx/4xx tests still pass unchanged.

Closes #603