### PR TITLE
Bound the Postgres connection pool with explicit, env-driven sizing (#605)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -11,7 +11,22 @@ class Settings(BaseSettings):
     # Defaulting to a sensible local docker default if not provided, 
     # but strictly it should come from .env
     DATABASE_URL: str
-    
+
+    # Connection pool sizing (#605). Without these, each process uses
+    # SQLAlchemy's implicit QueuePool default of 5 persistent + 10 overflow = 15
+    # connections. Web (uvicorn) and worker each open their own pool against one
+    # managed Postgres, so the implicit totals approach a small plan's
+    # connection ceiling and a leaked/long-held session blocks the pool for
+    # DB_POOL_TIMEOUT seconds before erroring. These bound it explicitly and are
+    # env-tunable per environment. Sized conservatively for two processes (web +
+    # worker) plus the worker's WORKER_POOL_SIZE concurrency against a typical
+    # ~100-connection managed-Postgres ceiling; raise per plan via the env.
+    # (Applied only to a real pooled backend; the SQLite test path ignores them.)
+    DB_POOL_SIZE: int = 5           # persistent connections kept open per process
+    DB_MAX_OVERFLOW: int = 5        # extra connections allowed under burst, then queue
+    DB_POOL_RECYCLE: int = 1800     # recycle a connection after this many seconds (30 min)
+    DB_POOL_TIMEOUT: int = 30       # seconds a checkout waits for a free connection
+
     # Redis
     REDIS_URL: str = "redis://localhost:6379/0"
 

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,19 +1,40 @@
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.orm import sessionmaker
 
-from app.core.config import settings
+from app.core.config import Settings, settings
 
-# Construct the database URL. 
-# We expect postgresql+psycopg:// from the environment.
-# If using standard postgres:// we might need string replacement if the driver demands it,
-# but for now we assume the .env is correct.
+# Construct the database URL.
+# We expect postgresql+psycopg:// from the environment (Settings normalises the
+# driver prefix). If using standard postgres:// the config validator rewrites it.
 
-engine = create_engine(
-    settings.DATABASE_URL,
-    pool_pre_ping=True,
-    # Echo SQL in local environment for debugging
-    echo=(settings.APP_ENV == "local") 
-)
+
+def _build_engine(db_settings: Settings) -> Engine:
+    """Build the SQLAlchemy engine with explicit, env-driven pool sizing (#605).
+
+    ``pool_pre_ping`` (checks a connection is alive before handing it out) always
+    applies. The QueuePool sizing (``pool_size``/``max_overflow``/
+    ``pool_recycle``/``pool_timeout``) is applied ONLY for a real pooled backend
+    (Postgres). SQLite (the test suite's in-memory DB) uses a different pool that
+    rejects those kwargs, so they are omitted there.
+    """
+    url = db_settings.DATABASE_URL
+    kwargs: dict = {
+        "pool_pre_ping": True,
+        # Echo SQL in local environment for debugging.
+        "echo": db_settings.APP_ENV == "local",
+    }
+    if make_url(url).get_backend_name() != "sqlite":
+        kwargs.update(
+            pool_size=db_settings.DB_POOL_SIZE,
+            max_overflow=db_settings.DB_MAX_OVERFLOW,
+            pool_recycle=db_settings.DB_POOL_RECYCLE,
+            pool_timeout=db_settings.DB_POOL_TIMEOUT,
+        )
+    return create_engine(url, **kwargs)
+
+
+engine = _build_engine(settings)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/backend/tests/test_db_pool_config.py
+++ b/backend/tests/test_db_pool_config.py
@@ -1,0 +1,82 @@
+"""Explicit, env-driven connection-pool sizing on the SQLAlchemy engine (#605).
+
+The engine must apply the configured QueuePool sizing for a real Postgres
+backend, so web + worker processes do not each open the implicit default pool
+(5 persistent + 10 overflow = 15 connections) against one managed Postgres.
+The SQLite path (tests, in-memory) must be left untouched, because SQLite's
+pool rejects ``pool_size``/``max_overflow``/``pool_timeout``.
+"""
+
+import app.db.session as session_module
+from app.core.config import Settings
+
+
+def _settings(url: str, **overrides) -> Settings:
+    return Settings(DATABASE_URL=url, **overrides)
+
+
+def _capture_create_engine(monkeypatch) -> dict:
+    captured: dict = {}
+
+    def fake_create_engine(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(session_module, "create_engine", fake_create_engine)
+    return captured
+
+
+def test_pool_settings_have_conservative_defaults():
+    s = _settings("postgresql+psycopg://u:p@h:5432/db")
+    assert s.DB_POOL_SIZE == 5
+    assert s.DB_MAX_OVERFLOW == 5
+    assert s.DB_POOL_RECYCLE == 1800
+    assert s.DB_POOL_TIMEOUT == 30
+
+
+def test_postgres_engine_gets_configured_pool(monkeypatch):
+    captured = _capture_create_engine(monkeypatch)
+    s = _settings(
+        "postgresql+psycopg://u:p@h:5432/db",
+        DB_POOL_SIZE=7,
+        DB_MAX_OVERFLOW=3,
+        DB_POOL_RECYCLE=900,
+        DB_POOL_TIMEOUT=15,
+    )
+
+    session_module._build_engine(s)
+
+    kwargs = captured["kwargs"]
+    assert kwargs["pool_pre_ping"] is True
+    assert kwargs["pool_size"] == 7
+    assert kwargs["max_overflow"] == 3
+    assert kwargs["pool_recycle"] == 900
+    assert kwargs["pool_timeout"] == 15
+
+
+def test_sqlite_engine_omits_queue_pool_args(monkeypatch):
+    captured = _capture_create_engine(monkeypatch)
+    s = _settings("sqlite:///:memory:", DB_POOL_SIZE=7)
+
+    session_module._build_engine(s)
+
+    kwargs = captured["kwargs"]
+    # pre-ping is safe and stays; queue-pool sizing must NOT be passed to SQLite.
+    assert kwargs["pool_pre_ping"] is True
+    assert "pool_size" not in kwargs
+    assert "max_overflow" not in kwargs
+    assert "pool_timeout" not in kwargs
+
+
+def test_real_postgres_engine_pool_is_bounded():
+    """Build a real (non-connecting) engine and confirm the live pool is bounded."""
+    engine = session_module._build_engine(
+        _settings(
+            "postgresql+psycopg://u:p@h:5432/db",
+            DB_POOL_SIZE=4,
+            DB_MAX_OVERFLOW=2,
+        )
+    )
+    # QueuePool.size() reports the configured persistent-connection count.
+    assert engine.pool.size() == 4


### PR DESCRIPTION
## Summary
The SQLAlchemy engine in `backend/app/db/session.py` set only `pool_pre_ping`, so each process fell back to SQLAlchemy's implicit `QueuePool` default of **5 persistent + 10 overflow = 15 connections**. The web (uvicorn) and worker processes each opened their own pool against one Railway managed Postgres, so under load the totals approached a small plan's connection ceiling, and a leaked or long-held session blocked the pool for the full `pool_timeout` (30s) before erroring. This bounds the pool explicitly and makes it tunable per environment via env vars, with no code change needed to retune.

## What changed
- Added four typed settings to `core/config.py` (pydantic-settings, matching the existing style):
  - `DB_POOL_SIZE` = **5** (persistent connections per process)
  - `DB_MAX_OVERFLOW` = **5** (extra connections allowed under burst, then callers queue)
  - `DB_POOL_RECYCLE` = **1800** (recycle a connection after 30 min)
  - `DB_POOL_TIMEOUT` = **30** (seconds a checkout waits for a free connection)
- Extracted a `_build_engine(settings)` helper in `db/session.py` that applies these alongside the retained `pool_pre_ping=True`. The public API (`engine`, `SessionLocal`, `get_db`) is unchanged.
- Pool sizing is applied **only to a real pooled backend (Postgres)**; a SQLite URL (the test suite's in-memory DB) omits the queue-pool kwargs, since SQLite's pool rejects `pool_size`/`max_overflow`/`pool_timeout`. Guarded by dialect via `make_url(url).get_backend_name()`.

## Sizing rationale (assumptions the owner can retune)
- **Assumed ceiling:** a typical small managed-Postgres plan around ~100 connections. Chosen defaults are deliberately smaller than the current implicit 15 per process.
- **Process/worker count:** two processes (web + worker). Each caps at `pool_size + max_overflow` = **10** connections, so the steady worst case is **~20** connections total, plus the worker's `WORKER_POOL_SIZE` forked workers each carrying their own pool (currently 2 in prod, so plan for `2 processes-worth on the worker side`). Even at `WORKER_POOL_SIZE=3` the ceiling stays well under 100 with generous headroom for migrations, `psql`, and monitoring.
- `pool_recycle` of 30 min guards against managed-Postgres idle-connection reaping and stale sockets.
- These are a **recommendation**; the owner can override every value via env vars per environment without a code change (e.g. raise `DB_POOL_SIZE` if the plan ceiling is larger, or drop it further on a tiny plan).

## Testing
- Added `backend/tests/test_db_pool_config.py`: asserts the Postgres path receives the configured `pool_size`/`max_overflow`/`pool_recycle`/`pool_timeout` with `pool_pre_ping`, the SQLite path omits the queue-pool kwargs, the defaults are the conservative values above, and a real (non-connecting) Postgres engine's live pool is bounded.
- Full backend baseline `make backend-test`: **1945 passed, 10 deselected** (integration), 7 pre-existing unrelated warnings.

Closes #605