### PR TITLE
Retry Anthropic 429 on the coach chat streaming path (#625)

### DIFF
--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -605,6 +605,8 @@ async def stream_chat_response(
     llm_messages = messages  # mutated across tool rounds (assistant + tool_result turns)
     assistant_text = None
     stream_failed = False
+    # The message served if the stream fails; the except may specialise it (#625).
+    stream_fail_message = "Sorry, I encountered an error. Please try again."
     tools_used: List[str] = []  # ordered, de-duped tool names, persisted for the trace
     last_heartbeat = time.monotonic()
     try:
@@ -673,12 +675,25 @@ async def stream_chat_response(
             assistant_text = _extract_block_text(final_msg.content_blocks)
             break
     except Exception as e:
-        logger.error("Chat streaming error: %s", e)
+        import anthropic
+
+        # #625: an exhausted 429 (the bounded retry in stream_chat_turn gave up)
+        # gets a transparent "busy, try again" message rather than the generic
+        # error — consistent with how the report path degrades on rate limits. Any
+        # other transport error keeps the generic message.
+        rate_limited = isinstance(e, anthropic.RateLimitError)
+        logger.error("Chat streaming error (rate_limited=%s): %s", rate_limited, e)
         stream_failed = True
+        stream_fail_message = (
+            "I'm getting a lot of requests right now, so I couldn't finish that "
+            "reply. Give me a moment and try again — your message is saved."
+            if rate_limited
+            else "Sorry, I encountered an error. Please try again."
+        )
 
     if stream_failed:
         # A transport-level error message is safe by construction; no gating needed.
-        assistant_text = "Sorry, I encountered an error. Please try again."
+        assistant_text = stream_fail_message
     else:
         # Defensive: the tools-off final round should always yield text; an empty
         # reply still gates safely below.

--- a/backend/app/services/coach/llm.py
+++ b/backend/app/services/coach/llm.py
@@ -435,10 +435,18 @@ class AnthropicClient:
         and the stop_reason for the tool loop to dispatch on.
 
         When `tools` is falsy the call carries no tool surface, forcing a text answer
-        (the loop's tools-off final round). No 429 retry here: the chat path's
-        rate-limit resilience is tracked separately (#625); a transport error
-        propagates to the caller's safe-degrade path, exactly as `stream_chat` does.
+        (the loop's tools-off final round).
+
+        429 resilience (#625): a rate limit is admission-time capacity, raised when
+        the request is issued — BEFORE the first token — so a bounded retry honoring
+        Retry-After (the same `_MAX_RATE_LIMIT_RETRIES` budget and backoff as the
+        report path, #603) re-issues the request with no duplicate output. If any
+        token has already streamed, we do NOT re-run (that would duplicate the
+        buffered reply); the 429 then propagates to the caller's safe-degrade path,
+        exactly as any other transport error does.
         """
+        import anthropic
+
         stream_kwargs: Dict[str, Any] = dict(
             model=self.model,
             max_tokens=max_tokens,
@@ -451,10 +459,29 @@ class AnthropicClient:
             stream_kwargs["tools"] = tools
             stream_kwargs["tool_choice"] = {"type": "auto"}
 
-        async with self.client.messages.stream(**stream_kwargs) as stream:
-            async for text in stream.text_stream:
-                yield ChatTurnDelta(text=text)
-            final = await stream.get_final_message()
+        rate_limit_retries = 0
+        while True:
+            started = False
+            try:
+                async with self.client.messages.stream(**stream_kwargs) as stream:
+                    async for text in stream.text_stream:
+                        started = True
+                        yield ChatTurnDelta(text=text)
+                    final = await stream.get_final_message()
+                break
+            except anthropic.RateLimitError as exc:
+                # Only retriable before the first token; once tokens have streamed a
+                # re-run would duplicate the buffered reply, so propagate instead.
+                if not started and rate_limit_retries < _MAX_RATE_LIMIT_RETRIES:
+                    delay = _rate_limit_backoff_seconds(exc, rate_limit_retries)
+                    rate_limit_retries += 1
+                    logger.warning(
+                        "anthropic_chat_rate_limit_retry",
+                        extra={"attempt": rate_limit_retries, "sleep": delay},
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                raise
 
         usage = getattr(final, "usage", None)
         yield ChatTurnDelta(

--- a/backend/tests/test_coach_chat_stream.py
+++ b/backend/tests/test_coach_chat_stream.py
@@ -157,6 +157,36 @@ def test_chat_works_before_a_report_exists(client, db):
     assert saved[1].content == reply
 
 
+def test_chat_degrades_gracefully_on_exhausted_rate_limit(client, db):
+    """#625: when the bounded 429 retry is exhausted, the chat turn degrades to a
+    transparent 'busy, try again' message with a 200/intact connection — not a
+    crash or the generic error."""
+    activity = _seed_activity_with_report(db)
+
+    import anthropic
+    import httpx
+
+    def _rate_limited():
+        req = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        resp = httpx.Response(status_code=429, request=req)
+        return anthropic.RateLimitError("rate limited", response=resp, body=None)
+
+    async def _stub(self, *, system, messages, tools=None, max_tokens=1024):
+        raise _rate_limited()
+        yield  # unreachable; makes this an async generator like the real method
+
+    with patch("app.services.coach.llm.AnthropicClient.stream_chat_turn", new=_stub):
+        resp = client.post(
+            f"/api/activities/{activity.id}/coach-chat",
+            json={"message": "How did I do?"},
+        )
+
+    assert resp.status_code == 200
+    assert "data: [DONE]" in resp.text
+    reconstructed = _reconstruct_from_sse(resp.text).lower()
+    assert "requests" in reconstructed and "moment" in reconstructed
+
+
 def test_chat_stream_reports_error_without_breaking_connection(client, db):
     """A failure mid-stream must not sever the connection (which the browser
     shows as a bare "Load failed") — it streams a readable message and closes

--- a/backend/tests/test_coach_llm_timeout_retry.py
+++ b/backend/tests/test_coach_llm_timeout_retry.py
@@ -399,3 +399,81 @@ async def test_generate_coach_message_retries_on_429_then_succeeds():
         result = await client.generate_coach_message(system="sys", user="user", tools=[])
 
     assert result.stop_reason == "end_turn"
+
+
+# ---------------------------------------------------------------------------
+# stream_chat_turn — 429 resilience on the CHAT streaming path (#625)
+#
+# The chat path streams tokens (an async generator), so it was left out of #603's
+# scope. A 429 is admission-time capacity raised before the first token, so a
+# bounded retry re-issues the request with no duplicate output; once tokens have
+# streamed it must NOT re-run (that would duplicate the buffered reply).
+# ---------------------------------------------------------------------------
+
+
+def _make_chat_streaming_ctx(outcomes):
+    """`messages.stream` factory shaped for stream_chat_turn. Each entry is
+    consumed per call: a BaseException raised on context entry (the admission-time
+    429), or a (deltas, final) tuple whose text_stream yields `deltas` then whose
+    get_final_message returns `final`."""
+    calls = iter(outcomes)
+
+    @asynccontextmanager
+    async def _ctx(*args, **kwargs):
+        outcome = next(calls)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        deltas, final = outcome
+
+        async def _text_stream():
+            for d in deltas:
+                yield d
+
+        stream = MagicMock()
+        stream.text_stream = _text_stream()
+        stream.get_final_message = AsyncMock(return_value=final)
+        yield stream
+
+    return _ctx
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_turn_retries_on_429_then_succeeds():
+    """A 429 on the first admission is retried; the second attempt streams the
+    reply, so the runner gets a brief wait instead of a failed turn."""
+    client = AnthropicClient(api_key="k", model="m")
+    err = _make_rate_limit_error(retry_after=1)
+    final = _make_ok_message_result()
+    client.client.messages.stream = _make_chat_streaming_ctx(
+        [err, (["Hello ", "there"], final)]
+    )
+
+    deltas = []
+    with patch("asyncio.sleep", new=AsyncMock()):
+        async for d in client.stream_chat_turn(
+            system="s", messages=[{"role": "user", "content": "hi"}]
+        ):
+            deltas.append(d)
+
+    text = "".join(d.text for d in deltas if d.text)
+    assert text == "Hello there"
+    finals = [d for d in deltas if d.final is not None]
+    assert finals and finals[-1].final.stop_reason == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_turn_propagates_429_after_retries_exhausted():
+    """When the bounded retry is exhausted the 429 propagates, so chat.py's
+    safe-degrade path serves a transparent 'busy, try again' message."""
+    client = AnthropicClient(api_key="k", model="m")
+    n = _llm_mod._MAX_RATE_LIMIT_RETRIES
+    client.client.messages.stream = _make_chat_streaming_ctx(
+        [_make_rate_limit_error() for _ in range(n + 1)]
+    )
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(anthropic.RateLimitError):
+            async for _ in client.stream_chat_turn(
+                system="s", messages=[{"role": "user", "content": "hi"}]
+            ):
+                pass


### PR DESCRIPTION
Closes #625.

## Problem
The report path retries a 429 with backoff (#603/#621), but the chat streaming path (`stream_chat_turn`) had no rate-limit retry, so under concurrent load (worker fuller turns + web chat streams) a 429 surfaced to the runner as a failed/aborted reply mid-conversation.

## Change
- **`llm.py` `stream_chat_turn`** — bounded 429 retry reusing the report path's `_MAX_RATE_LIMIT_RETRIES` budget, Retry-After honoring, and capped backoff (`_rate_limit_backoff_seconds`). A 429 is admission-time capacity raised **before the first token**, so re-issuing the request produces no duplicate output. A `started` guard ensures that if any token has already streamed we do **not** re-run (that would duplicate the buffered reply) and instead propagate.
- **`chat.py` `stream_chat_response`** — on an exhausted 429 (or any error), the existing safe-degrade path now distinguishes a `RateLimitError` and serves a transparent *"getting a lot of requests, give me a moment and try again — your message is saved"* message, consistent with how the report path degrades, rather than the generic error.

## Decision notes
- **Technical:** retry at the stream-admission point rather than around the whole tool loop — that is exactly where the 429 fires and where a re-issue is safe. The #340 buffer-then-validate design means no bytes reach the client during the retry, so the typing effect is unaffected.
- **North Star:** a briefly rate-limited coach should just wait and answer (the retry does this); when genuinely saturated, an honest "busy, try again" beats a silent failure.

## Tests
- `test_coach_llm_timeout_retry.py`:
  - `test_stream_chat_turn_retries_on_429_then_succeeds` — first admission 429, second streams the reply.
  - `test_stream_chat_turn_propagates_429_after_retries_exhausted` — propagates after the bounded budget.
- `test_coach_chat_stream.py::test_chat_degrades_gracefully_on_exhausted_rate_limit` — end-to-end through the endpoint: exhausted 429 yields the busy message with 200 + intact `[DONE]` stream.
- Full backend suite: **2167 passed, 12 deselected**, no regressions.