### PR TITLE
Fade rolling leading-edge block like calendar edge buckets (#630)

### DIFF
--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -573,8 +573,9 @@ def build_weekly_buckets(
     bar (#566); ``total_*`` stays the in-period sum.
     Pass ``rolling_anchor`` (today) to bucket by 7-day blocks rolling back from
     that anchor instead of ISO-Monday weeks (#630): the bars then roll back from
-    the current date. When set, no faded out-of-window segment is produced (the
-    leading edge is simply a shorter bar); ``pre_window_daily`` is ignored.
+    the current date. A leading block that only partly overlaps the window fades
+    its out-of-window days via ``pre_window_daily``, the same as a calendar edge
+    week — the bar shows the whole block, in-window solid and excluded part faded.
     """
     def _key(d: date) -> date:
         if rolling_anchor is not None:
@@ -610,20 +611,18 @@ def build_weekly_buckets(
         cursor += timedelta(weeks=1)
 
     # Edge-bucket coverage (#566): mark how much of each week falls inside the
-    # selected window [since, end]. Rolling bins align to the window, so the only
-    # partial is the leading short bar and it carries no faded segment (#630).
+    # selected window [since, end] so the chart can fade the partial leading week.
+    # Rolling and calendar are handled the same here (#630): a leading rolling
+    # block that only partly overlaps the window shows its out-of-window days as a
+    # faded segment, exactly like a calendar edge week — the bar shows the whole
+    # 7-day block, in-window solid and the excluded part faded.
     for w in buckets.values():
-        in_days, out_days = _coverage_days(
+        w.in_period_days, w.out_of_period_days = _coverage_days(
             w.week_start, w.week_start + timedelta(days=6), since, end
         )
-        w.in_period_days = in_days
-        w.out_of_period_days = 0 if rolling_anchor is not None else out_days
-    # Carry the out-of-window value of a leading edge week's earlier days
-    # (calendar mode only — rolling bins show no faded segment).
-    if rolling_anchor is None:
-        _add_out_of_period_values(
-            buckets, pre_window_daily, lambda d: d - timedelta(days=d.weekday())
-        )
+    # Carry the out-of-window value of a leading edge week's earlier days, keyed
+    # the same way the buckets are (rolling block start or ISO Monday).
+    _add_out_of_period_values(buckets, pre_window_daily, _key)
 
     return sorted(buckets.values(), key=lambda w: w.week_start)
 
@@ -645,9 +644,9 @@ def build_period_buckets(
     they default to the range start and today.
     Pass ``rolling_anchor`` (today) to bucket by fixed-width blocks rolling back
     from that anchor instead of the calendar grid (#630): 14-day blocks for
-    ``biweekly``, 30-day blocks for ``monthly``. When set, no faded out-of-window
-    segment is produced (the leading edge is a shorter bar); ``pre_window_daily``
-    is ignored.
+    ``biweekly``, 30-day blocks for ``monthly``. A leading block that only partly
+    overlaps the window fades its out-of-window days via ``pre_window_daily``, the
+    same as a calendar edge bucket.
     """
     bin_days = _ROLLING_BIN_DAYS[period]  # rolling-mode block width
 
@@ -693,18 +692,16 @@ def build_period_buckets(
 
     # Edge-bucket coverage (#566): the bucket's full span is [period_start,
     # span_end] (the calendar month / fortnight in calendar mode, a fixed
-    # 14-/30-day block in rolling mode); mark how much falls inside [since, end].
+    # 14-/30-day block in rolling mode); mark how much falls inside [since, end]
+    # so a leading edge bucket fades its out-of-window part in either mode (#630).
     for b in buckets.values():
         span_end = _span_end(b.period_start)
-        in_days, out_days = _coverage_days(b.period_start, span_end, since, end)
-        b.in_period_days = in_days
-        b.out_of_period_days = 0 if rolling_anchor is not None else out_days
-    # Carry the out-of-window value of a leading edge bucket's earlier days
-    # (calendar mode only — rolling bins show no faded segment).
-    if rolling_anchor is None:
-        _add_out_of_period_values(
-            buckets, pre_window_daily, lambda d: _period_start(d, period)
+        b.in_period_days, b.out_of_period_days = _coverage_days(
+            b.period_start, span_end, since, end
         )
+    # Carry the out-of-window value of a leading edge bucket's earlier days, keyed
+    # the same way the buckets are (rolling block start or calendar period start).
+    _add_out_of_period_values(buckets, pre_window_daily, _key)
 
     return sorted(buckets.values(), key=lambda b: b.period_start)
 
@@ -1041,15 +1038,22 @@ def get_trends_report(
     # 2. Daily facts (sum per local date)
     daily_facts = build_daily_facts(activity_facts)
 
-    # #566: the days just before the window — back to the 1st of `since`'s month,
-    # the earliest leading-bucket start across the week / 2-week / month
-    # granularities — so a leading edge bucket can show the value of its
-    # out-of-window days as a faded stacked segment (the bar then shows the whole
-    # week/period, not just the in-window slice). Kept separate from
+    # #566/#630: the days just before the window, back to the earliest leading
+    # edge-bucket start across the week / 2-week / month granularities, so a
+    # leading edge bucket can show the value of its out-of-window days as a faded
+    # stacked segment (the bar then shows the whole week/period, not just the
+    # in-window slice). Calendar buckets snap to the 1st of `since`'s month;
+    # rolling blocks are anchored to today, and the three widths don't nest, so
+    # take the earliest of the three leading-block starts. Kept separate from
     # daily_facts so the summary/header totals stay strictly in-period.
     pre_window_daily: List[DailyFact] = []
-    if mode == "calendar" and since is not None:
-        pre_start = _period_start(since, "monthly")
+    if since is not None:
+        if rolling_anchor is not None:
+            pre_start = min(
+                _rolling_bin_start(since, rolling_anchor, d) for d in (7, 14, 30)
+            )
+        else:
+            pre_start = _period_start(since, "monthly")
         if pre_start < since:
             pre_facts = _query_activity_facts(
                 db, pre_start, since, types=types, user_id=user_id

--- a/backend/tests/test_trends_rolling.py
+++ b/backend/tests/test_trends_rolling.py
@@ -3,9 +3,10 @@
 In rolling mode the week / 2-week / month bars must be fixed-width blocks
 anchored to the current date — the newest bar ends today and each older bar is
 the preceding block — instead of snapping to ISO-Monday weeks, the epoch
-fortnight grid, or calendar months (which is what calendar mode keeps). The
-leading block is simply a shorter bar (fewer in-window days) with no faded
-out-of-window segment.
+fortnight grid, or calendar months (which is what calendar mode keeps). A
+leading block that only partly overlaps the window shows its out-of-window days
+as a faded segment, exactly like a calendar edge bucket (the bar shows the whole
+block, in-window solid and the excluded part faded).
 """
 
 import uuid
@@ -46,14 +47,20 @@ def test_rolling_bin_is_a_fixed_grid_back_from_the_anchor():
         )
 
 
-def test_rolling_weekly_leading_block_is_a_short_bar_with_no_fade():
+def test_rolling_weekly_leading_block_fades_its_out_of_window_days():
     # 30-day window ending the anchor: since = anchor-29. Weekly (7-day) blocks
-    # back from the anchor give a 2-day leading block, in-window only, no spill.
+    # back from the anchor give a leading block that straddles the window start,
+    # so its out-of-window days show as a faded segment (like a calendar edge
+    # week), carrying the value of a run that fell before the window.
     since = _ANCHOR - timedelta(days=29)
-    facts = [DailyFact(_ANCHOR)]
-    facts[0].total_distance_m = 4000
+    in_window = [DailyFact(_ANCHOR)]
+    in_window[0].total_distance_m = 4000
+    # A run 3 days before the window start lands in the leading block's faded part.
+    pre = [DailyFact(since - timedelta(days=3))]
+    pre[0].total_distance_m = 5000
     weeks = build_weekly_buckets(
-        facts, since=since, until=_ANCHOR, rolling_anchor=_ANCHOR
+        in_window, since=since, until=_ANCHOR, rolling_anchor=_ANCHOR,
+        pre_window_daily=pre,
     )
 
     # Newest block ends on the anchor; blocks step back by exactly 7 days.
@@ -62,17 +69,21 @@ def test_rolling_weekly_leading_block_is_a_short_bar_with_no_fade():
     for a, b in zip(starts, starts[1:]):
         assert (b - a).days == 7
 
-    # Leading block: only its in-window days count, and there is NO faded segment.
-    assert weeks[0].in_period_days == 2       # since (anchor-29) .. block end
-    assert weeks[0].out_of_period_days == 0
-    assert all(w.out_of_period_days == 0 for w in weeks)
-    assert all(w.out_of_period_distance_m == 0 for w in weeks)
-    # Interior blocks are full 7-day weeks.
-    assert weeks[1].in_period_days == 7
+    # Leading block: 2 in-window days + 5 out-of-window, with the pre-window run
+    # carried as the faded out-of-window value (the bar shows the whole week).
+    lead = weeks[0]
+    assert lead.in_period_days == 2
+    assert lead.out_of_period_days == 5
+    assert lead.out_of_period_distance_m == 5000
+    # The newest, fully-in-window block never fades.
+    assert weeks[-1].in_period_days == 7
+    assert weeks[-1].out_of_period_days == 0
 
 
 def test_rolling_monthly_blocks_are_thirty_day_steps_from_the_anchor():
-    since = _ANCHOR - timedelta(days=89)  # ~3M
+    # 100-day window: not a multiple of 30, so the leading 30-day block straddles
+    # the window start and must fade (a clean multiple like 90 would not).
+    since = _ANCHOR - timedelta(days=100)
     facts = [DailyFact(_ANCHOR)]
     months = build_period_buckets(
         facts, "monthly", since=since, until=_ANCHOR, rolling_anchor=_ANCHOR
@@ -81,7 +92,10 @@ def test_rolling_monthly_blocks_are_thirty_day_steps_from_the_anchor():
     starts = [m.period_start for m in months]
     for a, b in zip(starts, starts[1:]):
         assert (b - a).days == 30
-    assert all(m.out_of_period_days == 0 for m in months)
+    # Newest block is fully in-window (no fade); the leading block straddles the
+    # window start, so it reports out-of-window days.
+    assert months[-1].out_of_period_days == 0
+    assert months[0].out_of_period_days > 0
 
 
 # --- end-to-end (anchored to the real today) ---------------------------------
@@ -121,11 +135,15 @@ def _activity_on(db, user_id, on: date, *, distance_m=5000, moving_time_s=1500):
 
 def test_rolling_weekly_bars_end_today_and_step_back(db):
     """Default (rolling) weekly bars: newest ends today, each older bar is the
-    preceding 7 days, and none carries a faded out-of-window segment."""
+    preceding 7 days, and the leading partial fades its excluded days like a
+    calendar edge week."""
     user_id = _user(db)
     today = date.today()
     _activity_on(db, user_id, today, distance_m=4000)
     _activity_on(db, user_id, today - timedelta(days=29), distance_m=1000)
+    # A run just before the 30-day window: it falls in the leading block's
+    # out-of-window (faded) part, not in the in-window totals.
+    _activity_on(db, user_id, today - timedelta(days=31), distance_m=700)
 
     report = get_trends_report(db, "30D", user_id=user_id)
     weekly = report.weekly_distance
@@ -134,12 +152,18 @@ def test_rolling_weekly_bars_end_today_and_step_back(db):
     assert weekly[-1].week_start == today - timedelta(days=6)
     for a, b in zip(weekly, weekly[1:]):
         assert (b.week_start - a.week_start).days == 7
-    # Rolling never fades: no out-of-window segment on any bar.
-    assert all(w.out_of_period_days == 0 for w in weekly)
-    assert all(w.out_of_period_distance_m == 0 for w in weekly)
-    # Today's run lands in the newest block; totals are conserved.
+    # Newest block is fully in-window: no fade.
+    assert weekly[-1].out_of_period_days == 0
+    assert weekly[-1].out_of_period_distance_m == 0
+    # Leading block straddles the window start: it fades its excluded days and
+    # carries the pre-window run as the faded value (bar shows the whole week).
+    assert weekly[0].out_of_period_days > 0
+    assert weekly[0].out_of_period_distance_m == 700
+    # Today's run lands in the newest block; in-window totals stay conserved and
+    # exclude the faded pre-window run.
     assert weekly[-1].total_distance_m == 4000
     assert sum(w.total_distance_m for w in weekly) == report.summary.total_distance_m
+    assert report.summary.total_distance_m == 5000  # 4000 + 1000, not the 700
 
 
 def test_rolling_monthly_and_biweekly_bars_end_today(db):


### PR DESCRIPTION
Follow-up to #631 (merged). Refs #630.

## Problem
After #631 made the rolling Trends bars roll back from today, the **leading** bar (the remainder when the window doesn't divide evenly into the bucket width — e.g. 30 days ÷ 7 = 4 weeks + 2 days) rendered as a clipped short bar showing only its in-window days. That read as "clipping the current week" and was inconsistent with the calendar view, which shows the full edge bucket with the excluded part faded.

## Fix
Make the rolling leading edge consistent with calendar: a leading rolling block that only partly overlaps the window now shows its out-of-window days as a **faded stacked segment**, exactly like a calendar edge week/month. The bar shows the whole 7/14/30-day block — in-window solid, excluded part faded — instead of a clipped bar.

- Unified the edge-coverage and out-of-window handling across both modes (rolling uses its today-anchored keys, calendar its grid).
- The pre-window fetch now reaches back to the earliest leading-block start across the week/2-week/month granularities, so every granularity's faded value is present (the rolling widths don't nest, so it takes the earliest of the three).
- In-window totals are unchanged, so the summary/header totals stay strictly in-period — the faded days are shown for context but never counted.

The newest bar is fully in-window and never fades; only a straddling leading block fades.

## Changes
- `backend/app/services/trends.py` — unify rolling/calendar edge handling; pre-window fetch covers all rolling granularities.
- `backend/tests/test_trends_rolling.py` — updated to assert the leading block fades and carries its out-of-window value, newest stays full/unfaded, and totals exclude the faded days.

No frontend change — the faded-segment rendering and note already exist (the calendar codepath); the backend now feeds them in rolling mode too.

## Verification
- 92 trends-related backend tests pass (updated rolling tests + preserved calendar tests + cross-granularity totals invariant).
- Reproduced the reported screenshot scenario (30D weekly, today = Mon Jul 6): the leading "Jun 8" bar now shows 16 km in-window solid + 40 km faded, the newest bar is a full 7-day block ending today, and the faded days are excluded from the summary total.

**Needs your visual sign-off:** how the faded leading bar reads on-screen in rolling mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GY2ccPRbNRCtHubaWTz6k

---
_Generated by [Claude Code](https://claude.ai/code/session_017GY2ccPRbNRCtHubaWTz6k)_