### PR TITLE
Let coach chat work before a report exists (#685)

### DIFF
--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -410,17 +410,12 @@ async def post_chat(
     """Send a message and stream the coach's response via SSE."""
     # P2.1: deny before opening the stream if the activity is not the user's.
     _require_owned_activity(db, activity_id, user)
-    # Validate that a coach report exists
-    existing = (
-        db.query(CoachReport)
-        .filter(CoachReport.activity_id == activity_id)
-        .first()
-    )
-    if not existing:
-        raise HTTPException(
-            status_code=400,
-            detail="Generate a coach report before starting a conversation.",
-        )
+    # #685: do NOT require an existing coach report. Under the receipt cadence a
+    # run's full report is generated asynchronously (~30 min after the session),
+    # so the activity page shows a live chat box before any report exists. The
+    # chat service degrades gracefully with no stored report — it answers from the
+    # activity's own data plus the on-demand query tools (#648) — so hard-blocking
+    # here with a 400 only surfaced to the runner as "couldn't reach your coach".
 
     async def event_stream():
         # Flush a comment frame immediately so the connection (and its 200) is

--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -441,17 +441,19 @@ async def stream_chat_response(
     # Uuid column type does not bind a str under SQLite (used in tests).
     activity_id = _coerce_uuid(activity_id)
 
+    # #685: a stored report is NOT required to chat. Under the receipt cadence the
+    # full report lands asynchronously (~30 min after the run), so a runner can open
+    # the activity and ask a question before any report exists. When there is no
+    # report the coach still answers from the activity's own data (splits, profile,
+    # cross-activity thread) plus the on-demand query tools (#648); a stored report,
+    # when present, adds the richer pack context. The safety-floor validator
+    # (`_validate_chat_text`) runs regardless and already tolerates an empty pack.
     report_row = get_active_report_row(db, activity_id) or (
         db.query(CoachReport)
         .filter(CoachReport.activity_id == activity_id)
         .order_by(CoachReport.created_at.desc())
         .first()
     )
-    if not report_row:
-        yield ChatStreamEvent(
-            text="I don't have an analysis for this activity yet. Please generate the coach report first."
-        )
-        return
 
     activity = (
         db.query(Activity)
@@ -478,9 +480,10 @@ async def stream_chat_response(
         )
         return
 
-    # Build context from the stored context pack
-    context_pack = report_row.context_pack or {}
-    report_content = report_row.report or {}
+    # Build context from the stored context pack (empty when no report exists yet,
+    # #685 — the coach then leans on the activity data + on-demand query tools).
+    context_pack = (report_row.context_pack if report_row else None) or {}
+    report_content = (report_row.report if report_row else None) or {}
 
     # Compute per-km splits from the activity's streams
     effective_type = activity.user_intent or activity.type
@@ -538,7 +541,9 @@ async def stream_chat_response(
     system_prompt = _build_chat_system_prompt(
         context_pack, report_content, profile_dict, splits_formatted,
         voice_block, cross_activity_block,
-        prompt_id=report_row.prompt_id,
+        # No stored report yet (#685): frame the (empty) pack under the active
+        # configured prompt so the coach view is byte-stable with the report path.
+        prompt_id=report_row.prompt_id if report_row else settings.COACH_PROMPT_ID,
     )
 
     # Save the user message

--- a/backend/tests/test_coach_chat_stream.py
+++ b/backend/tests/test_coach_chat_stream.py
@@ -45,6 +45,32 @@ def _seed_activity_with_report(db) -> Activity:
     return activity
 
 
+def _seed_activity_without_report(db) -> Activity:
+    """An activity with metrics but NO CoachReport — the receipt-cadence window
+    where the report is still generating asynchronously (#685)."""
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    db.add(UserProfile(user_id=user.id, goal_type="general", experience_level="intermediate", weekly_days_available=4, max_hr=190))
+    db.add(StravaAccount(user_id=user.id, strava_athlete_id=7, access_token="t", refresh_token="r", expires_at=9999999999, scope="read"))
+    activity = Activity(
+        user_id=user.id, strava_activity_id=99,
+        start_date=datetime(2026, 5, 27, 10, 0, 0), type="Run", name="Fresh run",
+        distance_m=5000, moving_time_s=1500, elapsed_time_s=1500, elev_gain_m=10.0,
+        avg_hr=140, raw_summary={},
+    )
+    db.add(activity)
+    db.commit()
+    db.add(DerivedMetric(
+        activity_id=activity.id, effort="easy", structure="continuous",
+        duration_class="standard", effort_score=50.0, flags=[],
+        confidence="medium", confidence_reasons=[],
+    ))
+    db.commit()
+    db.refresh(activity)
+    return activity
+
+
 def _reconstruct_from_sse(raw: str) -> str:
     """Reconstruct the assistant text from the SSE stream the frontend's way:
     split on the blank-line event delimiter, then JSON-decode each data frame."""
@@ -83,6 +109,42 @@ def test_chat_stream_preserves_multiline_markdown(client, db):
     reconstructed = _reconstruct_from_sse(resp.text)
     assert reconstructed == reply, f"got {reconstructed!r}"
     # The user turn and the assembled assistant turn are both persisted.
+    from app.models.coach_chat_message import CoachChatMessage
+
+    saved = (
+        db.query(CoachChatMessage)
+        .filter(CoachChatMessage.activity_id == activity.id)
+        .order_by(CoachChatMessage.created_at.asc())
+        .all()
+    )
+    assert [m.role for m in saved] == ["user", "assistant"]
+    assert saved[1].content == reply
+
+
+def test_chat_works_before_a_report_exists(client, db):
+    """#685: chatting an activity that has no CoachReport yet must NOT fail. It
+    used to 400 (surfaced as "couldn't reach your coach"); now the stream opens
+    200 and the coach answers from the activity's own data + query tools."""
+    activity = _seed_activity_without_report(db)
+    from app.models.coach_report import CoachReport
+
+    assert (
+        db.query(CoachReport).filter(CoachReport.activity_id == activity.id).count() == 0
+    )
+
+    reply = "Nice steady effort. Let's talk about it."
+    stub = chat_turn_stub(["Nice steady effort. ", "Let's talk about it."])
+    with patch("app.services.coach.llm.AnthropicClient.stream_chat_turn", new=stub):
+        resp = client.post(
+            f"/api/activities/{activity.id}/coach-chat",
+            json={"message": "How did that run go?"},
+        )
+
+    assert resp.status_code == 200
+    reconstructed = _reconstruct_from_sse(resp.text)
+    assert reconstructed == reply, f"got {reconstructed!r}"
+
+    # The turn is persisted like any other, so the conversation continues.
     from app.models.coach_chat_message import CoachChatMessage
 
     saved = (


### PR DESCRIPTION
Closes #685.

## Problem
Chatting an activity with no `CoachReport` yet failed with "couldn't reach your coach". `post_chat` raised **HTTP 400** before opening the SSE stream, and the frontend surfaces any non-2xx as that generic error (`CoachChat.tsx` catch-all). Under the receipt cadence a run's full report is generated **asynchronously (~30 min after the session)**, while the activity page renders a live chat box as soon as metrics exist (`CoachSection` gates on `hasMetrics`, not on a report). So the runner routinely lands in that window and hits the 400.

The chat **service** already degraded gracefully when no report existed — but the endpoint's 400 pre-empted it, and the service's own fallback ("generate the coach report first") was misleading jargon since the report auto-generates.

## Change
- **`api/coach.py`** — remove the redundant 400 guard; the stream opens 200 and the service handles the no-report case.
- **`services/coach/chat.py`** — drop the early return and make the three report-derived values None-safe:
  - `context_pack` → `{}`
  - `report_content` → `{}`
  - `prompt_id` → `settings.COACH_PROMPT_ID` (keeps the outgoing coach view byte-stable with the report path)

The coach then answers from the activity's own data (splits, profile, cross-activity thread) plus the **on-demand query tools (#648)**; a stored report, when present, still adds the richer pack context. `_build_chat_system_prompt` / `coach_llm_view` already tolerate an empty pack, and `_validate_chat_text` (the medical-scope safety floor) runs regardless — **no floor is lowered**.

## Decision notes
- **North Star:** a good coach engages when asked right after a run, rather than telling the runner to "generate a report first" — app jargon that reads as broken, especially when the report auto-generates anyway. So the fix *enables* chat, not just softens the error.
- **No frontend change:** the chat box is already shown when metrics exist; that is now the correct behaviour rather than a trap.

## Tests
- `test_coach_chat_stream.py::test_chat_works_before_a_report_exists` — POST to an activity with metrics but **zero** `CoachReport` rows returns 200, streams a real coach reply, and persists the user+assistant turns. Exercises the empty-pack path end-to-end through the real endpoint.
- Full chat suite (58 tests) and full backend suite pass: **2165 passed, 12 deselected**, no regressions.