### PR TITLE
Exculpate this run's own band in intensity.this_run_vs_recent (#679)

### DIFF
--- a/backend/app/services/coach/intensity.py
+++ b/backend/app/services/coach/intensity.py
@@ -249,8 +249,15 @@ def build_intensity(
         mean_ordinal = (
             sum(adj[b] * _BAND_ORDINAL[b] for b in _BANDS) / n if n else 0.0
         )
+        # Symmetric confounder exculpation (#679): the recent mean is computed on the
+        # exculpated view (`adj`), so exculpate THIS run's own band the same way before
+        # comparing. Otherwise a hot/hilly/stimulant run's inflated raw band is judged
+        # against a baseline that WAS corrected for the same effect, and the verdict
+        # over-reports "harder than recent". `this_session.band` still reports the raw
+        # measured band; only this comparison is exculpated (mirrors intensity_read._vs_recent).
+        this_effective_band = _effective_band(this_fact, confounded_ids)
         this_run_vs_recent = _direction(
-            _BAND_ORDINAL[this_band] - mean_ordinal,
+            _BAND_ORDINAL[this_effective_band] - mean_ordinal,
             _VS_RECENT_DEADBAND,
             "harder",
             "easier",

--- a/backend/tests/test_intensity.py
+++ b/backend/tests/test_intensity.py
@@ -108,6 +108,28 @@ def test_this_run_vs_recent_in_line():
     assert ctx.this_run_vs_recent == "in_line"
 
 
+def test_this_run_vs_recent_exculpates_this_runs_own_confounded_band():
+    # #679: this run reads "hard" on HR but a confounder fired (heat/hills/stimulant),
+    # against an all-easy recent window that is ALREADY exculpated. Symmetrically
+    # exculpating this run's own band makes the comparison fair, so the confounded hard
+    # run reads in_line rather than over-reporting "harder than recent".
+    facts = [_Fact("this", 0, effort="hard")]
+    facts += _window("easy", start_id=10, days_base=2, n=6)
+    ctx = build_intensity(facts, {"this"}, "this", AS_OF)
+    assert ctx.this_session.band == "hard"  # the reported band stays the raw measured one
+    assert ctx.this_session.hr_confounded is True
+    assert ctx.this_run_vs_recent == "in_line"  # symmetric: not over-reported as harder
+
+
+def test_this_run_vs_recent_still_harder_when_this_run_not_confounded():
+    # The guard against over-correction: a genuinely hard run (no confounder) against an
+    # all-easy window still reads "harder" — exculpation only applies when a signal fired.
+    facts = [_Fact("this", 0, effort="hard")]
+    facts += _window("easy", start_id=10, days_base=2, n=6)
+    ctx = build_intensity(facts, set(), "this", AS_OF)
+    assert ctx.this_run_vs_recent == "harder"
+
+
 # --------------------------------------------------------------------------- #
 # Confounder exculpation                                                       #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #679.

## Problem
In the `intensity` pack section (`build_intensity`), the `this_run_vs_recent` verdict corrected one side of the comparison but not the other:
- the **recent-window mean** is computed on the confounder-**exculpated** view (`distribution_adjusted`): a past session whose HR drift fired a heat/hills/stimulant discount is downgraded to easy;
- **this run's own band** was the **raw** HR effort-axis collapse, with no exculpation.

So on a run where a confounder fired, this run's inflated band was judged against a baseline corrected for the same effect, and the verdict over-reported "harder than recent". Example: recent weeks all genuinely easy; today's run in the heat reads "hard" but a discount fires → old logic said "harder"; a symmetric read is "in_line".

## Fix
Exculpate this run's band the same way (`_effective_band`) before the comparison — mirroring what ADR 0026 Slice 3's merged `intensity_read._vs_recent` already does. `this_session.band` still reports the **raw measured band**; only the `this_run_vs_recent` comparison is exculpated.

## Decision notes
- **Fixed in place** rather than letting it lapse with the eventual `intensity`-section retirement: the standalone section is still emitted by the `coach_message_lean_v1` rollback target and `v14`, so the asymmetry is live there.
- **Technical:** this is a pack-**data** change, not prompt text — reports that emit `intensity` regenerate under the versioned cache (the normal cost of a pack change). Pack **structure** is unchanged (same field), so no flow-graph regen.
- **North Star:** a good coach shouldn't call a confounded run "harder than recent" when the same confounder was already corrected out of the baseline.

## Tests
- `test_intensity.py::test_this_run_vs_recent_exculpates_this_runs_own_confounded_band` — confounded hard run vs all-easy exculpated window now reads `in_line`; the reported band stays `hard`.
- `test_this_run_vs_recent_still_harder_when_this_run_not_confounded` — guards against over-correction: a genuinely hard run (no confounder) still reads `harder`.
- Full backend suite: **2166 passed, 12 deselected**, no regressions (no byte-stability pin tripped).