### PR TITLE
Make the RPE-vs-HR weighting symmetric and discount-not-substitute (#654)

### DIFF
--- a/backend/app/schemas/coach_context.py
+++ b/backend/app/schemas/coach_context.py
@@ -183,8 +183,11 @@ class PerceivedEffortContext(BaseModel):
     (RPE) and what HR showed, plus a pain-score trend.
 
     `divergence` is a signed 1-5-band gap (positive = felt harder than HR
-    showed); `recommended_weighting` is "rpe_over_hr" when an HR confounder fired
-    (RPE survives HR distortion), else "balanced", or "hr_only" with no RPE.
+    showed); `recommended_weighting` is a symmetric, direction-driven confidence
+    tilt (#654): "lead_with_felt" when it felt harder than HR showed, "dont_dismiss_hr"
+    when it felt easier (hold both — real zone time is real work), "balanced" when
+    aligned, or "hr_only" with no RPE. A fired confounder (`hr_confounded`) informs
+    the drift read, not this weighting.
     `pain_trend` is None (no data), an abstention marker (too few samples), or a
     direction+slope trend dict scoped to this run's pain location; never a
     diagnosis. All RPE/pain fields degrade to None/empty when
@@ -890,7 +893,7 @@ class IntensityFeltVsMeasured(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     read: str                                 # aligned | felt_harder | felt_easier
-    trust: str                                # rpe_over_hr | balanced
+    trust: str                                # lead_with_felt | dont_dismiss_hr | balanced (#654)
 
 
 class IntensityDriftRead(BaseModel):

--- a/backend/app/services/coach/perceived_effort.py
+++ b/backend/app/services/coach/perceived_effort.py
@@ -3,9 +3,18 @@ what the body showed (HR-derived intensity), plus a pain-score trend.
 
 This app uniquely holds both sides of the perception-vs-physiology gap, and that
 gap is coaching signal (ADR-0007's "the gap is the signal", extended from
-intent-vs-execution to perception-vs-physiology). When an HR confounder fired
-(N4 discount_signals), RPE is the more trustworthy intensity read because it
-survives HR distortion, so the coach should weight it above HR.
+intent-vs-execution to perception-vs-physiology).
+
+The weighting the coach should lean toward is a function of the gap DIRECTION, and
+symmetric (#654). A run that felt HARDER than HR showed carries a real experience
+the HR number misses (heat, fatigue, poor fuelling), so lean toward the felt read.
+A run that felt EASIER than HR showed is the mirror: the easy feel is real, but the
+time actually spent in the HR zones is real cardiovascular work too, so do NOT
+declare the run purely easy on the RPE alone — hold both. Earlier this resolved
+one-directionally ("an HR confounder fired, so trust the RPE"), which let a run
+with real Z3-Z4 time be called "genuinely easy" on RPE 3. A fired confounder
+lowers confidence in the DRIFT/fatigue read (it leads the drift elsewhere in the
+pack), it does not license substituting RPE for the measured intensity.
 
 Design note: divergence is computed against the HR-derived `effort` axis
 (intensity), NOT `effort_score`. `effort_score` is a TRIMP-like cumulative load
@@ -63,15 +72,30 @@ def compute_divergence(rpe: Optional[int], effort_axis: Optional[str]) -> Option
     return {"divergence": divergence, "direction": direction}
 
 
-def recommend_weighting(rpe: Optional[int], hr_confounded: bool) -> str:
-    """Which intensity signal the report should lead with.
+def recommend_weighting(rpe: Optional[int], divergence_direction: Optional[str]) -> str:
+    """How the coach should weigh the felt (RPE) vs measured (HR) intensity reads —
+    a confidence tilt, never a substitution, and symmetric in the gap direction (#654).
 
-    No RPE -> HR is all we have. A confounder fired and we have RPE -> weight RPE
-    over HR (it survives HR distortion). Otherwise both agree enough to balance."""
+    - No RPE -> `hr_only`: HR is all we have.
+    - `felt_harder` -> `lead_with_felt`: the runner felt it substantially harder than
+      HR showed. That harder experience is real signal (heat, fatigue, fuelling) the
+      HR number misses, so lead with it rather than flattening it into the HR band.
+    - `felt_easier` -> `dont_dismiss_hr`: the mirror. The easy feel is real, but the
+      time actually spent in the HR zones is real cardiovascular work, so hold both and
+      do NOT call the run purely easy on the RPE alone.
+    - otherwise (`aligned` / unknown) -> `balanced`: the two agree enough to weigh together.
+
+    Deliberately NOT keyed on whether an HR confounder fired: a confounder inflates HR
+    and so lowers confidence in the DRIFT/fatigue read (it leads the drift elsewhere in
+    the pack), but it never licenses substituting RPE for the measured intensity, and it
+    only physically explains a `felt_easier` gap anyway. The `hr_confounded` fact still
+    rides the pack for the coach to explain WHY HR was elevated."""
     if rpe is None:
         return "hr_only"
-    if hr_confounded:
-        return "rpe_over_hr"
+    if divergence_direction == "felt_harder":
+        return "lead_with_felt"
+    if divergence_direction == "felt_easier":
+        return "dont_dismiss_hr"
     return "balanced"
 
 
@@ -118,6 +142,8 @@ def build_perceived_effort(
         divergence=divergence["divergence"] if divergence else None,
         divergence_direction=divergence["direction"] if divergence else None,
         hr_confounded=hr_confounded,
-        recommended_weighting=recommend_weighting(rpe, hr_confounded),
+        recommended_weighting=recommend_weighting(
+            rpe, divergence["direction"] if divergence else None
+        ),
         pain_trend=compute_pain_trend(pain_scores),
     )

--- a/backend/tests/test_intensity_read.py
+++ b/backend/tests/test_intensity_read.py
@@ -64,12 +64,12 @@ def test_felt_vs_measured_present_with_a_check_in():
     read = build_intensity_read(
         this_session=_session(),
         distribution_adjusted=None,
-        perceived_effort=_pe(divergence_direction="felt_harder", recommended_weighting="rpe_over_hr"),
+        perceived_effort=_pe(divergence_direction="felt_harder", recommended_weighting="lead_with_felt"),
         calibration_hr_drift=_calibrated_drift(),
         confounders=["heat"],
     )
     assert read.felt_vs_measured.read == "felt_harder"
-    assert read.felt_vs_measured.trust == "rpe_over_hr"
+    assert read.felt_vs_measured.trust == "lead_with_felt"
 
 
 def test_felt_vs_measured_absent_without_rpe():

--- a/backend/tests/test_perceived_effort.py
+++ b/backend/tests/test_perceived_effort.py
@@ -48,13 +48,22 @@ class TestComputeDivergence:
 
 class TestRecommendWeighting:
     def test_hr_only_when_no_rpe(self):
-        assert recommend_weighting(rpe=None, hr_confounded=True) == "hr_only"
+        assert recommend_weighting(rpe=None, divergence_direction=None) == "hr_only"
 
-    def test_rpe_over_hr_when_confounded(self):
-        assert recommend_weighting(rpe=8, hr_confounded=True) == "rpe_over_hr"
+    def test_lead_with_felt_when_felt_harder(self):
+        # The runner felt it much harder than HR showed: lead with the felt read.
+        assert recommend_weighting(rpe=8, divergence_direction="felt_harder") == "lead_with_felt"
 
-    def test_balanced_when_clean(self):
-        assert recommend_weighting(rpe=8, hr_confounded=False) == "balanced"
+    def test_dont_dismiss_hr_when_felt_easier(self):
+        # The mirror (#654): felt easy but real HR work — hold both, don't call it easy.
+        assert recommend_weighting(rpe=3, divergence_direction="felt_easier") == "dont_dismiss_hr"
+
+    def test_balanced_when_aligned(self):
+        assert recommend_weighting(rpe=5, divergence_direction="aligned") == "balanced"
+
+    def test_balanced_when_direction_unknown(self):
+        # No effort axis to compare against -> no divergence direction -> balanced.
+        assert recommend_weighting(rpe=5, divergence_direction=None) == "balanced"
 
 
 class TestComputePainTrend:
@@ -87,8 +96,8 @@ class TestComputePainTrend:
 
 
 class TestBuildPerceivedEffort:
-    def test_heat_suppressed_hard_run_weights_rpe(self):
-        # The brief's canonical case.
+    def test_heat_suppressed_hard_run_leads_with_felt(self):
+        # The runner felt it hard while HR read easy: lead with their felt read.
         ctx = build_perceived_effort(
             rpe=8,
             effort_axis="easy",
@@ -102,8 +111,25 @@ class TestBuildPerceivedEffort:
         assert ctx.divergence == 2
         assert ctx.divergence_direction == "felt_harder"
         assert ctx.hr_confounded is True
-        assert ctx.recommended_weighting == "rpe_over_hr"
+        assert ctx.recommended_weighting == "lead_with_felt"
         assert ctx.pain_trend is None
+
+    def test_easy_rpe_with_real_hr_work_does_not_dismiss_hr(self):
+        # #654: an easy RPE on a run with real Z3-Z4 HR time, even with an HR
+        # confounder, must NOT resolve to 'trust RPE, genuinely easy'. It holds both.
+        ctx = build_perceived_effort(
+            rpe=3,
+            effort_axis="tempo",  # HR-derived intensity band 4
+            effort_score=45.0,
+            discount_signals={"likely_inflated_by": ["stimulant_use"], "confidence": "high"},
+            pain_scores=[],
+        )
+        assert ctx.rpe == 3
+        assert ctx.divergence == -2  # RPE band 2 - HR band 4
+        assert ctx.divergence_direction == "felt_easier"
+        assert ctx.hr_confounded is True
+        # The fix: not a wholesale substitution toward RPE, but hold both reads.
+        assert ctx.recommended_weighting == "dont_dismiss_hr"
 
     def test_no_checkin_degrades_safely(self):
         ctx = build_perceived_effort(
@@ -127,14 +153,17 @@ class TestBuildPerceivedEffort:
         assert ctx.pain_trend["abstained"] is False
 
     def test_empty_inflators_not_confounded(self):
-        # discount_signals present but no concrete confound (temp-unknown case).
+        # discount_signals present but no concrete confound (temp-unknown case): the
+        # confounder does not fire. Weighting is now direction-driven (#654), so this
+        # felt-harder run leads with the felt read regardless of the (absent) confound.
         ctx = build_perceived_effort(
             rpe=8, effort_axis="easy", effort_score=4.0,
             discount_signals={"likely_inflated_by": [], "confidence": "low"},
             pain_scores=[],
         )
         assert ctx.hr_confounded is False
-        assert ctx.recommended_weighting == "balanced"
+        assert ctx.divergence_direction == "felt_harder"
+        assert ctx.recommended_weighting == "lead_with_felt"
 
     def test_min_pain_samples_is_four(self):
         assert MIN_PAIN_SAMPLES == 4

--- a/backend/tests/test_perceived_effort_context.py
+++ b/backend/tests/test_perceived_effort_context.py
@@ -75,7 +75,7 @@ class TestPerceivedEffortInPack:
         assert pe.divergence == 2
         assert pe.divergence_direction == "felt_harder"
         assert pe.hr_confounded is True
-        assert pe.recommended_weighting == "rpe_over_hr"
+        assert pe.recommended_weighting == "lead_with_felt"
 
     def test_serialization_folds_out_duplicate_scalars(self, db):
         """One-fact-one-place: the builder populates perceived_effort.rpe/effort_score
@@ -103,7 +103,7 @@ class TestPerceivedEffortInPack:
         assert out["metrics"]["hr_drift"] == 9.0
         # The derived read the section exists for survives.
         assert out["perceived_effort"]["divergence"] == 2
-        assert out["perceived_effort"]["recommended_weighting"] == "rpe_over_hr"
+        assert out["perceived_effort"]["recommended_weighting"] == "lead_with_felt"
 
     def test_no_checkin_degrades_safely(self, db):
         user_id = _user(db)


### PR DESCRIPTION
Closes #654.

## Problem
The M6 perceived-effort weighting resolved **one-directionally**: whenever an HR confounder fired, `recommend_weighting` returned `"rpe_over_hr"` ("trust the RPE, discount HR") regardless of the gap direction. That let an 8.9 km run at 159 avg / 178 max HR with real Z3-Z4 time be called **"genuinely easy" on RPE 3 alone** — the easy RPE wholesale substituted for the measured intensity. There was no symmetric signal for "the easy RPE may be under-reporting real work."

## Change
`recommend_weighting` becomes a symmetric function of the gap **direction**, and a confidence tilt rather than a substitution:

| gap | value | meaning |
|---|---|---|
| `felt_harder` | `lead_with_felt` | the runner's harder experience is real signal HR misses; lead with it (preserves the prior heat-suppressed case's intent) |
| `felt_easier` | `dont_dismiss_hr` | the mirror — the easy feel is real, but the time in the HR zones is real cardiovascular work; **hold both, don't call it easy** |
| `aligned`/unknown | `balanced` | weigh together |
| no RPE | `hr_only` | HR is all we have |

It is **no longer keyed on `hr_confounded`**: a confounder inflates HR and so lowers confidence in the *drift/fatigue* read (which it already leads elsewhere in the pack), but it never licenses substituting RPE for the measured intensity, and it only physically explains a `felt_easier` gap. The `hr_confounded` fact still rides the pack so the coach can explain *why* HR was elevated.

## Decision notes
- **North Star:** a good coach holds both readings; a discount lowers confidence in one, it does not erase the other. Declaring a run with real Z3-Z4 time "genuinely easy" is exactly the misread this removes.
- **Technical (why data-only, no prompt edit):** the live lean/grouped prompt reads this field's value **raw** — it does not spell the values out — and the verbose explanations live in frozen, byte-stable base prompts (`SYSTEM_PROMPT_MESSAGE_V1` and the whole vN chain) that can't be edited without breaking every version's pin test. So the fix is carried entirely by **self-descriptive value names**; no prompt text is touched. Pack **structure** is unchanged (same field, new vocabulary), so no flow-graph regen is needed, and the frozen prompts keep their old `rpe_over_hr` explanation (harmless on rollback).

## Tests
- `test_perceived_effort.py`: direction-driven weighting unit tests + `test_easy_rpe_with_real_hr_work_does_not_dismiss_hr` (the #654 regression: RPE 3 / tempo HR / confounder → `dont_dismiss_hr`, not a substitution).
- Updated `test_perceived_effort_context.py` and `test_intensity_read.py` (the `trust` field) to the new vocabulary.
- Full backend suite: **2167 passed, 12 deselected**, no regressions. (The frozen-prompt `test_v3_adds_perceived_effort_rule` still passes — no prompt text changed.)