### PR TITLE
Fix double-normalized average cadence on the activity page (#684)

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -2,6 +2,8 @@ from datetime import date, datetime, timedelta
 from typing import Annotated, List, Optional
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from sqlalchemy import select
 
@@ -240,7 +242,12 @@ def read_activities(
                 activity, Classification.from_metrics(activity.metrics)
             )
         responses.append(response)
-    return responses
+    # #684: the models above are already validated once (model_validate). Returning
+    # them directly would let FastAPI re-validate against `response_model`, re-running
+    # `ActivityRead.normalize_run_cadence` — a NON-idempotent single-leg->two-leg
+    # doubling — a second time, so avg_cadence would be doubled twice. Serialize the
+    # already-normalized instances directly to keep normalization at exactly one pass.
+    return JSONResponse(content=jsonable_encoder(responses))
 
 @router.get("/activities/{activity_id}", response_model=ActivityDetailRead)
 def read_activity(
@@ -293,7 +300,14 @@ def read_activity(
             sample_count=readiness.sample_count,
         )
 
-    return response
+    # #684: `response` is already validated once (model_validate above). Returning it
+    # directly would let FastAPI re-validate it against `response_model`, re-running
+    # the cadence normalizers (`normalize_run_cadence`, `normalize_stream_cadence`) —
+    # each a NON-idempotent `< 130 spm -> double` rule — a SECOND time, doubling
+    # avg_cadence and the raw cadence stream twice while the guarded smoothed_cadence
+    # recompute stays at one doubling (the 254-vs-127 split). Serialize the
+    # already-normalized instance directly so normalization runs at exactly one pass.
+    return JSONResponse(content=jsonable_encoder(response))
 
 @router.post("/activities/{activity_id}/checkin", response_model=CheckInRead)
 def create_checkin(

--- a/backend/tests/test_cadence_normalization_684.py
+++ b/backend/tests/test_cadence_normalization_684.py
@@ -1,0 +1,105 @@
+"""#684: the two average-cadence figures on the activity page must agree.
+
+The detail read-model normalizes cadence (single-leg spm -> two-leg spm) in
+`@model_validator(mode="after")` methods. Those validators mutate `avg_cadence`
+and the raw cadence stream and then re-read them, so they are NOT idempotent: the
+`< 130 spm -> double` rule doubles an already-doubled value again. The endpoint
+validated the model twice (an explicit `model_validate` plus FastAPI's
+`response_model` re-validation), so `avg_cadence` was doubled twice (63 -> 126 ->
+252) while the guarded `smoothed_cadence` recompute stayed at one doubling (126).
+Result: Metrics panel showed 254 spm, the chart header 127 spm — exactly 2x.
+
+These tests hit the real endpoint through the FastAPI test client, so they
+exercise the actual double-validation, not a mirror of the validators.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+from app.models import Activity, ActivityStream, DerivedMetric, User
+from app.models.user_profile import UserProfile
+
+_BASE = datetime(2026, 7, 14, 9, 0, tzinfo=timezone.utc)
+
+# A realistic single-leg walking cadence stream (~63 spm one foot -> ~126 spm
+# both feet). Constant so the expected two-leg value is unambiguous.
+_SINGLE_LEG_SPM = 63.0
+_N = 30
+
+
+def _seed_activity_with_cadence(db) -> Activity:
+    user = User(email=f"cad-{uuid.uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    db.add(UserProfile(user_id=user.id, goal_type="general",
+                       experience_level="intermediate", weekly_days_available=4, max_hr=190))
+    activity = Activity(
+        user_id=user.id,
+        strava_activity_id=int(_BASE.timestamp()) + uuid.uuid4().int % 100_000,
+        start_date=_BASE, type="Walk", name="Evening walk",
+        distance_m=5050, moving_time_s=2940, elapsed_time_s=2940, elev_gain_m=10.0,
+        avg_hr=110, average_speed_mps=1.7, avg_cadence=_SINGLE_LEG_SPM, raw_summary={},
+    )
+    db.add(activity)
+    db.commit()
+    db.add(DerivedMetric(
+        activity_id=activity.id, effort_score=30.0, confidence="high",
+        flags=[], confidence_reasons=[],
+    ))
+    # Streams needed for smoothed_cadence generation: cadence + time (+ velocity/moving).
+    db.add(ActivityStream(activity_id=activity.id, stream_type="cadence",
+                          data=[_SINGLE_LEG_SPM] * _N))
+    db.add(ActivityStream(activity_id=activity.id, stream_type="time",
+                          data=list(range(_N))))
+    db.add(ActivityStream(activity_id=activity.id, stream_type="velocity_smooth",
+                          data=[1.7] * _N))
+    db.add(ActivityStream(activity_id=activity.id, stream_type="moving",
+                          data=[True] * _N))
+    db.commit()
+    db.refresh(activity)
+    return activity
+
+
+def _mean(values):
+    nums = [v for v in values if isinstance(v, (int, float))]
+    return sum(nums) / len(nums) if nums else None
+
+
+def test_detail_avg_cadence_agrees_with_charted_stream(client, db):
+    """The Metrics `avg_cadence` and the cadence chart's average (the mean of the
+    `smoothed_cadence` stream) must be the same number, and it must be the
+    plausible two-leg value (~126 spm), not double-doubled (~252)."""
+    activity = _seed_activity_with_cadence(db)
+
+    resp = client.get(f"/api/activities/{activity.id}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    avg_cadence = body["avg_cadence"]
+    assert avg_cadence is not None
+
+    streams = {s["stream_type"]: s["data"] for s in body["streams"]}
+    assert "smoothed_cadence" in streams, "chart uses the smoothed_cadence stream"
+    chart_avg = _mean(streams["smoothed_cadence"])
+    assert chart_avg is not None
+
+    # The two page figures must agree (the core of #684).
+    assert abs(avg_cadence - chart_avg) < 1.0, (
+        f"Metrics avg_cadence {avg_cadence} disagrees with chart avg {chart_avg}"
+    )
+    # And it must be doubled exactly once (single-leg -> two-leg), not twice.
+    assert 110 <= avg_cadence <= 150, f"avg_cadence {avg_cadence} looks double-doubled"
+
+
+def test_detail_raw_cadence_stream_not_double_doubled(client, db):
+    """The raw cadence stream served for the chart's faint secondary line must be
+    doubled once (~126), so the chart's Max is plausible rather than ~488."""
+    activity = _seed_activity_with_cadence(db)
+
+    resp = client.get(f"/api/activities/{activity.id}")
+    assert resp.status_code == 200, resp.text
+    streams = {s["stream_type"]: s["data"] for s in resp.json()["streams"]}
+
+    raw = [v for v in streams["cadence"] if isinstance(v, (int, float))]
+    assert raw, "raw cadence stream present"
+    assert max(raw) <= 150, f"raw cadence max {max(raw)} is double-doubled"


### PR DESCRIPTION
Closes #684.

## Problem
The activity page showed two disagreeing average-cadence figures for the same activity:
- **Metrics panel:** `Avg Cadence: 254 spm`
- **Cadence chart header:** `Avg: 127 spm` (and an implausible `Max: 488 spm`)

Exactly 2×, and 254 spm is physically impossible for a walk.

## Root cause
The detail/list read models normalize cadence (single-leg → two-leg spm) in `@model_validator(mode="after")` methods that **mutate and then re-read** `avg_cadence` and the raw cadence stream. The rule is `cadence < 130 spm → ×2`, which is **not idempotent** — a once-doubled 63→126 is still < 130, so a second pass doubles it again to 252.

Both endpoints validate the model **twice**:
1. an explicit `ActivityDetailRead.model_validate(activity)` (to inject splits/laps/training_load), then
2. FastAPI re-validating the returned instance against `response_model`.

So `avg_cadence` and the raw cadence stream got doubled twice (63 → 126 → 252), while the `smoothed_cadence` recompute the chart charts is dedup-guarded and stayed at one doubling (126). Result: Metrics 254, chart 127, and a raw secondary line peaking ~488.

Confirmed at the **real FastAPI endpoint** (not a mirror) by the new red test: raw cadence max came back `252.0`.

## Fix
Return the already-validated instance serialized directly — `JSONResponse(jsonable_encoder(...))` — at both the detail (`GET /activities/{id}`) and list (`GET /activities`) endpoints. FastAPI passes a `Response` through untouched, so it does **not** re-validate against `response_model`, and the read-model normalizers run at exactly one pass (the count they were written for). No cadence logic changes; the serialized JSON is equivalent to the `response_model` output (existing detail/list tests still pass, and `raw_summary` stays off `ActivityRead` since it's declared on `ActivityCreate`, not the base).

## Decision notes
- **Technical:** fixing the double-validation is the true root cause and the least invasive change. Making the threshold-doubling itself idempotent is impossible near the 130 boundary (a genuine both-legs 126 is indistinguishable from a doubled single-leg 63); moving normalization out of the validators would touch 7 call sites. This keeps the change to the two endpoints that actually double-validated.
- **Scope:** fixed the list endpoint too — its `ActivityRead` carries the same non-idempotent `avg_cadence` normalizer and the same double-validation pattern, so it had the same latent bug.

## Tests
- `test_cadence_normalization_684.py` (hits the real endpoint via TestClient):
  - `test_detail_avg_cadence_agrees_with_charted_stream` — Metrics `avg_cadence` == mean(`smoothed_cadence`), and ~126 (doubled once), not ~252.
  - `test_detail_raw_cadence_stream_not_double_doubled` — served raw cadence max is plausible, not ~252/488.
- Both red before the fix (raw max 252), green after.
- Full backend suite: **2166 passed, 12 deselected**, no regressions.