### PR TITLE
Diagram: #522 off-state as capture-driven chips (no banners) + kill-switch drift guard

### DIFF
--- a/docs/diagrams/ai-flow-graph.html
+++ b/docs/diagrams/ai-flow-graph.html
@@ -179,8 +179,6 @@
   /* the destination label inside a fate chip ("where it went") */
   .fate-to { color:#aeb8c9; font-weight:600; }
   .fate-to::before { content:'→\00a0'; color:#6b7280; font-weight:400; }
-  .fatebanner { font-size:11.5px; color:var(--muted); line-height:1.5; background:rgba(252,211,77,.06);
-    border:1px solid rgba(252,211,77,.18); border-left:3px solid #fcd34d; border-radius:5px; padding:7px 10px; margin:9px 0; }
   /* the system prompt, rendered as labelled layers (each tagged with the version that added it) */
   .prompt { display:flex; flex-direction:column; gap:7px; margin-top:8px; }
   .pseg { border:1px solid #23262d; border-left:3px solid #3a3f47; border-radius:6px; background:#0e1014; overflow:hidden; }

--- a/docs/diagrams/ai-flow-graph.html
+++ b/docs/diagrams/ai-flow-graph.html
@@ -118,8 +118,6 @@
   .writes .f { font-family:ui-monospace,Menlo,monospace; color:#7dd3fc; }
   .writes .val { color:var(--ink); font-family:ui-monospace,Menlo,monospace; }
   .lineage { display:none; }
-  .offbanner { background:rgba(239,68,68,.1); border:1px solid rgba(239,68,68,.35); color:#fca5a5;
-    border-radius:7px; padding:7px 9px; margin-top:8px; font-size:11px; line-height:1.5; }
   .note { font-size:11px; color:var(--muted); margin:6px 2px 0; }
   .prose { background:#0c0f14; border:1px solid var(--line); border-radius:8px; padding:11px 13px; margin-top:8px;
     font-size:12.5px; line-height:1.6; color:#d2d8e3; }

--- a/docs/diagrams/check_diagram_drift.py
+++ b/docs/diagrams/check_diagram_drift.py
@@ -20,6 +20,15 @@ LIVE code:
      map (so it carries a fate chip). This is what hid efficiency_analysis / confidence /
      training_context.
 
+  3. KILL-SWITCH PARITY. The diagram's captured `D.flags` (the COACH_*_ENABLED values the
+     capture was generated under) must match the prod-parity values documented in
+     backend/.env.example. This pins the diagram to prod: it catches a capture regenerated
+     with the wrong local config (e.g. every switch left on while prod runs the lean pack —
+     the exact bug that made stops_analysis read as forwarded), and the reverse, a change to
+     .env.example that was not followed by a regenerate. It ties the diagram to the committed
+     prod-parity contract (.env.example), not to live Railway — keeping .env.example itself
+     current with prod stays a human step.
+
 It does NOT verify edge correctness (which upstream stage feeds which node) — that is harder
 to mechanise and still relies on the periodic human/agent audit. This guard's job is narrow
 and high-value: no pack section or metric column can ever again reach the model with no node.
@@ -39,6 +48,7 @@ _HERE = Path(__file__).resolve().parent
 _BACKEND = _HERE.parents[1] / "backend"
 _FLOW_NODES = _HERE / "flow-nodes.js"
 _GENERATOR = _HERE / "generate_flow_nodes_data.py"
+_ENV_EXAMPLE = _BACKEND / ".env.example"
 
 # CoachContextPack fields that intentionally have NO node in the diagram. Keep this list
 # tiny and documented — every entry is a field the model carries in the schema but that is
@@ -88,7 +98,9 @@ def _pack_keys_bound_by_nodes(src: str) -> set[str]:
         id_m = re.match(r"\{\s*id:'(p_\w+)'", chunk)
         if not id_m:
             continue
-        key_m = re.search(r"\bj(?:Tall)?Prov\('(\w+)'\)", chunk) or re.search(r"\bP\.(\w+)", chunk)
+        # jProv('k') / jTallProv('k') and their per-field-override variants jProvX('k',{...}) /
+        # jTallProvX('k',{...}); else fall back to the first P.<key> the node renders.
+        key_m = re.search(r"\bj(?:Tall)?ProvX?\('(\w+)'", chunk) or re.search(r"\bP\.(\w+)", chunk)
         if key_m:
             keys.add(key_m.group(1))
     return keys
@@ -107,6 +119,22 @@ def _fate_derived_keys(src: str) -> set[str]:
         keys |= set(re.findall(r"'(\w+)'", arr_m.group(1)))
     keys |= set(re.findall(r"\bm\.(\w+)\s*=", block))
     return keys
+
+
+def _diagram_captured_flags(flow_src: str) -> dict[str, bool]:
+    """The COACH_*_ENABLED values the capture was generated under, read from the DATA blob's
+    `flags` object. These `"COACH_X_ENABLED":true|false` pairs appear ONLY inside that object
+    (the JS logic references the flags as single-quoted string literals, never `"...":bool`)."""
+    return {k: v == "true" for k, v in
+            re.findall(r'"(COACH_[A-Z_]+_ENABLED)":(true|false)', flow_src)}
+
+
+def _env_example_flags() -> dict[str, bool]:
+    """The prod-parity COACH_*_ENABLED values documented in backend/.env.example."""
+    if not _ENV_EXAMPLE.is_file():
+        return {}
+    return {k: v == "true" for k, v in
+            re.findall(r'^(COACH_[A-Z_]+_ENABLED)=(true|false)', _ENV_EXAMPLE.read_text(), re.M)}
 
 
 def _generator_dm_fields(src: str) -> set[str]:
@@ -182,6 +210,31 @@ def check_drift() -> list[str]:
     if spurious_fate:
         problems.append(
             f"FATE_DERIVED maps keys that are not DerivedMetric columns: {sorted(spurious_fate)}. Remove them.")
+
+    # 3. Kill-switch parity: the captured D.flags must match .env.example's prod-parity block.
+    captured = _diagram_captured_flags(flow_src)
+    documented = _env_example_flags()
+    if not captured:
+        problems.append(
+            "The diagram carries NO captured COACH_*_ENABLED flags — regenerate it under the "
+            "prod-parity config (backend/.env mirroring .env.example) so the off-state chips are "
+            "capture-driven. See generate_flow_nodes_data.py.")
+    elif not documented:
+        problems.append(
+            "backend/.env.example documents no COACH_*_ENABLED prod-parity block, so the diagram's "
+            "kill-switch state cannot be verified against prod. Add the prod-parity flags to .env.example.")
+    else:
+        mismatched = sorted(
+            f"{k} (diagram={captured[k]}, .env.example={documented[k]})"
+            for k in captured.keys() & documented.keys()
+            if captured[k] != documented[k]
+        )
+        if mismatched:
+            problems.append(
+                "The diagram was generated under coach kill-switch flags that DISAGREE with the "
+                f"prod-parity set in backend/.env.example: {mismatched}. Regenerate flow-nodes.js "
+                "under prod-parity config (or update .env.example if prod itself changed), so the "
+                "diagram reflects what prod actually sends.")
 
     return problems
 

--- a/docs/diagrams/flow-nodes.js
+++ b/docs/diagrams/flow-nodes.js
@@ -295,8 +295,8 @@ const fmt = (x)=> (x===null||x===undefined)?'null':(typeof x==='object'?JSON.str
 const _toModel = {f:'forwarded',to:'the model',note:'placed into json.dumps(pack) — the model’s user message — on the single hop into the call'};
 const _gatedModel = (passed,note)=>({f:'gated',passed:passed,to:'the model',note:note});
 // True when a #522 kill switch is ACTUALLY off in this capture (D.flags carries the
-// generator's real COACH_*_ENABLED values). Shared by the fate maps below and the
-// OFF_522 banner helpers, so both read the capture instead of a static claim.
+// generator's real COACH_*_ENABLED values). Drives the section fates below and the
+// per-field DROPPED_522 chips, so the off-state always reads off the capture.
 const _flagOff = (flag)=> !!(D.flags && D.flags[flag]===false);
 const PACK_PROV = {
   activity:          {src:{id:'act_row',label:'Activity row'},          fate:_toModel},
@@ -325,6 +325,22 @@ function provMaps(section){
 }
 const jProv     = (section)=> renderTree(P[section], false, ...provMaps(section));
 const jTallProv = (section)=> renderTree(P[section], true,  ...provMaps(section));
+// A #522 kill switch that is OFF in this capture removes an input from the coach. Instead of
+// a separate banner, the affected FIELD carries a `dropped` fate chip naming the flag, so the
+// chip is accurate to what prod actually sends (the reported inconsistency: a gated field must
+// not read as "forwarded"). Capture-driven via D.flags, like everything else here.
+const DROPPED_522 = (flag, note)=> ({f:'dropped', to:null, note:'removed for the coach — '+flag+'=false (#522). '+(note||'')});
+// The per-field fate override for a flag that is off, else null (keep the section's normal fate).
+const off522Fate = (flag, note)=> _flagOff(flag) ? DROPPED_522(flag, note) : null;
+// provMaps + a {field: fateOrNull} override map (null entries ignored), so one nested field can
+// carry a dropped chip while its siblings keep the section fate.
+function provMapsX(section, overrides){
+  const [src,fate]=provMaps(section);
+  if(fate && overrides) for(const k in overrides){ if(overrides[k]) fate[k]=overrides[k]; }
+  return [src,fate];
+}
+const jProvX     = (section, ov)=> renderTree(P[section], false, ...provMapsX(section, ov));
+const jTallProvX = (section, ov)=> renderTree(P[section], true,  ...provMapsX(section, ov));
 
 /* The read-time BUILDER (derivation) nodes render the same data one hop earlier — they
    COMPUTE it from their inputs and forward it into the matching pack.<section>. So their
@@ -349,18 +365,12 @@ function jp(obj, key, tall){
 
 /* ---------- the graph ---------- */
 // from = upstream sources (where this node's data came from). consumers are derived by inversion.
-// #522 coach-input kill switches: eleven reversible config gates (COACH_*_ENABLED) that
-// remove a section / prompt part / input from what the coach receives. This capture was
-// regenerated with all eleven set OFF, so their nodes are greyed (off:true) and their data
-// is dropped; flip the flag back on (default) to restore. Reusable banner:
-// #522 kill-switch banners are CAPTURE-DRIVEN: they render only when the referenced
-// COACH_*_ENABLED switch is ACTUALLY off in this capture (D.flags carries the generator's
-// real settings). The flag name is read straight out of the banner text (which already
-// names it), so an all-on capture shows no "off" banner that would contradict the field
-// chips. Missing D.flags (pre-flags capture) => silent, the safe default.
-const _anyFlagOff = (what)=> (String(what).match(/COACH_[A-Z_]+_ENABLED/g)||[]).some(_flagOff);
-const OFF_522  = (what)=> _anyFlagOff(what) ? '<div class="offbanner"><b>Turned OFF (#522).</b> '+what+' Reversible config flip (a COACH_*_ENABLED setting); on by default.</div>' : '';
-const OFF_522P = (what)=> _anyFlagOff(what) ? '<div class="offbanner"><b>Partly OFF (#522).</b> '+what+'</div>' : '';
+// #522 coach-input kill switches: reversible config gates (COACH_*_ENABLED) that remove a
+// section / prompt part / input from what the coach receives. The off-state is capture-driven:
+// whole-section / prompt-injection nodes grey via the content-presence NODE_ACTIVE rules
+// (ai-flow-graph.html), and a nested field that is dropped-to-null carries a `dropped (#522)`
+// fate chip (DROPPED_522, keyed on D.flags). No separate banner, so nothing can drift out of
+// sync with the field chips. Missing D.flags (pre-flags capture) => nothing marked off.
 const NODES = [
 
 /* ===== LAYER: MODEL ===== */
@@ -389,14 +399,12 @@ const NODES = [
 { id:'playbook', off:true, layer:'model', kind:'code', tag:'prompt', badge:'disabled',
   title:'playbook (classification)', path:'services/coach/prompts.build_system_prompt',
   from:['a_classifier'],
-  body:()=> OFF_522('<code>COACH_PLAYBOOK_ENABLED=false</code> — the activity-type playbook is no longer appended to the system prompt.')
-    + _promptHTML(SYSTEM_PROMPT, c=>c==='play')
+  body:()=> _promptHTML(SYSTEM_PROMPT, c=>c==='play')
 },
 { id:'voice_block', off:true, layer:'model', kind:'code', tag:'prompt', badge:'disabled',
   title:'voice block (rendered)', path:'services/coach/prompts.render_voice_block',
   from:['d_relationship'],
-  body:()=> OFF_522('<code>COACH_VOICE_BLOCK_ENABLED=false</code> — the rendered per-runner voice block is no longer appended to the system prompt.')
-    + _promptHTML(SYSTEM_PROMPT, c=>c==='voice')
+  body:()=> _promptHTML(SYSTEM_PROMPT, c=>c==='voice')
 },
 { id:'sysprompt', layer:'model', kind:'code', tag:'prompt',
   title:'build_system_prompt('+D.meta.prompt_id+', mode, voice)', path:'services/coach/prompts.py',
@@ -419,34 +427,35 @@ const NODES = [
     _IV_KEYS.forEach(k=>{ if(k in fate) fate[k]={f:'gated',to:'the model',note:'gated interval-session group; reaches the model only when an interval/workout was detected'}; });
     // the collapsed signal the real pack ships when no session was detected → it still feeds the model
     if('interval_workout' in fate) fate.interval_workout={f:'gated',passed:false,to:'the model',note:'the interval/workout gate did not fire; the three columns collapsed to this one signal in the pack (CoachContextPack.to_serializable_dict)'};
-    return OFF_522P('<code>stops_analysis</code> is dropped for the coach (<code>COACH_STOPS_ANALYSIS_ENABLED=false</code>, now null here); the pipeline still computes + stores it on the DerivedMetric for non-coach use.')
-      + '<div class="fatebanner">Each field carries two chips: <span class="srctag" style="cursor:default">↤ where it was written</span> one stage earlier, and its <b>fate</b> on this last hop — <span class="fate-forwarded">forwarded → the model</span> (this pack <em>is</em> the model’s input, so nothing is dropped here). The interval/workout group is <span class="fate-gated">gated</span>: collapsed to one row when no session was detected.</div>'
+    // #522: with COACH_STOPS_ANALYSIS_ENABLED off, stops_analysis is null in the pack — dropped
+    // for the coach (the pipeline still computes + stores it on the DerivedMetric for non-coach use).
+    if('stops_analysis' in fate){ const d=off522Fate('COACH_STOPS_ANALYSIS_ENABLED','sent as null; still stored on the DerivedMetric for risk/flags + the detail view.'); if(d) fate.stops_analysis=d; }
+    return '<div class="fatebanner">Each field carries two chips: <span class="srctag" style="cursor:default">↤ where it was written</span> one stage earlier, and its <b>fate</b> on this last hop — <span class="fate-forwarded">forwarded → the model</span> (this pack <em>is</em> the model’s input). A field a #522 kill switch turned off is <span class="fate-dropped">dropped</span> (sent null, coach ignores it); the interval/workout group is <span class="fate-gated">gated</span>: collapsed to one row when no session was detected.</div>'
       + renderTree(obj, true, src, fate); } },
 { id:'p_check_in', layer:'pack', kind:'code', tag:'fact', title:'pack.check_in', path:'context.py',
-  from:['checkin'], body:()=> OFF_522P('<code>sleep_quality</code> is dropped for the coach (<code>COACH_SLEEP_QUALITY_ENABLED=false</code>); <code>risk.py</code>/<code>flags.py</code> keep their safe defaults.')+ jProv('check_in') },
+  from:['checkin'], body:()=> jProvX('check_in', {sleep_quality: off522Fate('COACH_SLEEP_QUALITY_ENABLED','risk.py/flags.py keep their safe defaults.')}) },
 { id:'p_profile', layer:'pack', kind:'code', tag:'fact', title:'pack.profile', path:'context.py',
   from:['profile'], body:()=> jProv('profile') },
 { id:'p_longitudinal', off:true, layer:'pack', kind:'memory', tag:'memory + fact', span:true, title:'pack.longitudinal', path:'retrieval.fetch_prior_digests + baseline', badge:'disabled',
   from:['d_baseline','d_memory'],
-  body:()=> OFF_522('<code>COACH_LONGITUDINAL_ENABLED=false</code> — the WHOLE section is dropped (both the <code>prior_reports</code> digest and the numeric <code>baseline_trend</code>).')
-    + (P.longitudinal ? jTallProv('longitudinal') : '<div class="data kv">section dropped from the pack</div>') },
+  body:()=> (P.longitudinal ? jTallProv('longitudinal')
+    : '<div class="data kv">'+(_flagOff('COACH_LONGITUDINAL_ENABLED') ? 'dropped — COACH_LONGITUDINAL_ENABLED=false (#522)' : 'section absent for this run')+'</div>') },
 { id:'p_perceived', layer:'pack', kind:'code', tag:'fact', title:'pack.perceived_effort', path:'perceived_effort.py',
   from:['d_perceived'], body:()=> jProv('perceived_effort') },
 { id:'p_adherence', off:true, layer:'pack', kind:'memory', tag:'memory', title:'pack.adherence', path:'adherence.py',
-  from:['d_memory'], body:()=> OFF_522('<code>COACH_ADHERENCE_ENABLED=false</code> — M7 adherence outcomes are not gathered for the coach (off by default, PR #418).')+ jProv('adherence') },
+  from:['d_memory'], body:()=> jProv('adherence') },
 { id:'p_calibration', layer:'pack', kind:'code', tag:'fact', title:'pack.calibration', path:'calibration.py',
   from:['d_calibration'],
   body:()=> jProv('calibration') },
 { id:'p_salience', off:true, layer:'pack', kind:'code', tag:'fact', title:'pack.salience', path:'salience.py + novelty.py', badge:'disabled',
-  from:['d_salience'], body:()=> OFF_522('<code>COACH_SALIENCE_ENABLED=false</code> — the section is dropped from the pack. (The deterministic fuller-turn scheduling that reuses the safety override is untouched.)')
-    + (P.salience ? jProv('salience') : '<div class="data kv">section dropped from the pack</div>') },
+  from:['d_salience'], body:()=> (P.salience ? jProv('salience')
+    : '<div class="data kv">'+(_flagOff('COACH_SALIENCE_ENABLED') ? 'dropped — COACH_SALIENCE_ENABLED=false (#522); fuller-turn scheduling is untouched' : 'section absent for this run')+'</div>') },
 { id:'p_continuity', off:true, layer:'pack', kind:'code', tag:'two-stage', title:'pack.continuity', path:'context.py', badge:'disabled',
-  from:[], body:()=> OFF_522('<code>COACH_CONTINUITY_ENABLED=false</code> — the section is dropped from the pack.')
-    + (P.continuity ? j(P.continuity) : '<div class="data kv">section dropped from the pack</div>') },
+  from:[], body:()=> (P.continuity ? j(P.continuity)
+    : '<div class="data kv">'+(_flagOff('COACH_CONTINUITY_ENABLED') ? 'dropped — COACH_CONTINUITY_ENABLED=false (#522)' : 'section absent for this run')+'</div>') },
 { id:'p_corpus', layer:'pack', kind:'runner', tag:'runner', span:true, title:'pack.corpus', path:'retrieval.fetch_corpus + corpus.py',
   from:['d_corpus','d_relationship','user_material'],
-  body:()=> OFF_522P('<code>house_principles</code> (HOUSE_CORE) stay on; <code>school</code> is dropped (<code>COACH_HOUSE_SCHOOLS_ENABLED=false</code>) and <code>user_materials</code> is dropped (<code>COACH_USER_MATERIALS_ENABLED=false</code>).')
-    + jTallProv('corpus') },
+  body:()=> jTallProvX('corpus', {school: off522Fate('COACH_HOUSE_SCHOOLS_ENABLED','HOUSE_CORE principles stay on; user_materials (COACH_USER_MATERIALS_ENABLED) is not read in at all.')}) },
 { id:'p_stance', layer:'pack', kind:'runner', tag:'runner', title:'pack.stance', path:'stance.py',
   from:['d_relationship'], body:()=> jProv('stance') },
 { id:'p_training_load', layer:'pack', kind:'code', tag:'fact', title:'pack.training_load', path:'readiness.build_readiness',
@@ -454,21 +463,21 @@ const NODES = [
 { id:'p_training_volume', layer:'pack', kind:'code', tag:'fact', title:'pack.training_volume', path:'context.py ← volume.build_training_volume',
   from:['d_volume'], body:()=> jProv('training_volume') },
 { id:'p_recent_training', layer:'pack', kind:'code', tag:'fact', span:true, title:'pack.recent_training', path:'context.py ← recent_training.build_recent_training',
-  from:['d_recent_training'], body:()=> OFF_522P('the <code>previous_30d</code> window is dropped (<code>COACH_PREVIOUS_30D_ENABLED=false</code>); <code>last_7d</code>/<code>last_30d</code> and the vs-prev reads are unaffected.')+ (P.recent_training ? jTallProv('recent_training') : '<div class="offbanner">Absent under '+D.meta.prompt_id+' (v11+ only).</div>') },
+  from:['d_recent_training'], body:()=> (P.recent_training ? jTallProv('recent_training') : '<div class="data kv">Absent under '+D.meta.prompt_id+' (v11+ only).</div>') },
 { id:'p_training_history', layer:'pack', kind:'code', tag:'fact', span:true, title:'pack.training_history', path:'context.py ← training_history.build_training_history',
-  from:['d_training_history'], body:()=> (P.training_history ? jTallProv('training_history') : '<div class="offbanner">Absent under '+D.meta.prompt_id+' (v12+ only).</div>') },
+  from:['d_training_history'], body:()=> (P.training_history ? jTallProv('training_history') : '<div class="data kv">Absent under '+D.meta.prompt_id+' (v12+ only).</div>') },
 { id:'p_memory', layer:'pack', kind:'memory', tag:'memory + fact', span:true, title:'pack.memory', path:'context._build_memory_context ← memory_store.get_memory',
   from:['d_runner_memory'],
-  body:()=> (P.memory ? jTallProv('memory') : '<div class="offbanner">Absent under '+D.meta.prompt_id+' — memory is emitted only under a memory-aware prompt (v13+) once the runner has a graduated profile. INERT in prod (config default pre-v13).</div>') },
+  body:()=> (P.memory ? jTallProv('memory') : '<div class="data kv">Absent under '+D.meta.prompt_id+' — memory is emitted only under a memory-aware prompt (v13+) once the runner has a graduated profile.</div>') },
 { id:'p_intensity', layer:'pack', kind:'code', tag:'fact', span:true, title:'pack.intensity', path:'context._build_intensity_context ← intensity.build_intensity',
   from:['d_intensity'],
-  body:()=> (P.intensity ? jTallProv('intensity') : '<div class="offbanner">Absent under '+D.meta.prompt_id+' (v14+ only). INERT in prod (config default pre-v14).</div>') },
+  body:()=> (P.intensity ? jTallProv('intensity') : '<div class="data kv">Absent under '+D.meta.prompt_id+' (v14+ only).</div>') },
 { id:'p_stream_view', layer:'pack', kind:'code', tag:'fact', span:true, title:'pack.stream_view', path:'context.py ← retrieval.fetch_stream_view',
   from:['derivedmetric'],
-  body:()=> (P.stream_view ? jTallProv('stream_view') : '<div class="offbanner">Absent under '+D.meta.prompt_id+' (v10/v11 only).</div>') },
+  body:()=> (P.stream_view ? jTallProv('stream_view') : '<div class="data kv">Absent under '+D.meta.prompt_id+' (v10/v11 only).</div>') },
 { id:'p_block', layer:'pack', kind:'code', tag:'multi-member only', span:true, title:'pack.block', path:'context._build_block_context',
   from:['act_row'],
-  body:()=> (P.block ? jTallProv('block') : '<div class="offbanner">Absent for this capture — the subject is a block-of-one, so <code>pack.block</code> is dropped. Present (and fed to the model) whenever the run shares a block with sibling activities.</div>') },
+  body:()=> (P.block ? jTallProv('block') : '<div class="data kv">Absent for this capture — the subject is a block-of-one, so <code>pack.block</code> is dropped. Present (and fed to the model) whenever the run shares a block with sibling activities.</div>') },
 { id:'p_safety', layer:'pack', kind:'gate', tag:'safety', title:'pack.safety_rules', path:'context.py (constant)',
   from:[], body:()=> j(P.safety_rules) },
 
