### PR TITLE
ADR 0026 Slice 1: group the coach context pack by the coaching question (#672)

### DIFF
--- a/backend/app/schemas/coach_context.py
+++ b/backend/app/schemas/coach_context.py
@@ -16,7 +16,7 @@ import json
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.schemas.material import DistilledMaterial
 from app.services.coach.prompt_features import PromptFeature
@@ -858,106 +858,405 @@ class MemoryContext(BaseModel):
     source_report_count: Optional[int] = None
 
 
-class CoachContextPack(BaseModel):
+# --- ADR 0026: the five coaching-question groups ---------------------------
+# Slice 1 (#672) reorganizes the pack from ~20 flat, milestone-named sections into
+# five groups named for the coaching question they answer, plus the top-level
+# safety floor. This slice is a PURE RELOCATION: each existing section moves under
+# its group INTACT (no merges — intensity_read/recent_weeks are slices 3/2 — and no
+# splits — longitudinal/calibration split in later slices). Each section keeps its
+# exact Optionality, so the grouped shape carries the identical leaf facts.
+#
+# The grouped model is the CANONICAL shape (build_context_pack returns it; slices
+# 2-5 add sections INTO these group models). Serialization derives the grouped dict
+# from the existing flat fold pipeline (`to_grouped_dict` == `_nest(to_serializable_
+# dict())`), so the flat pack stays byte-identical for prod (`coach_message_lean_v1`)
+# and every historical prompt, and `flatten(grouped) == flat` holds by construction.
+
+
+class ThisRun(BaseModel):
+    """ADR 0026: what was this session, and how hard was it really?"""
     model_config = ConfigDict(extra="forbid")
 
     activity: ActivityContext
     metrics: MetricsContext
     check_in: CheckInContext
-    profile: ProfileContext
-    # #451: the legacy coarse recent-volume summary, RETIRED. No longer populated —
-    # the rich `recent_training` section plus the `training_volume` vs-norm verdict
-    # supersede it (the three-way overlap is gone). Kept as an Optional field so
-    # STORED pre-#451 packs (which carry it) still validate under extra="forbid" — the
-    # chat read path and eval harness both strict-parse historical packs — and dropped
-    # from serialization when None so new packs never carry it.
-    recent_training_summary: Optional[RecentTrainingSummary] = None
-    # M4 longitudinal contrast. Normally always present; Optional so the #522
-    # COACH_LONGITUDINAL_ENABLED kill switch can drop the whole section (the builder
-    # returns None when disabled, the PACK_SECTIONS registry pops it). Every normal
-    # construction still passes the real object, so the default path is byte-stable.
-    longitudinal: Optional[LongitudinalContext] = None
     perceived_effort: PerceivedEffortContext
-    adherence: AdherenceContext
     calibration: CalibrationContext
-    # M4 (ADR 0025) retired the belief loop + A2c narrative + M10 preference.
-    # These three fields are kept as never-populated Optional deprecated STUBS so a
-    # historical stored pack carrying them still strict-parses under extra="forbid"
-    # (the chat read path + eval harness load old packs); they are never set by the
-    # builder and drop from serialization when None via the PACK_SECTIONS registry.
+    stream_view: Optional[Dict[str, Any]] = None
+    block: Optional[BlockContext] = None
+    intensity: Optional["IntensityContext"] = None
+
+
+class RightNow(BaseModel):
+    """ADR 0026: how is the runner currently? (slice 2 merges volume+recent into
+    recent_weeks and renames training_load -> readiness)."""
+    model_config = ConfigDict(extra="forbid")
+
+    training_load: Optional["TrainingLoadContext"] = None
+    training_volume: Optional["TrainingVolumeContext"] = None
+    recent_training: Optional["RecentTrainingContext"] = None
+
+
+class TheRunner(BaseModel):
+    """ADR 0026: who is this runner, and where are they going?"""
+    model_config = ConfigDict(extra="forbid")
+
+    profile: ProfileContext
+    memory: Optional["MemoryContext"] = None
+    training_history: Optional["TrainingHistoryContext"] = None
+
+
+class OurThread(BaseModel):
+    """ADR 0026: what did I say last time, and did it land? (slice 3 splits
+    longitudinal.baseline_trend out to the_runner.typical_trend)."""
+    model_config = ConfigDict(extra="forbid")
+
+    adherence: AdherenceContext
+    continuity: Optional[ContinuityContext] = Field(default_factory=ContinuityContext)
+    longitudinal: Optional[LongitudinalContext] = None
+
+
+class HowToCoach(BaseModel):
+    """ADR 0026: delivery and philosophy, NEVER facts (voice lives in the system
+    prompt, not the pack)."""
+    model_config = ConfigDict(extra="forbid")
+
+    corpus: Optional["CorpusContext"] = None
+    stance: Optional["StanceContext"] = None
+
+
+# The section -> group relocation map. Every flat section name maps to the group
+# attribute it now lives under; a name absent here is a top-level meta field
+# (salience, safety_rules, the retired stubs). This one table drives un-grouping
+# (`_flat_data`), nesting (`_nest_flat`), and the legacy-flat loader (`load`).
+_SECTION_GROUP: Dict[str, str] = {
+    "activity": "this_run",
+    "metrics": "this_run",
+    "check_in": "this_run",
+    "perceived_effort": "this_run",
+    "calibration": "this_run",
+    "stream_view": "this_run",
+    "block": "this_run",
+    "intensity": "this_run",
+    "training_load": "right_now",
+    "training_volume": "right_now",
+    "recent_training": "right_now",
+    "profile": "the_runner",
+    "memory": "the_runner",
+    "training_history": "the_runner",
+    "adherence": "our_thread",
+    "continuity": "our_thread",
+    "longitudinal": "our_thread",
+    "corpus": "how_to_coach",
+    "stance": "how_to_coach",
+}
+
+_GROUP_NAMES: tuple[str, ...] = (
+    "this_run",
+    "right_now",
+    "the_runner",
+    "our_thread",
+    "how_to_coach",
+)
+
+# Sentinel so `from_sections` can tell an OMITTED salience/continuity (→ present empty
+# object, the old default_factory behaviour) from an explicit None (→ the #522
+# kill-switch drop). A plain `None` default could not distinguish the two.
+_UNSET: Any = object()
+
+# Flat section order preserved from the pre-ADR-0026 field declaration, so the flat
+# serialized dict's key order is unchanged (tidy diffs; the hash uses sort_keys).
+_FLAT_ORDER: tuple[str, ...] = (
+    "activity",
+    "metrics",
+    "check_in",
+    "profile",
+    "recent_training_summary",
+    "longitudinal",
+    "perceived_effort",
+    "adherence",
+    "calibration",
+    "believed_facts",
+    "preference_profile",
+    "narrative",
+    "salience",
+    "continuity",
+    "block",
+    "corpus",
+    "stance",
+    "training_load",
+    "training_volume",
+    "stream_view",
+    "recent_training",
+    "training_history",
+    "memory",
+    "intensity",
+    "safety_rules",
+)
+
+
+def _nest_flat(flat: Dict[str, Any]) -> Dict[str, Any]:
+    """Relocate a FLAT serialized pack dict into the five groups (ADR 0026).
+
+    Pure key relocation: each section key present in `flat` moves under its group
+    per `_SECTION_GROUP`; unmapped keys (salience/safety_rules/retired stubs) stay
+    top-level. Empty groups are dropped, so `flatten(nest(flat)) == flat`. Used for
+    both grouped serialization (`to_grouped_dict`) and the legacy-flat loader."""
+    groups: Dict[str, Dict[str, Any]] = {g: {} for g in _GROUP_NAMES}
+    out: Dict[str, Any] = {}
+    for key, value in flat.items():
+        group = _SECTION_GROUP.get(key)
+        if group is not None:
+            groups[group][key] = value
+        else:
+            out[key] = value
+    for group in _GROUP_NAMES:
+        if groups[group]:
+            out[group] = groups[group]
+    return out
+
+
+def unnest_pack(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Hoist the ADR 0026 group sections back to the top level (inverse of `_nest_flat`).
+
+    Tolerant, read-only, NON-validating: a flat dict (no group keys) is returned
+    unchanged, a partial or empty dict is fine. For call sites that need to READ a
+    section's presence from a stored pack of EITHER shape (e.g. the chat authority-
+    tiering gate) without paying a full `load` + re-serialize (which would reject an
+    empty `{}`)."""
+    if not isinstance(data, dict):
+        return data
+    out: Dict[str, Any] = {}
+    for key, value in data.items():
+        if key in _GROUP_NAMES and isinstance(value, dict):
+            out.update(value)
+        else:
+            out[key] = value
+    return out
+
+
+class CoachContextPack(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # ADR 0026: the five coaching-question groups + the top-level safety floor.
+    this_run: ThisRun
+    right_now: RightNow = Field(default_factory=RightNow)
+    the_runner: TheRunner
+    our_thread: OurThread
+    how_to_coach: HowToCoach = Field(default_factory=HowToCoach)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_flat_shape(cls, data: Any) -> Any:
+        """ADR 0026: make `model_validate` tolerant of BOTH pack shapes. A grouped dict
+        (or a kwargs dict from `from_sections`, which carries the group keys) validates
+        as-is; a legacy FLAT dict — every historical stored pack, and any caller that
+        still hands a flat dict — is relocated into the five groups via `_nest_flat`
+        first. This is the ONE place the flat->grouped adaptation lives, so every
+        `model_validate` call site (chat, eval harness/fixtures, tests) keeps working."""
+        if isinstance(data, dict) and not any(g in data for g in _GROUP_NAMES):
+            return _nest_flat(data)
+        return data
+    # A4 salience substrate (novelty + safety override): a routing signal for the
+    # opener, not a coaching-question fact, so it stays top-level meta (ADR 0026 slice
+    # 5 drops it from the fuller pack). Optional (#522) so COACH_SALIENCE_ENABLED can
+    # drop it; default_factory keeps it a present empty object otherwise (byte-stable).
+    salience: Optional[SalienceContext] = Field(default_factory=SalienceContext)
+    safety_rules: SafetyRules
+    # Retired-section stubs (kept top-level, NEVER populated, dropped when None) so a
+    # historical stored FLAT pack carrying them still strict-parses under extra="forbid"
+    # after `_nest_flat` relocates the live sections: #451 recent_training_summary and
+    # the M4/ADR 0025 belief/preference/narrative loop. Only the retired-summary and
+    # stub fields; the live sections all live under their groups now.
+    recent_training_summary: Optional[RecentTrainingSummary] = None
     believed_facts: Optional[BelievedFactsContext] = None
     preference_profile: Optional[PreferenceProfile] = None
     narrative: Optional[NarrativeContext] = None
-    # A4 salience substrate: novelty + safety override. Defaulted (empty) so every
-    # pre-A4 fixture and the legacy/single-shot paths stay valid; the opener and
-    # fuller builders populate it. Adding it changes the pack fingerprint, so v2
-    # reports regenerate — the same intentional shape-change A2c made for narrative.
-    # Optional (#522) so COACH_SALIENCE_ENABLED can drop the section; the
-    # default_factory keeps it an empty object (present, byte-stable) for every
-    # construction that does not explicitly pass None.
-    salience: Optional[SalienceContext] = Field(default_factory=SalienceContext)
-    # A4 fuller-turn continuity (opener prose + any reply). Defaulted (empty) for
-    # the opener stage and single-shot exchanges; only the fuller path populates it.
-    # Optional (#522) so COACH_CONTINUITY_ENABLED can drop the section; the
-    # default_factory keeps it an empty object (present, byte-stable) otherwise.
-    continuity: Optional[ContinuityContext] = Field(default_factory=ContinuityContext)
-    # A1 multi-member block aggregate. None for a block-of-one and OMITTED from
-    # serialization entirely (AC8: the solo-run pack stays byte-stable pre/post A1).
-    block: Optional[BlockContext] = None
-    # P1.2 coaching corpus (ADR 0014). None under every non-corpus prompt and OMITTED
-    # from serialization entirely, exactly like `block`, so the pack stays byte-stable
-    # pre/post P1.2 (AC1/AC7); populated only under a corpus-aware prompt id.
-    corpus: Optional["CorpusContext"] = None
-    # P1.3 coaching stance — emphasis axes (ADR 0015). None under every non-stance
-    # prompt and OMITTED from serialization entirely, exactly like `corpus`/`block`,
-    # so the pack stays byte-stable pre/post P1.3 (AC1/AC7); populated only under a
-    # stance-aware prompt id.
-    stance: Optional["StanceContext"] = None
-    # P3 training-load readiness (ADR 0016). None under every non-training-load
-    # prompt and OMITTED from serialization entirely, exactly like `corpus`/`stance`/
-    # `block`, so the pack stays byte-stable pre/post P3 (AC1/AC7); populated only
-    # under a training-load-aware prompt id.
-    training_load: Optional["TrainingLoadContext"] = None
-    # #400 frequency-/volume-vs-norm. None under every non-volume prompt and OMITTED
-    # from serialization entirely, exactly like `training_load`/`corpus`/`block`, so
-    # the pack stays byte-stable pre/post #400; populated only under a volume-aware
-    # prompt id.
-    training_volume: Optional["TrainingVolumeContext"] = None
-    # #443 consolidated stream view (A2a): the <=60-pt aligned HR/pace/grade/cadence
-    # downsample, carried in the DEFAULT pack so the coach reads the run's shape on
-    # every report. None under every non-stream-view prompt and OMITTED from
-    # serialization entirely, exactly like `training_volume`/`training_load`/`corpus`/
-    # `block`, so the pack stays byte-stable pre/post #443; populated only under a
-    # stream-view-aware prompt id. It is a downsampled VIEW, never a measurement, and
-    # never overrides the re-derived metrics (prompt addendum).
-    stream_view: Optional[Dict[str, Any]] = None
-    # #444 modality-aware recent-training picture (per-type breakdown + per-activity
-    # detail + vs-typical/vs-prev with basis). None under every non-recent-training
-    # prompt and OMITTED from serialization entirely, exactly like the other gated
-    # sections, so the pack stays byte-stable pre/post #444; populated only under a
-    # recent-training-aware prompt id.
-    recent_training: Optional["RecentTrainingContext"] = None
-    # #561 multi-year training-history picture (the LOD volume ladder + durability
-    # traits). None under every non-training-history prompt and OMITTED from
-    # serialization entirely, exactly like the other gated sections, so the pack
-    # stays byte-stable pre/post #561; populated only under a training-history-aware
-    # prompt id, and only when history beyond the recent window exists to describe.
-    training_history: Optional["TrainingHistoryContext"] = None
-    # ADR 0025 runner memory profile, surfaced whole. None under every non-memory
-    # prompt and OMITTED from serialization (the gated-section idiom), so the pack
-    # stays byte-stable pre/post v13; populated only under a memory-aware prompt id,
-    # and only when a profile row exists for the runner.
-    memory: Optional["MemoryContext"] = None
-    # #578 intensity-distribution-and-trend signal. None under every non-intensity prompt
-    # and OMITTED from serialization (the gated-section idiom), so the pack stays
-    # byte-stable pre/post v14; populated only under an intensity-aware prompt id, and
-    # only when there is something to say (the builder returns None otherwise).
-    intensity: Optional["IntensityContext"] = None
-    safety_rules: SafetyRules
+
+    # --- Flat accessor properties (ADR 0026) --------------------------------
+    # Read-only flat views over the canonical grouped model, so the ~150 existing
+    # `pack.<section>` typed reads (validator, eval, chat, tests) keep working without
+    # churn. NEW code (slices 2-5) reads the grouped path directly; these accessors
+    # are the compat layer, not the interface. The LLM-facing string paths (prompt +
+    # validator evidence regexes) move to the grouped paths independently.
+    @property
+    def activity(self) -> ActivityContext:
+        return self.this_run.activity
+
+    @property
+    def metrics(self) -> MetricsContext:
+        return self.this_run.metrics
+
+    @property
+    def check_in(self) -> CheckInContext:
+        return self.this_run.check_in
+
+    @property
+    def perceived_effort(self) -> PerceivedEffortContext:
+        return self.this_run.perceived_effort
+
+    @property
+    def calibration(self) -> CalibrationContext:
+        return self.this_run.calibration
+
+    @property
+    def stream_view(self) -> Optional[Dict[str, Any]]:
+        return self.this_run.stream_view
+
+    @property
+    def block(self) -> Optional[BlockContext]:
+        return self.this_run.block
+
+    @property
+    def intensity(self) -> Optional["IntensityContext"]:
+        return self.this_run.intensity
+
+    @property
+    def training_load(self) -> Optional["TrainingLoadContext"]:
+        return self.right_now.training_load
+
+    @property
+    def training_volume(self) -> Optional["TrainingVolumeContext"]:
+        return self.right_now.training_volume
+
+    @property
+    def recent_training(self) -> Optional["RecentTrainingContext"]:
+        return self.right_now.recent_training
+
+    @property
+    def profile(self) -> ProfileContext:
+        return self.the_runner.profile
+
+    @property
+    def memory(self) -> Optional["MemoryContext"]:
+        return self.the_runner.memory
+
+    @property
+    def training_history(self) -> Optional["TrainingHistoryContext"]:
+        return self.the_runner.training_history
+
+    @property
+    def adherence(self) -> AdherenceContext:
+        return self.our_thread.adherence
+
+    @property
+    def continuity(self) -> Optional[ContinuityContext]:
+        return self.our_thread.continuity
+
+    @property
+    def longitudinal(self) -> Optional[LongitudinalContext]:
+        return self.our_thread.longitudinal
+
+    @property
+    def corpus(self) -> Optional["CorpusContext"]:
+        return self.how_to_coach.corpus
+
+    @property
+    def stance(self) -> Optional["StanceContext"]:
+        return self.how_to_coach.stance
+
+    @classmethod
+    def from_sections(
+        cls,
+        *,
+        activity: ActivityContext,
+        metrics: MetricsContext,
+        check_in: CheckInContext,
+        profile: ProfileContext,
+        perceived_effort: PerceivedEffortContext,
+        adherence: AdherenceContext,
+        calibration: CalibrationContext,
+        safety_rules: SafetyRules,
+        longitudinal: Optional[LongitudinalContext] = None,
+        salience: Optional[SalienceContext] = _UNSET,
+        continuity: Optional[ContinuityContext] = _UNSET,
+        block: Optional[BlockContext] = None,
+        corpus: Optional["CorpusContext"] = None,
+        stance: Optional["StanceContext"] = None,
+        training_load: Optional["TrainingLoadContext"] = None,
+        training_volume: Optional["TrainingVolumeContext"] = None,
+        stream_view: Optional[Dict[str, Any]] = None,
+        recent_training: Optional["RecentTrainingContext"] = None,
+        training_history: Optional["TrainingHistoryContext"] = None,
+        memory: Optional["MemoryContext"] = None,
+        intensity: Optional["IntensityContext"] = None,
+        recent_training_summary: Optional[RecentTrainingSummary] = None,
+        believed_facts: Optional[BelievedFactsContext] = None,
+        preference_profile: Optional[PreferenceProfile] = None,
+        narrative: Optional[NarrativeContext] = None,
+    ) -> "CoachContextPack":
+        """Build the grouped pack from the flat section objects the builder produces
+        (ADR 0026). Slices 2-5 that add a section wire it here and on its group model.
+        `salience`/`continuity` default to a present empty object (byte-stable) unless
+        the caller explicitly passes None (the #522 kill-switch drop)."""
+        return cls(
+            this_run=ThisRun(
+                activity=activity,
+                metrics=metrics,
+                check_in=check_in,
+                perceived_effort=perceived_effort,
+                calibration=calibration,
+                stream_view=stream_view,
+                block=block,
+                intensity=intensity,
+            ),
+            right_now=RightNow(
+                training_load=training_load,
+                training_volume=training_volume,
+                recent_training=recent_training,
+            ),
+            the_runner=TheRunner(
+                profile=profile,
+                memory=memory,
+                training_history=training_history,
+            ),
+            our_thread=OurThread(
+                adherence=adherence,
+                continuity=(ContinuityContext() if continuity is _UNSET else continuity),
+                longitudinal=longitudinal,
+            ),
+            how_to_coach=HowToCoach(corpus=corpus, stance=stance),
+            salience=(SalienceContext() if salience is _UNSET else salience),
+            safety_rules=safety_rules,
+            recent_training_summary=recent_training_summary,
+            believed_facts=believed_facts,
+            preference_profile=preference_profile,
+            narrative=narrative,
+        )
+
+    @classmethod
+    def load(cls, data: Any) -> "CoachContextPack":
+        """Parse a stored pack dict of EITHER shape (ADR 0026). A thin, self-documenting
+        alias for `model_validate` (the `_accept_flat_shape` before-validator does the
+        flat->grouped relocation), so the intent at the historical-pack load sites (chat,
+        eval harness/fixtures) reads clearly."""
+        return cls.model_validate(data)
+
+    def _flat_data(self) -> Dict[str, Any]:
+        """Un-group into the flat `{section: dict|None}` shape the pre-ADR-0026 model
+        produced from `model_dump`, in the original field order. The flat fold
+        pipeline in `to_serializable_dict` then runs UNCHANGED over it, so the flat
+        serialized pack (prod + historical prompts) stays byte-identical."""
+        groups = {
+            "this_run": self.this_run,
+            "right_now": self.right_now,
+            "the_runner": self.the_runner,
+            "our_thread": self.our_thread,
+            "how_to_coach": self.how_to_coach,
+        }
+        data: Dict[str, Any] = {}
+        for name in _FLAT_ORDER:
+            group = _SECTION_GROUP.get(name)
+            value = getattr(groups[group], name) if group is not None else getattr(self, name)
+            data[name] = (
+                value.model_dump(mode="python") if isinstance(value, BaseModel) else value
+            )
+        return data
 
     def to_serializable_dict(self) -> Dict[str, Any]:
-        """Serialise to the JSON-primitive dict shape the LLM input and DB column expect."""
-        data = self.model_dump(mode="python")
+        """Serialise to the FLAT JSON-primitive dict (prod + historical prompts).
+        Byte-identical to the pre-ADR-0026 output. `to_grouped_dict` re-nests this."""
+        data = self._flat_data()
         # The byte-stable-drop invariant lives in ONE place: every gated/optional
         # pack section that must vanish (not appear as a null key) when absent is a
         # PACK_SECTIONS descriptor, and this loop applies the drop uniformly. A
@@ -1031,6 +1330,13 @@ class CoachContextPack(BaseModel):
         if isinstance(cal, dict) and isinstance(cal.get("hr_drift"), dict):
             cal["hr_drift"].pop("observed_drift_pct", None)
         return data
+
+    def to_grouped_dict(self) -> Dict[str, Any]:
+        """Serialise to the GROUPED JSON dict the ADR 0026 grouped prompt reads: the
+        flat serialization re-nested into the five coaching-question groups. Derived
+        from `to_serializable_dict`, so `flatten(to_grouped_dict()) == to_serializable_
+        dict()` holds by construction and every flat-side fold/drop is inherited."""
+        return _nest_flat(self.to_serializable_dict())
 
     def fingerprint(self) -> str:
         """Deterministic SHA-256 cache key. Byte-identical to the legacy hash_context_pack output."""
@@ -1213,13 +1519,15 @@ PACK_SECTIONS: tuple[PackSection, ...] = (
 def _assert_descriptors_match_fields() -> None:
     """Fail loudly AT IMPORT on a descriptor/field mismatch.
 
-    Every ``PackSection.field`` MUST name a declared Optional field on
-    ``CoachContextPack`` whose default is ``None`` (so the drop-when-None contract
-    holds). A typo or a renamed field turns from a silent byte-stability break into
-    a startup ``RuntimeError``. This is the import-time guard the #493 constraint
-    requires, pairing with the #328 prompt-feature manifest: the field stays
-    statically declared, the registry asserts it exists."""
-    model_fields = CoachContextPack.model_fields
+    Every ``PackSection.field`` MUST name a FLAT section that the drop loop can pop
+    from the un-grouped ``_flat_data`` dict — i.e. a section relocated into a group
+    (``_SECTION_GROUP``) or a top-level meta field on ``CoachContextPack`` (ADR 0026;
+    the group container fields ``this_run``/… are not flat sections). A typo or a
+    renamed field turns from a silent byte-stability break into a startup
+    ``RuntimeError``, pairing with the #328 prompt-feature manifest."""
+    flat_universe = set(_SECTION_GROUP) | (
+        set(CoachContextPack.model_fields) - set(_GROUP_NAMES)
+    )
     seen: set[str] = set()
     for section in PACK_SECTIONS:
         if section.field in seen:
@@ -1228,11 +1536,11 @@ def _assert_descriptors_match_fields() -> None:
                 f"{section.field!r}."
             )
         seen.add(section.field)
-        if section.field not in model_fields:
+        if section.field not in flat_universe:
             raise RuntimeError(
                 f"PackSection registry: descriptor names field {section.field!r}, "
-                f"which is not declared on CoachContextPack. Declare the Optional "
-                f"field on the model or fix the descriptor."
+                f"which is not a flat section (grouped section or top-level meta). "
+                f"Fix the descriptor or declare the field."
             )
 
 

--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -26,7 +26,7 @@ from app.models.coach_chat_message import CoachChatMessage
 from app.models.coach_report import CoachReport
 from app.models.coaching_relationship import CoachingRelationship
 from app.schemas.chat import ChatMessageRead
-from app.schemas.coach_context import CoachContextPack
+from app.schemas.coach_context import CoachContextPack, unnest_pack
 from app.services.coach.llm import AnthropicClient
 from app.services.coach.prompts import render_voice_block
 from app.services.coach.query_tools import (
@@ -82,7 +82,7 @@ def _validate_chat_text(text: str, context_pack: dict) -> List[PolicyViolation]:
     violations: List[PolicyViolation] = []
     violations += check_medical_overreach(text)
     try:
-        pack = CoachContextPack.model_validate(context_pack)
+        pack = CoachContextPack.load(context_pack)
     except Exception:
         return violations
     violations += check_uncalibrated_zones(pack.metrics.zones_calibrated, text)
@@ -252,15 +252,20 @@ def _render_authority_tiering(
     always emitted. With every section present the render is byte-identical to the prior
     static block.
     """
+    # ADR 0026: a grouped stored pack nests these sections under their groups
+    # (the_runner.memory, how_to_coach.corpus, right_now.training_load), so flatten to
+    # a top-level view first. `unnest_pack` is tolerant of a flat or empty pack, so the
+    # presence gate reads identically for both shapes.
+    flat_pack = unnest_pack(context_pack)
     bullets = []
     if voice_present:
         bullets.append(_VOICE_TIER)
-    if context_pack.get("memory"):
+    if flat_pack.get("memory"):
         bullets.append(_MEMORY_TIER)
-    corpus = context_pack.get("corpus")
+    corpus = flat_pack.get("corpus")
     if corpus:
         bullets.append(_CORPUS_TIER if corpus.get("user_materials") else _CORPUS_ONLY_TIER)
-    if context_pack.get("training_load"):
+    if flat_pack.get("training_load"):
         bullets.append(_TRAINING_LOAD_TIER)
     if cross_activity_present:
         bullets.append(_RELATIONSHIP_CONVERSATION_TIER)

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -221,7 +221,10 @@ def build_context_pack(
     # training-load/volume/recent-training signals key on it (each derives the exact
     # flavour it needs — start_date for readiness, the local calendar day for volume).
     as_of = activity.start_date
-    return CoachContextPack(
+    # ADR 0026: build the grouped pack from flat section objects. from_sections wraps
+    # each section into its coaching-question group (this_run/right_now/…); the flat
+    # kwargs below are unchanged, so the gathering logic is untouched.
+    return CoachContextPack.from_sections(
         activity=f.activity,
         metrics=f.metrics,
         check_in=f.check_in,

--- a/backend/app/services/coach/eval/fixtures.py
+++ b/backend/app/services/coach/eval/fixtures.py
@@ -96,7 +96,7 @@ def _pack(**section_overrides) -> CoachContextPack:
     pack = {k: dict(v) if isinstance(v, dict) else v for k, v in _BASE_PACK.items()}
     for section, override in section_overrides.items():
         pack[section] = {**pack[section], **override}
-    return CoachContextPack.model_validate(pack)
+    return CoachContextPack.load(pack)
 
 
 def known_good_report() -> Tuple[CoachReportContent, CoachContextPack]:

--- a/backend/app/services/coach/eval/harness.py
+++ b/backend/app/services/coach/eval/harness.py
@@ -178,7 +178,7 @@ def score_db_reports(
             # Parse (drifted/corrupt pack) and score (a pathological assertion)
             # both guarded: one bad report becomes an error, never a crashed run.
             content = _validate_report(row.schema_version, row.report)
-            pack = CoachContextPack.model_validate(row.context_pack)
+            pack = CoachContextPack.load(row.context_pack)
             score = score_report(
                 content, pack,
                 report_id=str(row.id),
@@ -249,7 +249,7 @@ async def judge_db_reports(
             continue
         try:
             content = _validate_report(row.schema_version, row.report)
-            pack = CoachContextPack.model_validate(row.context_pack)
+            pack = CoachContextPack.load(row.context_pack)
             verdict = await judge_report(client, content, pack)
         except Exception as exc:
             summary = str(exc).splitlines()[0] if str(exc) else type(exc).__name__

--- a/backend/app/services/coach/prompt_features.py
+++ b/backend/app/services/coach/prompt_features.py
@@ -209,6 +209,28 @@ PROMPT_FEATURES: dict[str, frozenset[PromptFeature]] = {
             _F.INTENSITY,
         }
     ),
+    # ADR 0026 Slice 1 — coach_message_lean_grouped_v1 is lean_v1 served the GROUPED
+    # pack (the same content re-nested into the five coaching-question groups). It
+    # carries the IDENTICAL twelve capabilities as lean_v1 (feature parity), so it
+    # receives the same pack CONTENT; only the SHAPE differs (prompts.is_grouped_pack_
+    # prompt drives to_grouped_dict serving). The A/B is grouped-vs-flat shape on the
+    # same disposition-first prose. Ships INERT.
+    "coach_message_lean_grouped_v1": frozenset(
+        {
+            _F.TWO_STAGE,
+            _F.VOICE,
+            _F.CORPUS,
+            _F.STANCE,
+            _F.TRAINING_LOAD,
+            _F.USER_MATERIALS,
+            _F.VOLUME,
+            _F.STREAM_VIEW,
+            _F.RECENT_TRAINING,
+            _F.TRAINING_HISTORY,
+            _F.MEMORY,
+            _F.INTENSITY,
+        }
+    ),
 }
 
 

--- a/backend/app/services/coach/prompts.py
+++ b/backend/app/services/coach/prompts.py
@@ -1006,6 +1006,66 @@ Anchor everything to the run's real data — invent no number, confound, or tren
 Write your opener now, then call record_coach_tail once."""
 
 
+# ===========================================================================
+# coach_message_lean_grouped_v1 — ADR 0026 Slice 1 (#672). The grouped-pack variant
+# of lean_v1. It receives the SAME pack CONTENT re-nested into the five coaching-
+# question groups (service serves pack.to_grouped_dict()), so the prompt is lean_v1
+# with exactly two navigational changes: (a) a "# How your context is organized"
+# orientation that names the five groups by the question each answers, and (b) the
+# only two dotted paths that MOVE under grouping (continuity.* is now under our_thread;
+# salience stays top-level, so salience.novelty is untouched). Everything else — the
+# identity, the one-rule-about-truth, the misread-numbers, the lane, the delivery
+# protocol, the worked examples — is BYTE-IDENTICAL to lean_v1, so the safety floor is
+# invariant by construction (pinned by test_message_prompt_lean_grouped). Feature
+# parity with lean_v1: the SAME twelve capabilities, so the A/B is grouped-vs-flat
+# pack SHAPE (+ the orientation) on the same disposition-first prose. Ships INERT.
+# ===========================================================================
+
+_GROUP_ORIENTATION = """# How your context is organized
+
+Everything I give you is grouped by the question it answers — read it the way you would think it through:
+- `this_run` — what this session was and how hard it really was: the activity, its metrics and timeline, their check-in.
+- `right_now` — how they are placed today: recent training load and readiness, and how these last weeks compare to their own normal.
+- `the_runner` — who they are and where they are going: their profile, their stated memory, their training history.
+- `our_thread` — what we have already said: recent reports, whether past advice landed, and any opener I have just sent with their reply.
+- `how_to_coach` — their chosen coaching school and emphasis (this shapes framing, never facts).
+Plus a top-level safety floor. A field lives inside the group whose question it answers; if a group or field is not there, it does not apply.
+
+"""
+
+_GROUP_ORIENTATION_OPENER = (
+    "Your context is grouped by the question it answers — `this_run` (today's session), "
+    "`right_now`, `the_runner`, `our_thread`, `how_to_coach` — plus a top-level safety floor.\n\n"
+)
+
+
+def _regroup_lean_prompt(text: str) -> str:
+    """ADR 0026: derive the grouped-pack FULLER prompt from a lean prompt. Insert the
+    group orientation before the truth rule, and re-anchor the only two dotted paths
+    that move under grouping (continuity -> our_thread.continuity; salience stays
+    top-level). Pure, so the grouped prompt is provably lean_v1 plus these two
+    navigational changes and the safety prose is byte-identical (pinned by test)."""
+    out = text.replace(
+        "continuity.opener_message", "our_thread.continuity.opener_message"
+    ).replace("continuity.reply", "our_thread.continuity.reply")
+    anchor = "# The one rule about what is true"
+    return out.replace(anchor, _GROUP_ORIENTATION + anchor, 1)
+
+
+def _regroup_lean_opener_prompt(text: str) -> str:
+    """ADR 0026: the grouped-pack OPENER prompt. The opener reads salience.novelty
+    (top-level, unchanged) and no continuity path, so it needs only the short group
+    orientation, inserted before the invariants section."""
+    anchor = "# What stays true, even here"
+    return text.replace(anchor, _GROUP_ORIENTATION_OPENER + anchor, 1)
+
+
+SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1 = _regroup_lean_prompt(SYSTEM_PROMPT_MESSAGE_LEAN_V1)
+SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1_OPENER = _regroup_lean_opener_prompt(
+    SYSTEM_PROMPT_MESSAGE_LEAN_V1_OPENER
+)
+
+
 PROMPT_VERSIONS = {
     "coach_report_v1": SYSTEM_PROMPT_V1,
     "coach_report_v2": SYSTEM_PROMPT_V2,
@@ -1056,6 +1116,10 @@ PROMPT_VERSIONS = {
     # Same twelve capabilities as v14 (identical pack), radically shorter prose. Ships
     # INERT; run locally with COACH_PROMPT_ID=coach_message_lean_v1.
     "coach_message_lean_v1": SYSTEM_PROMPT_MESSAGE_LEAN_V1,
+    # ADR 0026 Slice 1 — the grouped-pack variant of lean_v1 (same content, re-nested
+    # into the five coaching-question groups + a group orientation). Feature parity
+    # with lean_v1; serves pack.to_grouped_dict(). Ships INERT.
+    "coach_message_lean_grouped_v1": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1,
 }
 
 # Prompt-id prefixes that select the A3 prose-message output family (schema 2.x).
@@ -1091,7 +1155,20 @@ _OPENER_PROMPTS = {
     "coach_message_v13": SYSTEM_PROMPT_MESSAGE_V13_OPENER,
     "coach_message_v14": SYSTEM_PROMPT_MESSAGE_V14_OPENER,
     "coach_message_lean_v1": SYSTEM_PROMPT_MESSAGE_LEAN_V1_OPENER,
+    "coach_message_lean_grouped_v1": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1_OPENER,
 }
+
+# ADR 0026 Slice 1: the prompt ids that receive the GROUPED pack serialization
+# (pack.to_grouped_dict()) instead of the flat one. This is a PRESENTATION flag, not a
+# pack-section capability, so it is a plain set here rather than a PromptFeature (which
+# gates what sections the pack CONTAINS). Every other prompt id serves the flat pack,
+# byte-stable.
+GROUPED_PACK_PROMPT_IDS: frozenset[str] = frozenset({"coach_message_lean_grouped_v1"})
+
+
+def is_grouped_pack_prompt(prompt_id: Optional[str]) -> bool:
+    """True when ``prompt_id`` receives the ADR 0026 grouped pack serialization."""
+    return prompt_id in GROUPED_PACK_PROMPT_IDS
 
 # The capability-gated prompt-id sets and predicates below are DERIVED VIEWS over
 # the prompt-feature manifest (prompt_features.PROMPT_FEATURES), the single source of

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -50,6 +50,7 @@ from app.services.coach.prompts import (
     TWO_STAGE_PROMPT_ID,
     TWO_STAGE_PROMPT_IDS,
     build_system_prompt,
+    is_grouped_pack_prompt,
 )
 from app.services.coach.prompt_features import PromptFeature, has_feature
 from app.services.coach.receipt_voice import voice_fingerprint
@@ -365,7 +366,15 @@ async def get_or_generate_coach_report(
     stance = _resolve_stance_for_activity(db, activity)
     pack = build_context_pack(db, activity, prompt_id=prompt_id, stance=stance)
     input_hash = pack.fingerprint()
-    pack_dict = pack.to_serializable_dict()
+    # ADR 0026: serve the grouped pack under a grouped-pack prompt id, the flat pack
+    # otherwise. The stored context_pack matches what the LLM saw; loaders (chat, eval)
+    # are shape-tolerant via CoachContextPack.load. The fingerprint stays flat-based, so
+    # the cache identity is unchanged.
+    pack_dict = (
+        pack.to_grouped_dict()
+        if is_grouped_pack_prompt(prompt_id)
+        else pack.to_serializable_dict()
+    )
 
     # Build prompt with activity-type playbook, selected from the axes (ADR 0007)
     classification = Classification.from_metrics(activity.metrics)
@@ -464,7 +473,15 @@ async def generate_opener(db: Session, activity_id: str) -> Optional[OpenerResul
         )
 
     input_hash = pack.fingerprint()
-    pack_dict = pack.to_serializable_dict()
+    # ADR 0026: serve the grouped pack under a grouped-pack prompt id, the flat pack
+    # otherwise. The stored context_pack matches what the LLM saw; loaders (chat, eval)
+    # are shape-tolerant via CoachContextPack.load. The fingerprint stays flat-based, so
+    # the cache identity is unchanged.
+    pack_dict = (
+        pack.to_grouped_dict()
+        if is_grouped_pack_prompt(prompt_id)
+        else pack.to_serializable_dict()
+    )
     # The opener is a brief reaction, not a playbook-driven analysis (mode="opener"
     # ignores the playbook), so the system prompt is the lean opener form. The voice
     # block (P1.1) rides both stages, so the opener already speaks in the declared
@@ -564,7 +581,15 @@ async def generate_fuller(
     stance = _resolve_stance_for_activity(db, activity)
     pack = build_context_pack(db, activity, continuity=continuity, prompt_id=prompt_id, stance=stance)
     input_hash = pack.fingerprint()
-    pack_dict = pack.to_serializable_dict()
+    # ADR 0026: serve the grouped pack under a grouped-pack prompt id, the flat pack
+    # otherwise. The stored context_pack matches what the LLM saw; loaders (chat, eval)
+    # are shape-tolerant via CoachContextPack.load. The fingerprint stays flat-based, so
+    # the cache identity is unchanged.
+    pack_dict = (
+        pack.to_grouped_dict()
+        if is_grouped_pack_prompt(prompt_id)
+        else pack.to_serializable_dict()
+    )
     classification = Classification.from_metrics(activity.metrics)
     voice = _resolve_voice_for_activity(db, activity)
     system_prompt = build_system_prompt(

--- a/backend/app/services/coach/validator.py
+++ b/backend/app/services/coach/validator.py
@@ -150,7 +150,12 @@ _NEGATION_PATTERN = re.compile(
 # ONLY the corpus path, never legitimate evidence or framing that merely DRAWS on
 # the corpus without citing it — so it can never cause a false-positive fallback.
 # This is the code half of the authority boundary that prompt rule 25 states.
-_CORPUS_FIELD_PATTERN = re.compile(r"^\s*corpus(?:\.|\[|\s*$)", re.IGNORECASE)
+# ADR 0026: under a grouped-pack prompt the corpus rides `how_to_coach.corpus`, so the
+# LLM cites it at that path; the optional `how_to_coach.` prefix matches both the flat
+# and grouped locations, still ONLY the corpus path (no false positives).
+_CORPUS_FIELD_PATTERN = re.compile(
+    r"^\s*(?:how_to_coach\.)?corpus(?:\.|\[|\s*$)", re.IGNORECASE
+)
 
 
 # --- Rule 8: user-materials-is-not-evidence boundary (P4, #286, ADR 0017) ---
@@ -164,7 +169,7 @@ _CORPUS_FIELD_PATTERN = re.compile(r"^\s*corpus(?:\.|\[|\s*$)", re.IGNORECASE)
 # (Rule 7's broader `corpus`-prefix pattern already catches these paths too; rule 8
 # is the materials-specific, clearer-message subset, the code half of prompt rule 28.)
 _USER_MATERIALS_FIELD_PATTERN = re.compile(
-    r"^\s*corpus\.user_materials(?:\.|\[|\s*$)", re.IGNORECASE
+    r"^\s*(?:how_to_coach\.)?corpus\.user_materials(?:\.|\[|\s*$)", re.IGNORECASE
 )
 
 

--- a/backend/tests/test_chat_system_prompt.py
+++ b/backend/tests/test_chat_system_prompt.py
@@ -24,6 +24,26 @@ def _full_tiering():
     return _render_authority_tiering(FULL_PACK, voice_present=True, cross_activity_present=True)
 
 
+# The SAME pack, ADR 0026-grouped: memory under the_runner, corpus under how_to_coach,
+# training_load under right_now. The chat tiering gate must read it identically.
+GROUPED_FULL_PACK = {
+    "the_runner": {"memory": {"who_you_are": ["marathoner"]}},
+    "how_to_coach": {"corpus": {"school": {"stance": "aerobic"}, "user_materials": [{"stance": "x"}]}},
+    "right_now": {"training_load": {"fitness": 40.0}},
+}
+
+
+def test_chat_tiering_reads_grouped_and_flat_packs_identically():
+    """ADR 0026: a grouped stored pack nests the tiered sections under their groups.
+    The gate (via unnest_pack) must brief the same tiers for both shapes, so a
+    grouped-prompt report's chat carries the same authority-tiering as a flat one."""
+    flat = _render_authority_tiering(FULL_PACK, voice_present=True, cross_activity_present=True)
+    grouped = _render_authority_tiering(
+        GROUPED_FULL_PACK, voice_present=True, cross_activity_present=True
+    )
+    assert grouped == flat
+
+
 def test_chat_template_renders_without_brace_errors():
     """`.format()` must survive — a literal `{`/`}` in the template would raise here."""
     rendered = _build_chat_system_prompt(

--- a/backend/tests/test_coach_context_pack.py
+++ b/backend/tests/test_coach_context_pack.py
@@ -305,13 +305,13 @@ def _legacy_sparse_pack() -> dict:
 
 def test_roundtrip_preserves_full_dict_shape():
     pack_dict = _legacy_full_pack()
-    pack = CoachContextPack.model_validate(pack_dict)
+    pack = CoachContextPack.load(pack_dict)
     assert pack.to_serializable_dict() == pack_dict
 
 
 def test_roundtrip_preserves_sparse_dict_shape():
     pack_dict = _legacy_sparse_pack()
-    pack = CoachContextPack.model_validate(pack_dict)
+    pack = CoachContextPack.load(pack_dict)
     assert pack.to_serializable_dict() == pack_dict
 
 
@@ -325,7 +325,7 @@ def test_no_session_collapses_interval_group_to_one_signal():
         "match_score": None, "detection_confidence": "low",
         "confidence_reasons": ["no_intervals_detected"], "detected_workout": None,
     }
-    out = CoachContextPack.model_validate(pack_dict).to_serializable_dict()["metrics"]
+    out = CoachContextPack.load(pack_dict).to_serializable_dict()["metrics"]
     assert out["interval_workout"] == "none detected"
     assert "interval_structure" not in out
     assert "workout_match" not in out
@@ -342,7 +342,7 @@ def test_detected_session_keeps_structured_interval_group():
         "summary": {"rep_count": 6},
     }
     pack_dict["metrics"]["workout_match"] = {"detection_confidence": "high", "match_score": 0.9}
-    out = CoachContextPack.model_validate(pack_dict).to_serializable_dict()["metrics"]
+    out = CoachContextPack.load(pack_dict).to_serializable_dict()["metrics"]
     assert out["interval_structure"]["summary"]["rep_count"] == 6
     assert out["workout_match"]["detection_confidence"] == "high"
     assert "interval_workout" not in out
@@ -363,7 +363,7 @@ def test_coach_view_drops_avg_speed_mps_from_work_segments():
         "summary": {"rep_count": 6},
     }
     pack_dict["metrics"]["workout_match"] = {"detection_confidence": "high", "match_score": 0.9}
-    pack = CoachContextPack.model_validate(pack_dict)
+    pack = CoachContextPack.load(pack_dict)
     seg = pack.to_serializable_dict()["metrics"]["interval_structure"]["work_segments"][0]
     assert "avg_speed_mps" not in seg          # dropped from the coach view
     assert seg["pace_s_per_km"] == 225         # coach reads pace instead
@@ -381,7 +381,7 @@ def test_old_verbose_no_session_pack_still_validates_and_collapses():
     old["metrics"]["workout_match"] = None
     old["metrics"]["interval_kpis"] = None
     old["metrics"].pop("interval_workout", None)
-    pack = CoachContextPack.model_validate(old)  # must not raise
+    pack = CoachContextPack.load(old)  # must not raise
     out = pack.to_serializable_dict()["metrics"]
     assert out["interval_workout"] == "none detected"
 
@@ -400,7 +400,7 @@ def test_folds_redundant_scalar_copies_out_of_serialization():
     old["calibration"]["hr_drift"]["observed_drift_pct"] = 9.0
     old["metrics"]["discount_signals"] = {"likely_inflated_by": ["heat"], "hr_drift_pct": 4.2}
 
-    out = CoachContextPack.model_validate(old).to_serializable_dict()  # must not raise
+    out = CoachContextPack.load(old).to_serializable_dict()  # must not raise
 
     assert "rpe" not in out["perceived_effort"]
     assert "effort_score" not in out["perceived_effort"]
@@ -416,17 +416,83 @@ def test_folds_redundant_scalar_copies_out_of_serialization():
     assert out["metrics"]["discount_signals"]["likely_inflated_by"] == ["heat"]
 
 
+# --- ADR 0026: the grouped envelope (flatten(grouped) == flat) -----------------
+
+
+def _flatten_grouped(grouped: dict) -> dict:
+    """Inverse of `_nest_flat`: hoist every group's sections back to the top level,
+    preserving the top-level meta keys, so a grouped pack can be compared leaf-for-leaf
+    against the flat serialization."""
+    from app.schemas.coach_context import _GROUP_NAMES
+
+    flat: dict = {}
+    for key, value in grouped.items():
+        if key in _GROUP_NAMES:
+            flat.update(value)
+        else:
+            flat[key] = value
+    return flat
+
+
+def test_grouped_dict_flattens_back_to_flat_full():
+    """The grouped serialization carries the IDENTICAL leaf facts as the flat one —
+    only the nesting differs (ADR 0026 content-preserving invariant)."""
+    pack = CoachContextPack.load(_legacy_full_pack())
+    grouped = pack.to_grouped_dict()
+    assert set(grouped) & {"this_run", "right_now", "the_runner", "our_thread"}
+    assert _flatten_grouped(grouped) == pack.to_serializable_dict()
+
+
+def test_grouped_dict_flattens_back_to_flat_sparse():
+    pack = CoachContextPack.load(_legacy_sparse_pack())
+    grouped = pack.to_grouped_dict()
+    assert _flatten_grouped(grouped) == pack.to_serializable_dict()
+
+
+def test_grouped_dict_places_sections_under_their_coaching_question_group():
+    """Slice 1 relocation is exact: each section sits under the group whose question
+    it answers, so slices 2-3 (recent_weeks / intensity_read) merge in place."""
+    pack = CoachContextPack.load(_legacy_full_pack())
+    grouped = pack.to_grouped_dict()
+    assert "metrics" in grouped["this_run"] and "calibration" in grouped["this_run"]
+    assert "perceived_effort" in grouped["this_run"]
+    assert "profile" in grouped["the_runner"]
+    assert "adherence" in grouped["our_thread"] and "longitudinal" in grouped["our_thread"]
+    # Top-level meta stays top-level, never grouped.
+    assert "safety_rules" in grouped and "salience" in grouped
+    assert "safety_rules" not in grouped.get("this_run", {})
+
+
+def test_empty_groups_are_dropped_from_grouped_serialization():
+    """A group whose sections are all gated-off/absent emits no key (byte-stable-drop
+    generalised to nested groups). The sparse pack carries no how_to_coach section."""
+    pack = CoachContextPack.load(_legacy_sparse_pack())
+    grouped = pack.to_grouped_dict()
+    # how_to_coach (corpus/stance) is absent in the sparse flat pack -> group dropped.
+    assert "how_to_coach" not in grouped
+
+
+def test_load_accepts_both_flat_and_grouped_shapes():
+    """`load`/`model_validate` are shape-tolerant: a legacy FLAT stored pack and the
+    grouped serialization of the same pack both parse to an equal flat serialization."""
+    flat = _legacy_full_pack()
+    from_flat = CoachContextPack.load(flat)
+    from_grouped = CoachContextPack.load(from_flat.to_grouped_dict())
+    assert from_flat.to_serializable_dict() == from_grouped.to_serializable_dict()
+    assert from_flat.fingerprint() == from_grouped.fingerprint()
+
+
 def test_fingerprint_matches_legacy_hash_full():
     pack_dict = _legacy_full_pack()
     expected = hash_context_pack(pack_dict)
-    pack = CoachContextPack.model_validate(pack_dict)
+    pack = CoachContextPack.load(pack_dict)
     assert pack.fingerprint() == expected
 
 
 def test_fingerprint_matches_legacy_hash_sparse():
     pack_dict = _legacy_sparse_pack()
     expected = hash_context_pack(pack_dict)
-    pack = CoachContextPack.model_validate(pack_dict)
+    pack = CoachContextPack.load(pack_dict)
     assert pack.fingerprint() == expected
 
 
@@ -490,7 +556,7 @@ def test_real_fixture_pack_roundtrips_through_typed_schema(db):
     pack_dict = pack.to_serializable_dict()
 
     # Round-trip through model_validate preserves the dict shape.
-    assert CoachContextPack.model_validate(pack_dict).to_serializable_dict() == pack_dict
+    assert CoachContextPack.load(pack_dict).to_serializable_dict() == pack_dict
     # The typed fingerprint matches the legacy dict-based hash byte-for-byte.
     assert pack.fingerprint() == hash_context_pack(pack_dict)
 
@@ -502,11 +568,20 @@ def test_pack_section_registry_covers_every_droppable_field():
     """Every Optional-and-dropped section is a PACK_SECTIONS descriptor, and every
     descriptor names a real declared field. This is the structural invariant the
     registry replaces seven hand-copied drop branches with."""
-    from app.schemas.coach_context import CoachContextPack, PACK_SECTIONS
+    from app.schemas.coach_context import (
+        CoachContextPack,
+        PACK_SECTIONS,
+        _GROUP_NAMES,
+        _SECTION_GROUP,
+    )
 
-    model_fields = CoachContextPack.model_fields
+    # ADR 0026: a droppable section is a flat section (relocated into a group) or a
+    # top-level meta field — not one of the group container fields.
+    flat_universe = set(_SECTION_GROUP) | (
+        set(CoachContextPack.model_fields) - set(_GROUP_NAMES)
+    )
     for section in PACK_SECTIONS:
-        assert section.field in model_fields, section.field
+        assert section.field in flat_universe, section.field
     # The seven prompt-gated sections named by #493 are all present.
     fields = {s.field for s in PACK_SECTIONS}
     assert {
@@ -531,7 +606,7 @@ def test_pack_section_descriptor_naming_unknown_field_fails_at_import_check():
     original = m.PACK_SECTIONS
     try:
         m.PACK_SECTIONS = original + (PackSection("this_field_does_not_exist"),)
-        with pytest.raises(RuntimeError, match="not declared on CoachContextPack"):
+        with pytest.raises(RuntimeError, match="not a flat section"):
             m._assert_descriptors_match_fields()
     finally:
         m.PACK_SECTIONS = original

--- a/backend/tests/test_message_prompt_lean_grouped.py
+++ b/backend/tests/test_message_prompt_lean_grouped.py
@@ -1,0 +1,110 @@
+"""Wiring + invariant pins for coach_message_lean_grouped_v1 (ADR 0026 Slice 1, #672).
+
+The grouped-pack variant of lean_v1: it receives the SAME pack CONTENT re-nested into
+the five coaching-question groups (service serves pack.to_grouped_dict()). The prompt
+is lean_v1 with exactly two navigational changes — a group orientation and the two
+continuity.* dotted paths re-anchored under our_thread — so the safety floor is
+invariant BY CONSTRUCTION. These tests pin exactly that.
+"""
+
+from app.core.config import settings
+from app.services.coach import prompts
+from app.services.coach.prompt_features import features_for
+from app.services.coach.prompts import (
+    MESSAGE_PROMPT_PREFIX,
+    PROMPT_VERSIONS,
+    SYSTEM_PROMPT_MESSAGE_LEAN_V1,
+    SYSTEM_PROMPT_MESSAGE_LEAN_V1_OPENER,
+    SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1,
+    SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1_OPENER,
+    _OPENER_PROMPTS,
+    build_system_prompt,
+    is_grouped_pack_prompt,
+)
+from app.services.coach.service import active_schema_version
+
+GROUPED = "coach_message_lean_grouped_v1"
+LEAN = "coach_message_lean_v1"
+V14 = "coach_message_v14"
+
+
+def test_grouped_registered_in_message_family_and_flagged_grouped():
+    assert GROUPED in PROMPT_VERSIONS
+    assert GROUPED in _OPENER_PROMPTS
+    assert GROUPED.startswith(MESSAGE_PROMPT_PREFIX)
+    assert active_schema_version(GROUPED) == active_schema_version(LEAN)
+    # The grouped-serving flag is on for GROUPED and off for the flat prompts.
+    assert is_grouped_pack_prompt(GROUPED)
+    assert not is_grouped_pack_prompt(LEAN)
+    assert not is_grouped_pack_prompt(V14)
+    assert not is_grouped_pack_prompt(None)
+
+
+def test_grouped_has_full_capability_parity_with_lean_v1():
+    """Same gated sections -> identical pack CONTENT. The A/B isolates the pack SHAPE
+    (+ the orientation), exactly as lean_v1 isolates the prose vs v14."""
+    assert features_for(GROUPED) == features_for(LEAN)
+
+
+def test_grouped_is_lean_v1_plus_orientation_and_continuity_repath_only():
+    """The load-bearing invariant: the grouped prompt is lean_v1 with ONLY the group
+    orientation inserted and the two continuity.* paths re-anchored under our_thread.
+    Reverting both changes reproduces lean_v1 BYTE-FOR-BYTE, so every safety-critical
+    line (the lane, the misread numbers, the truth rule, the worked examples) is
+    unchanged and the floor cannot have drifted."""
+    # Pinned as a pure derivation of lean_v1.
+    assert SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1 == prompts._regroup_lean_prompt(
+        SYSTEM_PROMPT_MESSAGE_LEAN_V1
+    )
+    # Reverting the two navigational changes yields lean_v1 exactly.
+    reverted = SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1.replace(
+        prompts._GROUP_ORIENTATION, ""
+    ).replace("our_thread.continuity", "continuity")
+    assert reverted == SYSTEM_PROMPT_MESSAGE_LEAN_V1
+
+
+def test_grouped_opener_is_lean_v1_opener_plus_orientation_only():
+    assert SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1_OPENER == prompts._regroup_lean_opener_prompt(
+        SYSTEM_PROMPT_MESSAGE_LEAN_V1_OPENER
+    )
+    reverted = SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1_OPENER.replace(
+        prompts._GROUP_ORIENTATION_OPENER, ""
+    )
+    assert reverted == SYSTEM_PROMPT_MESSAGE_LEAN_V1_OPENER
+
+
+def test_grouped_orientation_names_the_five_coaching_question_groups():
+    text = SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1
+    assert "How your context is organized" in text
+    for group in ("this_run", "right_now", "the_runner", "our_thread", "how_to_coach"):
+        assert f"`{group}`" in text
+    # continuity is re-anchored under our_thread; the bare flat path is gone.
+    assert "our_thread.continuity.opener_message" in text
+    assert "our_thread.continuity.reply" in text
+
+
+def test_grouped_keeps_the_load_bearing_safety_surface_verbatim():
+    """Defense in depth over the derivation pin: the safety lane, the misread-number
+    facts, and the truth rule appear verbatim in the grouped prompt."""
+    lean = SYSTEM_PROMPT_MESSAGE_LEAN_V1
+    grouped = SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1
+    for anchor in (
+        "Stay in general-wellness coaching.",
+        "`effort_score` is cumulative training LOAD",
+        "`discount_signals` is authoritative.",
+        "When `zones_calibrated` is false",
+        "For acute pain (pain_score >= 7)",
+    ):
+        assert anchor in lean and anchor in grouped, anchor
+
+
+def test_grouped_builds_for_both_modes():
+    fuller = build_system_prompt(GROUPED, mode="fuller", voice=None)
+    opener = build_system_prompt(GROUPED, mode="opener", voice=None)
+    assert SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1 in fuller
+    assert SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1_OPENER in opener
+    assert "YOUR VOICE FOR THIS RUNNER" in fuller  # voice-aware, like lean_v1
+
+
+def test_grouped_ships_inert():
+    assert settings.COACH_PROMPT_ID != GROUPED

--- a/backend/tests/test_message_prompt_v10.py
+++ b/backend/tests/test_message_prompt_v10.py
@@ -37,6 +37,7 @@ def test_v10_registered_carries_every_v9_capability_plus_stream_view():
     assert STREAM_VIEW_PROMPT_IDS == {
         V10, "coach_message_v11", "coach_message_v12", "coach_message_v13",
         "coach_message_v14", "coach_message_lean_v1",
+        "coach_message_lean_grouped_v1",
     }
     assert V10 in _OPENER_PROMPTS  # has a distinct opener form (two-stage)
     # same schema family as v9 (so v10 reports regenerate, prior history retained).

--- a/backend/tests/test_message_prompt_v11.py
+++ b/backend/tests/test_message_prompt_v11.py
@@ -36,6 +36,7 @@ def test_v11_registered_carries_every_v10_capability_plus_recent_training():
     assert RECENT_TRAINING_PROMPT_IDS == {
         V11, "coach_message_v12", "coach_message_v13", "coach_message_v14",
         "coach_message_lean_v1",
+        "coach_message_lean_grouped_v1",
     }
     assert V11 in _OPENER_PROMPTS  # has a distinct opener form (two-stage)
     # same schema family as v10 (so v11 reports regenerate, prior history retained).

--- a/backend/tests/test_message_prompt_v12.py
+++ b/backend/tests/test_message_prompt_v12.py
@@ -35,6 +35,7 @@ def test_v12_registered_carries_every_v11_capability_plus_training_history():
     assert V12 in TRAINING_HISTORY_PROMPT_IDS  # ...plus the new TRAINING_HISTORY capability
     assert TRAINING_HISTORY_PROMPT_IDS == {
         V12, "coach_message_v13", "coach_message_v14", "coach_message_lean_v1",
+        "coach_message_lean_grouped_v1",
     }
     assert V12 in _OPENER_PROMPTS  # has a distinct opener form (two-stage)
     # same schema family as v11 (so v12 reports regenerate, prior history retained).

--- a/backend/tests/test_message_prompt_v14.py
+++ b/backend/tests/test_message_prompt_v14.py
@@ -34,7 +34,7 @@ def test_v14_registered_carries_every_v13_capability_plus_intensity():
     assert V14 in MEMORY_PROMPT_IDS  # inherits v13's capabilities
     assert V14 in INTENSITY_PROMPT_IDS  # ...plus the new INTENSITY capability
     # v14 and the lean experiment (full-capability parity) are the INTENSITY-aware ids.
-    assert INTENSITY_PROMPT_IDS == {V14, "coach_message_lean_v1"}
+    assert INTENSITY_PROMPT_IDS == {V14, "coach_message_lean_v1", "coach_message_lean_grouped_v1"}
     assert V14 in _OPENER_PROMPTS  # has a distinct opener form (two-stage)
     # same schema family as v13 (so v14 reports regenerate, prior history retained).
     assert active_schema_version(V14) == active_schema_version(V13)

--- a/backend/tests/test_message_prompt_v9.py
+++ b/backend/tests/test_message_prompt_v9.py
@@ -45,6 +45,7 @@ def test_v9_registered_in_message_family_and_gate_sets():
     assert VOLUME_PROMPT_IDS == {
         V9, "coach_message_v10", "coach_message_v11", "coach_message_v12",
         "coach_message_v13", "coach_message_v14", "coach_message_lean_v1",
+        "coach_message_lean_grouped_v1",
     }
     # same schema family as v8 (so v9 reports regenerate, prior history retained).
     assert active_schema_version(V9) == active_schema_version(V8)

--- a/backend/tests/test_pack_single_home_facts.py
+++ b/backend/tests/test_pack_single_home_facts.py
@@ -132,9 +132,11 @@ def _build_fully_populated_pack(db):
 def test_folded_facts_each_have_exactly_one_home(db):
     pack = _build_fully_populated_pack(db)
 
-    # Precondition: the un-dropped MODEL dump still carries every copy (the fold is
+    # Precondition: the un-dropped FLAT data still carries every copy (the fold is
     # serialization-only; the derived reads compute from them). Guards a vacuous pass.
-    model = pack.model_dump(mode="python")
+    # ADR 0026: `_flat_data` is the un-grouped, pre-fold flat shape the old model_dump
+    # produced, so the flat copy paths (perceived_effort.rpe, …) resolve.
+    model = pack._flat_data()
     for label, copy_path, _home_path in SINGLE_HOME_FACTS:
         targets = list(_iter_targets(model, copy_path))
         assert targets and all(c.get(k) is not None for c, k in targets), (

--- a/backend/tests/test_prompt_features.py
+++ b/backend/tests/test_prompt_features.py
@@ -137,6 +137,22 @@ EXPECTED_CAPABILITIES = {
         F.MEMORY,
         F.INTENSITY,
     },
+    # ADR 0026 Slice 1 — the grouped-pack variant of lean_v1: full capability parity
+    # (same pack CONTENT), differing only in the pack SHAPE it is served.
+    "coach_message_lean_grouped_v1": {
+        F.TWO_STAGE,
+        F.VOICE,
+        F.CORPUS,
+        F.STANCE,
+        F.TRAINING_LOAD,
+        F.USER_MATERIALS,
+        F.VOLUME,
+        F.STREAM_VIEW,
+        F.RECENT_TRAINING,
+        F.TRAINING_HISTORY,
+        F.MEMORY,
+        F.INTENSITY,
+    },
 }
 
 # Ids that must carry NO capabilities (the inert-under-rollback set).
@@ -183,6 +199,7 @@ def test_memory_feature_is_active_on_v13():
     supersets and carry MEMORY too, #578.)"""
     assert prompts.MEMORY_PROMPT_IDS == {
         "coach_message_v13", "coach_message_v14", "coach_message_lean_v1",
+        "coach_message_lean_grouped_v1",
     }
     assert prompts.is_memory_prompt("coach_message_v13") is True
     assert prompts.is_memory_prompt("coach_message_v12") is False
@@ -190,59 +207,60 @@ def test_memory_feature_is_active_on_v13():
 
 def test_derived_sets_match_captured_membership():
     """Belt-and-suspenders: the derived sets equal the explicit captured membership."""
-    # coach_message_lean_v1 (the experiment) carries the FULL capability set, so it joins
-    # every derived set below alongside the vN ids it shares that feature with.
+    # coach_message_lean_v1 (the experiment) and coach_message_lean_grouped_v1 (ADR 0026)
+    # both carry the FULL capability set, so both join every derived set below.
     LEAN = "coach_message_lean_v1"
+    GROUPED = "coach_message_lean_grouped_v1"
     assert prompts.TWO_STAGE_PROMPT_IDS == {
         "coach_message_v2", "coach_message_v3", "coach_message_v4",
         "coach_message_v5", "coach_message_v6", "coach_message_v7", "coach_message_v8",
         "coach_message_v9", "coach_message_v10", "coach_message_v11", "coach_message_v12",
-        "coach_message_v13", "coach_message_v14", LEAN,
+        "coach_message_v13", "coach_message_v14", LEAN, GROUPED,
     }
     assert prompts.VOICE_PROMPT_IDS == {
         "coach_message_v3", "coach_message_v4", "coach_message_v5",
         "coach_message_v6", "coach_message_v7", "coach_message_v8", "coach_message_v9",
         "coach_message_v10", "coach_message_v11", "coach_message_v12", "coach_message_v13",
-        "coach_message_v14", LEAN,
+        "coach_message_v14", LEAN, GROUPED,
     }
     assert prompts.CORPUS_PROMPT_IDS == {
         "coach_message_v4", "coach_message_v5", "coach_message_v6",
         "coach_message_v7", "coach_message_v8", "coach_message_v9", "coach_message_v10",
         "coach_message_v11", "coach_message_v12", "coach_message_v13", "coach_message_v14",
-        LEAN,
+        LEAN, GROUPED,
     }
     assert prompts.STANCE_PROMPT_IDS == {
         "coach_message_v5", "coach_message_v6", "coach_message_v7", "coach_message_v8",
         "coach_message_v9", "coach_message_v10", "coach_message_v11", "coach_message_v12",
-        "coach_message_v13", "coach_message_v14", LEAN,
+        "coach_message_v13", "coach_message_v14", LEAN, GROUPED,
     }
     assert prompts.TRAINING_LOAD_PROMPT_IDS == {
         "coach_message_v6", "coach_message_v7", "coach_message_v8", "coach_message_v9",
         "coach_message_v10", "coach_message_v11", "coach_message_v12", "coach_message_v13",
-        "coach_message_v14", LEAN,
+        "coach_message_v14", LEAN, GROUPED,
     }
     assert prompts.USER_MATERIALS_PROMPT_IDS == {
         "coach_message_v7", "coach_message_v8", "coach_message_v9", "coach_message_v10",
         "coach_message_v11", "coach_message_v12", "coach_message_v13", "coach_message_v14",
-        LEAN,
+        LEAN, GROUPED,
     }
     assert prompts.VOLUME_PROMPT_IDS == {
         "coach_message_v9", "coach_message_v10", "coach_message_v11", "coach_message_v12",
-        "coach_message_v13", "coach_message_v14", LEAN,
+        "coach_message_v13", "coach_message_v14", LEAN, GROUPED,
     }
     assert prompts.STREAM_VIEW_PROMPT_IDS == {
         "coach_message_v10", "coach_message_v11", "coach_message_v12", "coach_message_v13",
-        "coach_message_v14", LEAN,
+        "coach_message_v14", LEAN, GROUPED,
     }
     assert prompts.RECENT_TRAINING_PROMPT_IDS == {
         "coach_message_v11", "coach_message_v12", "coach_message_v13", "coach_message_v14",
-        LEAN,
+        LEAN, GROUPED,
     }
     assert prompts.TRAINING_HISTORY_PROMPT_IDS == {
-        "coach_message_v12", "coach_message_v13", "coach_message_v14", LEAN,
+        "coach_message_v12", "coach_message_v13", "coach_message_v14", LEAN, GROUPED,
     }
-    assert prompts.MEMORY_PROMPT_IDS == {"coach_message_v13", "coach_message_v14", LEAN}
-    assert prompts.INTENSITY_PROMPT_IDS == {"coach_message_v14", LEAN}
+    assert prompts.MEMORY_PROMPT_IDS == {"coach_message_v13", "coach_message_v14", LEAN, GROUPED}
+    assert prompts.INTENSITY_PROMPT_IDS == {"coach_message_v14", LEAN, GROUPED}
 
 
 def test_predicates_agree_with_has_feature():

--- a/docs/adr/0026-coach-pack-is-grouped-by-the-coaching-question.md
+++ b/docs/adr/0026-coach-pack-is-grouped-by-the-coaching-question.md
@@ -1,0 +1,61 @@
+# The coach context pack is grouped by the coaching question, not the milestone that built it
+
+The coach context pack grew one milestone at a time. Every capability — training load (#276), volume-vs-norm (#400), recent-training (#444), training-history (#561), intensity (#578), calibration (M9), perceived effort (M6), longitudinal contrast (M4) — arrived as its own top-level pack section, named after the code that produced it and shaped like the row it came from. The result is ~20 flat sections whose names encode the implementation, not the question each answers, handed to the model as one minified `json.dumps` blob.
+
+Two structural failures follow from that history, and both degrade the read.
+
+**The pack has two overlap swamps, each on a single axis.** "How is the runner right now" is answered four times — `training_load`, `training_volume`, `recent_training`, and `intensity.distribution` — each in its own units, with a rolling-7d window sitting next to a partial calendar week (the root of #653; #670 carves this one). Separately, "how hard was this run, really" is answered four times too — the HR-derived `effort` axis in `metrics`, `perceived_effort` (RPE vs HR), `calibration.hr_drift` (this drift vs the runner's typical), and `intensity.this_session` — so the coach assembles the intensity picture from four places. Sibling sections on the same axis invite the model to narrate each in isolation; the #636 "recovery collapsed to 6 bpm" misread was exactly that failure, in raw units.
+
+**The envelope forces navigation by implementation name.** Because the top level is flat and the keys are milestone names (`training_load`, `discount_signals`, `recent_training_summary`), the model reads the pack by the shape of our codebase rather than by the shape of a coach's reasoning. A good running coach — a role the model already knows deeply — runs a finished run and this runner through a small, stable set of questions. The pack should present itself the same way, so the model's latent coaching knowledge navigates by intent.
+
+This is an altitude problem (per `aiw-prompt-smith`): most of the pack sits at the altitude of the milestone that built it, when it should sit at the altitude of the coaching question it serves.
+
+## Decision
+
+Reorganize the context pack into **five groups named for the coaching question they answer**, plus the safety floor. The sections do not change what they mean; they move under the question they serve, and the two overlap swamps collapse into one read each.
+
+```
+this_run       — what was this session, and how hard was it really?
+                 activity · metrics · stream_view · check_in · intensity_read · referral · block
+right_now      — how is the runner currently?
+                 readiness · recent_weeks
+the_runner     — who are they, and where are they going?
+                 profile · memory · training_history · typical_trend
+our_thread     — what did I say last time, and did it land?
+                 last_reports · adherence · continuity
+how_to_coach   — delivery and philosophy, NEVER facts
+                 corpus · stance          (voice stays in the system prompt)
+safety_rules   — the floor, stays top-level
+```
+
+Four properties are load-bearing:
+
+1. **Grouped by the question, so the model reads by intent.** The five group keys are the leading words — `this_run`, `right_now`, `the_runner`, `our_thread`, `how_to_coach` — and every future section has an obvious home. Two sections that straddled two questions are dissolved into the groups they actually belong to: `longitudinal` splits (its `prior_reports` are *what I said last time* → `our_thread.last_reports`; its `baseline_trend` is *the runner's trajectory* → `the_runner.typical_trend`), and `calibration` splits (its `hr_drift` comparison is *this run's drift* → `this_run.intensity_read`; its `referral` is a this-run safety nudge → `this_run.referral`, promoted to its own key because burying a safety surface invites misses). `intensity` naturally separates for the same reason — `this_session` is about this run, `distribution`/`trend` is about right now.
+
+2. **The two overlap swamps become one read each.** `this_run.intensity_read` is the single "how hard, really" read, merging `perceived_effort` + `calibration.hr_drift` + `intensity.this_session` + `discount_signals` (HR band + within-run split + RPE-vs-HR gap + drift-vs-your-typical + confounders). `right_now.recent_weeks` is the single "recent training" read, merging `training_volume` + `recent_training` + `intensity.distribution` on one week model. The coach stops assembling a picture from four siblings.
+
+3. **Shape moves before content.** The regroup ships FIRST as a **content-preserving** slice: the leaf facts are byte-identical, only the nesting changes, so it is testable by asserting the flattened fact set is unchanged. The swamp merges and the day-resolved `recent_weeks` week model (#670) follow as separate content slices *inside* the stable envelope. Separating the mechanical shape migration from the content redesign de-risks both and keeps each slice small and reversible.
+
+4. **Coach-native leaves, but the JSON stays and the verdict stays the coach's.** Within the envelope, leaf framing follows the #637 template — coach-native units and reference frames and trends (pace not m/s, % of max not raw bpm, vs-your-norm not isolated points), because the recovery-6bpm bug was a *units-and-frame* failure. It is NOT a licence to pre-compute the coaching conclusion: a good-coach model reads splits and drift on its own (`aiw-prompt-smith`: trust the model for judgment, constrain it for interfaces). We fix the interface — units, frames, trends, and the envelope — and leave the call to the coach.
+
+The pack stays a JSON object (byte-stable, cacheable, read by the deterministic validator and the eval harness). The `PACK_SECTIONS` byte-stable-drop registry extends to drop empty nested groups, and every path consumer — validator evidence paths (`corpus.*` → `how_to_coach.corpus.*`), eval extractors, the chat read path's strict re-parse, and the `flow-nodes.js` diagram — moves in lockstep with a new prompt version that reads the new paths. The regroup changes the pack fingerprint, so reports regenerate, exactly as every prior prompt-version pack change has.
+
+## Considered options
+
+- **Reshape sections in place, keep the flat top level (Option A).** Rejected: merging the two swamps in place fixes the worst reads but leaves the map — the model keeps navigating by milestone name, and every future section still lands as another flat sibling with no home. The envelope *is* the same altitude fix as the leaves; doing only the leaves pays the migration cost and still leaves the higher-altitude problem.
+- **Compose a prose briefing instead of a JSON pack.** Rejected: prose reads most naturally, but it trades away the properties the pack exists to keep — byte-stable fingerprint caching, deterministic-validator readability, and the strict re-parse the chat path and eval harness depend on. The altitude fix is achievable *within* JSON (grouped envelope + coach-native leaves); we do not need to leave the format to get it.
+- **Pre-compute the coaching verdict into each leaf.** Rejected: the recovery-6bpm misread was a units-and-frame failure, not a missing-conclusion failure. Pre-chewing the verdict starves the model's own coaching judgment — the whole reason we ground the coach as *a good running coach*. Give coach-native units, frames, and trends; leave the read to the coach, backed by the deterministic floor.
+- **Land the envelope and #670's content in one migration.** Rejected: bundling the mechanical shape move with the `recent_weeks` content redesign makes one large, hard-to-verify change. Shipping the content-preserving regroup first (flattened fact set unchanged) gives a clean, independently-testable migration, after which the content slices are small moves within a stable shape.
+
+## Consequences
+
+- **Slicing, under the #638 coach-value-per-token umbrella:**
+  1. **Slice 1 — the content-preserving regroup.** This ADR + the five group models in `coach_context.py`, `PACK_SECTIONS` extended to drop empty nested groups, builders emit the grouped shape, and every path consumer (validator, eval, chat strict-parse, diagram) plus a new prompt version updated in lockstep. Leaf facts byte-identical.
+  2. **Slice 2 — `right_now` content** (#670, rescoped): the day-resolved `recent_weeks` and the single configurable week model, inside the envelope.
+  3. **Slice 3 — `this_run.intensity_read` merge**: the four intensity lenses collapsed into one read.
+  4. **Slice 4 — coach-frame the `metrics` leaves**: % of max not raw bpm, pace not m/s throughout, drop over-precise decimals.
+  5. **Slice 5 — cleanups + flip**: `salience` drops from the fuller pack (it is a routing signal for opener depth and the safety force, consumed before the fuller turn is scheduled, so it steers nothing in the fuller pack); final prompt tune; eval; owner flip.
+- **Issue structure:** #638 stays the audit umbrella; #670 is rescoped from "rename the three recent sections" to Slice 2 (its rename is subsumed by the envelope); Slice 1 and Slice 3 are their own issues.
+- **The safety floor is invariant across the regroup.** Slice 1 changes only nesting, not facts, so the medical-scope validator (rule 5) and the eval `*_preserved_safety_surface` assertions hold by construction; the validator's evidence-path rules (corpus / user-materials-is-not-evidence) are re-anchored to the new paths in the same slice. `referral` is promoted, not weakened.
+- **Every pack-shape slice keeps the existing disciplines:** byte-stable-drop for gated/empty sections (now including nested groups), a regenerated `flow-nodes.js` diagram in the same PR, and the eval preserved-safety-surface run.
+- Future reviews should not re-suggest a flat milestone-named section, nor a section that answers a question another group already owns: a new capability joins the group whose question it serves, or it earns a new question. The five-question envelope is the design, not an accident of build order.

--- a/docs/diagrams/check_diagram_drift.py
+++ b/docs/diagrams/check_diagram_drift.py
@@ -70,10 +70,24 @@ _DM_NON_DATA = {"id", "activity_id", "created_at", "updated_at"}
 
 
 def _canonical_pack_sections() -> set[str]:
-    """The pack sections the live CoachContextPack schema can emit to the LLM."""
-    from app.schemas.coach_context import CoachContextPack  # lazy: needs the app importable
+    """The FLAT pack sections the live CoachContextPack schema can emit to the LLM.
 
-    return set(CoachContextPack.model_fields.keys())
+    ADR 0026 grouped the schema's top-level fields into five coaching-question groups
+    (this_run/right_now/…), but the SERIALIZED pack the LLM receives still carries the
+    flat sections (to_serializable_dict), and the diagram depicts that flat data flow.
+    So the drift guard enumerates the flat section universe — every section relocated
+    into a group (_SECTION_GROUP) plus the top-level meta fields (salience/safety_rules/
+    retired stubs), excluding the group container fields — not the grouped top level. A
+    genuinely new pack section still trips the guard: it is declared on a group model
+    and wired into _SECTION_GROUP, so it appears here with no p_* node."""
+    from app.schemas.coach_context import (  # lazy: needs the app importable
+        CoachContextPack,
+        _GROUP_NAMES,
+        _SECTION_GROUP,
+    )
+
+    top_level_meta = set(CoachContextPack.model_fields.keys()) - set(_GROUP_NAMES)
+    return set(_SECTION_GROUP) | top_level_meta
 
 
 def _canonical_derived_columns() -> set[str]:


### PR DESCRIPTION
Slice 1 of ADR 0026 (the five-question coach-pack envelope), under the #638 coach-value-per-token umbrella. Rescopes nothing else; #670 (Slice 2) and #673 (Slice 3) build on this.

## What
Reorganize `CoachContextPack` from ~20 flat, milestone-named sections into five groups named for the coaching question each answers, plus the top-level safety floor:

```
this_run     activity · metrics · stream_view · check_in · perceived_effort · calibration · intensity · block
right_now    training_load · training_volume · recent_training
the_runner   profile · memory · training_history
our_thread   adherence · longitudinal · continuity
how_to_coach corpus · stance
safety_rules · salience   (top-level)
```

This slice moves **shape only** — every section relocates into its group intact. The merges (`intensity_read`, `recent_weeks`) and splits are the content slices (#673 / #670) that follow, inside this stable envelope.

## Design
- **Grouped-canonical model.** `build_context_pack` returns the grouped object via `from_sections`; slices 2-5 add sections onto the group models. Read-only flat accessor properties keep the ~150 existing `pack.<section>` typed reads working unchanged.
- **Byte-stable by construction.** `to_serializable_dict()` stays the flat serialization (byte-identical fingerprint for prod `coach_message_lean_v1` and every historical prompt); `to_grouped_dict()` = `nest()` of it, so `flatten(grouped) == flat`. A `mode="before"` validator + `load()` make `model_validate` tolerant of both shapes, so every stored-pack loader (chat, eval) keeps working.
- **New prompt, off by default.** `coach_message_lean_grouped_v1` is `lean_v1` served the grouped pack: `lean_v1` + a group orientation naming the five groups + the two `continuity.*` paths re-anchored under `our_thread`. Reverting both yields `lean_v1` verbatim, so the safety floor is invariant by construction. Feature parity with `lean_v1`; ships **inert** (config default unchanged).
- **Consumers in lockstep.** `service.py` serves grouped under `is_grouped_pack_prompt` (flat otherwise); validator evidence-path regexes accept `how_to_coach.corpus`; chat authority-tiering gate reads via `unnest_pack`; diagram drift guard enumerates the flat section universe.

## Verification
- Full backend suite green: **2062 passed** (+14 over baseline), run with the code-default coach flags.
- Refactor invariant (prod byte-stable): proven by the legacy-hash `fingerprint` characterization tests.
- Feature invariant: `flatten(grouped) == flat`, group placement, empty-group drop, both-shape `load`, the prompt floor-invariance pin, and the chat gate reading flat/grouped identically.

## Not covered here (by design)
- **Live end-to-end** under the grouped prompt (a real LLM generating → validator → eval preserved-safety) — needs an API call; the prompt ships inert so no runtime path exercises it yet.
- **Diagram group-nodes** in `flow-nodes.js` — deferred until the grouped prompt is activated (Slice 5); the active flow is still flat, so the drift guard passes.

ADR: `docs/adr/0026-coach-pack-is-grouped-by-the-coaching-question.md`
Closes #672.