### PR TITLE
ADR 0026 Slice 2 PR 2: rebase + enrich training_history (#670)

### DIFF
--- a/backend/app/schemas/coach_context.py
+++ b/backend/app/schemas/coach_context.py
@@ -725,19 +725,38 @@ class RecentTrainingContext(BaseModel):
     has_baseline: bool
 
 
+class TrainingHistoryTypeShare(BaseModel):
+    """ADR 0026 Slice 2 (#670): one activity type's weekly rate + session share within a
+    training-history bucket. Present only on the recent-weeks-bounded (grouped_v2) ladder,
+    so the coach never reads a blended distance total as running mileage (a 171 km ski week
+    is a `BackcountrySki` row, not run distance)."""
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    avg_weekly_distance_m: int
+    avg_weekly_sessions: float
+    share_pct: float  # share of the bucket's sessions that are this type
+
+
 class TrainingHistoryBucket(BaseModel):
     """#561: one coarse, far-horizon volume bucket in the level-of-detail ladder.
 
-    The deep history reaches the coach at DECAYING resolution: `recent_training`
-    owns the detailed last ~60 days in full (its last_7d/last_30d/previous_30d
-    windows all live within 0-60d), so this ladder starts AFTER that and widens as it
-    goes back (2-6 months, 6-12 months, 1-2 years, 2-5 years, 5+ years), each bucket
-    reporting an AVERAGE WEEKLY rate so buckets of unequal width stay directly
-    comparable (the runner's own "20 km/week" read). The weekly average divides by
-    the weeks the bucket actually spans WITHIN the runner's history (so a
-    partially-covered bucket is not deflated), mirroring the volume.py clamp. A
-    bucket is emitted only when it holds real data, so the ladder self-sizes to how
-    far the history reaches."""
+    The deep history reaches the coach at DECAYING resolution: the recent window owns
+    the detailed near term in full (under the original ladder `recent_training`'s
+    last_7d/last_30d/previous_30d all live within 0-60d; under the ADR 0026 Slice 2
+    grouped_v2 ladder `recent_weeks` owns the last ~2 weeks day by day), so this ladder
+    starts AFTER that and widens as it goes back, each bucket reporting an AVERAGE WEEKLY
+    rate so buckets of unequal width stay directly comparable (the runner's own
+    "20 km/week" read). The weekly average divides by the weeks the bucket actually spans
+    WITHIN the runner's history (so a partially-covered bucket is not deflated), mirroring
+    the volume.py clamp. A bucket is emitted only when it holds real data, so the ladder
+    self-sizes to how far the history reaches.
+
+    The four `*_load`/`by_type`/`from_date`/`to_date` fields ride ONLY the grouped_v2
+    ladder (Optional-None on the original 60d ladder and surgically dropped there, so every
+    prior prompt is byte-identical): a modality-agnostic weekly LOAD rate, the per-type
+    split (so cross-training is never read as running), and explicit calendar bounds for
+    the relative label."""
     model_config = ConfigDict(extra="forbid")
 
     label: str            # human horizon, e.g. "2-6 months ago"
@@ -747,6 +766,11 @@ class TrainingHistoryBucket(BaseModel):
     avg_weekly_distance_m: int
     avg_weekly_sessions: float
     run_share_pct: float  # share of this bucket's sessions that are runs (modality mix)
+    # ADR 0026 Slice 2 (#670): grouped_v2-only enrichments (dropped when None, byte-stable).
+    from_date: Optional[str] = None   # oldest calendar edge, month-year e.g. "Jul 2025"
+    to_date: Optional[str] = None      # newest calendar edge, month-year e.g. "Jan 2026"
+    avg_weekly_load: Optional[int] = None  # effort_score/week (modality-agnostic training load)
+    by_type: Optional[List["TrainingHistoryTypeShare"]] = None  # per-type split, most-frequent-first
 
 
 class TrainingHistoryTraits(BaseModel):
@@ -769,6 +793,12 @@ class TrainingHistoryTraits(BaseModel):
     trajectory_direction: str                        # up | in_line | down | no_norm (recent 12mo vs prior 12mo)
     trajectory_pct: Optional[float] = None           # recent-12mo vs prior-12mo weekly rate
     time_at_current_load_years: Optional[float] = None  # span the trailing-4wk rate stayed within a band of current
+    # ADR 0026 Slice 2 (#670): the modality-agnostic LOAD durability read, riding ONLY the
+    # grouped_v2 ladder (Optional-None + surgically dropped on the original ladder, so every
+    # prior prompt is byte-identical). effort_score is comparable across modalities, so a
+    # ski/bike block still counts as sustained training even when running distance is low.
+    peak_sustained_weekly_load: Optional[int] = None      # highest rolling 4-week avg weekly effort_score
+    current_vs_peak_load_pct: Optional[float] = None      # last-4wk load rate / peak load * 100; None when peak load is 0
 
 
 class TrainingHistoryContext(BaseModel):
@@ -1700,6 +1730,27 @@ def _strip_nulls_in_place(obj: Any) -> None:
             _strip_nulls_in_place(v)
 
 
+def _drop_training_history_v2_fields(th: Dict[str, Any], _data: Dict[str, Any]) -> None:
+    """ADR 0026 Slice 2 (#670): the grouped_v2-only training-history enrichments
+    (per-bucket `by_type`/`avg_weekly_load`/`from_date`/`to_date` + the trait
+    `peak_sustained_weekly_load`/`current_vs_peak_load_pct`) ride the SAME schema as the
+    original 60d ladder. On the original ladder they are unset (None); pop exactly those
+    keys so every prior prompt's section is BYTE-IDENTICAL to its pre-Slice-2 shape. The
+    grouped_v2 ladder always populates them (a bucket's `by_type` is a non-empty list, the
+    traits' `peak_sustained_weekly_load` is a set int), so this is a no-op there — and it
+    deliberately does NOT touch the pre-existing Optional trait nulls (`current_vs_peak_pct`
+    etc.), which still serialize as null exactly as today. Re-parse stays safe: every popped
+    field defaults to None when absent."""
+    traits = th.get("traits")
+    if isinstance(traits, dict) and traits.get("peak_sustained_weekly_load") is None:
+        traits.pop("peak_sustained_weekly_load", None)
+        traits.pop("current_vs_peak_load_pct", None)
+    for bucket in th.get("timeline", []) or []:
+        if isinstance(bucket, dict) and bucket.get("by_type") is None:
+            for key in ("from_date", "to_date", "avg_weekly_load", "by_type"):
+                bucket.pop(key, None)
+
+
 def _drop_recent_weeks_nulls(rw: Dict[str, Any], _data: Dict[str, Any]) -> None:
     """ADR 0026 Slice 2 (#670): make the recent_weeks section's sparse per-activity/day/
     verdict fields cost nothing when absent. Every leaf that does not apply (a no-HR
@@ -1745,7 +1796,16 @@ PACK_SECTIONS: tuple[PackSection, ...] = (
         PromptFeature.RECENT_WEEKS,
         nested_drop=_drop_recent_weeks_nulls,
     ),
-    PackSection("training_history", PromptFeature.TRAINING_HISTORY),  # #561
+    # #561, redefined ADR 0026 Slice 2 (#670): populated by EITHER the original
+    # TRAINING_HISTORY signal (60d ladder, every prior prompt) or the TRAINING_HISTORY_2WK
+    # signal (14d-bounded, enriched ladder, grouped_v2) — mutually exclusive, so this ONE
+    # descriptor drops the field only when both abstain. The nested_drop surgically strips
+    # the grouped_v2-only enrichment keys on the original ladder, keeping it byte-identical.
+    PackSection(
+        "training_history",
+        PromptFeature.TRAINING_HISTORY,
+        nested_drop=_drop_training_history_v2_fields,
+    ),
     PackSection("memory", PromptFeature.MEMORY),  # ADR 0025 runner memory profile
     PackSection("intensity", PromptFeature.INTENSITY),  # #578 intensity distribution + trend
     # #451: the retired legacy summary — droppable but NOT prompt-gated (no longer

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -277,7 +277,14 @@ def build_context_pack(
         readiness=gather(_READINESS_SIGNAL, db, activity, prompt_id, as_of),
         recent_weeks=gather(_RECENT_WEEKS_SIGNAL, db, activity, prompt_id, as_of),
         # #561 multi-year training-history picture (LOD volume ladder + durability traits).
-        training_history=gather(_TRAINING_HISTORY_SIGNAL, db, activity, prompt_id, as_of),
+        # ADR 0026 Slice 2 (#670): EITHER the original 60d ladder (every prior prompt) OR
+        # the rebased-after-recent_weeks 14d ladder (grouped_v2), never both — the two
+        # signals are mutually exclusive by prompt feature, so one abstains (None) and the
+        # `or` selects the other into the ONE `training_history` pack key.
+        training_history=(
+            gather(_TRAINING_HISTORY_SIGNAL, db, activity, prompt_id, as_of)
+            or gather(_TRAINING_HISTORY_2WK_SIGNAL, db, activity, prompt_id, as_of)
+        ),
         # ADR 0025 runner memory profile (stored-artifact read, memory-aware prompt only).
         memory=gather(_MEMORY_SIGNAL, db, activity, prompt_id, as_of),
         # #578 intensity distribution + trend (read-time scan, intensity-aware prompt only).
@@ -569,6 +576,29 @@ def _build_training_history_context(
 
     `COACH_TRAINING_HISTORY_ENABLED` (#561) is an independent operator off-switch:
     when False the section is dropped without a full prompt rollback."""
+    return _training_history_section(db, activity, recent_weeks_bound=False)
+
+
+def _build_training_history_2wk_context(
+    db: Session, activity: Activity, as_of: datetime
+) -> Optional[TrainingHistoryContext]:
+    """ADR 0026 Slice 2 (#670): the REBASED `training_history` pack section, or None.
+
+    Identical to `_build_training_history_context` (same wide fetch, same abstention, same
+    `COACH_TRAINING_HISTORY_ENABLED` off-switch) except the ladder begins after the 2-week
+    `recent_weeks` window instead of the retired 60d `recent_training` window, and each
+    bucket is enriched with a modality-agnostic weekly LOAD rate, a per-type split, and
+    calendar bounds. Gated on `TRAINING_HISTORY_2WK` via the seam, carried ONLY by the
+    grouped_v2 prompt (INSTEAD of `TRAINING_HISTORY`), so exactly one training-history
+    signal ever fires and every prior prompt keeps the 60d ladder byte-identically."""
+    return _training_history_section(db, activity, recent_weeks_bound=True)
+
+
+def _training_history_section(
+    db: Session, activity: Activity, *, recent_weeks_bound: bool
+) -> Optional[TrainingHistoryContext]:
+    """Shared body for the two training-history signals: the wide summary-only history
+    fetch + off-switch, dispatching to the original or the rebased/enriched ladder."""
     if not settings.COACH_TRAINING_HISTORY_ENABLED:
         return None
     local_day = activity.local_start.date()
@@ -578,7 +608,7 @@ def _build_training_history_context(
         local_day + timedelta(days=1),
         user_id=activity.user_id,
     )
-    return build_training_history(facts, local_day)
+    return build_training_history(facts, local_day, recent_weeks_bound=recent_weeks_bound)
 
 
 # The fetch span for the intensity scan: the 28-day recent window plus its equal prior
@@ -1444,6 +1474,14 @@ _RECENT_WEEKS_SIGNAL = ReadTimeSignal(
 _TRAINING_HISTORY_SIGNAL = ReadTimeSignal(
     "training_history", _build_training_history_context, PromptFeature.TRAINING_HISTORY
 )
+# ADR 0026 Slice 2 (#670): the rebased/enriched training-history ladder for grouped_v2.
+# Mutually exclusive with _TRAINING_HISTORY_SIGNAL by prompt feature; the assembler `or`s
+# the two into the ONE `training_history` pack key.
+_TRAINING_HISTORY_2WK_SIGNAL = ReadTimeSignal(
+    "training_history_2wk",
+    _build_training_history_2wk_context,
+    PromptFeature.TRAINING_HISTORY_2WK,
+)
 _MEMORY_SIGNAL = ReadTimeSignal("memory", _build_memory_context, PromptFeature.MEMORY)
 _INTENSITY_SIGNAL = ReadTimeSignal(
     "intensity", _build_intensity_context, PromptFeature.INTENSITY
@@ -1464,6 +1502,7 @@ READ_TIME_SIGNALS: Dict[str, ReadTimeSignal] = {
         _READINESS_SIGNAL,
         _RECENT_WEEKS_SIGNAL,
         _TRAINING_HISTORY_SIGNAL,
+        _TRAINING_HISTORY_2WK_SIGNAL,
         _MEMORY_SIGNAL,
         _INTENSITY_SIGNAL,
     )

--- a/backend/app/services/coach/prompt_features.py
+++ b/backend/app/services/coach/prompt_features.py
@@ -48,6 +48,7 @@ class PromptFeature(Enum):
     INTENSITY = "intensity"            # #578 deterministic intensity-distribution-and-trend section
     READINESS = "readiness"            # ADR 0026 Slice 2 (#670): `right_now.readiness` (renamed training_load)
     RECENT_WEEKS = "recent_weeks"      # ADR 0026 Slice 2 (#670): merged day-resolved `right_now.recent_weeks`
+    TRAINING_HISTORY_2WK = "training_history_2wk"  # ADR 0026 Slice 2 (#670): `training_history` ladder rebased after the 2-week recent_weeks window (enriched: by_type + load + dates)
 
 
 # One row per prompt id, listing its FULL capability set. Read a row to know
@@ -236,9 +237,12 @@ PROMPT_FEATURES: dict[str, frozenset[PromptFeature]] = {
     # ADR 0026 Slice 2 (#670) — coach_message_lean_grouped_v2 is the grouped prompt whose
     # `right_now` group carries the REDEFINED content: TRAINING_LOAD -> READINESS (a keyed
     # rename) and VOLUME + RECENT_TRAINING -> RECENT_WEEKS (the merged day-resolved read).
-    # It carries every OTHER grouped_v1 capability unchanged, so only the two overlap
-    # swamps move; under it the three old `right_now` sections drop and the two new ones
-    # appear. Every prior prompt keeps the old three (byte-stable). Ships INERT.
+    # PR 2 additionally redefines `the_runner.training_history`: TRAINING_HISTORY ->
+    # TRAINING_HISTORY_2WK (the SAME section, its ladder rebased to begin after the 2-week
+    # recent_weeks window instead of the retired 60d recent_training window, and enriched).
+    # It carries every OTHER grouped_v1 capability unchanged; under it the three old
+    # `right_now` sections + the 60d training-history ladder drop and their redefined
+    # replacements appear. Every prior prompt keeps the originals (byte-stable). Ships INERT.
     "coach_message_lean_grouped_v2": frozenset(
         {
             _F.TWO_STAGE,
@@ -249,7 +253,7 @@ PROMPT_FEATURES: dict[str, frozenset[PromptFeature]] = {
             _F.USER_MATERIALS,
             _F.RECENT_WEEKS,
             _F.STREAM_VIEW,
-            _F.TRAINING_HISTORY,
+            _F.TRAINING_HISTORY_2WK,
             _F.MEMORY,
             _F.INTENSITY,
         }

--- a/backend/app/services/coach/prompts.py
+++ b/backend/app/services/coach/prompts.py
@@ -1246,9 +1246,15 @@ STREAM_VIEW_PROMPT_IDS = ids_with(PromptFeature.STREAM_VIEW)
 # context-pack section (gates _build_recent_training_context).
 RECENT_TRAINING_PROMPT_IDS = ids_with(PromptFeature.RECENT_TRAINING)
 
-# Prompt ids that carry the #561 training-history addendum AND the `training_history`
-# context-pack section (gates _build_training_history_context).
+# Prompt ids that carry the #561 training-history addendum AND the ORIGINAL 60d-bounded
+# `training_history` ladder (gates _build_training_history_context).
 TRAINING_HISTORY_PROMPT_IDS = ids_with(PromptFeature.TRAINING_HISTORY)
+
+# ADR 0026 Slice 2 (#670): prompt ids whose `training_history` ladder is REBASED to begin
+# after the 2-week recent_weeks window (and enriched with by_type/load/dates) — gates
+# _build_training_history_2wk_context. Mutually exclusive with TRAINING_HISTORY_PROMPT_IDS
+# (grouped_v2 carries this one INSTEAD), so exactly one training-history signal ever fires.
+TRAINING_HISTORY_2WK_PROMPT_IDS = ids_with(PromptFeature.TRAINING_HISTORY_2WK)
 
 # Prompt ids that carry the runner-memory addendum AND the `memory` context-pack
 # section (ADR 0025). Empty until M3 attaches PromptFeature.MEMORY to
@@ -1330,6 +1336,15 @@ def is_training_history_prompt(prompt_id: Optional[str]) -> bool:
     durability traits stay out of the pack (byte-stable under v11 and below) and the
     signal is wholly inert under a rollback."""
     return has_feature(prompt_id, PromptFeature.TRAINING_HISTORY)
+
+
+def is_training_history_2wk_prompt(prompt_id: Optional[str]) -> bool:
+    """True when the active prompt carries the ADR 0026 Slice 2 rebased `training_history`
+    ladder (grouped_v2): the coarse ladder begins after the 2-week recent_weeks window and
+    each bucket is enriched (by_type + load + calendar bounds). Mutually exclusive with
+    `is_training_history_prompt` — grouped_v2 carries this INSTEAD — so exactly one
+    training-history signal fires and every prior prompt keeps the 60d ladder byte-stable."""
+    return has_feature(prompt_id, PromptFeature.TRAINING_HISTORY_2WK)
 
 
 def is_memory_prompt(prompt_id: Optional[str]) -> bool:

--- a/backend/app/services/coach/training_history.py
+++ b/backend/app/services/coach/training_history.py
@@ -7,10 +7,13 @@ know which one it is talking to. The thing that tells them apart is not any sing
 total but the SHAPE of volume over time and the durability it implies.
 
 This section carries that shape at a deliberately DECAYING resolution (a
-level-of-detail ladder): the detailed last ~60 days are already owned IN FULL by
-`recent_training` (its last_7d/last_30d/previous_30d windows all live within 0-60d),
-so this picture begins exactly where that section ends and WIDENS as it goes back —
-2-6 months, 6-12 months, 1-2 years, 2-5 years, then an open 5+ years tail. Each
+level-of-detail ladder): the detailed near term is already owned IN FULL by the recent
+window — the original ladder begins after `recent_training`'s 0-60d, while the ADR 0026
+Slice 2 grouped_v2 ladder (`recent_weeks_bound=True`) begins after `recent_weeks`'s ~2
+weeks (a 14-60d bridging bucket fills the gap) and additionally carries a modality-agnostic
+weekly LOAD rate, a per-type split, and calendar bounds so cross-training is never read as
+running mileage. Either way it WIDENS as it goes back — 2-6 months, 6-12 months, 1-2
+years, 2-5 years, then an open 5+ years tail. Each
 bucket reports an AVERAGE WEEKLY rate (not a raw total), so buckets of unequal width
 stay directly comparable, and the average divides by the weeks the bucket actually
 spans within the runner's history (the volume.py clamp idiom) so a partially-covered
@@ -39,6 +42,7 @@ from app.schemas.coach_context import (
     TrainingHistoryBucket,
     TrainingHistoryContext,
     TrainingHistoryTraits,
+    TrainingHistoryTypeShare,
 )
 
 # The richness-decaying ladder: (start_days_ago, end_days_ago, label). The 0-60d
@@ -53,6 +57,15 @@ _BUCKETS: Tuple[Tuple[int, Optional[int], str], ...] = (
     (730, 1825, "2-5 years ago"),
     (1825, None, "5+ years ago"),
 )
+
+# ADR 0026 Slice 2 (#670): the grouped_v2 ladder. `recent_weeks` owns only the last ~2
+# weeks day by day, so the coarse ladder must begin at 14 days (not 60) or the 14-60d
+# training-response window would reach the coach through NO section. Option A: add ONE
+# bridging bucket (14-60d) and keep the rest of the coarse ladder unchanged, so the ladder
+# stays coarse and does not re-answer what day-resolved `recent_weeks` already covers.
+_BUCKETS_2WK: Tuple[Tuple[int, Optional[int], str], ...] = (
+    (14, 60, "2 weeks - 2 months ago"),
+) + _BUCKETS
 
 # Emit the section at all only when there is real history beyond the recent window:
 # below this, `recent_training`/`training_volume` already say everything there is to
@@ -90,15 +103,65 @@ def _distance(fact: Any) -> float:
     return fact.distance_m or 0
 
 
+def _load(fact: Any) -> float:
+    return getattr(fact, "effort_score", None) or 0
+
+
+def _month_year(as_of: date, days_ago: int) -> str:
+    """The calendar month-year `days_ago` before `as_of`, e.g. "Jul 2025". Month-year
+    (not an exact day) suits a coarse decaying ladder — a "2-5 years ago" bucket reads
+    naturally as a month range, unlike day-resolved `recent_weeks`."""
+    return (as_of - timedelta(days=days_ago)).strftime("%b %Y")
+
+
+def _by_type_shares(
+    in_bucket: List[Any], weeks: float
+) -> List[TrainingHistoryTypeShare]:
+    """Per-activity-type weekly rate + session share within a bucket, most-frequent-first
+    (ties broken by type name), so a cross-training block (a ski/bike week) is never read
+    as running mileage. Mirrors `recent_weeks._by_type_totals`, in the ladder's weekly-rate
+    framing."""
+    groups: dict = {}
+    for f in in_bucket:
+        t = (f.activity_type or "unknown")
+        g = groups.setdefault(t, {"sessions": 0, "distance_m": 0.0})
+        g["sessions"] += 1
+        g["distance_m"] += _distance(f)
+    total = len(in_bucket)
+    out: List[TrainingHistoryTypeShare] = []
+    for t in sorted(groups, key=lambda k: (-groups[k]["sessions"], k)):
+        g = groups[t]
+        out.append(
+            TrainingHistoryTypeShare(
+                type=t,
+                avg_weekly_distance_m=int(g["distance_m"] / weeks),
+                avg_weekly_sessions=round(g["sessions"] / weeks, 2),
+                share_pct=round(g["sessions"] / total * 100.0, 1),
+            )
+        )
+    return out
+
+
 def _bucket(
-    facts: List[Any], as_of: date, first_age: int, start: int, end: Optional[int], label: str
+    facts: List[Any],
+    as_of: date,
+    first_age: int,
+    start: int,
+    end: Optional[int],
+    label: str,
+    *,
+    enriched: bool = False,
 ) -> Optional[TrainingHistoryBucket]:
     """One ladder bucket as an average WEEKLY rate, or None when it holds too little.
 
     The averaging denominator is the weeks the bucket actually spans WITHIN history:
     the bucket window [start, end) in age-days is clamped to the runner's first
     activity (`first_age` = age of the oldest activity), so a bucket only partially
-    covered by history is not deflated by dividing across pre-history days."""
+    covered by history is not deflated by dividing across pre-history days.
+
+    `enriched` (grouped_v2, ADR 0026 Slice 2) additionally populates the modality-agnostic
+    weekly LOAD rate, the per-type split, and the calendar bounds; left None on the original
+    ladder (and surgically dropped there) so every prior prompt stays byte-identical."""
     covered_end = first_age + 1 if end is None else min(end, first_age + 1)
     span_days = covered_end - start
     if span_days < _MIN_BUCKET_SPAN_DAYS:  # too thin a sliver to name as a bucket
@@ -119,6 +182,12 @@ def _bucket(
         avg_weekly_distance_m=int(total_distance / weeks),
         avg_weekly_sessions=round(len(in_bucket) / weeks, 2),
         run_share_pct=round(runs / len(in_bucket) * 100.0, 1),
+        from_date=_month_year(as_of, covered_end) if enriched else None,
+        to_date=_month_year(as_of, start) if enriched else None,
+        avg_weekly_load=(
+            int(sum(_load(f) for f in in_bucket) / weeks) if enriched else None
+        ),
+        by_type=_by_type_shares(in_bucket, weeks) if enriched else None,
     )
 
 
@@ -133,6 +202,21 @@ def _weekly_distance_back(facts: List[Any], as_of: date, n_weeks: int) -> List[f
         wk = age // 7
         if 0 <= wk < n_weeks:
             series[wk] += _distance(f)
+    return series
+
+
+def _weekly_load_back(facts: List[Any], as_of: date, n_weeks: int) -> List[float]:
+    """Weekly effort_score (training load) totals indexed BACK from `as_of`, same
+    indexing as `_weekly_distance_back` — the modality-agnostic load series behind the
+    grouped_v2 load traits."""
+    series = [0.0] * n_weeks
+    for f in facts:
+        age = _age_days(f, as_of)
+        if age < 0:
+            continue
+        wk = age // 7
+        if 0 <= wk < n_weeks:
+            series[wk] += _load(f)
     return series
 
 
@@ -199,14 +283,24 @@ def _time_at_current_load_years(series: List[float], current: float) -> Optional
     return round(weeks_held * 7 / 365.25, 1)
 
 
-def build_training_history(facts: List[Any], as_of: date) -> Optional[TrainingHistoryContext]:
+def build_training_history(
+    facts: List[Any], as_of: date, *, recent_weeks_bound: bool = False
+) -> Optional[TrainingHistoryContext]:
     """Build the multi-year training-history picture as of `as_of`, or None when the
     runner has too little history beyond the recent window to describe (the section
     is then dropped from serialization, byte-stable). Facts are duck-typed
-    `ActivityFact`s: each needs `local_date`, `activity_type`, `distance_m`.
+    `ActivityFact`s: each needs `local_date`, `activity_type`, `distance_m` (and, on the
+    enriched path, `effort_score`).
 
     Expects facts spanning the runner's full available history (the caller fetches a
-    wide window); buckets and traits self-limit to what is present."""
+    wide window); buckets and traits self-limit to what is present.
+
+    `recent_weeks_bound` (ADR 0026 Slice 2 / grouped_v2, #670): begin the ladder at 14 days
+    (after the day-resolved `recent_weeks` window) instead of 60, and enrich each bucket
+    with a modality-agnostic weekly LOAD rate, a per-type split, and calendar bounds, plus
+    two LOAD durability traits. Default False reproduces the original 60d ladder
+    BYTE-IDENTICALLY (the enrichment fields stay None and are dropped), so every prior
+    prompt is untouched."""
     dated = [f for f in facts if _age_days(f, as_of) >= 0]
     if len(dated) < _MIN_ACTIVITIES:
         return None
@@ -223,6 +317,21 @@ def build_training_history(facts: List[Any], as_of: date) -> Optional[TrainingHi
     current = _trailing_4wk(series, 0)
     trajectory_dir, trajectory_pct = _trajectory(dated, as_of, first_age)
 
+    # grouped_v2: the modality-agnostic LOAD durability read (effort_score peak + vs-peak),
+    # so a ski/bike block still reads as sustained training. None on the original ladder.
+    peak_load: Optional[int] = None
+    current_vs_peak_load_pct: Optional[float] = None
+    if recent_weeks_bound:
+        load_series = _weekly_load_back(dated, as_of, n_weeks)
+        peak_load_rate = max(
+            (_trailing_4wk(load_series, i) for i in range(len(load_series))), default=0.0
+        )
+        current_load = _trailing_4wk(load_series, 0)
+        peak_load = int(peak_load_rate)
+        current_vs_peak_load_pct = (
+            round(current_load / peak_load_rate * 100.0, 1) if peak_load_rate > 0 else None
+        )
+
     traits = TrainingHistoryTraits(
         training_age_years=round(first_age / 365.25, 1),
         peak_sustained_weekly_distance_m=int(peak),
@@ -232,12 +341,20 @@ def build_training_history(facts: List[Any], as_of: date) -> Optional[TrainingHi
         trajectory_direction=trajectory_dir,
         trajectory_pct=trajectory_pct,
         time_at_current_load_years=_time_at_current_load_years(series, current),
+        peak_sustained_weekly_load=peak_load,
+        current_vs_peak_load_pct=current_vs_peak_load_pct,
     )
 
+    ladder = _BUCKETS_2WK if recent_weeks_bound else _BUCKETS
     timeline = [
         b
-        for (start, end, label) in _BUCKETS
-        if (b := _bucket(dated, as_of, first_age, start, end, label)) is not None
+        for (start, end, label) in ladder
+        if (
+            b := _bucket(
+                dated, as_of, first_age, start, end, label, enriched=recent_weeks_bound
+            )
+        )
+        is not None
     ]
 
     return TrainingHistoryContext(traits=traits, timeline=timeline)

--- a/backend/tests/test_message_prompt_lean_grouped_v2.py
+++ b/backend/tests/test_message_prompt_lean_grouped_v2.py
@@ -37,13 +37,15 @@ def test_grouped_v2_registered_and_flagged_grouped():
     assert is_grouped_pack_prompt(GROUPED2)
 
 
-def test_grouped_v2_swaps_only_the_right_now_features():
-    """It carries every lean_v1 capability EXCEPT training_load/volume/recent_training,
-    which it REPLACES with readiness/recent_weeks — a deliberate non-superset."""
+def test_grouped_v2_swaps_the_redefined_features():
+    """It carries every lean_v1 capability EXCEPT the ones ADR 0026 Slice 2 redefines:
+    right_now's training_load/volume/recent_training -> readiness/recent_weeks, and (PR 2)
+    the_runner's training_history -> training_history_2wk (the rebased/enriched ladder). A
+    deliberate non-superset — the redefined sections carry their new features INSTEAD."""
     expected = (
         features_for(LEAN)
-        - {F.TRAINING_LOAD, F.VOLUME, F.RECENT_TRAINING}
-    ) | {F.READINESS, F.RECENT_WEEKS}
+        - {F.TRAINING_LOAD, F.VOLUME, F.RECENT_TRAINING, F.TRAINING_HISTORY}
+    ) | {F.READINESS, F.RECENT_WEEKS, F.TRAINING_HISTORY_2WK}
     assert features_for(GROUPED2) == expected
 
 

--- a/backend/tests/test_message_prompt_lean_v1.py
+++ b/backend/tests/test_message_prompt_lean_v1.py
@@ -65,11 +65,14 @@ def test_lean_v1_has_full_capability_parity_with_v14():
     """The experiment receives the IDENTICAL context pack as v14 (same gated sections),
     so the A/B isolates the system-prompt text. That parity is the whole design."""
     assert features_for(LEAN) == features_for(V14)
-    # ADR 0026 Slice 2 (#670) added the mutually-exclusive READINESS/RECENT_WEEKS
-    # alternatives (they REPLACE training_load/volume/recent_training under grouped_v2),
-    # so no single prompt carries the full union; lean_v1 carries every ADDITIVE feature.
+    # ADR 0026 Slice 2 (#670) added the mutually-exclusive READINESS/RECENT_WEEKS and (PR 2)
+    # TRAINING_HISTORY_2WK alternatives (they REPLACE training_load/volume/recent_training/
+    # training_history under grouped_v2), so no single prompt carries the full union;
+    # lean_v1 carries every ADDITIVE feature.
     from app.services.coach.prompt_features import PromptFeature as _F
-    every_additive = set().union(*PROMPT_FEATURES.values()) - {_F.READINESS, _F.RECENT_WEEKS}
+    every_additive = set().union(*PROMPT_FEATURES.values()) - {
+        _F.READINESS, _F.RECENT_WEEKS, _F.TRAINING_HISTORY_2WK
+    }
     assert features_for(LEAN) == every_additive
 
 

--- a/backend/tests/test_message_prompt_v12.py
+++ b/backend/tests/test_message_prompt_v12.py
@@ -33,10 +33,11 @@ def test_v12_registered_carries_every_v11_capability_plus_training_history():
     assert V12.startswith(MESSAGE_PROMPT_PREFIX)  # -> schema 2.0 by prefix
     assert V12 in RECENT_TRAINING_PROMPT_IDS  # inherits v11's capabilities
     assert V12 in TRAINING_HISTORY_PROMPT_IDS  # ...plus the new TRAINING_HISTORY capability
+    # ADR 0026 Slice 2 PR 2 (#670): grouped_v2 REBASES training_history (carries
+    # TRAINING_HISTORY_2WK instead), so it drops OUT of the original-ladder set.
     assert TRAINING_HISTORY_PROMPT_IDS == {
         V12, "coach_message_v13", "coach_message_v14", "coach_message_lean_v1",
         "coach_message_lean_grouped_v1",
-        "coach_message_lean_grouped_v2",  # ADR 0026 Slice 2 keeps TRAINING_HISTORY
     }
     assert V12 in _OPENER_PROMPTS  # has a distinct opener form (two-stage)
     # same schema family as v11 (so v12 reports regenerate, prior history retained).

--- a/backend/tests/test_prompt_features.py
+++ b/backend/tests/test_prompt_features.py
@@ -154,9 +154,11 @@ EXPECTED_CAPABILITIES = {
         F.INTENSITY,
     },
     # ADR 0026 Slice 2 (#670) — grouped_v2 redefines the `right_now` content: it REPLACES
-    # TRAINING_LOAD -> READINESS and VOLUME + RECENT_TRAINING -> RECENT_WEEKS, keeping
-    # every other grouped_v1 capability. It is deliberately NOT a superset of grouped_v1
-    # (the two overlap swamps move), so it carries 11 features, not 12.
+    # TRAINING_LOAD -> READINESS and VOLUME + RECENT_TRAINING -> RECENT_WEEKS. PR 2 also
+    # REBASES the_runner.training_history: TRAINING_HISTORY -> TRAINING_HISTORY_2WK (the same
+    # section, ladder rebased after the 2-week recent_weeks window + enriched). It keeps
+    # every other grouped_v1 capability, so it is deliberately NOT a superset of grouped_v1
+    # (the overlap swamps + the training-history boundary move); it carries 11 features.
     "coach_message_lean_grouped_v2": {
         F.TWO_STAGE,
         F.VOICE,
@@ -166,7 +168,7 @@ EXPECTED_CAPABILITIES = {
         F.USER_MATERIALS,
         F.RECENT_WEEKS,
         F.STREAM_VIEW,
-        F.TRAINING_HISTORY,
+        F.TRAINING_HISTORY_2WK,
         F.MEMORY,
         F.INTENSITY,
     },
@@ -205,6 +207,7 @@ def test_derived_sets_equal_manifest_views():
     assert prompts.STREAM_VIEW_PROMPT_IDS == ids_with(F.STREAM_VIEW)
     assert prompts.RECENT_TRAINING_PROMPT_IDS == ids_with(F.RECENT_TRAINING)
     assert prompts.TRAINING_HISTORY_PROMPT_IDS == ids_with(F.TRAINING_HISTORY)
+    assert prompts.TRAINING_HISTORY_2WK_PROMPT_IDS == ids_with(F.TRAINING_HISTORY_2WK)
     assert prompts.MEMORY_PROMPT_IDS == ids_with(F.MEMORY)
 
 
@@ -280,9 +283,12 @@ def test_derived_sets_match_captured_membership():
         "coach_message_v11", "coach_message_v12", "coach_message_v13", "coach_message_v14",
         LEAN, GROUPED,
     }
+    # Slice 2 PR 2: grouped_v2 REBASES training_history (carries TRAINING_HISTORY_2WK
+    # instead), so it drops OUT of the original-ladder set and is the sole member of the new.
     assert prompts.TRAINING_HISTORY_PROMPT_IDS == {
-        "coach_message_v12", "coach_message_v13", "coach_message_v14", LEAN, GROUPED, GROUPED2,
+        "coach_message_v12", "coach_message_v13", "coach_message_v14", LEAN, GROUPED,
     }
+    assert prompts.TRAINING_HISTORY_2WK_PROMPT_IDS == {GROUPED2}
     assert prompts.MEMORY_PROMPT_IDS == {
         "coach_message_v13", "coach_message_v14", LEAN, GROUPED, GROUPED2,
     }
@@ -304,6 +310,7 @@ def test_predicates_agree_with_has_feature():
         assert prompts.is_stream_view_prompt(pid) == has_feature(pid, F.STREAM_VIEW)
         assert prompts.is_recent_training_prompt(pid) == has_feature(pid, F.RECENT_TRAINING)
         assert prompts.is_training_history_prompt(pid) == has_feature(pid, F.TRAINING_HISTORY)
+        assert prompts.is_training_history_2wk_prompt(pid) == has_feature(pid, F.TRAINING_HISTORY_2WK)
         assert prompts.is_memory_prompt(pid) == has_feature(pid, F.MEMORY)
 
 
@@ -325,8 +332,9 @@ def test_fullest_message_prompt_is_the_max_capability_id():
     # alternatives — READINESS/RECENT_WEEKS REPLACE TRAINING_LOAD/VOLUME/RECENT_TRAINING
     # under the grouped_v2 prompt — so no single prompt carries the full union; the
     # fullest carries the pre-Slice-2 (larger) side of each swap. The redefined sections
-    # are guarded by their own Slice-2 tests.
-    ALTERNATIVE_FEATURES = {F.READINESS, F.RECENT_WEEKS}
+    # are guarded by their own Slice-2 tests. PR 2 adds TRAINING_HISTORY_2WK as a third
+    # alternative (grouped_v2 carries it INSTEAD of TRAINING_HISTORY).
+    ALTERNATIVE_FEATURES = {F.READINESS, F.RECENT_WEEKS, F.TRAINING_HISTORY_2WK}
     every_feature = set().union(*PROMPT_FEATURES.values())
     assert set(PROMPT_FEATURES[fullest]) == every_feature - ALTERNATIVE_FEATURES
 

--- a/backend/tests/test_read_time_signals.py
+++ b/backend/tests/test_read_time_signals.py
@@ -47,10 +47,12 @@ def test_all_signals_registered_under_one_interface():
         "training_load",
         "training_volume",
         "recent_training",
-        # ADR 0026 Slice 2 (#670): the redefined right_now content signals.
+        # ADR 0026 Slice 2 (#670): the redefined right_now content signals + the rebased
+        # training-history ladder (PR 2), which coexists with the original for byte-stability.
         "readiness",
         "recent_weeks",
         "training_history",
+        "training_history_2wk",
         "memory",
         "intensity",
     }

--- a/backend/tests/test_training_history.py
+++ b/backend/tests/test_training_history.py
@@ -189,3 +189,93 @@ def test_single_stray_old_activity_does_not_paint_a_deep_bucket():
     ctx = build_training_history(facts, AS_OF)
     labels = {b.label for b in ctx.timeline}
     assert "5+ years ago" not in labels
+
+
+# --------------------------------------------------------------------------- #
+# ADR 0026 Slice 2 PR 2 (#670): the recent-weeks-bounded (grouped_v2) ladder    #
+# --------------------------------------------------------------------------- #
+
+
+class _LoadFact(_Fact):
+    """A fact carrying an effort_score, for the load-aware grouped_v2 ladder."""
+
+    def __init__(self, local_date, *, activity_type="Run", distance_m=0.0, effort_score=0.0):
+        super().__init__(local_date, activity_type=activity_type, distance_m=distance_m)
+        self.effort_score = effort_score
+
+
+def test_bound_ladder_starts_at_two_weeks_default_starts_at_sixty():
+    """The rebased ladder adds the 14-60d bridging bucket that the 60d ladder omits, so the
+    training-response window is no longer a blind spot beside the 2-week recent_weeks read."""
+    facts = _weekly(60, lambda w: 30_000)  # ~14 months
+    default = build_training_history(facts, AS_OF)
+    bound = build_training_history(facts, AS_OF, recent_weeks_bound=True)
+    assert "2 weeks - 2 months ago" not in {b.label for b in default.timeline}
+    bridge = next(b for b in bound.timeline if b.label == "2 weeks - 2 months ago")
+    assert bridge.start_days_ago == 14 and bridge.end_days_ago == 60
+    # Everything else in the ladder is unchanged: same coarse buckets beyond 60d.
+    assert {b.label for b in default.timeline} <= {b.label for b in bound.timeline}
+
+
+def test_default_ladder_carries_no_enrichment_fields():
+    """Byte-stability guard: the original path leaves every grouped_v2-only field unset, so
+    the surgical drop can strip them and every prior prompt stays byte-identical."""
+    facts = _weekly(60, lambda w: 30_000)
+    ctx = build_training_history(facts, AS_OF)
+    for b in ctx.timeline:
+        assert b.from_date is None and b.to_date is None
+        assert b.avg_weekly_load is None and b.by_type is None
+    assert ctx.traits.peak_sustained_weekly_load is None
+    assert ctx.traits.current_vs_peak_load_pct is None
+
+
+def test_bound_ladder_enriches_each_bucket():
+    facts = [
+        _LoadFact(AS_OF - timedelta(days=7 * w), distance_m=30_000, effort_score=250.0)
+        for w in range(60)
+    ]
+    ctx = build_training_history(facts, AS_OF, recent_weeks_bound=True)
+    for b in ctx.timeline:
+        assert b.from_date is not None and b.to_date is not None
+        assert b.avg_weekly_load is not None and b.avg_weekly_load > 0
+        assert b.by_type and b.by_type[0].type == "Run"
+
+
+def test_by_type_keeps_cross_training_out_of_running_mileage():
+    """The ski example: a block of high-distance non-run activity must read as its own type,
+    never inflating the bucket's running mileage."""
+    facts = []
+    for w in range(30):  # ~7 months, runs
+        facts.append(_LoadFact(AS_OF - timedelta(days=7 * w), distance_m=10_000, effort_score=120.0))
+    # A ski week deep in the 2-6 month bucket: huge distance, one session.
+    facts.append(
+        _LoadFact(AS_OF - timedelta(days=100), activity_type="BackcountrySki",
+                  distance_m=171_000, effort_score=600.0)
+    )
+    ctx = build_training_history(facts, AS_OF, recent_weeks_bound=True)
+    bucket = next(b for b in ctx.timeline if b.start_days_ago == 60)  # "2-6 months ago"
+    by_type = {t.type: t for t in bucket.by_type}
+    assert "BackcountrySki" in by_type
+    run = by_type["Run"]
+    # Run weekly distance reflects only the ~10 km/week runs, never the 171 km ski.
+    assert run.avg_weekly_distance_m < 20_000
+
+
+def test_bound_ladder_populates_load_traits():
+    facts = [
+        _LoadFact(AS_OF - timedelta(days=7 * w), distance_m=30_000, effort_score=300.0)
+        for w in range(60)
+    ]
+    ctx = build_training_history(facts, AS_OF, recent_weeks_bound=True)
+    assert ctx.traits.peak_sustained_weekly_load is not None
+    assert ctx.traits.peak_sustained_weekly_load > 0
+    # Flat load throughout -> current sits at the peak.
+    assert ctx.traits.current_vs_peak_load_pct == 100.0
+
+
+def test_bound_ladder_still_respects_min_history():
+    """The emit threshold is unchanged (owner call): a runner under the 42-day floor gets
+    no section even on the rebased ladder, so a near-new runner is not handed a near-empty
+    history story."""
+    facts = [_Fact(AS_OF - timedelta(days=d), distance_m=8_000) for d in range(0, 35, 2)]
+    assert build_training_history(facts, AS_OF, recent_weeks_bound=True) is None

--- a/backend/tests/test_training_history_in_pack.py
+++ b/backend/tests/test_training_history_in_pack.py
@@ -1,0 +1,127 @@
+"""ADR 0026 Slice 2 PR 2 (#670): the rebased `training_history` ladder in the coach pack.
+
+Under the grouped_v2 prompt the `the_runner.training_history` section is REBASED to begin
+after the 2-week `recent_weeks` window (a 14-60d bridging bucket) and each bucket is
+enriched with a modality-agnostic weekly load, a per-type split, and calendar bounds. Under
+every prior prompt (prod lean_v1, grouped_v1, v12) the ORIGINAL 60d ladder emits with none
+of those keys, so the prior packs stay byte-identical. Both signals write the ONE
+`training_history` pack key; they are mutually exclusive by prompt feature.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from app.models import Activity, DerivedMetric, User
+from app.schemas.coach_context import CoachContextPack
+from app.services.coach.context import build_context_pack
+
+# The grouped_v2-only enrichment keys that must NOT leak into any prior prompt's pack.
+_BUCKET_ENRICHMENTS = ("from_date", "to_date", "avg_weekly_load", "by_type")
+_TRAIT_ENRICHMENTS = ("peak_sustained_weekly_load", "current_vs_peak_load_pct")
+
+GROUPED2 = "coach_message_lean_grouped_v2"
+PRIOR = "coach_message_lean_v1"  # carries the original TRAINING_HISTORY ladder
+
+
+def _seed(db) -> Activity:
+    """~2 years of history (enough to cross the 42-day / 8-activity floor and paint several
+    ladder buckets), with a cross-training block so by_type has a non-run type to separate."""
+    user = User(id=uuid.uuid4(), email=f"th-{uuid.uuid4()}@example.com")
+    db.add(user)
+    db.flush()
+    base = datetime(2026, 7, 15, 10, 0, tzinfo=timezone.utc)
+    subject = None
+    for w in range(104):  # one activity per week, ~2 years back
+        start = base - timedelta(days=7 * w)
+        is_ski = 26 <= w < 34  # a cross-training block ~6-8 months back
+        act = Activity(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            strava_activity_id=abs(hash(str(uuid.uuid4()))) % 10**9,
+            name="Session",
+            type="BackcountrySki" if is_ski else "Run",
+            start_date=start,
+            start_date_local=start,
+            distance_m=40_000 if is_ski else 12_000,
+            moving_time_s=6000 if is_ski else 3000,
+            elapsed_time_s=6000 if is_ski else 3000,
+            avg_hr=150.0,
+            raw_summary={},
+        )
+        db.add(act)
+        db.flush()
+        db.add(
+            DerivedMetric(
+                id=uuid.uuid4(),
+                activity_id=act.id,
+                effort="easy",
+                structure="continuous",
+                duration_class="standard",
+                effort_score=200.0 if is_ski else 90.0,
+                hr_drift=3.0,
+                flags=[],
+                confidence="high",
+                confidence_reasons=[],
+            )
+        )
+        db.flush()
+        if w == 0:
+            subject = act
+    db.refresh(subject)
+    return subject
+
+
+def test_grouped_v2_training_history_is_rebased_and_enriched(db):
+    activity = _seed(db)
+    pack = build_context_pack(db, activity, prompt_id=GROUPED2)
+
+    assert pack.training_history is not None
+    th = pack.to_serializable_dict()["training_history"]
+
+    # The rebased ladder carries the 14-60d bridging bucket the 60d ladder omits.
+    labels = {b["label"] for b in th["timeline"]}
+    assert "2 weeks - 2 months ago" in labels
+
+    # Every bucket is enriched, and the cross-training block reads as its own type.
+    for bucket in th["timeline"]:
+        for k in _BUCKET_ENRICHMENTS:
+            assert k in bucket, (bucket["label"], k)
+    all_types = {t["type"] for b in th["timeline"] for t in b["by_type"]}
+    assert "BackcountrySki" in all_types
+
+    # Load traits ride the section.
+    for k in _TRAIT_ENRICHMENTS:
+        assert k in th["traits"]
+
+    # It lives under the_runner in the grouped serialization.
+    assert "training_history" in pack.to_grouped_dict()["the_runner"]
+
+
+def test_prior_prompt_training_history_is_byte_stable(db):
+    """Under a prior prompt the ORIGINAL 60d ladder emits with NONE of the grouped_v2
+    enrichment keys anywhere in the section — so the prior pack fingerprint is unchanged."""
+    activity = _seed(db)
+    pack = build_context_pack(db, activity, prompt_id=PRIOR)
+
+    assert pack.training_history is not None
+    th = pack.to_serializable_dict()["training_history"]
+
+    assert "2 weeks - 2 months ago" not in {b["label"] for b in th["timeline"]}
+    for bucket in th["timeline"]:
+        for k in _BUCKET_ENRICHMENTS:
+            assert k not in bucket, (bucket["label"], k)
+    for k in _TRAIT_ENRICHMENTS:
+        assert k not in th["traits"]
+    # The pre-existing Optional trait nulls are untouched by the surgical drop.
+    assert "current_vs_peak_pct" in th["traits"]
+
+
+def test_grouped_v2_pack_strict_reparses(db):
+    """The chat read path + eval harness strict-re-parse a STORED pack; both the flat and
+    grouped serializations of the enriched section must round-trip through load()."""
+    activity = _seed(db)
+    pack = build_context_pack(db, activity, prompt_id=GROUPED2)
+    for shape in (pack.to_serializable_dict(), pack.to_grouped_dict()):
+        reloaded = CoachContextPack.load(shape)
+        assert reloaded.training_history is not None
+        assert reloaded.training_history.timeline[0].by_type is not None


### PR DESCRIPTION
Second PR of **Slice 2** (#670) under the ADR 0026 five-question coach-pack envelope. Redefines `the_runner.training_history` behind the inert grouped prompt `coach_message_lean_grouped_v2`, keeping every prior prompt (prod `coach_message_lean_v1`, `grouped_v1`, v12+) **byte-identical**. Ships **inert**.

## What changes (grouped_v2 only)

With `recent_weeks` (PR 1) now owning the detailed last ~2 weeks day by day, the training-history ladder is rebased to begin after that window instead of the retired 60d `recent_training` window, and each bucket is coach-framed to fix a real misread.

- **Rebased ladder:** one bridging bucket `(14-60d, "2 weeks - 2 months ago")` fills the gap `recent_weeks` no longer covers; the coarse tail (2-6mo, 6-12mo, 1-2y, 2-5y, 5y+) is unchanged (Option A). `_MIN_HISTORY_DAYS=42` kept.
- **Modality made explicit:** each bucket carries a per-type `by_type` split and a modality-agnostic `avg_weekly_load` (effort_score/week), so a 171 km ski week reads as `BackcountrySki`, never as running mileage.
- **Load durability traits:** `peak_sustained_weekly_load` + `current_vs_peak_load_pct` (trajectory stays distance-based).
- **Dated bounds:** month-year `from_date`/`to_date` per bucket.

## Mechanism (mirrors PR 1's readiness/recent_weeks idiom)

- New `PromptFeature.TRAINING_HISTORY_2WK`, carried by `grouped_v2` **INSTEAD of** `TRAINING_HISTORY`.
- Two mutually-exclusive `ReadTimeSignal`s write the one `training_history` pack key; the assembler `or`s them, so exactly one fires per prompt.
- Byte-stability by construction: the base builder path is the unchanged default; the enrichment fields are Optional and surgically dropped on the original ladder (pre-existing trait nulls preserved). No prompt prose change (the lean base names no window boundary); no diagram change (the flat section key is unchanged).

## Verification

- New builder unit tests (bridging bucket, by_type keeps cross-training out of run mileage, load traits, min-history floor) + end-to-end pack tests (grouped_v2 rebased+enriched under `the_runner`; prior prompts leak no enrichment key; strict re-parse round-trips).
- Before/after key-set diff confirms the prior-prompt section keys+values equal `main`.
- Full CI-parity suite **2102 passed, 2 skipped** (+9 new); eval self-test green; diagram drift guard green.

## Owner decisions folded in
Ladder = Option A (one bridging bucket); emit threshold kept at 42 days; modality via `by_type`, load in traits, month-year dates.

## Follow-ups noted (out of scope)
- Distances still serialize in raw meters (coach-native km reframing is Slice 4).
- `run_share_pct` is now partly redundant with `by_type` share under the enriched path (possible future fold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)