@@ -483,18 +492,17 @@ const NODES = [
 { id:'d_volume', layer:'deriv', kind:'code', tag:'read-time', title:'volume.build_training_volume (#400/#451)', path:'services/coach/volume.py',
   from:['act_row','derivedmetric'], body:()=> jp(P.training_volume,'d_volume') },
 { id:'d_recent_training', layer:'deriv', kind:'code', tag:'read-time', title:'recent_training.build_recent_training (#444)', path:'services/coach/recent_training.py',
-  from:['act_row','derivedmetric'], body:()=> (P.recent_training ? jp(P.recent_training,'d_recent_training',true) : '<div class="offbanner">Absent under '+D.meta.prompt_id+'.</div>') },
+  from:['act_row','derivedmetric'], body:()=> (P.recent_training ? jp(P.recent_training,'d_recent_training',true) : '<div class="data kv">Absent under '+D.meta.prompt_id+'.</div>') },
 { id:'d_training_history', layer:'deriv', kind:'code', tag:'read-time', title:'training_history.build_training_history (#561)', path:'services/coach/training_history.py',
-  from:['act_row','derivedmetric'], body:()=> (P.training_history ? jp(P.training_history,'d_training_history',true) : '<div class="offbanner">Absent under '+D.meta.prompt_id+' (v12+ only).</div>') },
+  from:['act_row','derivedmetric'], body:()=> (P.training_history ? jp(P.training_history,'d_training_history',true) : '<div class="data kv">Absent under '+D.meta.prompt_id+' (v12+ only).</div>') },
 { id:'d_intensity', layer:'deriv', kind:'code', tag:'read-time', title:'intensity.build_intensity (#578)', path:'services/coach/intensity.py',
-  from:['act_row','derivedmetric'], body:()=> (P.intensity ? jp(P.intensity,'d_intensity',true) : '<div class="offbanner">Absent under '+D.meta.prompt_id+' (v14+ only).</div>') },
+  from:['act_row','derivedmetric'], body:()=> (P.intensity ? jp(P.intensity,'d_intensity',true) : '<div class="data kv">Absent under '+D.meta.prompt_id+' (v14+ only).</div>') },
 { id:'d_readiness', layer:'deriv', kind:'code', tag:'read-time', title:'readiness.build_readiness (P3)', path:'services/readiness.py',
   from:['derivedmetric'],
   body:()=> jp(P.training_load,'d_readiness') },
 { id:'d_baseline', off:true, layer:'deriv', kind:'code', tag:'rolling norm', title:'baseline (RunnerBaseline, M2)', path:'services/analysis/baseline.py', badge:'disabled',
   from:['derivedmetric'],
-  body:()=> OFF_522('its only consumer, <code>pack.longitudinal.baseline_trend</code>, is dropped (<code>COACH_LONGITUDINAL_ENABLED=false</code>), so the baseline no longer reaches the coach.')
-    + (P.longitudinal && P.longitudinal.baseline_trend ? jp(P.longitudinal.baseline_trend,'d_baseline') : '<div class="data kv">not forwarded (longitudinal dropped)</div>') },
+  body:()=> (P.longitudinal && P.longitudinal.baseline_trend ? jp(P.longitudinal.baseline_trend,'d_baseline') : '<div class="data kv">not forwarded (longitudinal dropped)</div>') },
 { id:'d_calibration', layer:'deriv', kind:'code', tag:'read-time', title:'calibration (M9)', path:'context._build_calibration_context + calibration.py',
   from:['derivedmetric','checkin'],
   body:()=> jp(P.calibration,'d_calibration') },
