### PR TITLE
Remove dead polling config; fix stale polling references

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -113,15 +113,12 @@ LLM_BUDGET_GLOBAL_MONTHLY_USD=0
 # deduped by an atomic Redis cooldown + a deterministic per-activity job id.
 COACH_REGEN_COOLDOWN_SECONDS=60
 
-# --- Polling fallback for missed Strava webhooks ---
-# Interval (seconds) at which the scheduler asks Strava for recent activities
-# and enqueues the pipeline for any new ones. Lower = fresher reports, more
-# Strava API usage. Strava's limit is 1000 requests/day per account; the
-# default of 120s sits at ~720/day.
-POLLING_INTERVAL_SECONDS=120
-# Lookback window (seconds) each poll asks Strava for. An ingestion outage
-# shorter than this window self-heals; a longer gap needs a manual POST /api/sync.
-POLLING_LOOKBACK_SECONDS=604800
+# --- Missed-webhook recovery (self-heal, #123/ADR 0006) ---
+# The time-based polling fallback was removed (its POLLING_* vars are gone): Strava's
+# rate limit is per-application, so steady-state polling across many users exhausts the
+# shared budget. Recovery is now a bounded, user-triggered self-heal check on app-open /
+# Refresh (POST /api/activities/refresh), capped once per user per this interval.
+SELF_HEAL_MIN_INTERVAL_SECONDS=60
 
 # --- Historical stream backfill (manual, self-pacing) ---
 # Activities per batch and the pause (seconds) before the next batch. Defaults

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -135,8 +135,8 @@ class Settings(BaseSettings):
     # self-pacing job fetches streams + re-runs analysis for activities that
     # were imported summary-only. Each batch makes one Strava call per activity;
     # batch size over the pause must stay under Strava's 100-requests/15-min
-    # ceiling alongside polling. Default 20 calls per 300s = 60/15min, plus
-    # polling's ~7, stays well under 100. The backfill is one-time, so the daily
+    # ceiling. Default 20 calls per 300s = 60/15min stays well under 100 even
+    # alongside the webhook/self-heal ingest calls. The backfill is one-time, so the daily
     # total is just the backlog size and converges to zero.
     BACKFILL_BATCH_SIZE: int = 20
     BACKFILL_BATCH_PAUSE_SECONDS: int = 300
@@ -146,7 +146,7 @@ class Settings(BaseSettings):
     # (no Strava calls), so a derivation change (e.g. #297 zone binning)
     # propagates to historical DerivedMetric rows. Unlike the stream backfill the
     # pacing is not rate-limit driven (re-analysis is local compute) — the pause
-    # just yields the single worker to webhooks/polling between batches, so the
+    # just yields the single worker to webhooks/self-heal between batches, so the
     # batch can be large and the pause short.
     REANALYZE_BATCH_SIZE: int = 100
     REANALYZE_BATCH_PAUSE_SECONDS: int = 5
@@ -156,7 +156,7 @@ class Settings(BaseSettings):
     # summaries per batch (no streams, no AI coach analysis, no notifications).
     # Each batch is a single Strava list call, far below the backfill's
     # per-activity stream cost; the pause only keeps the worker free for
-    # webhooks/polling between batches. 50 activities per page (Strava's max).
+    # webhooks/self-heal between batches. 50 activities per page (Strava's max).
     IMPORT_PAGE_SIZE: int = 50
     IMPORT_BATCH_PAUSE_SECONDS: int = 5
 

--- a/backend/app/jobs/backfill_streams.py
+++ b/backend/app/jobs/backfill_streams.py
@@ -14,7 +14,7 @@ activity is attempted exactly once, guaranteeing convergence.
 Pacing: when work remains after a batch, the job schedules its own successor via
 rq-scheduler `enqueue_in` after `BACKFILL_BATCH_PAUSE_SECONDS`, keeping the
 worker free between batches and the combined Strava call rate under the
-100-requests/15-min ceiling alongside polling. See #110.
+100-requests/15-min ceiling. See #110.
 """
 
 import asyncio

--- a/backend/app/jobs/process_new_activity.py
+++ b/backend/app/jobs/process_new_activity.py
@@ -1,6 +1,7 @@
 """Pipeline job for a fresh activity.
 
