### PR TITLE
Diagram: omit the grouped-replaced flat pack nodes instead of greying them

### DIFF
--- a/docs/diagrams/flow-nodes.js
+++ b/docs/diagrams/flow-nodes.js
@@ -663,6 +663,24 @@ const NODES = [
   from:[], body:()=> '' },
 ];
 
+/* ---------- omit the flat sections the live grouped pack STRUCTURALLY REPLACES ----------
+   perceived_effort / calibration / training_load / training_volume / recent_training / intensity
+   are still declared on CoachContextPack — so the drift guard binds each to a p_* node here, and
+   a flat-prompt rollback repopulates them — but the LIVE grouped pack emits their merged
+   successors instead (intensity_read / referral / readiness / recent_weeks / intensity_mix). When
+   the flat section is absent from THIS capture the node is not "empty this run", it is gone from
+   how the pack builds now: we drop it from the drawn NODES entirely and strip it from every
+   from-edge, so the deriv builders route straight to their grouped successor with no dead box in
+   between. Capture-driven: a rollback capture (flat prompt) has P.<section> present, HIDDEN is
+   empty, and the flat node draws again with zero code change. The source text is untouched (only
+   the runtime array is pruned), so the drift guard still sees every p_* binding. */
+const _REPLACED_BY_GROUPED = { p_perceived:'perceived_effort', p_calibration:'calibration',
+  p_training_load:'training_load', p_training_volume:'training_volume',
+  p_recent_training:'recent_training', p_intensity:'intensity' };
+const HIDDEN = new Set(Object.keys(_REPLACED_BY_GROUPED).filter(id=>!P[_REPLACED_BY_GROUPED[id]]));
+for(const id of HIDDEN){ const i=NODES.findIndex(n=>n.id===id); if(i>=0) NODES.splice(i,1); }
+NODES.forEach(n=>{ if(n.from) n.from=n.from.filter(s=>!HIDDEN.has(s)); });
+
 /* ---------- build adjacency ---------- */
 const byId = Object.fromEntries(NODES.map(n=>[n.id,n]));
 const consumers = {}; NODES.forEach(n=>consumers[n.id]=[]);


### PR DESCRIPTION
## Why
Under the live grouped prompt (`coach_message_lean_grouped_v5`) the flat pack sections `perceived_effort` / `calibration` / `training_load` / `training_volume` / `recent_training` / `intensity` are structurally replaced by merged reads (`intensity_read` / `referral` / `readiness` / `recent_weeks` / `intensity_mix`). PR #687 kept their nodes as greyed **"Absent under … merged into …"** boxes, so a grouped capture rendered a column of dead nodes and the deriv builders visibly routed into them.

## What changed (view/diagram only — no app code)
`flow-nodes.js`:
- When a replaced flat section is absent from the capture, its `p_*` node is **dropped from the drawn graph entirely** (not greyed) and **stripped from every from-edge**, so the read-time builders route straight to their grouped successor with no dead node in between:
  - `perceived_effort` / `calibration` / `intensity` → `pack.this_run.intensity_read` (+ `intensity_mix`, `referral`)
  - `training_volume` / `recent_training` → `pack.right_now.recent_weeks`
  - `training_load` → `pack.right_now.readiness`
  - the model node's "came from" now lists only live grouped sections.
- **Hide, not delete.** The six sections still exist on `CoachContextPack` (a flat-prompt rollback repopulates them) and the drift guard requires a `p_*` node per schema section — so the node objects stay in the source (only the runtime `NODES` array is pruned). Capture-driven and reversible: a flat rollback capture has the section present, `HIDDEN` is empty, and the flat node draws again with zero code change.
- Conditionally-empty-but-live nodes (`longitudinal` / `adherence` / `salience` / `continuity` / `this_run.referral`) are **kept** as greyed "empty this run" — they're real parts of the live grouped pack that just didn't fire this run.

## Verification
- `make diagram-check` / `check_diagram_drift.py` **green**; `test_diagram_drift.py` **passes**.
- All 58 drawn node `body()` functions render without throwing (node harness).
- Loaded + interacted in-browser: 58 nodes, the six replaced sections gone, **no console errors**, layout intact; drawer confirms deriv builders feed only the grouped successors and the model's "came from" carries no dead flat section.