### PR TITLE
Render chat tables + show a persistent tool-use trace (#648 follow-up)

### DIFF
--- a/backend/alembic/versions/a3f1c9d7e208_add_chat_message_tools_used.py
+++ b/backend/alembic/versions/a3f1c9d7e208_add_chat_message_tools_used.py
@@ -1,0 +1,31 @@
+"""add coach_chat_messages.tools_used
+
+#648 follow-up: persist the on-demand data tools the coach ran for an assistant
+turn, so the chat UI can render a "looked up …" trace that survives a reload.
+Nullable JSON list of tool names; existing rows read as null (no trace).
+
+Revision ID: a3f1c9d7e208
+Revises: 2f8b6d3a1c90
+Create Date: 2026-07-12
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a3f1c9d7e208"
+down_revision: Union[str, None] = "2f8b6d3a1c90"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "coach_chat_messages",
+        sa.Column("tools_used", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("coach_chat_messages", "tools_used")

--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -439,7 +439,7 @@ async def post_chat(
                     # runs. A JSON OBJECT payload (vs the string payload of a content
                     # frame), so the client renders it as status instead of appending
                     # it to the reply.
-                    yield f"data: {json.dumps({'type': 'status', 'label': event.status_label})}\n\n"
+                    yield f"data: {json.dumps({'type': 'status', 'label': event.status_label, 'tool': event.status_tool})}\n\n"
                 else:
                     yield _sse_data(event.text)
         except Exception:

--- a/backend/app/models/coach_chat_message.py
+++ b/backend/app/models/coach_chat_message.py
@@ -1,7 +1,8 @@
 import uuid
 from datetime import datetime
+from typing import Optional
 
-from sqlalchemy import ForeignKey, DateTime, String, Text, Uuid
+from sqlalchemy import ForeignKey, DateTime, JSON, String, Text, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
@@ -16,6 +17,11 @@ class CoachChatMessage(Base):
     activity_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("activities.id"), index=True)
     role: Mapped[str] = mapped_column(String(16))  # "user" or "assistant"
     content: Mapped[str] = mapped_column(Text)
+    # #648 follow-up: the on-demand data tools the coach ran to produce this
+    # assistant turn (ordered, de-duplicated tool names), so the UI can show a
+    # persistent "looked up …" trace that survives a reload. Null on user turns and
+    # on assistant turns that answered without a fetch.
+    tools_used: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -14,6 +14,9 @@ class ChatMessageRead(BaseModel):
     activity_id: UUID
     role: str
     content: str
+    # #648 f/u: the on-demand data tools the coach ran for this turn (null when none),
+    # so the UI can render a persistent "looked up …" trace after a reload.
+    tools_used: Optional[List[str]] = None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -110,6 +110,7 @@ class ChatStreamEvent:
     text: str = ""
     is_heartbeat: bool = False
     status_label: str = ""  # #648: ephemeral "fetching data" affordance
+    status_tool: str = ""   # the tool name behind that affordance (for the persistent trace)
 
 
 # How often a keepalive heartbeat is emitted while the reply is being buffered
@@ -555,6 +556,7 @@ async def stream_chat_response(
     llm_messages = messages  # mutated across tool rounds (assistant + tool_result turns)
     assistant_text = None
     stream_failed = False
+    tools_used: List[str] = []  # ordered, de-duped tool names, persisted for the trace
     last_heartbeat = time.monotonic()
     try:
         for round_idx in range(_MAX_TOOL_ROUNDS):
@@ -598,9 +600,13 @@ async def stream_chat_response(
                 tool_results = []
                 for blk in tool_uses:
                     name = _block_attr(blk, "name")
-                    # Show the ephemeral affordance BEFORE the fetch runs (#648).
+                    if name and name not in tools_used:
+                        tools_used.append(name)
+                    # Show the ephemeral affordance BEFORE the fetch runs (#648). Carry
+                    # the tool name so the client can build the persistent trace too.
                     yield ChatStreamEvent(
-                        status_label=TOOL_STATUS_LABELS.get(name, "Looking that up…")
+                        status_label=TOOL_STATUS_LABELS.get(name, "Looking that up…"),
+                        status_tool=name or "",
                     )
                     last_heartbeat = time.monotonic()
                     result = execute_chat_tool(
@@ -653,11 +659,13 @@ async def stream_chat_response(
     for piece in _slice_for_stream(assistant_text):
         yield ChatStreamEvent(text=piece)
 
-    # Save the validated assistant response (never the raw gated text).
+    # Save the validated assistant response (never the raw gated text), tagged with
+    # the data tools this turn ran so the UI can show a persistent trace (#648 f/u).
     assistant_msg = CoachChatMessage(
         activity_id=activity_id,
         role="assistant",
         content=assistant_text,
+        tools_used=tools_used or None,
     )
     db.add(assistant_msg)
     db.commit()

--- a/backend/tests/test_chat_tool_loop.py
+++ b/backend/tests/test_chat_tool_loop.py
@@ -13,8 +13,12 @@ from uuid import uuid4
 
 import pytest
 
-from app.models import Activity, DerivedMetric
-from app.services.coach.chat import MEDICAL_REDIRECT_MESSAGE, stream_chat_response
+from app.models import Activity, CoachChatMessage, DerivedMetric
+from app.services.coach.chat import (
+    MEDICAL_REDIRECT_MESSAGE,
+    get_chat_history,
+    stream_chat_response,
+)
 from app.services.coach.llm import AnthropicClient
 from app.services.coach.query_tools import CHAT_TOOLS
 from tests._chat_stubs import chat_tool_loop_stub
@@ -128,3 +132,54 @@ async def test_direct_answer_without_a_tool_call(db):
 
     assert not any(ev.status_label for ev in events)
     assert "Nice easy run today, well controlled." in "".join(ev.text for ev in events if ev.text)
+
+
+@pytest.mark.asyncio
+async def test_tools_used_persisted_and_returned_in_history(db):
+    """#648 f/u: a turn that runs data tools banks their names on the assistant
+    message and every status frame carries the tool name, so the UI can render a
+    persistent trace that survives a reload."""
+    activity = _seed_activity_with_report(db)
+    _past_run(db, activity.user_id, days_ago=5, distance_m=12000)
+
+    stub = chat_tool_loop_stub([
+        [{"name": "list_activities_in_range", "input": {"window": "last_30_days"}}],
+        "Your longest recent run was 12.0 km.",
+    ])
+    with patch.object(AnthropicClient, "stream_chat_turn", new=stub):
+        events = await _drain(db, activity.id, "how far was my longest run?")
+
+    # the status frame carries the tool name for the live/persistent trace
+    assert any(ev.status_tool == "list_activities_in_range" for ev in events)
+
+    # the assistant row banked the tool it ran
+    saved = (
+        db.query(CoachChatMessage)
+        .filter(CoachChatMessage.activity_id == activity.id,
+                CoachChatMessage.role == "assistant")
+        .one()
+    )
+    assert saved.tools_used == ["list_activities_in_range"]
+
+    # and the history read surfaces it (from_attributes) for a reloaded UI
+    history = get_chat_history(db, str(activity.id))
+    assistant = [m for m in history if m.role == "assistant"][-1]
+    assert assistant.tools_used == ["list_activities_in_range"]
+
+
+@pytest.mark.asyncio
+async def test_tools_used_null_when_no_fetch(db):
+    """A no-tool turn stores tools_used as null, so the trace renders nothing rather
+    than an empty chip row."""
+    activity = _seed_activity_with_report(db)
+    stub = chat_tool_loop_stub(["Nice easy run, nothing to fetch."])
+    with patch.object(AnthropicClient, "stream_chat_turn", new=stub):
+        await _drain(db, activity.id, "how did I do?")
+
+    saved = (
+        db.query(CoachChatMessage)
+        .filter(CoachChatMessage.activity_id == activity.id,
+                CoachChatMessage.role == "assistant")
+        .one()
+    )
+    assert saved.tools_used is None

--- a/frontend/components/CoachChat.tsx
+++ b/frontend/components/CoachChat.tsx
@@ -2,11 +2,44 @@
 
 import { useState, useEffect, useRef, useCallback, forwardRef, useImperativeHandle } from 'react';
 import { ChatMessage, CoachReport, isMessageReport } from '@/lib/types';
-import { MessageCircle, Send, Loader2, RotateCcw, Sparkles } from 'lucide-react';
+import { MessageCircle, Send, Loader2, RotateCcw, Sparkles, Search } from 'lucide-react';
 import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 interface Props {
   activityId: string;
+}
+
+// #648 f/u: friendly past-tense labels for the persistent tool-use trace shown on
+// an assistant turn that fetched data. Keyed by the backend tool name carried on
+// each status frame (and persisted to CoachChatMessage.tools_used). An unknown key
+// falls back to a generic phrasing so a new tool never renders a raw identifier.
+const TOOL_TRACE_LABELS: Record<string, string> = {
+  list_activities_in_range: 'Looked up your training history',
+  get_session_detail: 'Pulled up a past session',
+  get_training_summary: 'Tallied your recent training',
+};
+
+const toolTraceLabel = (name: string): string =>
+  TOOL_TRACE_LABELS[name] ?? 'Looked up your training data';
+
+// The persistent "looked up …" trace rendered above an assistant turn that ran one
+// or more data tools. Survives a reload because tools_used is stored on the message.
+function ToolTrace({ tools }: { tools: string[] }) {
+  if (!tools.length) return null;
+  return (
+    <div className="mb-1.5 flex flex-wrap gap-1.5">
+      {tools.map((name, i) => (
+        <span
+          key={`${name}-${i}`}
+          className="inline-flex items-center gap-1 rounded-full bg-blue-50 dark:bg-blue-900/30 px-2 py-0.5 text-[11px] font-medium text-blue-600 dark:text-blue-300"
+        >
+          <Search className="w-2.5 h-2.5 shrink-0" />
+          {toolTraceLabel(name)}
+        </span>
+      ))}
+    </div>
+  );
 }
 
 // Imperative handle so a sibling (the report panel's question chips) can kick off
@@ -140,6 +173,10 @@ const CoachChat = forwardRef<CoachChatHandle, Props>(function CoachChat({ activi
 
       const decoder = new TextDecoder();
       let fullResponse = '';
+      // #648 f/u: accumulate the data tools the coach ran this turn (ordered,
+      // de-duplicated) so we can attach them to the finalized assistant message
+      // and render a persistent "looked up …" trace that survives a reload.
+      const toolsUsed: string[] = [];
       // SSE events are delimited by a blank line. Buffer across reads so an
       // event split over two network chunks is reassembled before parsing.
       let buffer = '';
@@ -152,11 +189,14 @@ const CoachChat = forwardRef<CoachChatHandle, Props>(function CoachChat({ activi
           try {
             // The backend JSON-encodes each chunk so multi-line markdown
             // survives the SSE protocol intact. A content frame is a JSON string;
-            // a status frame (#648) is a JSON object {type:'status',label} shown
-            // as an ephemeral "fetching" affordance, not appended to the reply.
+            // a status frame (#648) is a JSON object {type:'status',label,tool}
+            // shown as an ephemeral "fetching" affordance (label), whose tool name
+            // is banked for the persistent trace, not appended to the reply.
             const parsed = JSON.parse(data);
             if (parsed && typeof parsed === 'object' && parsed.type === 'status') {
               setFetchingLabel(parsed.label ?? '');
+              const tool = typeof parsed.tool === 'string' ? parsed.tool : '';
+              if (tool && !toolsUsed.includes(tool)) toolsUsed.push(tool);
             } else if (typeof parsed === 'string') {
               fullResponse += parsed;
               setStreamingText(fullResponse);
@@ -185,6 +225,7 @@ const CoachChat = forwardRef<CoachChatHandle, Props>(function CoachChat({ activi
         activity_id: activityId,
         role: 'assistant',
         content: fullResponse,
+        tools_used: toolsUsed.length ? toolsUsed : null,
         created_at: new Date().toISOString(),
       };
       setMessages(prev => [...prev, assistantMsg]);
@@ -356,8 +397,9 @@ const CoachChat = forwardRef<CoachChatHandle, Props>(function CoachChat({ activi
               </div>
             ) : (
               <div className="max-w-[85%] rounded-lg px-3 py-2 text-sm bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200">
+                <ToolTrace tools={msg.tools_used ?? []} />
                 <div className="prose prose-sm prose-gray dark:prose-invert max-w-none prose-p:my-1.5 prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5 prose-headings:mt-3 prose-headings:mb-1.5 prose-headings:text-sm">
-                  <Markdown>{msg.content}</Markdown>
+                  <Markdown remarkPlugins={[remarkGfm]}>{msg.content}</Markdown>
                 </div>
               </div>
             )}
@@ -367,7 +409,7 @@ const CoachChat = forwardRef<CoachChatHandle, Props>(function CoachChat({ activi
           <div className="flex justify-start">
             <div className="max-w-[85%] rounded-lg px-3 py-2 text-sm bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200">
               <div className="prose prose-sm prose-gray dark:prose-invert max-w-none prose-p:my-1.5 prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5 prose-headings:mt-3 prose-headings:mb-1.5 prose-headings:text-sm">
-                <Markdown>{streamingText}</Markdown>
+                <Markdown remarkPlugins={[remarkGfm]}>{streamingText}</Markdown>
               </div>
               <span className="inline-block w-1.5 h-4 bg-gray-400 dark:bg-gray-500 ml-0.5 animate-pulse" />
             </div>

--- a/frontend/components/CoachReportPanel.tsx
+++ b/frontend/components/CoachReportPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { CoachReport, CoachReportBody, isMessageReport, isOpenerOnly } from '@/lib/types';
 import { Sparkles, ChevronRight, AlertTriangle, HelpCircle, Loader2, RefreshCw, Copy, Check } from 'lucide-react';
 
@@ -390,7 +391,7 @@ export default function CoachReportPanel({ activityId, hasMetrics, onStartChat }
                 {/* Opener turn (stage one) */}
                 {hasOpener && (
                   <div className="prose prose-sm prose-gray dark:prose-invert max-w-none prose-p:my-2 prose-ul:my-2 prose-li:my-0.5 prose-headings:mt-3 prose-headings:mb-1.5">
-                    <Markdown>{body.opener_message as string}</Markdown>
+                    <Markdown remarkPlugins={[remarkGfm]}>{body.opener_message as string}</Markdown>
                   </div>
                 )}
 
@@ -410,7 +411,7 @@ export default function CoachReportPanel({ activityId, hasMetrics, onStartChat }
                       <h3 className="text-lg font-serif font-semibold text-gray-900 dark:text-gray-100 mb-2">{body.headline}</h3>
                     )}
                     <div className="prose prose-sm prose-gray dark:prose-invert max-w-none prose-p:my-2 prose-ul:my-2 prose-li:my-0.5 prose-headings:mt-3 prose-headings:mb-1.5">
-                      <Markdown>{body.message}</Markdown>
+                      <Markdown remarkPlugins={[remarkGfm]}>{body.message}</Markdown>
                     </div>
                   </>
                 )}

--- a/frontend/lib/types/chat.ts
+++ b/frontend/lib/types/chat.ts
@@ -3,5 +3,9 @@ export interface ChatMessage {
   activity_id: string;
   role: "user" | "assistant";
   content: string;
+  // #648 f/u: the on-demand data tools the coach ran for this assistant turn
+  // (null/absent when none), so the UI can show a persistent "looked up …" trace
+  // that survives a reload. User turns never carry it.
+  tools_used?: string[] | null;
   created_at: string;
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,8 @@
         "react": "^18",
         "react-dom": "^18",
         "react-markdown": "^10.1.0",
-        "recharts": "^3.7.0"
+        "recharts": "^3.7.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.19",
@@ -4629,6 +4630,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4637,6 +4648,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -4657,6 +4696,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4869,6 +5009,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -6243,6 +6504,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -6270,6 +6549,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^10.1.0",
-    "recharts": "^3.7.0"
+    "recharts": "^3.7.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",


### PR DESCRIPTION
Two chat-surface fixes on top of the #648 on-demand data tools (PR #662).

## remark-gfm (table rendering)
The coach can emit valid GFM tables, but react-markdown lacked the plugin so tables rendered as raw `| ... |` pipes. Added `remark-gfm` and wired `remarkPlugins={[remarkGfm]}` into every `<Markdown>`: `CoachChat` (history + streaming) and `CoachReportPanel` (opener + fuller).

## Persistent tool-use trace (A + B)
The runner couldn't see when the coach fetched training data on demand. Now they can, and it survives a reload:

- **Persist (B):** new `CoachChatMessage.tools_used` (nullable JSON list, migration `a3f1c9d7e208`). `chat.py` banks the ordered, de-duped tool names and saves them on the assistant row; the SSE status frame carries the tool name alongside its label; `ChatMessageRead` + the history read surface it.
- **Session + render (A):** `CoachChat` accumulates tool names from status frames during streaming, attaches them to the finished message, and renders a `ToolTrace` chip ("Looked up your training history") above any assistant turn that fetched. Driven from persisted `tools_used`, so it renders identically live and after a reload. The live ephemeral "fetching" affordance is unchanged.

## Verification
- Backend suite **2037 passed** (prod-parity coach flags set for the local `.env` byte-stable tests). Includes 2 new tests: `tools_used` is persisted + returned by history, the status frame carries the tool name, and a no-fetch turn stores null.
- Frontend `next lint` + `next build` clean.
- Browser-verified on a seeded local DB against a fresh page load (data served from the history endpoint = the survives-reload path): the GFM table rendered as a real HTML table and the "Looked up your training history" chip rendered above the assistant message.

## Known simplifications (non-blocking)
- Friendly labels live in two places (backend present-tense live labels, frontend past-tense trace labels) with a graceful generic fallback for unknown tools.
- The trace shows *that* a tool ran, not *what window* it fetched; multi-window calls of the same tool collapse to one chip.