### PR TITLE
Fix Trends rolling view to roll back from today, not calendar chunks (#630)

### DIFF
--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -231,6 +231,27 @@ def _next_period_start(start: date, period: str) -> date:
     return start + timedelta(days=14)
 
 
+# ---------------------------------------------------------------------------
+# 3c. Rolling-mode bins (#630)
+# ---------------------------------------------------------------------------
+#
+# In rolling mode the bars must roll back from the current date, not snap to
+# calendar boundaries (ISO-Monday weeks / calendar months / the epoch-anchored
+# fortnight grid above). So a day's bucket is chosen by its offset back from the
+# anchor (today): the newest bin ends today and each older bin is the preceding
+# fixed-width block. Calendar mode is unchanged and keeps the calendar-anchored
+# keys above. "month" has no fixed length, so a rolling month is a 30-day block.
+_ROLLING_BIN_DAYS = {"biweekly": 14, "monthly": 30}
+
+
+def _rolling_bin_start(d: date, anchor: date, bin_days: int) -> date:
+    """First local day of the today-anchored rolling bin of width ``bin_days``
+    that ``d`` falls in. The newest bin is ``[anchor - bin_days + 1, anchor]``;
+    older bins step back by ``bin_days``. ``d`` is assumed on or before ``anchor``."""
+    k = (anchor - d).days // bin_days
+    return anchor - timedelta(days=(k + 1) * bin_days - 1)
+
+
 def _coverage_days(
     span_start: date,
     span_end: date,
@@ -537,9 +558,10 @@ def build_weekly_buckets(
     since: Optional[date] = None,
     until: Optional[date] = None,
     pre_window_daily: Optional[List[DailyFact]] = None,
+    rolling_anchor: Optional[date] = None,
 ) -> List[WeekBucket]:
     """
-    Roll daily facts into ISO-week buckets (Monday start).
+    Roll daily facts into 7-day buckets.
     Fills every week in the range so charts have continuous x-axes.
 
     Pass ``since`` to override the window start (the #400 calendar mode).
@@ -549,46 +571,59 @@ def build_weekly_buckets(
     Pass ``pre_window_daily`` (days just before ``since``) so a leading edge
     week carries the value of its out-of-window days for the stacked partial
     bar (#566); ``total_*`` stays the in-period sum.
+    Pass ``rolling_anchor`` (today) to bucket by 7-day blocks rolling back from
+    that anchor instead of ISO-Monday weeks (#630): the bars then roll back from
+    the current date. When set, no faded out-of-window segment is produced (the
+    leading edge is simply a shorter bar); ``pre_window_daily`` is ignored.
     """
+    def _key(d: date) -> date:
+        if rolling_anchor is not None:
+            return _rolling_bin_start(d, rolling_anchor, 7)
+        return d - timedelta(days=d.weekday())
+
     # Build buckets from actual data first
     buckets: dict[date, WeekBucket] = {}
     for df in daily_facts:
-        monday = df.local_date - timedelta(days=df.local_date.weekday())
-        if monday not in buckets:
-            buckets[monday] = WeekBucket(monday)
-        buckets[monday].add(df)
+        k = _key(df.local_date)
+        if k not in buckets:
+            buckets[k] = WeekBucket(k)
+        buckets[k].add(df)
 
     # Determine the full span of weeks to show
     end = until if until is not None else date.today()
-    end_monday = end - timedelta(days=end.weekday())  # last week to show
+    end_key = _key(end)  # last week to show
 
     if since is None:
         since = _resolve_since(range_key)
     if since is not None:
-        start_monday = since - timedelta(days=since.weekday())
+        start_key = _key(since)
     elif daily_facts:
-        earliest = daily_facts[0].local_date
-        start_monday = earliest - timedelta(days=earliest.weekday())
+        start_key = _key(daily_facts[0].local_date)
     else:
-        start_monday = end_monday
+        start_key = end_key
 
-    # Walk from start_monday to end_monday, inserting empty buckets
-    cursor = start_monday
-    while cursor <= end_monday:
+    # Walk from start_key to end_key, inserting empty buckets (7-day step either way)
+    cursor = start_key
+    while cursor <= end_key:
         if cursor not in buckets:
             buckets[cursor] = WeekBucket(cursor)
         cursor += timedelta(weeks=1)
 
     # Edge-bucket coverage (#566): mark how much of each week falls inside the
-    # selected window [since, end] so the chart can fade partial weeks.
+    # selected window [since, end]. Rolling bins align to the window, so the only
+    # partial is the leading short bar and it carries no faded segment (#630).
     for w in buckets.values():
-        w.in_period_days, w.out_of_period_days = _coverage_days(
+        in_days, out_days = _coverage_days(
             w.week_start, w.week_start + timedelta(days=6), since, end
         )
-    # Carry the out-of-window value of a leading edge week's earlier days.
-    _add_out_of_period_values(
-        buckets, pre_window_daily, lambda d: d - timedelta(days=d.weekday())
-    )
+        w.in_period_days = in_days
+        w.out_of_period_days = 0 if rolling_anchor is not None else out_days
+    # Carry the out-of-window value of a leading edge week's earlier days
+    # (calendar mode only — rolling bins show no faded segment).
+    if rolling_anchor is None:
+        _add_out_of_period_values(
+            buckets, pre_window_daily, lambda d: d - timedelta(days=d.weekday())
+        )
 
     return sorted(buckets.values(), key=lambda w: w.week_start)
 
@@ -600,6 +635,7 @@ def build_period_buckets(
     since: Optional[date] = None,
     until: Optional[date] = None,
     pre_window_daily: Optional[List[DailyFact]] = None,
+    rolling_anchor: Optional[date] = None,
 ) -> List[PeriodBucket]:
     """Roll daily facts into coarse buckets (#432) for ``biweekly`` or ``monthly``.
 
@@ -607,23 +643,45 @@ def build_period_buckets(
     empty bucket across the window so charts have continuous x-axes. ``since`` /
     ``until`` override the window start/end (the #400/#413 calendar framing);
     they default to the range start and today.
+    Pass ``rolling_anchor`` (today) to bucket by fixed-width blocks rolling back
+    from that anchor instead of the calendar grid (#630): 14-day blocks for
+    ``biweekly``, 30-day blocks for ``monthly``. When set, no faded out-of-window
+    segment is produced (the leading edge is a shorter bar); ``pre_window_daily``
+    is ignored.
     """
+    bin_days = _ROLLING_BIN_DAYS[period]  # rolling-mode block width
+
+    def _key(d: date) -> date:
+        if rolling_anchor is not None:
+            return _rolling_bin_start(d, rolling_anchor, bin_days)
+        return _period_start(d, period)
+
+    def _advance(cur: date) -> date:
+        if rolling_anchor is not None:
+            return cur + timedelta(days=bin_days)
+        return _next_period_start(cur, period)
+
+    def _span_end(start: date) -> date:
+        if rolling_anchor is not None:
+            return start + timedelta(days=bin_days - 1)
+        return _next_period_start(start, period) - timedelta(days=1)
+
     buckets: dict[date, PeriodBucket] = {}
     for df in daily_facts:
-        ps = _period_start(df.local_date, period)
+        ps = _key(df.local_date)
         if ps not in buckets:
             buckets[ps] = PeriodBucket(ps)
         buckets[ps].add(df)
 
     end = until if until is not None else date.today()
-    end_start = _period_start(end, period)
+    end_start = _key(end)
 
     if since is None:
         since = _resolve_since(range_key)
     if since is not None:
-        start = _period_start(since, period)
+        start = _key(since)
     elif daily_facts:
-        start = _period_start(daily_facts[0].local_date, period)
+        start = _key(daily_facts[0].local_date)
     else:
         start = end_start
 
@@ -631,20 +689,22 @@ def build_period_buckets(
     while cursor <= end_start:
         if cursor not in buckets:
             buckets[cursor] = PeriodBucket(cursor)
-        cursor = _next_period_start(cursor, period)
+        cursor = _advance(cursor)
 
     # Edge-bucket coverage (#566): the bucket's full span is [period_start,
-    # next_period_start - 1 day] (14 days for biweekly, the calendar month for
-    # monthly); mark how much falls inside the selected window [since, end].
+    # span_end] (the calendar month / fortnight in calendar mode, a fixed
+    # 14-/30-day block in rolling mode); mark how much falls inside [since, end].
     for b in buckets.values():
-        span_end = _next_period_start(b.period_start, period) - timedelta(days=1)
-        b.in_period_days, b.out_of_period_days = _coverage_days(
-            b.period_start, span_end, since, end
+        span_end = _span_end(b.period_start)
+        in_days, out_days = _coverage_days(b.period_start, span_end, since, end)
+        b.in_period_days = in_days
+        b.out_of_period_days = 0 if rolling_anchor is not None else out_days
+    # Carry the out-of-window value of a leading edge bucket's earlier days
+    # (calendar mode only — rolling bins show no faded segment).
+    if rolling_anchor is None:
+        _add_out_of_period_values(
+            buckets, pre_window_daily, lambda d: _period_start(d, period)
         )
-    # Carry the out-of-window value of a leading edge bucket's earlier days.
-    _add_out_of_period_values(
-        buckets, pre_window_daily, lambda d: _period_start(d, period)
-    )
 
     return sorted(buckets.values(), key=lambda b: b.period_start)
 
@@ -764,22 +824,28 @@ def _collapse_to_3_zones(time_in_zones: dict) -> tuple[int, int, int]:
 def build_zone_load_weekly(
     activity_facts: List[ActivityFact],
     weekly_buckets: List["WeekBucket"],
+    rolling_anchor: Optional[date] = None,
 ) -> List[dict]:
     """
     Aggregate per-activity time_in_zones into weekly 3-zone buckets.
 
     Returns one dict per week: {week_start, easy_min, moderate_min, hard_min}.
-    Weeks with no zone data get zeros.
+    Weeks with no zone data get zeros. ``rolling_anchor`` must match the value
+    passed to ``build_weekly_buckets`` so the zone keys line up with the bars
+    (#630): today-anchored 7-day bins when set, ISO-Monday weeks otherwise.
     """
-    # Sum zone seconds per ISO-week Monday
+    # Sum zone seconds per bucket key (must match the weekly_buckets keys)
     zone_by_week: dict[date, tuple[int, int, int]] = {}
     for af in activity_facts:
         if not af.time_in_zones:
             continue
-        monday = af.local_date - timedelta(days=af.local_date.weekday())
+        if rolling_anchor is not None:
+            key = _rolling_bin_start(af.local_date, rolling_anchor, 7)
+        else:
+            key = af.local_date - timedelta(days=af.local_date.weekday())
         easy_s, mod_s, hard_s = _collapse_to_3_zones(af.time_in_zones)
-        prev = zone_by_week.get(monday, (0, 0, 0))
-        zone_by_week[monday] = (
+        prev = zone_by_week.get(key, (0, 0, 0))
+        zone_by_week[key] = (
             prev[0] + easy_s,
             prev[1] + mod_s,
             prev[2] + hard_s,
@@ -834,13 +900,22 @@ def build_zone_load_period(
     activity_facts: List[ActivityFact],
     period_buckets: List["PeriodBucket"],
     period: str,
+    rolling_anchor: Optional[date] = None,
 ) -> List[dict]:
-    """Per-coarse-bucket 3-zone minutes (#432), continuous over ``period_buckets``."""
+    """Per-coarse-bucket 3-zone minutes (#432), continuous over ``period_buckets``.
+
+    ``rolling_anchor`` must match ``build_period_buckets`` so the zone keys line
+    up with the bars (#630): today-anchored 14-/30-day bins when set, the
+    calendar grid otherwise.
+    """
     zone_by_period: dict[date, tuple[int, int, int]] = {}
     for af in activity_facts:
         if not af.time_in_zones:
             continue
-        ps = _period_start(af.local_date, period)
+        if rolling_anchor is not None:
+            ps = _rolling_bin_start(af.local_date, rolling_anchor, _ROLLING_BIN_DAYS[period])
+        else:
+            ps = _period_start(af.local_date, period)
         easy_s, mod_s, hard_s = _collapse_to_3_zones(af.time_in_zones)
         prev = zone_by_period.get(ps, (0, 0, 0))
         zone_by_period[ps] = (
@@ -944,6 +1019,11 @@ def get_trends_report(
     # comparison spans [prev_start, prev_end). Calendar mode shifts both.
     since, prev_start, prev_end = _resolve_window(range_upper, mode)
 
+    # Rolling mode buckets the bars in fixed-width blocks rolling back from today
+    # rather than snapping to the calendar grid (#630). None keeps the calendar
+    # keying (ISO-Monday weeks / calendar months / the fortnight grid).
+    rolling_anchor: Optional[date] = date.today() if mode == "rolling" else None
+
     # Chart x-axis frame end (#413): rolling stops at today (until=None); calendar
     # spans the whole current period (e.g. Mon–Sun for 7D), so the period's last
     # day frames the chart and days after today render as empty bars.
@@ -968,7 +1048,7 @@ def get_trends_report(
     # week/period, not just the in-window slice). Kept separate from
     # daily_facts so the summary/header totals stay strictly in-period.
     pre_window_daily: List[DailyFact] = []
-    if since is not None:
+    if mode == "calendar" and since is not None:
         pre_start = _period_start(since, "monthly")
         if pre_start < since:
             pre_facts = _query_activity_facts(
@@ -1031,7 +1111,7 @@ def get_trends_report(
     # 4. Weekly buckets (continuous — includes empty weeks)
     weekly = build_weekly_buckets(
         daily_facts, range_key=range_upper, since=since, until=until,
-        pre_window_daily=pre_window_daily,
+        pre_window_daily=pre_window_daily, rolling_anchor=rolling_anchor,
     )
 
     weekly_distance = [
@@ -1072,11 +1152,11 @@ def get_trends_report(
     # 4b. Coarse buckets (#432): 2-week and month rollups of the same daily facts.
     biweekly = build_period_buckets(
         daily_facts, "biweekly", range_key=range_upper, since=since, until=until,
-        pre_window_daily=pre_window_daily,
+        pre_window_daily=pre_window_daily, rolling_anchor=rolling_anchor,
     )
     monthly = build_period_buckets(
         daily_facts, "monthly", range_key=range_upper, since=since, until=until,
-        pre_window_daily=pre_window_daily,
+        pre_window_daily=pre_window_daily, rolling_anchor=rolling_anchor,
     )
 
     def _period_distance(buckets: List[PeriodBucket]) -> List[PeriodDistancePoint]:
@@ -1146,7 +1226,7 @@ def get_trends_report(
     # 9. Zone load (3-zone stacked bar)
     weekly_zone_load = [
         ZoneLoadWeekPoint(**p)
-        for p in build_zone_load_weekly(activity_facts, weekly)
+        for p in build_zone_load_weekly(activity_facts, weekly, rolling_anchor=rolling_anchor)
     ]
     daily_zone_load = [
         DailyZoneLoadPoint(**p)
@@ -1154,11 +1234,11 @@ def get_trends_report(
     ]
     biweekly_zone_load = [
         PeriodZoneLoadPoint(**p)
-        for p in build_zone_load_period(activity_facts, biweekly, "biweekly")
+        for p in build_zone_load_period(activity_facts, biweekly, "biweekly", rolling_anchor=rolling_anchor)
     ]
     monthly_zone_load = [
         PeriodZoneLoadPoint(**p)
-        for p in build_zone_load_period(activity_facts, monthly, "monthly")
+        for p in build_zone_load_period(activity_facts, monthly, "monthly", rolling_anchor=rolling_anchor)
     ]
 
     return TrendsResponse(

--- a/backend/tests/test_trends_granularity.py
+++ b/backend/tests/test_trends_granularity.py
@@ -168,10 +168,28 @@ def test_window_total_is_identical_across_all_granularities(db):
 
 
 def test_coarse_series_are_continuous_over_the_range(db):
+    """Default (rolling) coarse series step by a fixed block width (#630): 14-day
+    fortnights and 30-day 'months' rolling back from today, with no gaps."""
     user_id = _user(db)
     _activity_on(db, user_id, date.today(), distance_m=4000)
 
     report = get_trends_report(db, "1Y", user_id=user_id)
+
+    bi = [p.period_start for p in report.biweekly_distance]
+    for a, b in zip(bi, bi[1:]):
+        assert (b - a).days == 14
+    mo = [p.period_start for p in report.monthly_distance]
+    for a, b in zip(mo, mo[1:]):
+        assert (b - a).days == 30
+
+
+def test_calendar_coarse_series_stay_on_the_calendar_grid(db):
+    """Calendar mode is unchanged (#630 is rolling-only): fortnights step 14 days
+    and months land on the 1st, incrementing by one calendar month."""
+    user_id = _user(db)
+    _activity_on(db, user_id, date.today(), distance_m=4000)
+
+    report = get_trends_report(db, "1Y", user_id=user_id, mode="calendar")
 
     bi = [p.period_start for p in report.biweekly_distance]
     for a, b in zip(bi, bi[1:]):

--- a/backend/tests/test_trends_rolling.py
+++ b/backend/tests/test_trends_rolling.py
@@ -1,0 +1,169 @@
+"""Rolling-mode bars roll back from today, not calendar chunks (#630).
+
+In rolling mode the week / 2-week / month bars must be fixed-width blocks
+anchored to the current date — the newest bar ends today and each older bar is
+the preceding block — instead of snapping to ISO-Monday weeks, the epoch
+fortnight grid, or calendar months (which is what calendar mode keeps). The
+leading block is simply a shorter bar (fewer in-window days) with no faded
+out-of-window segment.
+"""
+
+import uuid
+from datetime import date, datetime, time, timedelta
+
+from app.models import Activity, DerivedMetric, User
+from app.services.trends import (
+    DailyFact,
+    _rolling_bin_start,
+    build_period_buckets,
+    build_weekly_buckets,
+    get_trends_report,
+)
+
+
+# --- pure keying -------------------------------------------------------------
+
+_ANCHOR = date(2026, 7, 8)  # a Wednesday — deliberately not week/month aligned
+
+
+def test_rolling_bin_newest_block_ends_on_the_anchor():
+    # The block containing the anchor starts bin_days-1 before it.
+    assert _rolling_bin_start(_ANCHOR, _ANCHOR, 7) == _ANCHOR - timedelta(days=6)
+    assert _rolling_bin_start(_ANCHOR, _ANCHOR, 14) == _ANCHOR - timedelta(days=13)
+    assert _rolling_bin_start(_ANCHOR, _ANCHOR, 30) == _ANCHOR - timedelta(days=29)
+
+
+def test_rolling_bin_is_a_fixed_grid_back_from_the_anchor():
+    for bin_days in (7, 14, 30):
+        start = _rolling_bin_start(_ANCHOR, _ANCHOR, bin_days)
+        # Every day within the block maps to the same start...
+        for offset in range(bin_days):
+            assert _rolling_bin_start(start + timedelta(days=offset), _ANCHOR, bin_days) == start
+        # ...and the day before opens the previous block, exactly bin_days back.
+        assert (
+            _rolling_bin_start(start - timedelta(days=1), _ANCHOR, bin_days)
+            == start - timedelta(days=bin_days)
+        )
+
+
+def test_rolling_weekly_leading_block_is_a_short_bar_with_no_fade():
+    # 30-day window ending the anchor: since = anchor-29. Weekly (7-day) blocks
+    # back from the anchor give a 2-day leading block, in-window only, no spill.
+    since = _ANCHOR - timedelta(days=29)
+    facts = [DailyFact(_ANCHOR)]
+    facts[0].total_distance_m = 4000
+    weeks = build_weekly_buckets(
+        facts, since=since, until=_ANCHOR, rolling_anchor=_ANCHOR
+    )
+
+    # Newest block ends on the anchor; blocks step back by exactly 7 days.
+    assert weeks[-1].week_start == _ANCHOR - timedelta(days=6)
+    starts = [w.week_start for w in weeks]
+    for a, b in zip(starts, starts[1:]):
+        assert (b - a).days == 7
+
+    # Leading block: only its in-window days count, and there is NO faded segment.
+    assert weeks[0].in_period_days == 2       # since (anchor-29) .. block end
+    assert weeks[0].out_of_period_days == 0
+    assert all(w.out_of_period_days == 0 for w in weeks)
+    assert all(w.out_of_period_distance_m == 0 for w in weeks)
+    # Interior blocks are full 7-day weeks.
+    assert weeks[1].in_period_days == 7
+
+
+def test_rolling_monthly_blocks_are_thirty_day_steps_from_the_anchor():
+    since = _ANCHOR - timedelta(days=89)  # ~3M
+    facts = [DailyFact(_ANCHOR)]
+    months = build_period_buckets(
+        facts, "monthly", since=since, until=_ANCHOR, rolling_anchor=_ANCHOR
+    )
+    assert months[-1].period_start == _ANCHOR - timedelta(days=29)
+    starts = [m.period_start for m in months]
+    for a, b in zip(starts, starts[1:]):
+        assert (b - a).days == 30
+    assert all(m.out_of_period_days == 0 for m in months)
+
+
+# --- end-to-end (anchored to the real today) ---------------------------------
+
+
+def _user(db) -> uuid.UUID:
+    user = User(email=f"{uuid.uuid4()}@example.com")
+    db.add(user)
+    db.flush()
+    return user.id
+
+
+def _activity_on(db, user_id, on: date, *, distance_m=5000, moving_time_s=1500):
+    activity = Activity(
+        user_id=user_id,
+        strava_activity_id=int(uuid.uuid4().int % 1_000_000_000),
+        start_date=datetime.combine(on, time(12, 0)),
+        type="Run",
+        name="Run",
+        distance_m=distance_m,
+        moving_time_s=moving_time_s,
+        elapsed_time_s=moving_time_s,
+        elev_gain_m=0.0,
+        raw_summary={},
+    )
+    db.add(activity)
+    db.flush()
+    db.add(
+        DerivedMetric(
+            id=uuid.uuid4(), activity_id=activity.id, effort_score=3.0,
+            confidence="high", flags=[], confidence_reasons=[],
+        )
+    )
+    db.flush()
+    return activity
+
+
+def test_rolling_weekly_bars_end_today_and_step_back(db):
+    """Default (rolling) weekly bars: newest ends today, each older bar is the
+    preceding 7 days, and none carries a faded out-of-window segment."""
+    user_id = _user(db)
+    today = date.today()
+    _activity_on(db, user_id, today, distance_m=4000)
+    _activity_on(db, user_id, today - timedelta(days=29), distance_m=1000)
+
+    report = get_trends_report(db, "30D", user_id=user_id)
+    weekly = report.weekly_distance
+
+    # Newest block ends today (starts 6 days before it), blocks step back by 7.
+    assert weekly[-1].week_start == today - timedelta(days=6)
+    for a, b in zip(weekly, weekly[1:]):
+        assert (b.week_start - a.week_start).days == 7
+    # Rolling never fades: no out-of-window segment on any bar.
+    assert all(w.out_of_period_days == 0 for w in weekly)
+    assert all(w.out_of_period_distance_m == 0 for w in weekly)
+    # Today's run lands in the newest block; totals are conserved.
+    assert weekly[-1].total_distance_m == 4000
+    assert sum(w.total_distance_m for w in weekly) == report.summary.total_distance_m
+
+
+def test_rolling_monthly_and_biweekly_bars_end_today(db):
+    user_id = _user(db)
+    today = date.today()
+    _activity_on(db, user_id, today, distance_m=4000)
+
+    report = get_trends_report(db, "3M", user_id=user_id)
+
+    assert report.monthly_distance[-1].period_start == today - timedelta(days=29)
+    for a, b in zip(report.monthly_distance, report.monthly_distance[1:]):
+        assert (b.period_start - a.period_start).days == 30
+
+    assert report.biweekly_distance[-1].period_start == today - timedelta(days=13)
+    for a, b in zip(report.biweekly_distance, report.biweekly_distance[1:]):
+        assert (b.period_start - a.period_start).days == 14
+
+
+def test_calendar_mode_still_snaps_weekly_bars_to_monday(db):
+    """Calendar mode is untouched (#630 is rolling-only): weekly bars still start
+    on Mondays, unlike the rolling bars above."""
+    user_id = _user(db)
+    _activity_on(db, user_id, date.today(), distance_m=4000)
+
+    report = get_trends_report(db, "3M", user_id=user_id, mode="calendar")
+
+    assert all(w.week_start.weekday() == 0 for w in report.weekly_distance)

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -6,7 +6,7 @@ import { formatDistanceKm, formatDuration } from "@/lib/format";
 import { fetchFromAPI } from "@/lib/api";
 import RangeSelector from "@/components/trends/RangeSelector";
 import GranularitySelector from "@/components/trends/GranularitySelector";
-import { resolveGranularity, DAYS_PER_BUCKET } from "@/components/trends/granularity";
+import { resolveGranularity, DAYS_PER_BUCKET, ROLLING_BIN_DAYS } from "@/components/trends/granularity";
 import ActivityTypeFilter from "@/components/trends/ActivityTypeFilter";
 import TrendBarChart from "@/components/trends/TrendBarChart";
 import SufferScoreChart from "@/components/trends/SufferScoreChart";
@@ -174,7 +174,13 @@ export default function TrendsPage() {
     const m = normByMetric[metric];
     if (!framing || !m || m.norm == null || framing.window_days <= 0) return undefined;
     const perDay = m.norm / framing.window_days;
-    return perDay * DAYS_PER_BUCKET[effectiveGranularity] * scale;
+    // Rolling buckets are fixed-width blocks (#630: month = 30d), so scale the
+    // per-day norm by the rolling bin width; calendar uses the mean month (30.44).
+    const bucketDays =
+      effectiveMode === "rolling"
+        ? ROLLING_BIN_DAYS[effectiveGranularity]
+        : DAYS_PER_BUCKET[effectiveGranularity];
+    return perDay * bucketDays * scale;
   };
 
   return (
@@ -302,6 +308,7 @@ export default function TrendsPage() {
               data.monthly_distance,
             )}
             granularity={effectiveGranularity}
+            rolling={effectiveMode === "rolling"}
             typical={typicalPerBucket("distance_m", 1 / 1000)}
             delta={
               <ComparisonRows
@@ -322,6 +329,7 @@ export default function TrendsPage() {
               data.monthly_time,
             )}
             granularity={effectiveGranularity}
+            rolling={effectiveMode === "rolling"}
             typical={typicalPerBucket("moving_time_s", 1 / 60)}
             delta={
               <ComparisonRows
@@ -342,6 +350,7 @@ export default function TrendsPage() {
               data.monthly_suffer_score,
             )}
             granularity={effectiveGranularity}
+            rolling={effectiveMode === "rolling"}
             typical={typicalPerBucket("effort_score", 1)}
             delta={
               <ComparisonRows
@@ -381,6 +390,7 @@ export default function TrendsPage() {
               data.monthly_zone_load,
             )}
             granularity={effectiveGranularity}
+            rolling={effectiveMode === "rolling"}
             delta={
               <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs tabular-nums">
                 {(

--- a/frontend/components/trends/SufferScoreChart.tsx
+++ b/frontend/components/trends/SufferScoreChart.tsx
@@ -18,10 +18,9 @@ import {
   PeriodSufferScorePoint,
   TrendsGranularity,
 } from "@/lib/types";
-import { formatDateLabel } from "@/lib/format";
 import ChartTooltip from "@/components/charts/ChartTooltip";
 import { TYPICAL_LINE_PROPS, renderTypicalLabel } from "./typicalLine";
-import { BUCKET_NOUN, bucketKey } from "./granularity";
+import { BUCKET_NOUN, bucketAxisLabel, bucketKey } from "./granularity";
 
 interface Props {
   data:
@@ -30,6 +29,9 @@ interface Props {
     | WeeklySufferScorePoint[]
     | PeriodSufferScorePoint[];
   granularity: TrendsGranularity;
+  /** Rolling mode (#630): coarse buckets roll back from today and are labelled by
+   * their end day rather than snapping to calendar chunks. */
+  rolling: boolean;
   /** Period-over-period delta shown under the title (e.g. a <StatDiff>). */
   delta?: ReactNode;
   /** Runner's typical load per bucket, in chart units (#413). Draws a dashed
@@ -37,7 +39,7 @@ interface Props {
   typical?: number;
 }
 
-export default function SufferScoreChart({ data, granularity, delta, typical }: Props) {
+export default function SufferScoreChart({ data, granularity, rolling, delta, typical }: Props) {
   // #566: an edge bucket straddles the selected period boundary; render the
   // whole bucket as a stacked bar — in-range load solid, out-of-range load
   // faded on top — so a partial week/period isn't misread as a low one and the
@@ -54,7 +56,7 @@ export default function SufferScoreChart({ data, granularity, delta, typical }: 
       outValue: outRaw > 0 ? outRaw : null,
       inRaw,
       outRaw,
-      label: formatDateLabel(bucketKey(d)),
+      label: bucketAxisLabel(bucketKey(d), granularity, rolling),
       partial: outDays > 0,
       inDays,
       totalDays: inDays != null ? inDays + outDays : null,

--- a/frontend/components/trends/TrendBarChart.tsx
+++ b/frontend/components/trends/TrendBarChart.tsx
@@ -12,15 +12,17 @@ import {
 } from "recharts";
 import { ReactNode } from "react";
 import { TrendsGranularity } from "@/lib/types";
-import { formatDateLabel } from "@/lib/format";
 import ChartTooltip from "@/components/charts/ChartTooltip";
 import { TYPICAL_LINE_PROPS, renderTypicalLabel } from "./typicalLine";
-import { BUCKET_NOUN, TOOLTIP_PREFIX, bucketKey } from "./granularity";
+import { BUCKET_NOUN, bucketAxisLabel, bucketKey, tooltipPrefixFor } from "./granularity";
 
 interface TrendBarChartProps {
   data: any[];
   type: "distance" | "time";
   granularity: TrendsGranularity;
+  /** Rolling mode (#630): coarse buckets roll back from today and are labelled by
+   * their end day, rather than snapping to calendar chunks. */
+  rolling: boolean;
   /** Period-over-period delta shown under the title (e.g. a <StatDiff>). */
   delta?: ReactNode;
   /** Runner's typical level per bucket, in chart units (#413). Draws a dashed
@@ -39,6 +41,7 @@ export default function TrendBarChart({
   data,
   type,
   granularity,
+  rolling,
   delta,
   typical,
 }: TrendBarChartProps) {
@@ -75,14 +78,14 @@ export default function TrendBarChart({
       outValue: outRaw > 0 ? toChart(outRaw) : null,
       inRaw,
       outRaw,
-      label: formatDateLabel(bucketKey(d)),
+      label: bucketAxisLabel(bucketKey(d), granularity, rolling),
       partial: outDays > 0,
       inDays,
       totalDays: inDays != null ? inDays + outDays : null,
     };
   });
 
-  const tooltipPrefix = TOOLTIP_PREFIX[granularity];
+  const tooltipPrefix = tooltipPrefixFor(granularity, rolling);
   // A faded segment is only drawn when an edge bucket has real out-of-range
   // value (a leading week reaching before the window); the trailing in-progress
   // bucket has none yet.

--- a/frontend/components/trends/ZoneLoadChart.tsx
+++ b/frontend/components/trends/ZoneLoadChart.tsx
@@ -17,12 +17,14 @@ import {
   PeriodZoneLoadPoint,
   TrendsGranularity,
 } from "@/lib/types";
-import { formatDateLabel } from "@/lib/format";
-import { BUCKET_NOUN, bucketKey } from "./granularity";
+import { BUCKET_NOUN, bucketAxisLabel, bucketKey } from "./granularity";
 
 interface ZoneLoadChartProps {
   data: ZoneLoadWeekPoint[] | DailyZoneLoadPoint[] | PeriodZoneLoadPoint[];
   granularity: TrendsGranularity;
+  /** Rolling mode (#630): coarse buckets roll back from today and are labelled by
+   * their end day rather than snapping to calendar chunks. */
+  rolling: boolean;
   /** Period-over-period delta shown under the title (e.g. a <StatDiff>). */
   delta?: ReactNode;
 }
@@ -70,7 +72,7 @@ function CustomTooltip({
   );
 }
 
-export default function ZoneLoadChart({ data, granularity, delta }: ZoneLoadChartProps) {
+export default function ZoneLoadChart({ data, granularity, rolling, delta }: ZoneLoadChartProps) {
   const title = `Training Load by Zone per ${BUCKET_NOUN[granularity]}`;
 
   // Check if all entries have zero zone data
@@ -91,7 +93,7 @@ export default function ZoneLoadChart({ data, granularity, delta }: ZoneLoadChar
 
   const chartData = data.map((d) => ({
     ...d,
-    label: formatDateLabel(bucketKey(d)),
+    label: bucketAxisLabel(bucketKey(d), granularity, rolling),
   }));
 
   return (

--- a/frontend/components/trends/granularity.ts
+++ b/frontend/components/trends/granularity.ts
@@ -6,6 +6,7 @@
 // 7D/30D showed daily bars, everything longer showed weekly bars.
 
 import type { TrendsGranularity, TrendsRange } from "@/lib/types";
+import { formatDateLabel } from "@/lib/format";
 
 export const GRANULARITY_LABEL: Record<TrendsGranularity, string> = {
   day: "Day",
@@ -23,12 +24,61 @@ export const BUCKET_NOUN: Record<TrendsGranularity, string> = {
 };
 
 // Prefix shown before a bucket's date in a chart tooltip.
+// Calendar mode: buckets are calendar chunks keyed by their first day ("Week of
+// Jun 15"). Rolling mode (#630): buckets roll back from today and are labelled
+// by the block's END (most recent) day, so the prefix names the trailing span.
 export const TOOLTIP_PREFIX: Record<TrendsGranularity, string> = {
   day: "",
   week: "Week of ",
   "2week": "Fortnight of ",
   month: "Month of ",
 };
+
+export const ROLLING_TOOLTIP_PREFIX: Record<TrendsGranularity, string> = {
+  day: "",
+  week: "Week ending ",
+  "2week": "2 weeks ending ",
+  month: "30 days ending ",
+};
+
+export function tooltipPrefixFor(
+  granularity: TrendsGranularity,
+  rolling: boolean,
+): string {
+  return rolling ? ROLLING_TOOLTIP_PREFIX[granularity] : TOOLTIP_PREFIX[granularity];
+}
+
+// Fixed block width per coarse granularity in rolling mode (#630). Matches the
+// backend rolling bins (week 7d, 2-week 14d, month 30d); day is a single day.
+export const ROLLING_BIN_DAYS: Record<TrendsGranularity, number> = {
+  day: 1,
+  week: 7,
+  "2week": 14,
+  month: 30,
+};
+
+// Add `days` to a "YYYY-MM-DD" key, staying in UTC so no timezone shift creeps
+// in (mirrors formatDateLabel's timezone-free parsing).
+function shiftISO(iso: string, days: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, (m || 1) - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + days);
+  return dt.toISOString().slice(0, 10);
+}
+
+// The x-axis label for a bucket. Calendar mode labels by the bucket's first day;
+// rolling mode (#630) labels a coarse bucket by its END day, so the bar reads as
+// "the trailing block ending here" rather than a calendar-chunk start date.
+export function bucketAxisLabel(
+  keyISO: string,
+  granularity: TrendsGranularity,
+  rolling: boolean,
+): string {
+  if (rolling && granularity !== "day") {
+    return formatDateLabel(shiftISO(keyISO, ROLLING_BIN_DAYS[granularity] - 1));
+  }
+  return formatDateLabel(keyISO);
+}
 
 // The bucket's first-day key, whichever granularity-specific field carries it.
 export function bucketKey(d: {


### PR DESCRIPTION
Fixes #630.

## Problem
On the Trends page in **rolling** mode, the week / 2-week / month bars were bucketed into calendar chunks — ISO-Monday weeks, the epoch-anchored fortnight grid, and calendar months — instead of blocks rolling back from the current date. The rolling/calendar toggle only shifted the *window*; the bucketing itself was always calendar-anchored, so the rolling view read the same as calendar. Daily granularity was already correct.

## Fix
In rolling mode, the coarse bars are now anchored to today: the newest bar ends today and each older bar is the preceding fixed-width block (7 / 14 / 30 days). A month has no fixed length, so a rolling month is a 30-day block. The leading block is a shorter, in-window-only bar with no faded out-of-window segment.

**Calendar mode is untouched** — it keeps ISO-Monday weeks, the fortnight grid, and calendar months.

Frontend: rolling coarse bars are labelled by their end (most recent) day ("Week ending Jul 6", "30 days ending Jul 6"), the faded-segment note no longer appears in rolling mode, and the typical reference line scales by the 30-day rolling month bin.

## Changes
- `backend/app/services/trends.py` — today-anchored rolling bin keying threaded through all six bucket builders (weekly, biweekly, monthly, and their zone-load counterparts); `pre_window_daily` fade path gated to calendar mode.
- `frontend/components/trends/` + `app/trends/page.tsx` — `rolling` flag threaded to the three bar charts; end-anchored labels and rolling tooltip prefixes centralised in `granularity.ts`.
- Tests: new `test_trends_rolling.py` (deterministic keying oracle + e2e: bars end today, step by 7/14/30, short leading bar with no fade); `test_trends_granularity.py` updated to assert rolling continuity in default mode and keep calendar-grid alignment under explicit calendar mode.

## Verification
- 92 trends-related backend tests pass, including the new rolling oracle/e2e tests, preserved+new calendar-mode tests, and the cross-granularity totals-conserved invariant.
- Ran the real `get_trends_report` on a realistic 13-week dataset: rolling weekly ends today / steps 7 / no fade; rolling monthly steps 30; calendar unchanged; totals conserved in both modes.
- Frontend `tsc`, `next lint`, and `next build` all clean.

**Needs human sign-off:** the label wording and the removed faded-note are a visual/UX judgment. There are no frontend unit tests for these chart components, so the label logic is verified by build + review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GY2ccPRbNRCtHubaWTz6k

---
_Generated by [Claude Code](https://claude.ai/code/session_017GY2ccPRbNRCtHubaWTz6k)_