@@ -502,23 +510,19 @@ const NODES = [
   from:['checkin','derivedmetric'],
   body:()=> jp(P.perceived_effort,'d_perceived') },
 { id:'d_salience', off:true, layer:'deriv', kind:'code', tag:'read-time', title:'salience · novelty', path:'salience.py + analysis/novelty.py', badge:'disabled',
-  from:['derivedmetric','checkin'], body:()=> OFF_522('its pack section <code>pack.salience</code> is dropped (<code>COACH_SALIENCE_ENABLED=false</code>); the safety-override scheduling still runs.')
-    + (P.salience ? jp(P.salience,'d_salience') : '<div class="data kv">not forwarded (salience dropped)</div>') },
+  from:['derivedmetric','checkin'], body:()=> (P.salience ? jp(P.salience,'d_salience') : '<div class="data kv">not forwarded (salience dropped)</div>') },
 { id:'d_memory', off:true, layer:'deriv', kind:'memory', tag:'prior-report scan', span:true, title:'prior-report read-time scan (M7 adherence)', path:'adherence.py (read-time)',
   from:['act_row'], badge:'disabled',
-  body:()=> OFF_522('<code>COACH_ADHERENCE_ENABLED=false</code> — the M7 adherence read-time scan is off (it replayed a rest-day fixation into every report, PR #418); its <code>adherence</code> section emits empty. Re-enable is a config flip (#402).')
-    + (P.adherence ? jp(P.adherence,'d_memory') : '<div class="data kv">not forwarded (adherence disabled)</div>') },
+  body:()=> (P.adherence ? jp(P.adherence,'d_memory') : '<div class="data kv">not forwarded (adherence disabled)</div>') },
 { id:'d_runner_memory', layer:'deriv', kind:'memory', tag:'rewritten profile', span:true, title:'runner memory (RunnerMemory.profile)', path:'memory_store.get_memory ← memory_update writer',
   from:['chat','checkin'],
   body:()=> (P.memory ? jp(P.memory,'d_runner_memory') : '<div class="data kv">no profile yet (cold start)</div>') },
 { id:'d_relationship', off:true, layer:'deriv', kind:'runner', tag:'runner-declared', title:'coaching_relationship', path:'app/models/coaching_relationship.py', badge:'disabled',
   from:[],
-  body:()=> OFF_522('<code>COACH_RELATIONSHIP_ENABLED=false</code> — the row is no longer read; Voice and Stance resolve to their defaults (and receipt voicing falls to the house floor).')
-    + '<div class="note">'+esc(D.relationship.note)+'</div>'
+  body:()=> '<div class="note">'+esc(D.relationship.note)+'</div>'
     + j(D.relationship) },
 { id:'d_corpus', off:true, layer:'deriv', kind:'runner', tag:'code-resident', title:'corpus.py (house schools)', path:'services/coach/corpus.py', badge:'disabled',
-  from:[], body:()=> OFF_522('<code>COACH_HOUSE_SCHOOLS_ENABLED=false</code> — the selected school is dropped from <code>pack.corpus</code>; HOUSE_CORE principles stay.')
-    + j({ school_id:(P.corpus && P.corpus.school ? P.corpus.school.id : '(dropped)'), house_principle_count:(P.corpus ? P.corpus.house_principles.length : 0) }) },
+  from:[], body:()=> j({ school_id:(P.corpus && P.corpus.school ? P.corpus.school.id : '(dropped)'), house_principle_count:(P.corpus ? P.corpus.house_principles.length : 0) }) },
 
 /* ===== LAYER: ANALYSIS PIPELINE ===== */
 { id:'smoothing', layer:'analysis', kind:'code', tag:'function · detail-view', title:'cadence smoothing', path:'services/analysis/smoothing.py \u2192 schemas/detail.py',
@@ -604,8 +608,7 @@ const NODES = [
   from:['strava'],
   body:()=> j(D.profile) },
 { id:'user_material', off:true, layer:'ingest', kind:'runner', tag:'runner upload · untrusted', title:'UserMaterial (distilled)', path:'app/models/user_material.py', badge:'disabled',
-  from:[], body:()=> OFF_522('<code>COACH_USER_MATERIALS_ENABLED=false</code> — materials are not read into <code>pack.corpus.user_materials</code>.')
-    + j({ note:'no active materials in this capture' }) },
+  from:[], body:()=> j({ note:'no active materials in this capture' }) },
 { id:'checkin', layer:'ingest', kind:'runner', tag:'runner input', title:'CheckIn', path:'app/models/checkin.py',
   from:[], body:()=> j(P.check_in) },
 { id:'chat', layer:'ingest', kind:'runner', tag:'runner input', title:'CoachChatMessage', path:'app/models/coach_chat_message.py',

--- a/docs/diagrams/flow-nodes.js
+++ b/docs/diagrams/flow-nodes.js
@@ -430,8 +430,7 @@ const NODES = [
     // #522: with COACH_STOPS_ANALYSIS_ENABLED off, stops_analysis is null in the pack — dropped
     // for the coach (the pipeline still computes + stores it on the DerivedMetric for non-coach use).
     if('stops_analysis' in fate){ const d=off522Fate('COACH_STOPS_ANALYSIS_ENABLED','sent as null; still stored on the DerivedMetric for risk/flags + the detail view.'); if(d) fate.stops_analysis=d; }
-    return '<div class="fatebanner">Each field carries two chips: <span class="srctag" style="cursor:default">↤ where it was written</span> one stage earlier, and its <b>fate</b> on this last hop — <span class="fate-forwarded">forwarded → the model</span> (this pack <em>is</em> the model’s input). A field a #522 kill switch turned off is <span class="fate-dropped">dropped</span> (sent null, coach ignores it); the interval/workout group is <span class="fate-gated">gated</span>: collapsed to one row when no session was detected.</div>'
-      + renderTree(obj, true, src, fate); } },
+    return renderTree(obj, true, src, fate); } },
 { id:'p_check_in', layer:'pack', kind:'code', tag:'fact', title:'pack.check_in', path:'context.py',
   from:['checkin'], body:()=> jProvX('check_in', {sleep_quality: off522Fate('COACH_SLEEP_QUALITY_ENABLED','risk.py/flags.py keep their safe defaults.')}) },
 { id:'p_profile', layer:'pack', kind:'code', tag:'fact', title:'pack.profile', path:'context.py',
@@ -484,8 +483,7 @@ const NODES = [
 /* ===== LAYER: DERIVATION ===== */
 { id:'derivedmetric', layer:'deriv', kind:'store', span:true, tag:'table — keystone', title:'DerivedMetric (one row per activity)', path:'app/models/derived_metric.py',
   from:['a_metrics','a_effort','a_classifier','a_intervals','a_flags','a_discount','a_streamview','a_confidence','a_training_context'],
-  body:()=> (_ivPassed(DM) ? '' : '<div class="fatebanner">The <b>interval/workout</b> group (<code>interval_structure</code> · <code>workout_match</code> · <code>interval_kpis</code>) is <span class="fate-gated">gated on detection</span>. No session was detected on this run, so in the <b>real pack</b> all three collapse to one <code>pack.metrics.interval_workout = "none detected"</code> field (<span class="fate-gated-blocked">gated:blocked</span>) — the model reads one "no workout" fact, not three null fields.</div>')
-    + (()=>{ const [obj,ex]=_withIntervalGate(DM);
+  body:()=> (()=>{ const [obj,ex]=_withIntervalGate(DM);
         const src=Object.assign({}, FIELD_SOURCE), fate=Object.assign({}, FATE_DERIVED);
         for(const k in ex){ src[k]=ex[k].src; fate[k]=ex[k].fate; }
         return renderTree(obj, true, src, fate); })() },
@@ -570,8 +568,7 @@ const NODES = [
   from:['act_streams'],
   body:()=> {
     const sv=STREAM_VIEW;
-    return '<div class="fatebanner">Downsampled from <b>'+sv.source_n+'</b> raw samples to <b>'+sv.n_points+'</b> aligned points. Onward hop (v10/v11): <code>DerivedMetric.stream_view → fetch_stream_view → pack.stream_view → the model</code>.</div>'
-      + writes([['DerivedMetric.stream_view', sv.n_points+' points × (time_s + 4 channels), deferred JSON']])
+    return writes([['DerivedMetric.stream_view', sv.n_points+' points × (time_s + 4 channels), deferred JSON']])
       + jTall(sv); } },
 { id:'a_confidence', layer:'analysis', kind:'code', tag:'function', title:'confidence', path:'services/analysis/_orchestrator.compute_confidence',
   from:['act_streams','a_intervals','checkin'],


### PR DESCRIPTION
Follow-ups from #640: three of the four you asked for (banners, chips, drift guard). The fourth — polling cleanup — is a separate dead-code sweep coming as its own PR.

## Banners → chips (asks 1 + 2)

The #522 off-state was shown two ways that only agreed by coincidence: a red "Turned OFF" banner (capture-driven) and a field chip that still read "forwarded" for a gated input. In the prod-parity capture, `stops_analysis` is sent as `null` yet its chip said forwarded — the inconsistency you flagged.

- **Removed every `OFF_522`/`OFF_522P` banner** and the `.offbanner` CSS.
- A field a #522 switch turned off now carries a **`✕ dropped`** fate chip (`DROPPED_522`, keyed on the captured `D.flags`) instead of `→ forwarded`: `stops_analysis`, `sleep_quality`, `corpus.school`.
- Whole-section kills (longitudinal/salience/continuity) stay **greyed** — the existing `NODE_ACTIVE` content rules already drive that — with a calm one-line "dropped — FLAG=false" empty state.
- The remaining prompt-absence notes lose the red banner styling for the calm `data-kv` empty-state; two stale "INERT in prod (pre-vNN)" clauses cut.

Everything is capture-driven off `D.flags`, so the chip can never disagree with what prod sent.

## Drift guard (ask 3)

`check_diagram_drift.py` gains a third check: the diagram's captured `D.flags` must equal the prod-parity `COACH_*_ENABLED` block in `backend/.env.example`. This catches the exact bug we hit (a capture regenerated with every switch left on while prod runs the lean pack) and the reverse (an `.env.example` edit not followed by a regenerate). It ties the diagram to the committed prod-parity contract; keeping `.env.example` itself current with live Railway stays a human step (CI has no prod access). Also taught the guard's pack parser the new `jProvX`/`jTallProvX` helpers.

## Verification

- In-browser (served locally): **0** `.offbanner` in the DOM; `stops_analysis` chip reads `dropped` (red) vs `forwarded` (amber) for normal fields; `sleep_quality` + `corpus.school` carry dropped chips; **no console errors**.
- Drift guard passes on the aligned state and **catches a simulated flag flip** (flipped a diagram flag → guard reports the mismatch).
- `test_diagram_drift.py` passes; `node --check` clean.
- Diff is pure JS-logic — I restored the generated `DATA`/`SYSTEM_PROMPT` lines so a stray capture-date bump doesn't bloat the review.

## Note

Whole-section-killed nodes were already greyed by content-presence rules, so the greying was correct before; this PR fixes the *field-level* chips (which weren't) and removes the redundant banners. Screenshot of the `stops_analysis` dropped chip is in the session.
