### PR TITLE
ADR 0026 Slice 4: coach-frame the pack's numeric leaves (#680)

### DIFF
--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -27,8 +27,10 @@ from app.models.coach_report import CoachReport
 from app.models.coaching_relationship import CoachingRelationship
 from app.schemas.chat import ChatMessageRead
 from app.schemas.coach_context import CoachContextPack, unnest_pack
+from app.services.coach import coach_units
+from app.services.coach.coach_framing import frame_pack
 from app.services.coach.llm import AnthropicClient
-from app.services.coach.prompts import render_voice_block
+from app.services.coach.prompts import is_metrics_coach_framed_prompt, render_voice_block
 from app.services.coach.query_tools import (
     CHAT_TOOLS,
     TOOL_STATUS_LABELS,
@@ -353,6 +355,7 @@ def _build_chat_system_prompt(
     voice_block: str = "",
     cross_activity_block: str = "",
     tiering_block: Optional[str] = None,
+    prompt_id: Optional[str] = None,
 ) -> str:
     """Assemble the chat system prompt from all context sources.
 
@@ -363,6 +366,12 @@ def _build_chat_system_prompt(
     a section gated off anywhere is also un-briefed here. `cross_activity_block` (#339)
     is the bounded cross-activity conversation digest, or "" when the runner has no
     other-activity chat.
+
+    `prompt_id` is the STORED report's prompt id: under a metrics-coach-framed prompt
+    (ADR 0026 Slice 4, #680) the pack sent to the chat LLM is reframed to coach-native
+    units so the chat reads the SAME framed facts the report did. The tiering read below
+    stays on the canonical `context_pack` (it needs typed facts), so only the outgoing
+    `context_pack_json` is framed; framing is byte-stable for every prior prompt.
     """
     if tiering_block is None:
         tiering_block = _render_authority_tiering(
@@ -370,8 +379,9 @@ def _build_chat_system_prompt(
             voice_present=bool(voice_block),
             cross_activity_present=bool(cross_activity_block),
         )
+    llm_pack = frame_pack(context_pack) if is_metrics_coach_framed_prompt(prompt_id) else context_pack
     return CHAT_SYSTEM_TEMPLATE.format(
-        context_pack_json=json.dumps(context_pack, default=str),
+        context_pack_json=json.dumps(llm_pack, default=str),
         report_json=json.dumps(report, default=str),
         profile_json=json.dumps(profile, default=str),
         splits_json=json.dumps(splits, default=str),
@@ -488,12 +498,11 @@ async def stream_chat_response(
             "avg_cadence_spm": round(s["avg_cadence"]) if s.get("avg_cadence") else None,
             "avg_watts": round(s["avg_watts"]) if s.get("avg_watts") else None,
         }
-        # Format pace as min:sec/km
-        pace = s.get("pace")
-        if pace and pace > 0:
-            mins = int(pace // 60)
-            secs = int(pace % 60)
-            entry["pace_per_km"] = f"{mins}:{secs:02d}"
+        # Format pace as min:sec/km via the shared coach-units formatter, so the chat
+        # splits render pace the same way as the framed pack and the query tools (#680).
+        pace_str = coach_units.pace_from_sec_per_km(s.get("pace"))
+        if pace_str:
+            entry["pace_per_km"] = pace_str
         splits_formatted.append(entry)
 
     # Get athlete profile
@@ -529,6 +538,7 @@ async def stream_chat_response(
     system_prompt = _build_chat_system_prompt(
         context_pack, report_content, profile_dict, splits_formatted,
         voice_block, cross_activity_block,
+        prompt_id=report_row.prompt_id,
     )
 
     # Save the user message

--- a/backend/app/services/coach/coach_framing.py
+++ b/backend/app/services/coach/coach_framing.py
@@ -1,0 +1,247 @@
+"""Coach-native reframing of the context pack's numeric leaves (ADR 0026 Slice 4, #680).
+
+`frame_pack` takes the GROUPED serialized pack (`CoachContextPack.to_grouped_dict`)
+and returns a copy whose leaf VALUES are in coach-native units and precision: km not
+metres, min:sec/km not m/s, minute-granularity session durations and second-resolution
+interval/zone times, bpm with a light % of max supplement on the two headline HRs, and
+no over-precise decimals, dropped efficiency curve, or per-rep start offsets.
+
+This is a ONE-WAY view for the outgoing LLM message only (report pack + chat pack): the
+values are strings/rounded numbers that cannot round-trip to typed facts, so the canonical
+unframed pack stays what is stored and what the validator, tiering, eval, and re-parse read.
+It is applied ONLY under a metrics-coach-framed prompt (`PromptFeature.METRICS_COACH_FRAMED`),
+so every prior prompt is byte-identical. Formatting delegates to `coach_units` so the report
+pack and the chat `query_tools` render every fact identically.
+
+Pure: no I/O, no DB. Missing/None leaves are skipped, never fabricated.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, Optional
+
+from app.services.coach import coach_units as u
+
+
+def frame_pack(grouped: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a coach-framed copy of the grouped pack dict. Input is not mutated."""
+    if not isinstance(grouped, dict):
+        return grouped
+    pack = copy.deepcopy(grouped)
+
+    max_hr = _runner_max_hr(pack)
+
+    this_run = pack.get("this_run")
+    if isinstance(this_run, dict):
+        _frame_activity(this_run.get("activity"), max_hr)
+        _frame_metrics(this_run.get("metrics"))
+
+    the_runner = pack.get("the_runner")
+    if isinstance(the_runner, dict):
+        _frame_training_history(the_runner.get("training_history"))
+
+    return pack
+
+
+# --- helpers ---------------------------------------------------------------
+
+def _runner_max_hr(pack: Dict[str, Any]) -> Optional[float]:
+    the_runner = pack.get("the_runner")
+    if isinstance(the_runner, dict):
+        profile = the_runner.get("profile")
+        if isinstance(profile, dict):
+            return profile.get("max_hr")
+    return None
+
+
+def _rename(d: Dict[str, Any], old: str, new: str, value: Any) -> None:
+    """Drop `old`, set `new=value`. Skips entirely when `value` is None (drop-when-N/A)."""
+    d.pop(old, None)
+    if value is not None:
+        d[new] = value
+
+
+def _set_if(d: Dict[str, Any], key: str, value: Any) -> None:
+    if value is not None:
+        d[key] = value
+    else:
+        d.pop(key, None)
+
+
+def _frame_activity(activity: Optional[Dict[str, Any]], max_hr: Optional[float]) -> None:
+    if not isinstance(activity, dict):
+        return
+    if "distance_m" in activity:
+        _rename(activity, "distance_m", "distance_km", u.km(activity.get("distance_m")))
+    if "moving_time_s" in activity:
+        _rename(activity, "moving_time_s", "duration", u.duration(activity.get("moving_time_s")))
+    # The two headline HRs get bpm + a % of max supplement; bpm stays primary.
+    if "avg_hr" in activity:
+        _set_if(activity, "avg_hr", u.hr_bpm(activity.get("avg_hr"), max_hr))
+    if "max_hr" in activity:
+        _set_if(activity, "max_hr", u.hr_bpm(activity.get("max_hr"), max_hr))
+    if "avg_cadence" in activity:
+        _set_if(activity, "avg_cadence", u.trim(_round(activity.get("avg_cadence"), 0)))
+    if "elev_gain_m" in activity:
+        _set_if(activity, "elev_gain_m", u.trim(activity.get("elev_gain_m")))
+
+
+def _frame_metrics(metrics: Optional[Dict[str, Any]]) -> None:
+    if not isinstance(metrics, dict):
+        return
+    if metrics.get("effort_score") is not None:
+        metrics["effort_score"] = u.trim(metrics["effort_score"])
+    if metrics.get("hr_drift") is not None:
+        metrics["hr_drift"] = u.trim(metrics["hr_drift"])
+
+    _frame_time_in_zones(metrics.get("time_in_zones"))
+    _frame_efficiency(metrics.get("efficiency_analysis"))
+    _frame_stops(metrics.get("stops_analysis"))
+    _frame_interval_structure(metrics.get("interval_structure"))
+    _frame_workout_match(metrics.get("workout_match"))
+    _frame_interval_kpis(metrics.get("interval_kpis"))
+    _frame_discount_signals(metrics.get("discount_signals"))
+
+
+def _frame_time_in_zones(tiz: Any) -> None:
+    if not isinstance(tiz, dict):
+        return
+    for zone, seconds in list(tiz.items()):
+        tiz[zone] = u.duration_precise(seconds)
+
+
+def _frame_efficiency(eff: Any) -> None:
+    if isinstance(eff, dict):
+        # 64 three-decimal m/min/bpm points are not a coaching artifact and invite
+        # noise-narration; average + best_sustained are the usable summary.
+        eff.pop("curve", None)
+
+
+def _frame_stops(stops: Any) -> None:
+    if not isinstance(stops, dict):
+        return
+    if "total_stopped_time_s" in stops:
+        _rename(stops, "total_stopped_time_s", "total_stopped_time",
+                u.duration_precise(stops.get("total_stopped_time_s")))
+    if "longest_stop_s" in stops:
+        _rename(stops, "longest_stop_s", "longest_stop", u.duration_precise(stops.get("longest_stop_s")))
+    for stop in stops.get("stops") or []:
+        if not isinstance(stop, dict):
+            continue
+        stop.pop("location", None)   # GPS lat/long: noise the coach cannot use
+        stop.pop("start_time", None)  # absolute offset: near-noise, avoids mixed units
+        if "duration_s" in stop:
+            _rename(stop, "duration_s", "duration", u.duration_precise(stop.get("duration_s")))
+        if "distance_m" in stop:
+            _set_if(stop, "distance_m", u.trim(_round(stop.get("distance_m"), 0)))
+
+
+def _frame_interval_structure(istruct: Any) -> None:
+    if not isinstance(istruct, dict):
+        return
+    if "warmup_duration_s" in istruct:
+        _rename(istruct, "warmup_duration_s", "warmup", u.duration_precise(istruct.get("warmup_duration_s")))
+    if "cooldown_duration_s" in istruct:
+        _rename(istruct, "cooldown_duration_s", "cooldown", u.duration_precise(istruct.get("cooldown_duration_s")))
+    for seg in istruct.get("work_segments") or []:
+        if not isinstance(seg, dict):
+            continue
+        seg.pop("start_time_s", None)  # per-rep offset: near-noise, avoids mixed units
+        if "duration_s" in seg:
+            _rename(seg, "duration_s", "duration", u.duration_precise(seg.get("duration_s")))
+        if "distance_m" in seg:
+            _set_if(seg, "distance_m", u.trim(_round(seg.get("distance_m"), 0)))  # reps stay metres
+        _plain_bpm(seg, "avg_hr")
+        _plain_bpm(seg, "peak_hr")
+    for seg in istruct.get("rest_segments") or []:
+        if not isinstance(seg, dict):
+            continue
+        if "duration_s" in seg:
+            _rename(seg, "duration_s", "duration", u.duration_precise(seg.get("duration_s")))
+        _plain_bpm(seg, "avg_hr")
+        if seg.get("hr_recovery_bpm") is not None:
+            seg["hr_recovery_bpm"] = u.trim(seg["hr_recovery_bpm"])
+    _frame_interval_summary(istruct.get("summary"))
+
+
+def _frame_interval_summary(summary: Any) -> None:
+    if not isinstance(summary, dict):
+        return
+    for old, new in (
+        ("total_work_time_s", "total_work_time"),
+        ("total_rest_time_s", "total_rest_time"),
+        ("avg_work_duration_s", "avg_work_duration"),
+        ("avg_rest_duration_s", "avg_rest_duration"),
+    ):
+        if old in summary:
+            _rename(summary, old, new, u.duration_precise(summary.get(old)))
+    if "avg_work_speed_mps" in summary:
+        _rename(summary, "avg_work_speed_mps", "avg_work_pace", u.pace_from_speed(summary.get("avg_work_speed_mps")))
+    if summary.get("avg_hr_recovery_bpm") is not None:
+        summary["avg_hr_recovery_bpm"] = u.trim(summary["avg_hr_recovery_bpm"])
+
+
+def _frame_workout_match(wm: Any) -> None:
+    if not isinstance(wm, dict):
+        return
+    detected = wm.get("detected_workout")
+    if not isinstance(detected, dict):
+        return
+    if "rep_duration_mean_s" in detected:
+        _rename(detected, "rep_duration_mean_s", "rep_duration_mean",
+                u.duration_precise(detected.get("rep_duration_mean_s")))
+    for old, new in (("total_work_time_s", "total_work_time"), ("total_rest_time_s", "total_rest_time")):
+        if old in detected:
+            _rename(detected, old, new, u.duration_precise(detected.get(old)))
+    if "rep_distance_mean_m" in detected:
+        _set_if(detected, "rep_distance_mean_m", u.trim(_round(detected.get("rep_distance_mean_m"), 0)))
+
+
+def _frame_interval_kpis(kpis: Any) -> None:
+    if not isinstance(kpis, dict):
+        return
+    if "total_z4_plus_s" in kpis:
+        _rename(kpis, "total_z4_plus_s", "total_z4_plus", u.duration_precise(kpis.get("total_z4_plus_s")))
+
+
+def _frame_discount_signals(ds: Any) -> None:
+    if not isinstance(ds, dict):
+        return
+    if ds.get("temperature_c") is not None:
+        ds["temperature_c"] = u.trim(ds["temperature_c"])
+
+
+def _frame_training_history(th: Any) -> None:
+    if not isinstance(th, dict):
+        return
+    traits = th.get("traits")
+    if isinstance(traits, dict) and "peak_sustained_weekly_distance_m" in traits:
+        _rename(traits, "peak_sustained_weekly_distance_m", "peak_sustained_weekly_km",
+                u.km(traits.get("peak_sustained_weekly_distance_m")))
+    for period in th.get("timeline") or []:
+        if not isinstance(period, dict):
+            continue
+        _frame_history_period(period)
+        for by in period.get("by_type") or []:
+            _frame_history_period(by)
+
+
+def _frame_history_period(period: Dict[str, Any]) -> None:
+    if "avg_weekly_distance_m" in period:
+        _rename(period, "avg_weekly_distance_m", "avg_weekly_km", u.km(period.get("avg_weekly_distance_m")))
+    if period.get("avg_weekly_sessions") is not None:
+        period["avg_weekly_sessions"] = _round(period["avg_weekly_sessions"], 1)
+
+
+# --- tiny numeric helpers --------------------------------------------------
+
+def _round(value: Any, ndigits: int) -> Any:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return round(value, ndigits) if ndigits else round(value)
+    return value
+
+
+def _plain_bpm(d: Dict[str, Any], key: str) -> None:
+    if d.get(key) is not None:
+        d[key] = u.bpm(d[key])

--- a/backend/app/services/coach/coach_units.py
+++ b/backend/app/services/coach/coach_units.py
@@ -1,0 +1,126 @@
+"""Canonical coach-facing unit formatting (ADR 0026 Slice 4, #680).
+
+One home for every "raw machine unit -> coach-native unit" conversion the coach
+LLM sees, so the report context pack (`coach_framing.frame_pack`) and the chat
+on-demand tools (`query_tools`) render the same fact the same way and can never
+drift. The #637 template: km not metres, min:sec/km not m/s, minute-granularity
+durations for whole sessions and second-resolution for interval/zone scale, bpm
+with an optional % of max supplement, and no over-precise trailing decimals.
+
+Pure functions, no I/O. Every formatter returns None for a missing input so a
+caller can drop the leaf rather than emit a null.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def km(distance_m: Optional[float]) -> Optional[float]:
+    """Metres -> kilometres at 1 dp (the pack-wide distance convention).
+
+    Interval-rep distances are deliberately NOT run through this: a 400 m rep is
+    coach-native in metres, so callers keep those as metres.
+    """
+    if not distance_m:
+        return None
+    return round(distance_m / 1000, 1)
+
+
+def duration(seconds: Optional[float]) -> Optional[str]:
+    """Whole-session / aggregate duration at minute granularity: '30m' / '1h01m'.
+
+    Matches the existing chat-tool convention. Seconds are noise at session scale
+    ("you ran 30 minutes", not "30 minutes 34 seconds").
+    """
+    if not seconds:
+        return None
+    s = int(seconds)
+    h, rem = divmod(s, 3600)
+    m, _ = divmod(rem, 60)
+    return f"{h}h{m:02d}m" if h else f"{m}m"
+
+
+def duration_precise(seconds: Optional[float]) -> Optional[str]:
+    """Second-resolution duration for interval/zone scale: 'M:SS' / 'H:MM:SS'.
+
+    Used where the seconds carry signal (a 90 s rep vs a 120 s rep) and where a
+    minute-granularity render would lie (12 s in Z1 -> '0m'). Hours are always
+    explicit so 'M:SS' can never be misread as hours.
+    """
+    if seconds is None:
+        return None
+    s = int(round(seconds))
+    if s < 0:
+        return None
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    if h:
+        return f"{h}:{m:02d}:{sec:02d}"
+    return f"{m}:{sec:02d}"
+
+
+def _fmt_pace(sec_per_km: float) -> str:
+    mins = int(sec_per_km // 60)
+    secs = int(round(sec_per_km % 60))
+    if secs == 60:
+        mins += 1
+        secs = 0
+    return f"{mins}:{secs:02d}/km"
+
+
+def pace(distance_m: Optional[float], moving_time_s: Optional[float]) -> Optional[str]:
+    """Average pace as 'm:ss/km' from distance + time, or None."""
+    if not distance_m or not moving_time_s or distance_m <= 0:
+        return None
+    return _fmt_pace(moving_time_s / (distance_m / 1000))
+
+
+def pace_from_speed(mps: Optional[float]) -> Optional[str]:
+    """Pace as 'm:ss/km' from a speed in m/s, or None."""
+    if not mps or mps <= 0:
+        return None
+    return _fmt_pace(1000.0 / mps)
+
+
+def pace_from_sec_per_km(sec_per_km: Optional[float]) -> Optional[str]:
+    """Pace as 'm:ss/km' from a value already in seconds/km, or None."""
+    if not sec_per_km or sec_per_km <= 0:
+        return None
+    return _fmt_pace(sec_per_km)
+
+
+def pct_of_max(hr: Optional[float], max_hr: Optional[float]) -> Optional[int]:
+    """HR as a whole % of the runner's max, or None when the max is unknown."""
+    if not hr or not max_hr or max_hr <= 0:
+        return None
+    return round(hr / max_hr * 100)
+
+
+def hr_bpm(hr: Optional[float], max_hr: Optional[float] = None) -> Optional[str]:
+    """'166 bpm (87% max)' when the max is known, else '166 bpm'; None -> None.
+
+    bpm stays the primary hard number (it is the ground truth; % of max only holds
+    if the runner's max is right), with % of max a light supplement.
+    """
+    if hr is None:
+        return None
+    b = round(hr)
+    pct = pct_of_max(hr, max_hr)
+    return f"{b} bpm ({pct}% max)" if pct is not None else f"{b} bpm"
+
+
+def bpm(hr: Optional[float]) -> Optional[int]:
+    """Plain rounded bpm for HR leaves that do NOT get the % max supplement
+    (per-rep, aggregate) -- the coach places them against the given max itself."""
+    return round(hr) if hr is not None else None
+
+
+def trim(value):
+    """Drop a trailing '.0' (101.0 -> 101, 30.0 -> 30); leave real fractionals and
+    non-numbers untouched."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value

--- a/backend/app/services/coach/prompt_features.py
+++ b/backend/app/services/coach/prompt_features.py
@@ -51,6 +51,7 @@ class PromptFeature(Enum):
     TRAINING_HISTORY_2WK = "training_history_2wk"  # ADR 0026 Slice 2 (#670): `training_history` ladder rebased after the 2-week recent_weeks window (enriched: by_type + load + dates)
     INTENSITY_READ = "intensity_read"  # ADR 0026 Slice 3 (#673): merged this-run `this_run.intensity_read` + promoted `this_run.referral` (retires perceived_effort/calibration/intensity)
     INTENSITY_MIX = "intensity_mix"    # ADR 0026 Slice 3 (#673): recent intensity distribution + trend `right_now.intensity_mix` (the "how hard lately" half of the retired intensity section)
+    METRICS_COACH_FRAMED = "metrics_coach_framed"  # ADR 0026 Slice 4 (#680): reframe the pack's numeric leaves to coach-native units/precision for the LLM view (km/pace/%max/MM:SS); presentation only, no new section
 
 
 # One row per prompt id, listing its FULL capability set. Read a row to know
@@ -283,6 +284,31 @@ PROMPT_FEATURES: dict[str, frozenset[PromptFeature]] = {
             _F.INTENSITY_MIX,
         }
     ),
+    # ADR 0026 Slice 4 (#680) — coach_message_lean_grouped_v4 reframes the pack's numeric
+    # leaves to coach-native units and precision for the outgoing LLM view (km not metres,
+    # min:sec/km not m/s, minute-granularity session durations + second-resolution interval/
+    # zone times, bpm with a % of max supplement on the two headline HRs, dropped efficiency
+    # curve + per-rep offsets, trimmed decimals). It carries every grouped_v3 capability plus
+    # METRICS_COACH_FRAMED; the reframing is a one-way serialization VIEW (report + chat pack)
+    # over the canonical unframed pack, so re-parse/validator/eval are untouched and every
+    # prior prompt is byte-identical. Ships INERT.
+    "coach_message_lean_grouped_v4": frozenset(
+        {
+            _F.TWO_STAGE,
+            _F.VOICE,
+            _F.CORPUS,
+            _F.STANCE,
+            _F.READINESS,
+            _F.USER_MATERIALS,
+            _F.RECENT_WEEKS,
+            _F.STREAM_VIEW,
+            _F.TRAINING_HISTORY_2WK,
+            _F.MEMORY,
+            _F.INTENSITY_READ,
+            _F.INTENSITY_MIX,
+            _F.METRICS_COACH_FRAMED,
+        }
+    ),
 }
 
 
@@ -349,6 +375,9 @@ ALTERNATIVE_FEATURES: frozenset[PromptFeature] = frozenset(
         PromptFeature.TRAINING_HISTORY_2WK,
         PromptFeature.INTENSITY_READ,
         PromptFeature.INTENSITY_MIX,
+        # ADR 0026 Slice 4 (#680): a presentation-only leaf reframing, not a new pack
+        # section, so it must not count toward "the fullest pack" additive ranking.
+        PromptFeature.METRICS_COACH_FRAMED,
     }
 )
 

--- a/backend/app/services/coach/prompts.py
+++ b/backend/app/services/coach/prompts.py
@@ -1178,6 +1178,12 @@ PROMPT_VERSIONS = {
     # `intensity_read` + promoted `referral` and whose `right_now` carries `intensity_mix`;
     # serves pack.to_grouped_dict(). Ships INERT.
     "coach_message_lean_grouped_v3": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V3,
+    # ADR 0026 Slice 4 (#680) — the grouped prompt whose numeric leaves are reframed to
+    # coach-native units/precision for the LLM view. The PROSE is byte-identical to
+    # grouped_v3 (the group structure is unchanged; only the leaf VALUES the coach reads
+    # change, via coach_framing.frame_pack gated on METRICS_COACH_FRAMED), so it reuses
+    # grouped_v3's system prompt. The A/B is the framed pack shape alone. Ships INERT.
+    "coach_message_lean_grouped_v4": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V3,
 }
 
 # Prompt-id prefixes that select the A3 prose-message output family (schema 2.x).
@@ -1216,6 +1222,9 @@ _OPENER_PROMPTS = {
     "coach_message_lean_grouped_v1": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V1_OPENER,
     "coach_message_lean_grouped_v2": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V2_OPENER,
     "coach_message_lean_grouped_v3": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V3_OPENER,
+    # ADR 0026 Slice 4 (#680): identical opener prose to grouped_v3 (framing is a pack-view
+    # change, not a prose change).
+    "coach_message_lean_grouped_v4": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V3_OPENER,
 }
 
 # ADR 0026 Slice 1: the prompt ids that receive the GROUPED pack serialization
@@ -1228,6 +1237,7 @@ GROUPED_PACK_PROMPT_IDS: frozenset[str] = frozenset(
         "coach_message_lean_grouped_v1",
         "coach_message_lean_grouped_v2",
         "coach_message_lean_grouped_v3",
+        "coach_message_lean_grouped_v4",
     }
 )
 
@@ -1316,6 +1326,11 @@ INTENSITY_READ_PROMPT_IDS = ids_with(PromptFeature.INTENSITY_READ)
 # distribution + trend `intensity_mix` (the "how hard lately" half of the retired
 # intensity section).
 INTENSITY_MIX_PROMPT_IDS = ids_with(PromptFeature.INTENSITY_MIX)
+
+# ADR 0026 Slice 4 (#680): prompt ids whose OUTGOING LLM pack view is reframed to
+# coach-native units/precision (coach_framing.frame_pack). A presentation-only flag over
+# the grouped pack; the stored/canonical pack, validator, tiering, and eval are unchanged.
+METRICS_COACH_FRAMED_PROMPT_IDS = ids_with(PromptFeature.METRICS_COACH_FRAMED)
 
 
 def is_corpus_prompt(prompt_id: Optional[str]) -> bool:
@@ -1424,6 +1439,16 @@ def is_intensity_mix_prompt(prompt_id: Optional[str]) -> bool:
     (the recent intensity distribution + trend). False for every prior prompt, which
     reads the recent half inside the combined `intensity` section instead."""
     return has_feature(prompt_id, PromptFeature.INTENSITY_MIX)
+
+
+def is_metrics_coach_framed_prompt(prompt_id: Optional[str]) -> bool:
+    """True when the active prompt's OUTGOING LLM pack is reframed to coach-native units
+    and precision (ADR 0026 Slice 4, #680): km not metres, min:sec/km not m/s, MM:SS
+    durations, bpm + % of max on the two headline HRs, dropped efficiency curve/offsets,
+    trimmed decimals. A one-way view over the canonical pack (report + chat), so the
+    stored pack, validator, tiering, and eval are unchanged; false for every prior prompt,
+    which reads the raw-unit leaves byte-stably under a rollback."""
+    return has_feature(prompt_id, PromptFeature.METRICS_COACH_FRAMED)
 
 
 def is_readiness_prompt(prompt_id: Optional[str]) -> bool:

--- a/backend/app/services/coach/query_tools.py
+++ b/backend/app/services/coach/query_tools.py
@@ -44,6 +44,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.models import Activity
 from app.models.derived_metric import DerivedMetric
+from app.services.coach import coach_units
 from app.services.analysis.splits import calculate_splits
 from app.services.coach.recent_training import _interval_shape
 from app.services.coach.volume import build_volume_report
@@ -168,27 +169,20 @@ def _resolve_type_filter(type_filter: Optional[str], db: Session, owner_user_id)
 
 # --- coach-framing helpers ---------------------------------------------------
 
+# The coach-framing conventions live in the shared `coach_units` module (ADR 0026
+# Slice 4, #680) so these tools and the report context pack (`coach_framing`) render
+# every fact identically. These thin wrappers keep the local call sites readable.
 def _km(distance_m: Optional[float]) -> Optional[float]:
-    return round(distance_m / 1000, 2) if distance_m else None
+    return coach_units.km(distance_m)
 
 
 def _duration(seconds: Optional[float]) -> Optional[str]:
-    if not seconds:
-        return None
-    s = int(seconds)
-    h, rem = divmod(s, 3600)
-    m, _ = divmod(rem, 60)
-    return f"{h}h{m:02d}m" if h else f"{m}m"
+    return coach_units.duration(seconds)
 
 
 def _pace(distance_m: Optional[float], moving_time_s: Optional[float]) -> Optional[str]:
-    """Average pace as min:sec/km, or None when it cannot be computed."""
-    if not distance_m or not moving_time_s or distance_m <= 0:
-        return None
-    sec_per_km = moving_time_s / (distance_m / 1000)
-    mins = int(sec_per_km // 60)
-    secs = int(sec_per_km % 60)
-    return f"{mins}:{secs:02d}"
+    """Average pace as 'm:ss/km', or None when it cannot be computed."""
+    return coach_units.pace(distance_m, moving_time_s)
 
 
 def _as_uuid(value) -> Optional[uuid.UUID]:
@@ -333,7 +327,7 @@ def get_session_detail(db: Session, owner_user_id, *, activity_id: str, today: d
         "avg_pace_per_km": _pace(activity.distance_m, activity.moving_time_s),
         "effort": m.effort if m else None,
         "effort_score": round(m.effort_score, 1) if m and m.effort_score is not None else None,
-        "avg_hr": activity.avg_hr,
+        "avg_hr": coach_units.bpm(activity.avg_hr),
         "avg_cadence_spm": round(activity.avg_cadence) if activity.avg_cadence else None,
         "hr_drift_pct": round(m.hr_drift, 1) if m and m.hr_drift is not None else None,
         "structure": m.structure if m else None,
@@ -343,11 +337,7 @@ def get_session_detail(db: Session, owner_user_id, *, activity_id: str, today: d
 
 
 def _fmt_seconds_per_km(sec_per_km: Optional[float]) -> Optional[str]:
-    if not sec_per_km or sec_per_km <= 0:
-        return None
-    mins = int(sec_per_km // 60)
-    secs = int(sec_per_km % 60)
-    return f"{mins}:{secs:02d}"
+    return coach_units.pace_from_sec_per_km(sec_per_km)
 
 
 def get_training_summary(

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -33,6 +33,7 @@ from app.schemas.coach_context import CoachContextPack, ContinuityContext
 from app.services.coach.budget import over_budget as budget_over, record as budget_record
 from app.services.coach.memory_update import enqueue_memory_update
 from app.services.coach.context import build_context_pack
+from app.services.coach.coach_framing import frame_pack
 from app.services.coach.digest import build_report_digest
 from app.services.coach.llm import AnthropicClient
 from app.services.coach.output_contract import (
@@ -51,6 +52,7 @@ from app.services.coach.prompts import (
     TWO_STAGE_PROMPT_IDS,
     build_system_prompt,
     is_grouped_pack_prompt,
+    is_metrics_coach_framed_prompt,
 )
 from app.services.coach.prompt_features import PromptFeature, has_feature
 from app.services.coach.receipt_voice import voice_fingerprint
@@ -130,6 +132,16 @@ _FALLBACK_MESSAGE = (
 _FALLBACK_OPENER_MESSAGE = (
     "Nice work getting that run in. I'll take a proper look and follow up shortly."
 )
+
+
+def _llm_pack_message(pack_dict: dict, prompt_id: Optional[str]) -> str:
+    """Serialize the pack for the outgoing LLM message. Under a metrics-coach-framed
+    prompt (ADR 0026 Slice 4, #680) the leaf VALUES are reframed to coach-native units
+    for the LLM view; the caller still STORES the canonical `pack_dict` (framing is a
+    one-way, lossy view, so the stored/re-parsed pack stays typed). Byte-identical to the
+    prior `json.dumps(pack_dict, default=str)` for every non-framed prompt."""
+    view = frame_pack(pack_dict) if is_metrics_coach_framed_prompt(prompt_id) else pack_dict
+    return json.dumps(view, default=str)
 
 
 def is_two_stage_prompt(prompt_id: str) -> bool:
@@ -382,7 +394,7 @@ async def get_or_generate_coach_report(
     system_prompt = build_system_prompt(
         prompt_id, playbook_key(activity, classification), voice=voice, pack=pack
     )
-    user_message = json.dumps(pack_dict, default=str)
+    user_message = _llm_pack_message(pack_dict, prompt_id)
 
     client = AnthropicClient(
         api_key=settings.ANTHROPIC_API_KEY,
@@ -488,7 +500,7 @@ async def generate_opener(db: Session, activity_id: str) -> Optional[OpenerResul
     # voice.
     voice = _resolve_voice_for_activity(db, activity)
     system_prompt = build_system_prompt(prompt_id, mode="opener", voice=voice, pack=pack)
-    user_message = json.dumps(pack_dict, default=str)
+    user_message = _llm_pack_message(pack_dict, prompt_id)
     client = AnthropicClient(
         api_key=settings.ANTHROPIC_API_KEY, model=settings.COACH_MODEL_ID
     )
@@ -595,7 +607,7 @@ async def generate_fuller(
     system_prompt = build_system_prompt(
         prompt_id, playbook_key(activity, classification), mode="fuller", voice=voice, pack=pack
     )
-    user_message = json.dumps(pack_dict, default=str)
+    user_message = _llm_pack_message(pack_dict, prompt_id)
     client = AnthropicClient(
         api_key=settings.ANTHROPIC_API_KEY, model=settings.COACH_MODEL_ID
     )

--- a/backend/tests/test_chat_query_tools.py
+++ b/backend/tests/test_chat_query_tools.py
@@ -143,7 +143,7 @@ def test_list_entries_are_coach_framed(db):
     out = qt.list_activities_in_range(db, u.id, window="last_7_days", type_filter=None, today=TODAY)
     entry = out["activities"][0]
     assert entry["distance_km"] == 8.0
-    assert entry["pace_per_km"] == "5:00"   # 2400s / 8km = 300s/km
+    assert entry["pace_per_km"] == "5:00/km"   # 2400s / 8km = 300s/km
     assert entry["duration"] == "40m"
     assert entry["long_run"] is True
     assert entry["weekday"]  # a given day, not a computed one

--- a/backend/tests/test_coach_framing.py
+++ b/backend/tests/test_coach_framing.py
@@ -1,0 +1,192 @@
+"""Contract for frame_pack, the coach-native leaf reframing (ADR 0026 Slice 4, #680).
+
+Input values mirror a real grouped_v3 pack (the seeded 2026-07-07 interval run).
+"""
+
+import copy
+
+import pytest
+
+from app.services.coach.coach_framing import frame_pack
+
+
+def _real_grouped():
+    """A grouped pack dict shaped like the live grouped_v3 output, real values."""
+    return {
+        "safety_rules": {"never_diagnose": True, "pain_severe_threshold": 7, "no_invented_facts": True},
+        "this_run": {
+            "activity": {
+                "date": "2026-07-07", "weekday": "Tue", "name": "Afternoon Run", "type": "Run",
+                "distance_m": 4879, "moving_time_s": 1834,
+                "avg_hr": 165.6, "max_hr": 186.0, "avg_cadence": 164.4, "elev_gain_m": 30.0,
+            },
+            "metrics": {
+                "headline": "Intervals", "effort": "hard", "effort_score": 101.0,
+                "hr_drift": 8.0, "pace_variability": 41.6,
+                "time_in_zones": {"Z1": 12, "Z2": 436, "Z3": 521, "Z4": 726, "Z5": 142},
+                "efficiency_analysis": {"average": 1.15, "best_sustained": 1.21,
+                                        "curve": [0.452, 0.626, 0.785], "unit": "m/min/bpm"},
+                "stops_analysis": {"total_stopped_time_s": 38, "stopped_count": 3, "longest_stop_s": 25,
+                                   "stops": [{"start_time": 219, "duration_s": 25,
+                                              "location": [51.12, 0.25], "distance_m": 363.5}]},
+                "interval_structure": {
+                    "warmup_duration_s": 450, "cooldown_duration_s": 239,
+                    "work_segments": [{"segment_number": 1, "start_time_s": 450, "duration_s": 90,
+                                       "distance_m": 400.0, "avg_hr": 163.9, "peak_hr": 181.0}],
+                    "rest_segments": [{"segment_number": 1, "duration_s": 89, "avg_hr": 165.1,
+                                       "hr_recovery_bpm": 15.9}],
+                    "summary": {"total_work_time_s": 660, "total_rest_time_s": 534,
+                                "work_to_rest_ratio": 1.24, "rep_count": 7, "avg_work_duration_s": 94,
+                                "work_duration_cv": 4.2, "avg_work_speed_mps": 4.25, "work_speed_cv": 4.2,
+                                "avg_rest_duration_s": 89, "avg_hr_recovery_bpm": 10.2},
+                },
+                "workout_match": {"match_score": 1.0, "detection_confidence": "high",
+                                  "detected_workout": {"reps_detected": 7, "rep_distance_mean_m": 400.0,
+                                                       "rep_distance_cv": 0.0, "rep_duration_mean_s": 94.3,
+                                                       "total_work_time_s": 660, "total_rest_time_s": 534,
+                                                       "work_to_rest_ratio": 1.24}},
+                "interval_kpis": {"rep_pace_consistency_cv": 4.2, "first_vs_last_fade": 0.95,
+                                  "recovery_quality_per_60s": 6.9, "work_rest_ratio": 1.24,
+                                  "total_z4_plus_s": 868},
+                "discount_signals": {"likely_inflated_by": ["heat"], "temperature_c": 30.0,
+                                     "confidence": "high", "interpretation": "heat"},
+            },
+        },
+        "the_runner": {
+            "profile": {"max_hr": 191, "current_weekly_km": 18},
+            "training_history": {
+                "traits": {"training_age_years": 1.1, "peak_sustained_weekly_distance_m": 71655,
+                           "current_vs_peak_pct": 73.0},
+                "timeline": [{"start_days_ago": 14, "end_days_ago": 60, "weeks": 6.6,
+                              "avg_weekly_distance_m": 43150, "avg_weekly_sessions": 16.43,
+                              "run_share_pct": 22.2, "avg_weekly_load": 825,
+                              "by_type": [{"avg_weekly_distance_m": 27160, "avg_weekly_sessions": 7.15,
+                                           "share_pct": 43.5}]}],
+            },
+        },
+    }
+
+
+class TestActivity:
+    def test_distance_time_hr(self):
+        out = frame_pack(_real_grouped())
+        act = out["this_run"]["activity"]
+        assert act["distance_km"] == 4.9
+        assert "distance_m" not in act
+        assert act["duration"] == "30m"
+        assert "moving_time_s" not in act
+        assert act["avg_hr"] == "166 bpm (87% max)"
+        assert act["max_hr"] == "186 bpm (97% max)"
+        assert act["avg_cadence"] == 164
+        assert act["elev_gain_m"] == 30 and isinstance(act["elev_gain_m"], int)
+
+
+class TestMetricsScalars:
+    def test_trim_and_zones(self):
+        out = frame_pack(_real_grouped())
+        m = out["this_run"]["metrics"]
+        assert m["effort_score"] == 101 and isinstance(m["effort_score"], int)
+        assert m["hr_drift"] == 8
+        assert m["pace_variability"] == 41.6   # real fractional %, untouched
+        assert m["time_in_zones"] == {"Z1": "0:12", "Z2": "7:16", "Z3": "8:41",
+                                      "Z4": "12:06", "Z5": "2:22"}
+
+    def test_efficiency_curve_dropped(self):
+        m = frame_pack(_real_grouped())["this_run"]["metrics"]
+        eff = m["efficiency_analysis"]
+        assert "curve" not in eff
+        assert eff["average"] == 1.15 and eff["best_sustained"] == 1.21
+
+    def test_stops_reframed_and_gps_dropped(self):
+        m = frame_pack(_real_grouped())["this_run"]["metrics"]
+        s = m["stops_analysis"]
+        assert s["total_stopped_time"] == "0:38"
+        assert s["longest_stop"] == "0:25"
+        stop = s["stops"][0]
+        assert "location" not in stop and "start_time" not in stop
+        assert stop["duration"] == "0:25"
+        assert stop["distance_m"] == 364
+
+    def test_discount_temp_trimmed(self):
+        m = frame_pack(_real_grouped())["this_run"]["metrics"]
+        assert m["discount_signals"]["temperature_c"] == 30
+
+
+class TestIntervals:
+    def test_work_segment(self):
+        m = frame_pack(_real_grouped())["this_run"]["metrics"]
+        seg = m["interval_structure"]["work_segments"][0]
+        assert "start_time_s" not in seg
+        assert seg["duration"] == "1:30"
+        assert seg["distance_m"] == 400          # reps stay metres
+        assert seg["avg_hr"] == 164 and seg["peak_hr"] == 181   # plain bpm, no % max
+
+    def test_rest_segment(self):
+        m = frame_pack(_real_grouped())["this_run"]["metrics"]
+        rest = m["interval_structure"]["rest_segments"][0]
+        assert rest["duration"] == "1:29"
+        assert rest["avg_hr"] == 165
+        assert rest["hr_recovery_bpm"] == 15.9   # a bpm delta, kept
+
+    def test_summary_pace_and_durations(self):
+        m = frame_pack(_real_grouped())["this_run"]["metrics"]
+        summ = m["interval_structure"]["summary"]
+        assert summ["warmup"] if False else True   # warmup lives on the structure, not summary
+        assert summ["total_work_time"] == "11:00"
+        assert summ["avg_work_duration"] == "1:34"
+        assert summ["avg_work_pace"] == "3:55/km"
+        assert summ["work_to_rest_ratio"] == 1.24   # ratio untouched
+        assert summ["rep_count"] == 7
+
+    def test_structure_warmup_cooldown(self):
+        m = frame_pack(_real_grouped())["this_run"]["metrics"]
+        istruct = m["interval_structure"]
+        assert istruct["warmup"] == "7:30"
+        assert istruct["cooldown"] == "3:59"
+
+    def test_workout_match(self):
+        m = frame_pack(_real_grouped())["this_run"]["metrics"]
+        dw = m["workout_match"]["detected_workout"]
+        assert dw["rep_duration_mean"] == "1:34"
+        assert dw["total_work_time"] == "11:00"
+        assert dw["rep_distance_mean_m"] == 400
+
+    def test_kpis_z4_time(self):
+        m = frame_pack(_real_grouped())["this_run"]["metrics"]
+        assert m["interval_kpis"]["total_z4_plus"] == "14:28"
+        assert m["interval_kpis"]["work_rest_ratio"] == 1.24
+
+
+class TestTrainingHistory:
+    def test_km_and_session_precision(self):
+        th = frame_pack(_real_grouped())["the_runner"]["training_history"]
+        assert th["traits"]["peak_sustained_weekly_km"] == 71.7
+        period = th["timeline"][0]
+        assert period["avg_weekly_km"] == 43.1
+        assert period["avg_weekly_sessions"] == 16.4
+        assert period["by_type"][0]["avg_weekly_km"] == 27.2
+        assert period["by_type"][0]["avg_weekly_sessions"] == 7.2
+
+
+class TestSafety:
+    def test_input_not_mutated(self):
+        src = _real_grouped()
+        snapshot = copy.deepcopy(src)
+        frame_pack(src)
+        assert src == snapshot
+
+    def test_missing_sections_safe(self):
+        assert frame_pack({}) == {}
+        assert frame_pack({"this_run": {}}) == {"this_run": {}}
+        assert frame_pack({"this_run": {"activity": None, "metrics": None}}) == {
+            "this_run": {"activity": None, "metrics": None}}
+
+    def test_no_max_hr_falls_back_to_plain_bpm(self):
+        src = _real_grouped()
+        src["the_runner"]["profile"].pop("max_hr")
+        act = frame_pack(src)["this_run"]["activity"]
+        assert act["avg_hr"] == "166 bpm"
+        assert act["max_hr"] == "186 bpm"
+
+    def test_non_dict_returned_as_is(self):
+        assert frame_pack(None) is None

--- a/backend/tests/test_coach_framing_in_pack.py
+++ b/backend/tests/test_coach_framing_in_pack.py
@@ -1,0 +1,113 @@
+"""ADR 0026 Slice 4 (#680): the coach-native leaf reframing in the REAL pack.
+
+Pinned here: the grouped-v4 prompt's canonical (stored) pack is byte-identical to
+grouped-v3's (framing adds no section and changes no stored fact); the grouped-v4
+OUTGOING LLM view is reframed to coach-native units (km / % max / MM:SS); and the
+service serialization helper frames ONLY under the metrics-coach-framed prompt, so every
+prior prompt's LLM message is byte-identical to the pre-Slice-4 serialization.
+"""
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from app.models import Activity, DerivedMetric, User, UserProfile
+from app.services.coach.context import build_context_pack
+from app.services.coach.coach_framing import frame_pack
+from app.services.coach.service import _llm_pack_message
+
+GROUPED3 = "coach_message_lean_grouped_v3"
+GROUPED4 = "coach_message_lean_grouped_v4"
+LEAN = "coach_message_lean_v1"
+V14 = "coach_message_v14"
+
+
+def _user(db):
+    uid = uuid.uuid4()
+    db.add(User(id=uid, email=f"test_{uid}@example.com"))
+    db.add(UserProfile(user_id=uid, goal_type="general_fitness", experience_level="intermediate",
+                       weekly_days_available=5, max_hr=190, max_hr_source="user", current_weekly_km=40))
+    db.flush()
+    return uid
+
+
+def _activity(db, user_id, *, days_ago=0, effort="easy", time_in_zones=None):
+    start = datetime(2026, 6, 28, 8, 0, tzinfo=timezone.utc) - timedelta(days=days_ago)
+    a = Activity(
+        id=uuid.uuid4(), user_id=user_id,
+        strava_activity_id=abs(hash(str(uuid.uuid4()))) % 10**9,
+        name="Run", type="Run", start_date=start, start_date_local=start,
+        distance_m=10000, moving_time_s=3600, elapsed_time_s=3700,
+        avg_hr=150.0, max_hr=175.0, avg_cadence=170.4, elev_gain_m=10.0,
+        average_speed_mps=2.78, raw_summary={},
+    )
+    db.add(a)
+    db.flush()
+    db.add(DerivedMetric(
+        id=uuid.uuid4(), activity_id=a.id, effort=effort, duration_class="standard",
+        structure="continuous", is_hilly=False, is_race=False, effort_score=42.0,
+        hr_drift=8.0, pace_variability=12.8, confidence="high", confidence_reasons=[],
+        flags=[], time_in_zones=time_in_zones or {"Z1": 12, "Z2": 436, "Z3": 521},
+        discount_signals=None,
+    ))
+    db.flush()
+    return a
+
+
+def _seed_window(db, uid, *, n=6):
+    for i in range(n):
+        _activity(db, uid, days_ago=2 + i, effort="easy")
+
+
+def test_grouped_v4_canonical_pack_equals_grouped_v3(db):
+    """Framing is a serialization VIEW, not a section: the stored/canonical grouped pack
+    under v4 is byte-identical to v3, so re-parse/validator/eval are unaffected."""
+    uid = _user(db)
+    subject = _activity(db, uid, days_ago=0, effort="hard")
+    _seed_window(db, uid)
+
+    d3 = build_context_pack(db, subject, prompt_id=GROUPED3).to_grouped_dict()
+    d4 = build_context_pack(db, subject, prompt_id=GROUPED4).to_grouped_dict()
+    assert d4 == d3
+
+
+def test_grouped_v4_llm_view_is_coach_framed(db):
+    uid = _user(db)
+    subject = _activity(db, uid, days_ago=0, effort="hard")
+    _seed_window(db, uid)
+
+    canonical = build_context_pack(db, subject, prompt_id=GROUPED4).to_grouped_dict()
+    view = frame_pack(canonical)
+
+    act = view["this_run"]["activity"]
+    assert act["distance_km"] == 10.0 and "distance_m" not in act
+    assert act["duration"] == "1h00m" and "moving_time_s" not in act
+    assert act["avg_hr"] == "150 bpm (79% max)"     # 150/190
+    assert act["max_hr"] == "175 bpm (92% max)"
+    assert act["avg_cadence"] == 170
+
+    m = view["this_run"]["metrics"]
+    assert m["effort_score"] == 42 and isinstance(m["effort_score"], int)
+    assert m["time_in_zones"] == {"Z1": "0:12", "Z2": "7:16", "Z3": "8:41"}
+
+    # the canonical pack still carries the raw leaves (framing did not mutate it)
+    assert canonical["this_run"]["activity"]["distance_m"] == 10000
+
+
+def test_service_helper_frames_only_under_the_feature(db):
+    uid = _user(db)
+    subject = _activity(db, uid, days_ago=0, effort="hard")
+    _seed_window(db, uid)
+
+    canonical = build_context_pack(db, subject, prompt_id=GROUPED4).to_grouped_dict()
+
+    # Non-framed prompts: byte-identical to the prior plain json.dumps (no leak).
+    plain = json.dumps(canonical, default=str)
+    assert _llm_pack_message(canonical, GROUPED3) == plain
+    assert _llm_pack_message(canonical, LEAN) == plain
+    assert _llm_pack_message(canonical, V14) == plain
+    assert _llm_pack_message(canonical, None) == plain
+
+    # Framed prompt: the reframed view.
+    assert _llm_pack_message(canonical, GROUPED4) == json.dumps(frame_pack(canonical), default=str)
+    assert _llm_pack_message(canonical, GROUPED4) != plain

--- a/backend/tests/test_coach_units.py
+++ b/backend/tests/test_coach_units.py
@@ -1,0 +1,101 @@
+"""Contract for the shared coach-facing unit formatters (ADR 0026 Slice 4, #680)."""
+
+import pytest
+
+from app.services.coach import coach_units as u
+
+
+class TestDistance:
+    def test_metres_to_km_one_dp(self):
+        assert u.km(4879) == 4.9
+        assert u.km(71655) == 71.7
+        assert u.km(43150) == 43.1   # round(43.15, 1) == 43.1 (pack-wide Python round)
+
+    def test_none_and_zero(self):
+        assert u.km(None) is None
+        assert u.km(0) is None
+
+
+class TestDuration:
+    def test_minute_granularity(self):
+        assert u.duration(1834) == "30m"        # 30:34 -> 30m (seconds dropped)
+        assert u.duration(2400) == "40m"
+        assert u.duration(3661) == "1h01m"
+
+    def test_none_and_zero(self):
+        assert u.duration(None) is None
+        assert u.duration(0) is None
+
+
+class TestDurationPrecise:
+    def test_second_resolution(self):
+        assert u.duration_precise(90) == "1:30"
+        assert u.duration_precise(12) == "0:12"     # short zone time, never '0m'
+        assert u.duration_precise(660) == "11:00"
+        assert u.duration_precise(436) == "7:16"
+
+    def test_explicit_hours(self):
+        assert u.duration_precise(3661) == "1:01:01"
+
+    def test_none_and_negative(self):
+        assert u.duration_precise(None) is None
+        assert u.duration_precise(-5) is None
+
+
+class TestPace:
+    def test_from_speed_mps(self):
+        # 4.25 m/s -> 1000/4.25 = 235.3 s/km -> 3:55/km
+        assert u.pace_from_speed(4.25) == "3:55/km"
+
+    def test_from_distance_and_time(self):
+        assert u.pace(8000, 2400) == "5:00/km"
+
+    def test_from_sec_per_km(self):
+        assert u.pace_from_sec_per_km(300) == "5:00/km"
+
+    def test_seconds_rounding_carry(self):
+        # 359.6 s/km rounds to 6:00, not 5:60
+        assert u.pace_from_sec_per_km(359.6) == "6:00/km"
+
+    def test_none_and_zero(self):
+        assert u.pace_from_speed(None) is None
+        assert u.pace_from_speed(0) is None
+        assert u.pace(0, 100) is None
+        assert u.pace(100, None) is None
+
+
+class TestHeartRate:
+    def test_bpm_with_pct_max(self):
+        assert u.hr_bpm(165.6, 191) == "166 bpm (87% max)"
+        assert u.hr_bpm(186.0, 191) == "186 bpm (97% max)"
+
+    def test_bpm_without_max_falls_back_to_plain(self):
+        assert u.hr_bpm(165.6, None) == "166 bpm"
+        assert u.hr_bpm(165.6, 0) == "166 bpm"
+
+    def test_plain_bpm(self):
+        assert u.bpm(163.9) == 164
+        assert u.bpm(None) is None
+
+    def test_pct_of_max(self):
+        assert u.pct_of_max(165.6, 191) == 87
+        assert u.pct_of_max(165.6, None) is None
+
+    def test_hr_none(self):
+        assert u.hr_bpm(None, 191) is None
+
+
+class TestTrim:
+    def test_drops_trailing_zero(self):
+        assert u.trim(101.0) == 101
+        assert u.trim(30.0) == 30
+        assert isinstance(u.trim(30.0), int)
+
+    def test_keeps_real_fractional(self):
+        assert u.trim(1.15) == 1.15
+        assert u.trim(4.2) == 4.2
+
+    def test_passes_through_non_numbers(self):
+        assert u.trim("easy") == "easy"
+        assert u.trim(None) is None
+        assert u.trim(True) is True

--- a/backend/tests/test_message_prompt_lean_v1.py
+++ b/backend/tests/test_message_prompt_lean_v1.py
@@ -70,10 +70,11 @@ def test_lean_v1_has_full_capability_parity_with_v14():
     # (they REPLACE training_load/volume/recent_training/training_history and
     # perceived_effort/calibration/intensity under the grouped prompts), so no single prompt
     # carries the full union; lean_v1 carries every ADDITIVE feature.
+    # Slice 4 (#680) adds METRICS_COACH_FRAMED, a presentation-only view flag on grouped_v4.
     from app.services.coach.prompt_features import PromptFeature as _F
     every_additive = set().union(*PROMPT_FEATURES.values()) - {
         _F.READINESS, _F.RECENT_WEEKS, _F.TRAINING_HISTORY_2WK,
-        _F.INTENSITY_READ, _F.INTENSITY_MIX,
+        _F.INTENSITY_READ, _F.INTENSITY_MIX, _F.METRICS_COACH_FRAMED,
     }
     assert features_for(LEAN) == every_additive
 

--- a/backend/tests/test_message_prompt_v10.py
+++ b/backend/tests/test_message_prompt_v10.py
@@ -40,6 +40,7 @@ def test_v10_registered_carries_every_v9_capability_plus_stream_view():
         "coach_message_lean_grouped_v1",
         "coach_message_lean_grouped_v2",  # ADR 0026 Slice 2 keeps STREAM_VIEW
         "coach_message_lean_grouped_v3",  # ADR 0026 Slice 3 keeps STREAM_VIEW
+        "coach_message_lean_grouped_v4",  # ADR 0026 Slice 4 keeps STREAM_VIEW
     }
     assert V10 in _OPENER_PROMPTS  # has a distinct opener form (two-stage)
     # same schema family as v9 (so v10 reports regenerate, prior history retained).

--- a/backend/tests/test_prompt_features.py
+++ b/backend/tests/test_prompt_features.py
@@ -190,6 +190,24 @@ EXPECTED_CAPABILITIES = {
         F.INTENSITY_READ,
         F.INTENSITY_MIX,
     },
+    # ADR 0026 Slice 4 (#680) — grouped_v4 = grouped_v3 + METRICS_COACH_FRAMED, a
+    # presentation-only leaf reframing of the outgoing LLM pack view (adds no section). It
+    # keeps every grouped_v3 capability; it carries 13 features.
+    "coach_message_lean_grouped_v4": {
+        F.TWO_STAGE,
+        F.VOICE,
+        F.CORPUS,
+        F.STANCE,
+        F.READINESS,
+        F.USER_MATERIALS,
+        F.RECENT_WEEKS,
+        F.STREAM_VIEW,
+        F.TRAINING_HISTORY_2WK,
+        F.MEMORY,
+        F.INTENSITY_READ,
+        F.INTENSITY_MIX,
+        F.METRICS_COACH_FRAMED,
+    },
 }
 
 # Ids that must carry NO capabilities (the inert-under-rollback set).
@@ -238,7 +256,7 @@ def test_memory_feature_is_active_on_v13():
     assert prompts.MEMORY_PROMPT_IDS == {
         "coach_message_v13", "coach_message_v14", "coach_message_lean_v1",
         "coach_message_lean_grouped_v1", "coach_message_lean_grouped_v2",
-        "coach_message_lean_grouped_v3",
+        "coach_message_lean_grouped_v3", "coach_message_lean_grouped_v4",
     }
     assert prompts.is_memory_prompt("coach_message_v13") is True
     assert prompts.is_memory_prompt("coach_message_v12") is False
@@ -260,28 +278,32 @@ def test_derived_sets_match_captured_membership():
     # the Slice-2 alternative sets (readiness/recent_weeks/training_history_2wk), and is
     # the sole member of the two new Slice-3 sets — while dropping OUT of INTENSITY.
     GROUPED3 = "coach_message_lean_grouped_v3"
+    # ADR 0026 Slice 4 (#680): grouped_v4 keeps every grouped_v3 capability and adds
+    # METRICS_COACH_FRAMED (a presentation-only view flag), so it joins exactly the same
+    # derived sets as grouped_v3 (additive shared sets + the Slice-2/3 alternative sets).
+    GROUPED4 = "coach_message_lean_grouped_v4"
     assert prompts.TWO_STAGE_PROMPT_IDS == {
         "coach_message_v2", "coach_message_v3", "coach_message_v4",
         "coach_message_v5", "coach_message_v6", "coach_message_v7", "coach_message_v8",
         "coach_message_v9", "coach_message_v10", "coach_message_v11", "coach_message_v12",
-        "coach_message_v13", "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3,
+        "coach_message_v13", "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4,
     }
     assert prompts.VOICE_PROMPT_IDS == {
         "coach_message_v3", "coach_message_v4", "coach_message_v5",
         "coach_message_v6", "coach_message_v7", "coach_message_v8", "coach_message_v9",
         "coach_message_v10", "coach_message_v11", "coach_message_v12", "coach_message_v13",
-        "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3,
+        "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4,
     }
     assert prompts.CORPUS_PROMPT_IDS == {
         "coach_message_v4", "coach_message_v5", "coach_message_v6",
         "coach_message_v7", "coach_message_v8", "coach_message_v9", "coach_message_v10",
         "coach_message_v11", "coach_message_v12", "coach_message_v13", "coach_message_v14",
-        LEAN, GROUPED, GROUPED2, GROUPED3,
+        LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4,
     }
     assert prompts.STANCE_PROMPT_IDS == {
         "coach_message_v5", "coach_message_v6", "coach_message_v7", "coach_message_v8",
         "coach_message_v9", "coach_message_v10", "coach_message_v11", "coach_message_v12",
-        "coach_message_v13", "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3,
+        "coach_message_v13", "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4,
     }
     # Slice 2: grouped_v2/v3 REPLACE training_load with readiness, so they are NOT here.
     assert prompts.TRAINING_LOAD_PROMPT_IDS == {
@@ -292,7 +314,7 @@ def test_derived_sets_match_captured_membership():
     assert prompts.USER_MATERIALS_PROMPT_IDS == {
         "coach_message_v7", "coach_message_v8", "coach_message_v9", "coach_message_v10",
         "coach_message_v11", "coach_message_v12", "coach_message_v13", "coach_message_v14",
-        LEAN, GROUPED, GROUPED2, GROUPED3,
+        LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4,
     }
     # Slice 2: grouped_v2/v3 REPLACE volume + recent_training with recent_weeks, so they
     # are absent from both of these sets.
@@ -302,7 +324,7 @@ def test_derived_sets_match_captured_membership():
     }
     assert prompts.STREAM_VIEW_PROMPT_IDS == {
         "coach_message_v10", "coach_message_v11", "coach_message_v12", "coach_message_v13",
-        "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3,
+        "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4,
     }
     assert prompts.RECENT_TRAINING_PROMPT_IDS == {
         "coach_message_v11", "coach_message_v12", "coach_message_v13", "coach_message_v14",
@@ -313,18 +335,20 @@ def test_derived_sets_match_captured_membership():
     assert prompts.TRAINING_HISTORY_PROMPT_IDS == {
         "coach_message_v12", "coach_message_v13", "coach_message_v14", LEAN, GROUPED,
     }
-    assert prompts.TRAINING_HISTORY_2WK_PROMPT_IDS == {GROUPED2, GROUPED3}
+    assert prompts.TRAINING_HISTORY_2WK_PROMPT_IDS == {GROUPED2, GROUPED3, GROUPED4}
     assert prompts.MEMORY_PROMPT_IDS == {
-        "coach_message_v13", "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3,
+        "coach_message_v13", "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4,
     }
-    # Slice 3: grouped_v3 REPLACES INTENSITY with INTENSITY_READ + INTENSITY_MIX, so it
-    # drops OUT of the intensity set and is the sole member of the two new ones.
+    # Slice 3: grouped_v3/v4 REPLACE INTENSITY with INTENSITY_READ + INTENSITY_MIX, so they
+    # drop OUT of the intensity set and are the members of the two new ones.
     assert prompts.INTENSITY_PROMPT_IDS == {"coach_message_v14", LEAN, GROUPED, GROUPED2}
-    assert prompts.INTENSITY_READ_PROMPT_IDS == {GROUPED3}
-    assert prompts.INTENSITY_MIX_PROMPT_IDS == {GROUPED3}
-    # Slice 2's two sets: grouped_v2 and grouped_v3 are the members.
-    assert prompts.READINESS_PROMPT_IDS == {GROUPED2, GROUPED3}
-    assert prompts.RECENT_WEEKS_PROMPT_IDS == {GROUPED2, GROUPED3}
+    assert prompts.INTENSITY_READ_PROMPT_IDS == {GROUPED3, GROUPED4}
+    assert prompts.INTENSITY_MIX_PROMPT_IDS == {GROUPED3, GROUPED4}
+    # Slice 2's two sets: grouped_v2/v3/v4 are the members.
+    assert prompts.READINESS_PROMPT_IDS == {GROUPED2, GROUPED3, GROUPED4}
+    assert prompts.RECENT_WEEKS_PROMPT_IDS == {GROUPED2, GROUPED3, GROUPED4}
+    # Slice 4: grouped_v4 is the sole carrier of the metrics-coach-framed view flag.
+    assert prompts.METRICS_COACH_FRAMED_PROMPT_IDS == {GROUPED4}
 
 
 def test_predicates_agree_with_has_feature():
@@ -343,6 +367,7 @@ def test_predicates_agree_with_has_feature():
         assert prompts.is_memory_prompt(pid) == has_feature(pid, F.MEMORY)
         assert prompts.is_intensity_read_prompt(pid) == has_feature(pid, F.INTENSITY_READ)
         assert prompts.is_intensity_mix_prompt(pid) == has_feature(pid, F.INTENSITY_MIX)
+        assert prompts.is_metrics_coach_framed_prompt(pid) == has_feature(pid, F.METRICS_COACH_FRAMED)
 
 
 def test_opener_prompts_cover_exactly_two_stage_ids():
@@ -355,8 +380,6 @@ def test_fullest_message_prompt_is_the_max_capability_id():
     coach_message id with the most capabilities (every gated section on) and must
     advance automatically as new versions are added — never a stale hardcode."""
     fullest = fullest_message_prompt_id()
-    max_n = max(len(f) for f in PROMPT_FEATURES.values())
-    assert len(PROMPT_FEATURES[fullest]) == max_n
     assert fullest.startswith("coach_message")
     # It carries every ADDITIVE feature any prompt carries, so no gated section is missed
     # by a guard built under it. ADR 0026 Slice 2 (#670) introduces MUTUALLY-EXCLUSIVE
@@ -367,10 +390,15 @@ def test_fullest_message_prompt_is_the_max_capability_id():
     # alternative (grouped_v2 carries it INSTEAD of TRAINING_HISTORY).
     # Slice 3 (#673) adds INTENSITY_READ + INTENSITY_MIX as two more alternatives (they
     # REPLACE perceived_effort/calibration/intensity under the grouped_v3 prompt).
+    # Slice 4 (#680) adds METRICS_COACH_FRAMED, a presentation-only view flag (no section),
+    # so grouped_v4 carries the max RAW count yet is NOT the additive-fullest — the ranking
+    # is by ADDITIVE features, so `fullest` stays grouped_v1.
     ALTERNATIVE_FEATURES = {
         F.READINESS, F.RECENT_WEEKS, F.TRAINING_HISTORY_2WK,
-        F.INTENSITY_READ, F.INTENSITY_MIX,
+        F.INTENSITY_READ, F.INTENSITY_MIX, F.METRICS_COACH_FRAMED,
     }
+    max_additive = max(len(set(f) - ALTERNATIVE_FEATURES) for f in PROMPT_FEATURES.values())
+    assert len(set(PROMPT_FEATURES[fullest]) - ALTERNATIVE_FEATURES) == max_additive
     every_feature = set().union(*PROMPT_FEATURES.values())
     assert set(PROMPT_FEATURES[fullest]) == every_feature - ALTERNATIVE_FEATURES
 


### PR DESCRIPTION
Closes #680. Slice 4 of ADR 0026 (coach pack grouped by the coaching question), under the #638 coach-value-per-token umbrella; follows Slice 3 (#678).

## What

Reframe the coach context pack's numeric leaves to coach-native units and precision for the outgoing LLM view, without changing any fact or pre-computing a verdict (the #637 template; fix the interface, leave the read to the coach):

- **metres → km** on session/weekly distances (`distance_km` in the key); interval reps stay in metres.
- **seconds → MM:SS / H:MM:SS** on interval/zone durations; **minute-granularity** (`30m`/`1h01m`) on whole-session durations; per-rep `start_time_s` offsets dropped.
- **m/s → pace** (`min:sec/km`).
- **bpm stays primary**, with a `(% max)` supplement on only the two headline scalars `activity.avg_hr`/`max_hr`.
- **drop the efficiency `curve`** (64 three-decimal points; keep average + best_sustained); **trim trailing decimals**; drop GPS lat/long from stops.

Unit always lives in the key or value string; no object mixes units.

## How

Consistency-first (owner directive): a shared `coach_units` module is the single home for every conversion, used by **both** `frame_pack` (the report + chat pack view) **and** `query_tools`/chat splits, so nothing can drift.

Framing is a **one-way serialization view** for the outgoing LLM message only, gated on a new `PromptFeature.METRICS_COACH_FRAMED` carried solely by a new inert `coach_message_lean_grouped_v4`. The canonical **unframed** grouped pack stays what is stored and what the validator, authority-tiering, eval, and strict re-parse read (framing is lossy: `"166 bpm (87% max)"` / `"30m"` can't round-trip to typed facts). So every prior prompt's LLM message is byte-identical, and the report and chat LLMs receive identical framed packs (only the system prompt differs).

## Files

- `services/coach/coach_units.py` (new) — shared km/duration/pace/bpm/%max/trim formatters.
- `services/coach/coach_framing.py` (new) — `frame_pack`, pure one-way view over the grouped pack.
- `services/coach/query_tools.py`, `chat.py` — unified onto `coach_units` (pace gains `/km`, km to 1dp).
- `services/coach/service.py` (3 seams), `chat.py` — frame the LLM message only, canonical pack stored.
- `services/coach/prompt_features.py`, `prompts.py` — `coach_message_lean_grouped_v4` + `is_metrics_coach_framed_prompt` + `METRICS_COACH_FRAMED` in `ALTERNATIVE_FEATURES`.
- tests: `test_coach_units`, `test_coach_framing`, `test_coach_framing_in_pack` + manifest pin updates.

## Verification

- Full suite **2161 passed / 2 skipped** under CI-parity env (baseline 2122 + 39 new).
- `make eval-selftest` green; diagram guard in sync (no section change).
- Real seeded data end-to-end: framed grouped_v4 view matches the agreed unit table; `grouped_v4 canonical == grouped_v3 canonical`; every prior prompt's LLM message byte-identical to the plain serialization; canonical pack retains raw typed leaves.

## Scope / notes

- Ships **inert**; production (`coach_message_lean_v1`) is untouched until the Slice 5 owner flip.
- Follow-ups deliberately left for Slice 5: chat per-split `distance_m`/`elapsed_time_s` stay raw (only pace unified); the Slice-3 `intensity_read.observed_pct` vs `metrics.hr_drift` duplication is untouched.