### PR TITLE
Make per-user singleton get-or-create race-safe (#598)

### DIFF
--- a/backend/app/api/profile.py
+++ b/backend/app/api/profile.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from typing import Optional
+from uuid import UUID
 
 from app.core.clerk_auth import verify_clerk_session
 from app.core.config import settings
@@ -10,6 +12,48 @@ from app.models import CoachingRelationship, User, StravaAccount, UserProfile
 from app.schemas import UserProfileRead, UserProfileCreate
 
 router = APIRouter()
+
+
+def _lookup_relationship(db: Session, user_id: UUID) -> Optional[CoachingRelationship]:
+    return db.execute(
+        select(CoachingRelationship).where(CoachingRelationship.user_id == user_id)
+    ).scalars().first()
+
+
+def _lookup_profile(db: Session, user_id: UUID) -> Optional[UserProfile]:
+    return db.execute(
+        select(UserProfile).where(UserProfile.user_id == user_id)
+    ).scalars().first()
+
+
+def _get_or_create_singleton(db: Session, lookup, create):
+    """Race-safe get-or-create for a per-user singleton row (#598).
+
+    A new user's first authenticated screen fires /profile, /coach/voice and
+    /coach/stance concurrently; each misses the SELECT below and attempts the
+    INSERT, and the losers violate the PK/unique constraint. Recover the way
+    ``resolve_user_by_email`` does for User: roll back the failed INSERT, expunge
+    the doomed instance so a later autoflush cannot retry it, and reuse the row
+    the winner committed.
+    """
+    existing = lookup()
+    if existing is not None:
+        return existing
+    row = create()
+    db.add(row)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        if row in db:
+            db.expunge(row)
+        existing = lookup()
+        if existing is None:
+            raise
+        return existing
+    db.refresh(row)
+    return row
+
 
 def get_current_user_profile(
     db: Session,
@@ -38,29 +82,28 @@ def get_current_user_profile(
         raise HTTPException(status_code=404, detail="No user found")
 
     # A1: the thin coaching_relationship singleton anchors the relationship from
-    # first contact, auto-created the way the default profile is below.
-    relationship_row = db.execute(
-        select(CoachingRelationship).where(CoachingRelationship.user_id == user.id)
-    ).scalars().first()
-    if not relationship_row:
-        db.add(CoachingRelationship(user_id=user.id))
-        db.commit()
+    # first contact, auto-created the way the default profile is below. Both
+    # get-or-creates are race-safe (#598): a fresh user's first screen fires
+    # several requests at once and the losers must recover, not 500.
+    _get_or_create_singleton(
+        db,
+        lambda: _lookup_relationship(db, user.id),
+        lambda: CoachingRelationship(user_id=user.id),
+    )
 
-    profile = db.execute(select(UserProfile).where(UserProfile.user_id == user.id)).scalars().first()
-    if not profile:
-        # Create default profile
-        profile = UserProfile(
+    profile = _get_or_create_singleton(
+        db,
+        lambda: _lookup_profile(db, user.id),
+        lambda: UserProfile(
             user_id=user.id,
             goal_type="general",
             experience_level="intermediate",
             weekly_days_available=4,
             current_weekly_km=20,
             upcoming_races=[],
-            max_hr=190
-        )
-        db.add(profile)
-        db.commit()
-        db.refresh(profile)
+            max_hr=190,
+        ),
+    )
 
     return profile
 

--- a/backend/tests/test_profile_singleton_race.py
+++ b/backend/tests/test_profile_singleton_race.py
@@ -1,0 +1,132 @@
+"""Race-safety of the per-user singleton get-or-create (#598).
+
+A new user's first authenticated screen fires /profile, /coach/voice and
+/coach/stance concurrently. All three land in ``get_current_user_profile``,
+miss the SELECT for the singleton rows (CoachingRelationship, UserProfile), and
+attempt the INSERT. The losers violate the unique/PK constraint and would 500
+on the user's very first screen. The fix mirrors the User recovery in
+``resolve_user_by_email``: roll back the failed INSERT and reuse the row the
+winner committed.
+
+These tests drive ``get_current_user_profile`` directly against a session with
+real commit isolation and force the initial lookup to miss (the race window
+between the SELECT and our own INSERT), so the recovery path is exercised.
+"""
+
+import pytest
+
+from app.api import profile as profile_module
+from app.api.profile import get_current_user_profile
+from app.models import CoachingRelationship, User, UserProfile
+
+
+@pytest.fixture
+def committing_db():
+    """A session whose commits actually persist.
+
+    The shared ``db`` fixture wraps everything in one outer transaction that is
+    rolled back at teardown, so an inner ``db.commit()`` does not truly persist
+    and the recovery path's ``db.rollback()`` would revert the winner's row too.
+    The race-recovery path needs real commit isolation.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    from app.db.base import Base
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _flaky_once(real):
+    """Wrap a lookup so its FIRST call misses (returns None), then behaves."""
+    calls = {"n": 0}
+
+    def flaky(session, user_id):
+        calls["n"] += 1
+        return None if calls["n"] == 1 else real(session, user_id)
+
+    return flaky
+
+
+def _make_user(db, email):
+    user = User(email=email)
+    db.add(user)
+    db.commit()
+    return user
+
+
+class TestSingletonGetOrCreateRace:
+    def test_relationship_create_recovers_from_race(self, committing_db, monkeypatch):
+        db = committing_db
+        user = _make_user(db, "racer1@example.com")
+        # A competing request already won the relationship INSERT.
+        db.add(CoachingRelationship(user_id=user.id))
+        db.commit()
+
+        # ...but our request's initial lookup missed it (the race window).
+        monkeypatch.setattr(
+            profile_module,
+            "_lookup_relationship",
+            _flaky_once(profile_module._lookup_relationship),
+        )
+
+        # Must recover, not 500 on the unique-user_id violation.
+        result = get_current_user_profile(db, user)
+
+        assert result.user_id == user.id
+        assert db.query(CoachingRelationship).count() == 1  # no duplicate/orphan
+
+    def test_profile_create_recovers_from_race(self, committing_db, monkeypatch):
+        db = committing_db
+        user = _make_user(db, "racer2@example.com")
+        # A competing request already won both singleton INSERTs.
+        db.add(CoachingRelationship(user_id=user.id))
+        db.add(
+            UserProfile(
+                user_id=user.id,
+                goal_type="general",
+                experience_level="intermediate",
+                weekly_days_available=4,
+                current_weekly_km=20,
+                upcoming_races=[],
+                max_hr=190,
+            )
+        )
+        db.commit()
+
+        # Force our profile lookup to miss the first time, so we attempt the
+        # INSERT and hit the primary-key (user_id) violation.
+        monkeypatch.setattr(
+            profile_module,
+            "_lookup_profile",
+            _flaky_once(profile_module._lookup_profile),
+        )
+
+        result = get_current_user_profile(db, user)
+
+        assert result.user_id == user.id
+        assert db.query(UserProfile).count() == 1  # reused the winner's row
+
+    def test_happy_path_creates_both_rows(self, committing_db):
+        """First caller with no rows creates the relationship and the profile."""
+        db = committing_db
+        user = _make_user(db, "fresh@example.com")
+
+        result = get_current_user_profile(db, user)
+
+        assert result.user_id == user.id
+        assert result.goal_type == "general"
+        assert db.query(CoachingRelationship).count() == 1
+        assert db.query(UserProfile).count() == 1


### PR DESCRIPTION
## Summary
A new user's first authenticated screen fires `/profile`, `/coach/voice` and `/coach/stance` concurrently. All three land in `get_current_user_profile`, miss the SELECT for the `CoachingRelationship` and `UserProfile` singleton rows, and attempt the INSERT. The bare `select -> add -> commit` had no `IntegrityError` recovery, so the losers violated the unique/PK constraint and 500'd on the user's very first screen. This wraps both creates in the same rollback-and-re-select recovery that `resolve_user_by_email` already uses for `User`.

## Get-or-create sites hardened
- `backend/app/api/profile.py` `get_current_user_profile` -> the `CoachingRelationship(user_id=...)` create (unique `user_id`).
- `backend/app/api/profile.py` `get_current_user_profile` -> the default `UserProfile(...)` create (PK `user_id`).
- `backend/app/api/coach.py` `_get_or_create_relationship` (the voice/stance endpoints) is covered by construction: it delegates to `get_current_user_profile`, so no separate change was needed. This is the single get-or-create site for both models across `backend/app`.

## Decisions / rationale
- Added a small local `_get_or_create_singleton(db, lookup, create)` helper plus two named lookup functions (`_lookup_relationship`, `_lookup_profile`) rather than duplicating the try/except at both sites. The recovery body mirrors `resolve_user_by_email` exactly: `db.rollback()`, expunge the doomed instance so a later autoflush cannot retry the conflicting INSERT, re-select, and re-raise if the row is still absent.
- Happy path preserved: the first caller creates the rows exactly as before. No schema change, no API-shape change, no new dependency.

## Testing
- New `backend/tests/test_profile_singleton_race.py`: relationship-race recovery, profile-race recovery (each with real commit isolation and a forced first-lookup miss, mirroring the existing `test_clerk_auth.py` race test), plus a happy-path create test. Red before the fix, green after.
- Full backend baseline `make backend-test`: 1944 passed, 10 deselected. No new failures; the emitted warnings are pre-existing and unrelated.

Closes #598