-Both the Strava webhook (`aspect_type=create`) and the polling fallback enqueue
+Both the Strava webhook (`aspect_type=create`) and the user-triggered self-heal
+check (#123/ADR 0006, which replaced the removed polling fallback) enqueue
 `process_new_activity_job`. Under the two-stage prompt (coach_message_v2) it runs
 ingest -> analyze -> block assignment, then schedules a BLOCK-COMPLETE check at
 +BLOCK_GAP_SECONDS (A1, ADR 0011) instead of opening the exchange inline: the
@@ -66,7 +67,7 @@ from app.services.strava_ingestion import (
 logger = logging.getLogger(__name__)
 
 # #215: the recovery trigger for a worker crash mid-pipeline. Once ingest has
-# persisted the Activity row, polling treats it as known and never re-picks it,
+# persisted the Activity row, the self-heal check treats it as known and never re-picks it,
 # so without a retry a crash between ingest and the opener notify/schedule
 # permanently strands the exchange. Every stage is idempotent on re-entry
 # (opener row reuse, per-stage sentinels, fuller sentinel), so a re-run is safe.

--- a/backend/app/jobs/reanalyze_history.py
+++ b/backend/app/jobs/reanalyze_history.py
@@ -22,7 +22,7 @@ re-derives until it passes where it stopped.
 
 Unlike the stream backfill (#110) the pacing is not rate-limit driven — there are
 no Strava calls — so the batch is large and the pause is short; it just yields
-the single worker to webhooks/polling between batches.
+the single worker to webhooks/self-heal between batches.
 """
 
 import logging

--- a/backend/app/jobs/strava_import.py
+++ b/backend/app/jobs/strava_import.py
@@ -25,7 +25,7 @@ State lives entirely in a `StravaImport` row:
 
 Pacing: when a full page comes back there is likely more history, so the job
 schedules its own successor via rq-scheduler after `IMPORT_BATCH_PAUSE_SECONDS`,
-keeping the single worker free for webhooks and polling between batches. Each
+keeping the single worker free for webhooks and self-heal between batches. Each
 batch is a single Strava list call (no per-activity stream calls), so the call
 rate stays comfortably under the 100-requests/15-min ceiling.
 """

--- a/backend/app/services/strava_ingestion/http_adapter.py
+++ b/backend/app/services/strava_ingestion/http_adapter.py
@@ -36,8 +36,8 @@ _MAX_INLINE_RETRY_AFTER_S = 5.0
 _MAX_PAGES = 40
 
 # Hard cap on how long we wait for a single Strava response. 30 s is well
-# above typical latency but short enough to free a worker within one polling
-# interval. Without this, a slow Strava response hangs the job queue forever.
+# above typical latency but short enough to free a stuck worker quickly.
+# Without this, a slow Strava response hangs the job queue forever.
 _HTTP_TIMEOUT_S = 30.0
 
 

--- a/backend/app/services/strava_ingestion/ingestion.py
+++ b/backend/app/services/strava_ingestion/ingestion.py
@@ -217,7 +217,7 @@ def upsert_activity(db: Session, raw: dict, user_id) -> Activity:
     existing = db.execute(stmt).scalars().first()
 
     # Preserve recorded laps across a lap-less re-sync. The detail endpoint
-    # (webhook/polling, ingest_activity_by_id) returns the runner's `laps`;
+    # (webhook/self-heal, ingest_activity_by_id) returns the runner's `laps`;
     # the summary list endpoint (manual sync, backfill) does not. Without this,
     # a routine "Sync Now" would overwrite an activity's recorded laps with a
     # lap-less payload and re-analysis would silently downgrade its lap-sourced
@@ -419,7 +419,7 @@ RECONCILE_MAX_PER_RUN = 25
 
 def _assign_block(db: Session, activity) -> None:
     """A1: every newly-ingested activity is grouped into its Block here, so all
-    ingest paths (webhook, polling, manual sync, backfill) converge on the same
+    ingest paths (webhook, self-heal, manual sync, backfill) converge on the same
     grouping. A re-synced activity keeps its block. Guarded: a grouping failure
     must never break ingestion (the baseline-recompute pattern).
 


### PR DESCRIPTION
## What

The time-based polling fallback was removed in #123 / ADR 0006 and replaced by the user-triggered self-heal check, but its config and comments lingered across the backend. This is a comment/doc-only cleanup.

## Changes

- **`.env.example`**: removed the phantom `POLLING_INTERVAL_SECONDS` / `POLLING_LOOKBACK_SECONDS` block — those vars no longer exist on `Settings` (not in `config.py`, no code references anything reads them). Replaced with a self-heal doc block + the real `SELF_HEAL_MIN_INTERVAL_SECONDS=60`.
- Fixed present-tense/live "polling" references in comments so they name the self-heal check:
  - `config.py` — backfill rate-budget math (dropped the misleading "plus polling's ~7 requests" clause), reanalyze/import worker-yield comments
  - `backfill_streams.py` — "alongside polling" ceiling note
  - `process_new_activity.py` — module docstring + the #215 retry-recovery comment ("polling treats it as known" → the self-heal check)
  - `reanalyze_history.py`, `strava_import.py` — "webhooks/polling" → "webhooks/self-heal"
  - `http_adapter.py` — "free a worker within one polling interval" reworded
  - `ingestion.py` — two ingest-path comments naming polling as a live path

Accurate historical mentions are kept (e.g. `self_heal.py` "replaces the removed polling fallback").

## Verification

Comment/doc-only, no behaviour change. Backend suite green against code defaults (1991 passed, 10 deselected).