### PR TITLE
Soft over-budget gate for non-essential aux Haiku jobs (#607)

### DIFF
--- a/backend/app/services/coach/memory_update.py
+++ b/backend/app/services/coach/memory_update.py
@@ -52,7 +52,7 @@ from app.schemas.coach_memory import (
     MEMORY_SECTION_FIELDS,
     RunnerMemoryProfile,
 )
-from app.services.coach.budget import record as budget_record
+from app.services.coach.budget import over_budget as budget_over, record as budget_record
 from app.services.coach.llm import AnthropicClient
 from app.services.coach.memory_store import upsert_memory
 from app.services.coach.retrieval import fetch_recent_user_digests
@@ -451,6 +451,17 @@ async def update_memory(
     sources = gather_memory_sources(db, user_id, as_of=as_of)
     if not sources.sources:
         return None  # cold start: nothing stated yet — no LLM call, no enqueue loop
+
+    # Soft over-budget entry gate (#607). Memory is a NON-ESSENTIAL, regenerable
+    # background artifact: at the per-user/global spend cap, PAUSE this pass rather
+    # than overshoot the ceiling with a Haiku call that only records spend after
+    # the fact. Non-fatal and retryable by construction — no LLM call, no write, the
+    # stored profile is unchanged, and the next non-fallback report re-enqueues
+    # update_memory_job once spend has rolled over. over_budget degrades to False on
+    # any backend error, so the cap never becomes an availability risk.
+    if budget_over(user_id):
+        logger.info("memory update skipped for user %s: over LLM budget", user_id)
+        return None
 
     if client is None:
         if not settings.ANTHROPIC_API_KEY:

--- a/backend/app/services/coach/receipt_voice.py
+++ b/backend/app/services/coach/receipt_voice.py
@@ -42,7 +42,7 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.models.coaching_relationship import CoachingRelationship
-from app.services.coach.budget import record as budget_record
+from app.services.coach.budget import over_budget as budget_over, record as budget_record
 from app.services.coach.llm import AnthropicClient
 from app.services.coach.receipt import (
     ALLOWED_SLOTS,
@@ -233,6 +233,20 @@ async def generate_receipt_templates(
     None when generation could not run / failed (the caller keeps the floor). The
     Haiku spend is recorded on the per-user budget counter when `user_id` is given
     (#472)."""
+    # Soft over-budget entry gate (#607). Voiced receipt templates are a
+    # NON-ESSENTIAL, regenerable convenience — the deterministic house-default floor
+    # covers the gap. At the per-user/global spend cap, PAUSE generation rather than
+    # overshoot the ceiling with a Haiku call that only records spend afterward.
+    # Non-fatal and retryable: returning None leaves the caller's provenance
+    # UNSTAMPED (`refresh_receipt_templates` returns without setting
+    # `receipt_templates_generated_at`), so `maybe_enqueue_lazy_refresh` re-attempts
+    # on the next receipt once spend has rolled over. Only gated when we know the
+    # user (spend is per-user); over_budget degrades to False on any backend error.
+    if user_id is not None and budget_over(user_id):
+        logger.info(
+            "receipt-voice generation skipped: over LLM budget; house-default floor stands"
+        )
+        return None
     if client is None:
         if not settings.ANTHROPIC_API_KEY:
             return None

--- a/backend/tests/test_memory_update.py
+++ b/backend/tests/test_memory_update.py
@@ -205,3 +205,61 @@ def test_writer_pass_is_idempotent_on_identical_sources(db):
     assert first_profile == second.profile
     assert RunnerMemoryProfile.model_validate(second.profile).goals_and_plans == ["Targeting a sub-3 marathon"]
     assert len(db.query(RunnerMemory).filter_by(user_id=uid).all()) == 1
+
+
+# --------------------------------------------------------------------------- #
+# #607 — soft over-budget entry gate (PAUSE, not overshoot; non-fatal).
+# --------------------------------------------------------------------------- #
+def _arm_over_budget(monkeypatch, user_id):
+    """Drive the real budget gate over a per-user daily ceiling for `user_id`.
+
+    Uses a fresh in-process gate + a real recorded overspend (not a mock of the
+    thing under test), mirroring test_budget_cap_guard. Returns nothing; caller
+    resets via budget.set_gate(None)."""
+    from app.core.config import settings
+    from app.services.coach import budget as B
+
+    B.set_gate(B.new_in_memory_gate())
+    monkeypatch.setattr(settings, "LLM_BUDGET_USER_DAILY_USD", 0.01)
+    B.record(user_id, "claude-opus-4-8", 1_000_000, 0)  # ~$5.00 >> $0.01 ceiling
+
+
+def test_over_budget_skips_llm_call_and_writes_nothing(db, monkeypatch):
+    """Over budget: the rewrite-from-source pass PAUSES — no Haiku call, no write,
+    the profile is unchanged (retryable on the next non-fallback report)."""
+    from app.services.coach import budget as B
+
+    uid = _user(db)
+    act = _activity(db, uid)
+    _note(db, act, "Left knee niggle since February")  # sources present (not cold start)
+
+    _arm_over_budget(monkeypatch, uid)
+    try:
+        stub = _StubClient([_cand("should never appear", "who_you_are", ["note0"])])
+        result = asyncio.run(update_memory(db, uid, client=stub))
+        assert result is None            # non-fatal skip
+        assert stub.calls == 0           # the aux Haiku call was NOT made
+        assert get_memory(db, uid) is None  # nothing written -> next report retries
+    finally:
+        B.set_gate(None)
+
+
+def test_under_budget_proceeds_as_before(db, monkeypatch):
+    """Under budget: behaviour is unchanged — the pass calls the writer and stores."""
+    from app.services.coach import budget as B
+
+    uid = _user(db)
+    a1 = _activity(db, uid, when=datetime(2026, 5, 1, 7, 0, tzinfo=timezone.utc))
+    a2 = _activity(db, uid, when=datetime(2026, 6, 1, 7, 0, tzinfo=timezone.utc))
+    _note(db, a1, "Sub-3 marathon")
+    _note(db, a2, "Sub-3 marathon again")
+
+    B.set_gate(B.new_in_memory_gate())  # fresh gate, no ceiling armed -> not over
+    try:
+        stub = _StubClient([_cand("Targeting a sub-3 marathon", "goals_and_plans", ["note0", "note1"])])
+        result = asyncio.run(update_memory(db, uid, client=stub))
+        assert stub.calls == 1
+        assert result is not None
+        assert get_memory(db, uid) is not None
+    finally:
+        B.set_gate(None)

--- a/backend/tests/test_receipt_voice.py
+++ b/backend/tests/test_receipt_voice.py
@@ -193,3 +193,70 @@ def test_lazy_refresh_skips_default_and_already_generated(db, monkeypatch):
     rel.receipt_templates_generated_at = datetime.now(timezone.utc)
     RV.maybe_enqueue_lazy_refresh(rel)
     assert calls == [rel.user_id]
+
+
+# --- #607: soft over-budget entry gate (PAUSE, not overshoot; non-fatal) -------
+
+
+def _arm_over_budget(monkeypatch, user_id):
+    """Drive the real budget gate over a per-user daily ceiling for `user_id`."""
+    from app.core.config import settings
+    from app.services.coach import budget as B
+
+    B.set_gate(B.new_in_memory_gate())
+    monkeypatch.setattr(settings, "LLM_BUDGET_USER_DAILY_USD", 0.01)
+    B.record(user_id, "claude-opus-4-8", 1_000_000, 0)  # ~$5.00 >> $0.01 ceiling
+
+
+@pytest.mark.asyncio
+async def test_generate_over_budget_skips_llm_returns_none(monkeypatch):
+    """Over budget: generation PAUSES — no Haiku call, returns None so the caller
+    keeps the house-default floor."""
+    from app.services.coach import budget as B
+
+    uid = uuid4()
+    _arm_over_budget(monkeypatch, uid)
+    try:
+        client = _client({"first": ["boom {type}? feel?"], "second": [], "multi": []})
+        out = await RV.generate_receipt_templates(_declared_voice(), client=client, user_id=uid)
+        assert out is None
+        client.generate_structured_with_usage.assert_not_called()
+    finally:
+        B.set_gate(None)
+
+
+@pytest.mark.asyncio
+async def test_refresh_over_budget_leaves_templates_regenerable(db, monkeypatch):
+    """Over budget through refresh: no call, provenance is left UNSTAMPED and the
+    stored set untouched, so the lazy path re-attempts once spend rolls over."""
+    from app.services.coach import budget as B
+
+    rel = _seed_relationship(db, preset="roast", freetext="be cheeky")
+    _arm_over_budget(monkeypatch, rel.user_id)
+    try:
+        client = _client({"first": ["boom {type}? feel?"], "second": [], "multi": []})
+        out = await RV.refresh_receipt_templates(db, rel.user_id, client=client)
+        client.generate_structured_with_usage.assert_not_called()
+        assert out is not None
+        assert out.receipt_templates_generated_at is None  # retryable: not stamped
+        assert out.receipt_templates is None
+        # the lazy path still sees "never generated" and will re-enqueue
+        assert RV.resolve_voice(out).is_default is False
+    finally:
+        B.set_gate(None)
+
+
+@pytest.mark.asyncio
+async def test_generate_under_budget_with_user_proceeds(monkeypatch):
+    """Under budget: passing a user_id does not gate — the call proceeds as before."""
+    from app.services.coach import budget as B
+
+    uid = uuid4()
+    B.set_gate(B.new_in_memory_gate())  # fresh gate, no ceiling armed -> not over
+    try:
+        client = _client({"first": ["boom {type}? feel?"], "second": [], "multi": []})
+        out = await RV.generate_receipt_templates(_declared_voice(), client=client, user_id=uid)
+        client.generate_structured_with_usage.assert_called_once()
+        assert out is not None
+    finally:
+        B.set_gate(None)


### PR DESCRIPTION
## Summary
The auxiliary Haiku paths (`material_distiller`, `memory_update`, `receipt_voice`) recorded spend on the per-user budget counter AFTER their Anthropic call but never checked the over-budget gate BEFORE it (record-only, not gated). At the global/user LLM cap the main report and chat degrade correctly, but every post-report memory rebuild and voice-change template regen still fired a Haiku call and only recorded spend afterward, so aux spend overshot the ceiling.

This adds a SOFT over-budget entry gate to the two NON-ESSENTIAL, regenerable jobs so they PAUSE instead of overshooting, while staying non-fatal (log + return, never raise). Record-only is deliberate elsewhere so background jobs never hard-fail on budget; the gate keeps that property.

## Jobs gated
- **memory-update** (`update_memory`): at the cap, skip the rewrite-from-source pass. No LLM call, no write, the stored profile is unchanged.
- **receipt-voice** (`generate_receipt_templates`): at the cap, skip generation and return `None`. The deterministic house-default receipt floor covers the gap.

Both mirror the existing main report/chat gate (`user_id is not None and budget_over(user_id)`), reuse the existing `budget.over_budget`/`record` helpers (no helper changes), and never raise. `over_budget` already degrades to `False` on any backend error, so the cap never becomes an availability risk. Under-budget behaviour is unchanged (the gate only fires when a ceiling is armed and at/over spend).

## How the skip stays retryable
- **memory-update**: returning `None` writes nothing; `service._fire_learning_loop` re-enqueues `update_memory_job` after the next non-fallback report, so the pass naturally re-attempts once spend rolls over (daily/monthly windows).
- **receipt-voice**: returning `None` makes `refresh_receipt_templates` return WITHOUT stamping `receipt_templates_generated_at`, so `maybe_enqueue_lazy_refresh` still sees "never generated" and re-enqueues a refresh on the next receipt. The house floor serves in the meantime.

## Left record-only: the material distiller (decision)
The issue names only receipt-voice and memory-update as the non-essential ones to gate. I left `material_distiller` record-only:
- It is user-facing: a runner has just uploaded a material and is polling `GET /api/coach/materials/{id}` for status. A silent skip would strand the row in `processing` forever, and marking it `failed` would present a transient budget condition as a permanent failure (the UI treats `failed` as retry-by-reupload).
- Its blast radius is small: distillation is a one-shot per upload bounded by the per-user `USER_MATERIAL_MAX_COUNT` cap, not a repeating background regen that fires after every report/voice-change.
- Gating it cleanly would require a new retryable status distinct from `processing`/`failed`, which is out of scope for this fix.

## Testing
- TDD red-green: added focused tests to `tests/test_memory_update.py` and `tests/test_receipt_voice.py`. Over-budget => the aux Haiku call is NOT made and the job returns non-fatally leaving a retryable state (memory: no row; receipt: provenance unstamped). Under-budget => the call proceeds and stores as before. The tests drive the REAL budget gate (a fresh in-process gate + a real recorded overspend against an armed ceiling), not a mock of the code under test.
- Full backend baseline `make backend-test`: **1946 passed, 10 deselected** (only pre-existing warnings, no failures).

Closes #607