### PR TITLE
Include VirtualRun in the auto coach-report run family (#644)

### DIFF
--- a/backend/app/jobs/process_new_activity.py
+++ b/backend/app/jobs/process_new_activity.py
@@ -39,7 +39,7 @@ from app.models import Activity, Block, Exchange, StravaAccount
 from app.models.coaching_relationship import CoachingRelationship
 from app.services.analysis import analyze_with_streams
 from app.services.analysis.classifier import Classification, compose_headline
-from app.services.blocks import activity_end, assign_activity_to_block
+from app.services.blocks import activity_end, assign_activity_to_block, is_run_activity
 from app.services.coach import exchange_lifecycle as lifecycle
 from app.services.coach.receipt import build_receipt
 from app.services.coach.service import (
@@ -195,13 +195,13 @@ def _is_run_activity(activity: Activity) -> bool:
     """Whether an activity counts as a run for AUTOMATIC coach-report gating (#643).
 
     A coach report is only auto-generated for runs; every activity still gets its
-    receipt / check-in notification, and on-demand regeneration stays ungated. Uses
-    the coarse Strava `type` (ordinary, trail, and Strava-app treadmill runs all keep
-    `type == "Run"`, so they count), matching `blocks.pick_primary`'s own run test so
-    this gate agrees with which activity `pick_primary` anchors the report on. A
-    distinct Strava `type` such as "VirtualRun" is NOT auto-reported today; broadening
-    that requires changing `pick_primary` too (the report anchor) and is a follow-up."""
-    return (activity.type or "").lower() == "run"
+    receipt / check-in notification, and on-demand regeneration stays ungated.
+    Delegates to `blocks.is_run_activity`, the single run-family predicate shared
+    with `pick_primary` (the report anchor), so the gate agrees with which activity
+    the report generates on. The run family covers the coarse `type == "Run"`
+    (ordinary, trail, treadmill) plus connected-platform "VirtualRun" (Zwift,
+    Peloton), which #644 brought into scope alongside the anchor."""
+    return is_run_activity(activity)
 
 
 def _exchange_for_activity(db: Session, activity: Activity) -> Optional[Exchange]:

--- a/backend/app/services/blocks.py
+++ b/backend/app/services/blocks.py
@@ -33,13 +33,33 @@ def activity_end(activity: Activity) -> datetime:
     return activity.start_date + timedelta(seconds=activity.elapsed_time_s or 0)
 
 
+# Strava `type` values that count as a run for block-anchoring and automatic
+# coach-report gating (#644). Ordinary, trail, and Strava-app treadmill runs all
+# collapse to "Run"; a connected-platform run (Zwift, Peloton) surfaces as the
+# distinct "VirtualRun" but is just as much a run the coach should anchor on and
+# report. Compared case-insensitively.
+RUN_ACTIVITY_TYPES = frozenset({"run", "virtualrun"})
+
+
+def is_run_activity(activity: Activity) -> bool:
+    """Whether an activity belongs to the run family (ordinary or virtual).
+
+    The single source of truth shared by `pick_primary` (which activity the
+    report anchors on) and the automatic coach-report gate in
+    `process_new_activity`, so "block contains a run" stays exactly equal to
+    "primary is a run" (#643/#644). Both must move together or the gate and the
+    anchor disagree.
+    """
+    return (activity.type or "").lower() in RUN_ACTIVITY_TYPES
+
+
 def pick_primary(members: Sequence[Activity]) -> Activity:
     """The block's primary activity: the run, else the longest member.
 
     Ties (several runs, or no run) resolve to the longest by elapsed time,
     then earliest start for determinism.
     """
-    runs = [a for a in members if (a.type or "").lower() == "run"]
+    runs = [a for a in members if is_run_activity(a)]
     pool = runs or list(members)
     return sorted(pool, key=lambda a: (-(a.elapsed_time_s or 0), a.start_date))[0]
 

--- a/backend/tests/test_blocks_service.py
+++ b/backend/tests/test_blocks_service.py
@@ -88,6 +88,22 @@ def test_activity_within_gap_joins_and_run_becomes_primary(db):
     assert db.query(Exchange).filter(Exchange.block_id == block.id).count() == 1
 
 
+def test_virtual_run_becomes_primary_over_a_longer_non_run(db):
+    """A connected-platform run (Zwift/Peloton) surfaces as `type == "VirtualRun"`;
+    it is still a run, so it wins the block primary over a longer walk (#644),
+    keeping "block contains a run" == "primary is a run"."""
+    user = _make_user(db)
+    walk = _make_activity(db, user, start=T0, elapsed=3600, type="Walk")  # longer
+    block = assign_activity_to_block(db, walk, gap_seconds=GAP)
+
+    vrun_start = T0 + timedelta(seconds=3600 + 600)  # 10 min after the walk ends
+    vrun = _make_activity(db, user, start=vrun_start, elapsed=1200, type="VirtualRun")
+    joined = assign_activity_to_block(db, vrun, gap_seconds=GAP)
+
+    assert joined.id == block.id
+    assert joined.primary_activity_id == vrun.id  # the virtual run wins over the longer walk
+
+
 def test_activity_past_gap_starts_a_new_block(db):
     user = _make_user(db)
     first = _make_activity(db, user, start=T0, elapsed=1500)

--- a/backend/tests/test_coach_report_runs_only_643.py
+++ b/backend/tests/test_coach_report_runs_only_643.py
@@ -6,11 +6,11 @@ and the single-shot on-ingest report) must only generate when the block's
 primary activity is a run. On-request regeneration is a separate path and stays
 ungated (not exercised here).
 
-"Running" is the coarse Strava ``type == "Run"`` (ordinary, trail, and
-Strava-app treadmill runs all keep ``type == "Run"``), matching
-``blocks.pick_primary`` so the gate agrees with which activity is chosen as the
-block primary the report generates on. A distinct ``type`` such as "VirtualRun"
-is a known gap (follow-up).
+"Running" is the run family shared with ``blocks.pick_primary`` so the gate
+agrees with which activity is chosen as the block primary the report generates
+on: the coarse Strava ``type == "Run"`` (ordinary, trail, and Strava-app
+treadmill runs all keep ``type == "Run"``) plus the distinct ``VirtualRun``
+(Zwift/Peloton connected-platform runs), brought into scope by #644.
 """
 
 from datetime import datetime
@@ -174,6 +174,29 @@ async def test_trail_run_still_gets_auto_report(db, receipt_cadence, notifier):
     assert result is not None
     row = get_active_report_row(db, run.id)
     assert row is not None and not row.is_fallback
+
+
+async def test_virtual_run_gets_auto_report(db, receipt_cadence, notifier):
+    """A connected-platform run (Zwift/Peloton) has Strava `type == "VirtualRun"`.
+    It is a run the coach should coach, so it is now in the auto-report run family
+    (#644) and gets its automatic report, not just a receipt."""
+    vrun = _seed(db, type="VirtualRun", name="Zwift session")
+    block = _block_of(db, vrun)
+    assert block.primary_activity_id == vrun.id  # picked as the run primary
+    await _send_receipt(db=db, activity=vrun, block=block, notifier=notifier)
+
+    with patch("app.services.coach.service.AnthropicClient",
+               return_value=_client_returning_fuller()):
+        result = await process_block_complete(
+            db=db, block_id=str(block.id), activity_id=str(vrun.id), notifier=notifier
+        )
+
+    assert result is not None
+    ex = _exchange_of(db, vrun)
+    assert ex.fuller_sent_at is not None  # closed: the report went
+    row = get_active_report_row(db, vrun.id)
+    assert row is not None and not row.is_fallback
+    assert len(notifier.sent) == 2  # receipt + report
 
 
 async def test_mixed_block_reports_on_run_primary(db, receipt_cadence, notifier):


### PR DESCRIPTION
Closes #644.

## Problem
A connected-platform run (Zwift, Peloton) surfaces on Strava as the distinct `type == "VirtualRun"`, not `"Run"`. The #643 run-gate and `blocks.pick_primary` both used the coarse `type == "Run"` test, so a virtual run was:
- **not chosen as its block's primary** (a longer walk/other member would win the anchor), and
- **not auto-reported** (the gate saw no run in the block).

The runner got only a receipt for a real training session. #644 flagged that broadening the gate alone is wrong — `pick_primary` uses the same test to choose the report anchor, so both must move together or "block contains a run" stops equalling "primary is a run".

## Change
One shared run-family predicate, `blocks.is_run_activity` (`type` in `{"run", "virtualrun"}`, case-insensitive), used in **both** places:
- `blocks.pick_primary` — the report anchor
- `process_new_activity._is_run_activity` — the auto-report gate (delegates to it)

`Activity` stores only the coarse `type` (no top-level `sport_type` column), and VirtualRun already surfaces there, so a predicate over `type` is sufficient; trail/treadmill runs keep `type == "Run"` and stay covered.

## Decision notes
- **North Star:** a good coach coaches virtual/indoor runs like outdoor ones; withholding a report for a real session is the misread to avoid. Platform-estimated pace/GPS quirks are already handled as data-quality caveats downstream, not a reason to skip the report.
- **Scope:** kept to the gate + anchor pair #644 names. Other run checks (classifier, novelty, modality) are separate concerns and untouched.

## Tests
- `test_blocks_service.py::test_virtual_run_becomes_primary_over_a_longer_non_run` — a VirtualRun wins the primary over a longer walk.
- `test_coach_report_runs_only_643.py::test_virtual_run_gets_auto_report` — a VirtualRun block gets receipt + full report (2 notifications), exchange closes.
- Both are genuine red→green against the old coarse test. Existing walk/trail/mixed-block cases still pass.

Full backend suite: **2166 passed, 12 deselected** (prod-parity coach flags), no regressions.