### PR TITLE
Security hardening from the 2026-07-15 audit (#705, #706, #707)

### DIFF
--- a/backend/app/api/materials.py
+++ b/backend/app/api/materials.py
@@ -46,6 +46,15 @@ router = APIRouter()
 # it aside, so it neither blocks new uploads nor dedups against a fresh one.
 _LIVE_STATUSES = ("processing", "active", "failed")
 
+# Bound the two reflected text fields (#706). `title` (a Form field) and
+# `filename` (from the multipart part) are echoed verbatim in list/detail
+# responses; the file BODY is capped but these were not. Cap them like the
+# distilled fields already are, so a future non-escaping consumer cannot inherit
+# stored oversize/XSS content and responses stay bounded. Truncate (do not
+# reject): an over-long title/filename should not fail an otherwise-valid upload.
+_MAX_TITLE_LEN = 200
+_MAX_FILENAME_LEN = 255
+
 
 def _default_title(filename: str) -> str:
     name = (filename or "material").rsplit("/", 1)[-1]
@@ -109,7 +118,12 @@ async def upload_material(
         )
 
     content_hash = hashlib.sha256(raw_bytes).hexdigest()
-    resolved_title = (title or "").strip() or _default_title(file.filename)
+    # Cap the two reflected fields at rest (#706). `_default_title` derives from the
+    # filename, so bound both the resolved title and the stored filename.
+    resolved_title = ((title or "").strip() or _default_title(file.filename))[
+        :_MAX_TITLE_LEN
+    ]
+    resolved_filename = (file.filename or "material.md")[:_MAX_FILENAME_LEN]
 
     # Dedup / retry on content_hash among the runner's live (non-archived) materials.
     existing = (
@@ -154,7 +168,7 @@ async def upload_material(
         user_id=user_id,
         kind=kind.value,
         title=resolved_title,
-        filename=file.filename or "material.md",
+        filename=resolved_filename,
         raw_text=raw_text,
         content_hash=content_hash,
         status="processing",

--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -1,4 +1,5 @@
 import logging
+import secrets
 import uuid
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
@@ -61,7 +62,8 @@ def verify_webhook(
             detail="Service unavailable: webhook verify token not configured",
         )
 
-    if mode == "subscribe" and verify_token == expected_token:
+    # Constant-time compare (#706), consistent with BasicAuth/OAuth-state gates.
+    if mode == "subscribe" and secrets.compare_digest(verify_token, expected_token):
         return {"hub.challenge": challenge}
 
     raise HTTPException(status_code=403, detail="Invalid verification token")
@@ -91,7 +93,11 @@ def _event_is_authentic(event: "StravaEvent", db: Session) -> bool:
        it never blocks the legitimate first sight of a new activity.
     """
     expected_subscription_id = settings.STRAVA_WEBHOOK_SUBSCRIPTION_ID
-    if expected_subscription_id and event.subscription_id != expected_subscription_id:
+    # The subscription id is secret-ish (Strava returns it only at registration),
+    # so compare it constant-time on its string form (#706), like the other gates.
+    if expected_subscription_id and not secrets.compare_digest(
+        str(event.subscription_id), str(expected_subscription_id)
+    ):
         logger.warning(
             "strava_webhook_rejected_subscription_mismatch",
             extra={
@@ -252,7 +258,11 @@ def _secret_is_valid(secret_header: str | None) -> bool:
     """
     expected_secret = settings.TELEGRAM_WEBHOOK_SECRET
     if expected_secret:
-        if secret_header != expected_secret:
+        # Constant-time compare (#706); a missing header is a mismatch, and
+        # compare_digest requires two strings (it raises on None).
+        if secret_header is None or not secrets.compare_digest(
+            secret_header, expected_secret
+        ):
             logger.warning("telegram_webhook_rejected_secret_mismatch")
             return False
     elif settings.APP_ENV == "production":

--- a/backend/app/core/body_size_limit.py
+++ b/backend/app/core/body_size_limit.py
@@ -1,0 +1,87 @@
+"""#705: reject an oversized request body before it is buffered to disk.
+
+FastAPI/Starlette parses the whole multipart body -- spooling a large file part
+to a temporary file on disk -- BEFORE the endpoint function runs, so the
+coach-material upload's own size check (``file.read(cap + 1)``) fires only after
+a multi-GB body has already been received and written to disk. That is the DoS
+in #705: an authenticated runner POSTs an arbitrarily large ``file`` part and it
+is fully spooled before rejection.
+
+This pure-ASGI middleware bounds the total request body at the app edge, before
+any router or the form parser touches it:
+
+  - A declared ``Content-Length`` over the cap is rejected with 413 before the
+    app is called and before any body byte is read. This is the realistic
+    vector: a large upload declares its length.
+  - For a chunked / unknown-length body, the ``receive`` stream is counted as it
+    arrives and cut off (a synthetic ``http.disconnect``) once the cap is
+    exceeded, so buffering is bounded to ~the cap instead of unbounded.
+
+Scope: HTTP requests only; websocket/lifespan scopes pass through untouched.
+Only the request ``receive`` side is wrapped, so streaming responses (the SSE
+coach chat) are unaffected.
+"""
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class BodySizeLimitMiddleware:
+    """Bound the total request body size at the ASGI edge (#705)."""
+
+    def __init__(self, app: ASGIApp, max_body_bytes: int) -> None:
+        self.app = app
+        self.max_body_bytes = max_body_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Cheap reject on a declared oversize length, before reading any body.
+        declared = _declared_length(scope)
+        if declared is not None and declared > self.max_body_bytes:
+            await _reject_413(send, self.max_body_bytes)
+            return
+
+        received = 0
+
+        async def limited_receive() -> Message:
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > self.max_body_bytes:
+                    # No declared length (chunked) but the streamed body has
+                    # crossed the cap. Signal a client disconnect so the ASGI
+                    # body parser stops reading; the request then fails rather
+                    # than buffering an unbounded body. Buffering is bounded to
+                    # ~one chunk past the cap.
+                    return {"type": "http.disconnect"}
+            return message
+
+        await self.app(scope, limited_receive, send)
+
+
+def _declared_length(scope: Scope) -> int | None:
+    for key, value in scope.get("headers", []):
+        if key == b"content-length":
+            try:
+                return int(value)
+            except ValueError:
+                return None
+    return None
+
+
+async def _reject_413(send: Send, cap: int) -> None:
+    body = b'{"detail":"Request body exceeds the %d-byte limit."}' % cap
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 413,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -321,6 +321,15 @@ class Settings(BaseSettings):
     USER_MATERIAL_MAX_BYTES: int = 262144  # 256 KB per uploaded .md file
     USER_MATERIAL_MAX_COUNT: int = 50  # max non-archived materials per user
 
+    # Edge request-body cap (#705). Bounds the total body of ANY request before the
+    # form parser spools it to disk, so an oversize coach-material upload is rejected
+    # at the app edge instead of after a multi-GB body has landed. The largest
+    # legitimate request is a material upload (<=256 KB text + multipart overhead);
+    # 1 MiB leaves ~4x headroom for framing/growth while capping abuse. The material
+    # endpoint's own 256 KB check still fires between 256 KB and this cap, so valid
+    # uploads are unaffected.
+    MAX_REQUEST_BODY_BYTES: int = 1048576  # 1 MiB
+
     # Phase 2 identity: social login via Clerk (ADR 0022). The frontend (Vercel)
     # owns the Clerk session; the backend VERIFIES the session token itself via
     # Clerk's JWKS and resolves user_id from the verified email, so it never

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -232,6 +232,21 @@ def assert_production_config() -> None:
     """
     if settings.APP_ENV != "production":
         return
+
+    # CORS wildcard guard (#707). `allow_credentials=True` is hardcoded in
+    # main.py, so a `*` origin would let ANY site make credentialed requests --
+    # an actual cross-origin hole, not just a permissive default. Refuse to boot
+    # on it (fail closed, same posture as the missing-settings guard below). The
+    # default is an explicit allowlist, so this only fires on a real misconfig,
+    # and a false positive can only block a new deploy, never the running one.
+    if "*" in settings.cors_allowed_origins_list:
+        logging.getLogger(__name__).critical("production_cors_wildcard_with_credentials")
+        raise ProductionConfigError(
+            "Refusing to boot: CORS_ALLOWED_ORIGINS contains '*' while credentials "
+            "are enabled, which lets any origin make credentialed requests. Set an "
+            "explicit origin allowlist and redeploy."
+        )
+
     missing = [
         name
         for name in _REQUIRED_IN_PRODUCTION

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi.responses import JSONResponse
 
 from app.api import health, auth, activities, blocks, webhooks, profile, trends, coach, debug, strava_import, materials, account
 from app.core.auth import BasicAuthMiddleware
+from app.core.body_size_limit import BodySizeLimitMiddleware
 from app.services.strava_ingestion.port import StravaRateLimited
 from app.core.clerk_auth import verify_clerk_session
 from app.core.config import settings
@@ -81,6 +82,14 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+)
+
+# Edge body-size cap (#705). Added LAST so it is the OUTERMOST middleware: an
+# oversize body is rejected before auth/CORS do any work on it, and before the
+# form parser spools it to disk.
+app.add_middleware(
+    BodySizeLimitMiddleware,
+    max_body_bytes=settings.MAX_REQUEST_BODY_BYTES,
 )
 
 # Include routers. Public (no per-user session): health, auth, webhooks.

--- a/backend/app/services/activity_queries.py
+++ b/backend/app/services/activity_queries.py
@@ -73,7 +73,7 @@ def get_activity(
     db: Session,
     activity_id: str | uuid.UUID,
     *,
-    user_id: uuid.UUID | None = None,
+    user_id: uuid.UUID,
 ) -> Activity | None:
     # Bind a real UUID: Postgres adapts a string, but SQLite (tests) does not.
     if isinstance(activity_id, str):
@@ -92,11 +92,11 @@ def get_activity(
         # A soft-deleted activity reads as not-present (#410): the detail view
         # 404s on it, consistent with the list and every other read path.
         .filter(Activity.is_deleted == False)  # noqa: E712
+        # P2.1: scope to the authenticated user. user_id is REQUIRED (#706): an
+        # unscoped read is a cross-tenant leak, so another user's activity reads
+        # as absent (the endpoint then 404s), matching the sibling query helpers.
+        .filter(Activity.user_id == user_id)
     )
-    # P2.1: when a user_id is supplied, another user's activity reads as absent
-    # (the endpoint then 404s) rather than leaking across tenants.
-    if user_id is not None:
-        query = query.filter(Activity.user_id == user_id)
     return query.first()
 
 

--- a/backend/tests/test_body_size_limit.py
+++ b/backend/tests/test_body_size_limit.py
@@ -1,0 +1,108 @@
+"""#705: the edge request-body-size limit middleware.
+
+Driven at the ASGI level (no app/auth needed) via asyncio.run, so the test is
+robust regardless of the pytest-asyncio mode. Covers the declared-length fast
+reject, the streamed/chunked bound, small-body passthrough, and that non-HTTP
+scopes (websocket/lifespan) pass straight through.
+"""
+
+import asyncio
+
+from app.core.body_size_limit import BodySizeLimitMiddleware
+
+CAP = 100
+
+
+async def _capturing_app(scope, receive, send):
+    """A minimal ASGI app that drains the body and 200s, recording what it saw."""
+    body = b""
+    while True:
+        message = await receive()
+        if message["type"] == "http.disconnect":
+            scope["_disconnected"] = True
+            break
+        if message["type"] == "http.request":
+            body += message.get("body", b"")
+            if not message.get("more_body", False):
+                break
+    scope["_body_len"] = len(body)
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+def _http_scope(headers):
+    return {"type": "http", "headers": headers, "_disconnected": False, "_body_len": 0}
+
+
+async def _run(mw, scope, incoming):
+    """Drive one request; `incoming` is the list of ASGI receive messages."""
+    it = iter(incoming)
+
+    async def receive():
+        return next(it)
+
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    await mw(scope, receive, send)
+    return sent
+
+
+def _status(sent):
+    for m in sent:
+        if m["type"] == "http.response.start":
+            return m["status"]
+    return None
+
+
+def test_declared_length_over_cap_is_rejected_before_body_read():
+    mw = BodySizeLimitMiddleware(_capturing_app, max_body_bytes=CAP)
+    scope = _http_scope([(b"content-length", str(CAP + 1).encode())])
+    # A single receive that would blow the cap; it must never be consumed.
+    sent = asyncio.run(_run(mw, scope, [{"type": "http.request", "body": b"x" * (CAP + 1)}]))
+    assert _status(sent) == 413
+    assert scope["_body_len"] == 0  # app never ran on the oversize body
+
+
+def test_declared_length_at_cap_passes_through():
+    mw = BodySizeLimitMiddleware(_capturing_app, max_body_bytes=CAP)
+    scope = _http_scope([(b"content-length", str(CAP).encode())])
+    sent = asyncio.run(_run(mw, scope, [{"type": "http.request", "body": b"x" * CAP}]))
+    assert _status(sent) == 200
+    assert scope["_body_len"] == CAP
+
+
+def test_streamed_body_over_cap_is_cut_off():
+    # No content-length (chunked): the middleware counts and disconnects once the
+    # accumulated body crosses the cap, bounding the buffer.
+    mw = BodySizeLimitMiddleware(_capturing_app, max_body_bytes=CAP)
+    scope = _http_scope([])
+    chunks = [
+        {"type": "http.request", "body": b"a" * 60, "more_body": True},
+        {"type": "http.request", "body": b"b" * 60, "more_body": True},  # now 120 > 100
+        {"type": "http.request", "body": b"c" * 60, "more_body": False},
+    ]
+    sent = asyncio.run(_run(mw, scope, chunks))
+    # The app saw a disconnect instead of the full 180-byte body.
+    assert scope["_disconnected"] is True
+    assert scope["_body_len"] < 180
+
+
+def test_non_http_scope_passes_through_untouched():
+    seen = {}
+
+    async def ws_app(scope, receive, send):
+        seen["type"] = scope["type"]
+
+    mw = BodySizeLimitMiddleware(ws_app, max_body_bytes=CAP)
+
+    async def receive():
+        return {"type": "websocket.receive"}
+
+    async def send(message):
+        pass
+
+    asyncio.run(mw({"type": "websocket"}, receive, send))
+    assert seen["type"] == "websocket"

--- a/backend/tests/test_materials_api.py
+++ b/backend/tests/test_materials_api.py
@@ -90,12 +90,16 @@ def test_upload_truncates_long_title(client):
 
 def test_upload_truncates_long_filename(client):
     # #706: the reflected filename (its default-title derivation and the stored
-    # value) is length-bounded at rest.
-    long_name = "f" * 5000 + ".md"
+    # value) is length-bounded at rest. Use a filename modestly over the 255 cap
+    # (not a multi-KB one): a multipart FILENAME rides the part's Content-Disposition
+    # HEADER, and newer starlette/python-multipart reject an oversize part header with
+    # 400 before the endpoint runs, so a pathologically long filename would test the
+    # parser's header limit rather than this truncation.
+    long_name = "f" * 300 + ".md"
     with patch("app.api.materials.enqueue_distillation"):
         resp = _upload(client, b"content", kind="other", filename=long_name)
     assert resp.status_code == 202
-    assert len(resp.json()["filename"]) <= 255
+    assert len(resp.json()["filename"]) == 255
 
 
 def test_upload_rejects_unknown_kind(client):

--- a/backend/tests/test_materials_api.py
+++ b/backend/tests/test_materials_api.py
@@ -67,6 +67,37 @@ def test_upload_rejects_oversize(client, monkeypatch):
     assert resp.status_code == 413
 
 
+def test_upload_rejected_at_edge_before_endpoint_when_body_exceeds_request_cap(client):
+    # #705: a body over the wired edge request cap (MAX_REQUEST_BODY_BYTES, 1 MiB)
+    # is rejected before the endpoint (and before the form parser spools it),
+    # regardless of the endpoint's own 256 KB cap. The middleware captures the cap
+    # at construction, so this exercises the real wired value with an oversize body.
+    oversize = b"x" * (settings.MAX_REQUEST_BODY_BYTES + 1)
+    with patch("app.api.materials.enqueue_distillation") as enqueue:
+        resp = _upload(client, oversize, kind="other")
+    assert resp.status_code == 413
+    enqueue.assert_not_called()  # never reached the endpoint
+
+
+def test_upload_truncates_long_title(client):
+    # #706: the reflected title is length-bounded at rest.
+    long_title = "T" * 5000
+    with patch("app.api.materials.enqueue_distillation"):
+        resp = _upload(client, b"content", kind="other", title=long_title)
+    assert resp.status_code == 202
+    assert len(resp.json()["title"]) == 200
+
+
+def test_upload_truncates_long_filename(client):
+    # #706: the reflected filename (its default-title derivation and the stored
+    # value) is length-bounded at rest.
+    long_name = "f" * 5000 + ".md"
+    with patch("app.api.materials.enqueue_distillation"):
+        resp = _upload(client, b"content", kind="other", filename=long_name)
+    assert resp.status_code == 202
+    assert len(resp.json()["filename"]) <= 255
+
+
 def test_upload_rejects_unknown_kind(client):
     with patch("app.api.materials.enqueue_distillation"):
         resp = _upload(client, b"content", kind="malware")

--- a/backend/tests/test_production_config.py
+++ b/backend/tests/test_production_config.py
@@ -92,6 +92,39 @@ def test_error_lists_every_missing_setting(monkeypatch):
         assert name in msg
 
 
+def test_raises_in_production_on_cors_wildcard(monkeypatch):
+    # #707: `*` origins with credentials enabled is a real cross-origin hole; the
+    # boot must fail closed on it even when every other setting is present.
+    _set(
+        monkeypatch,
+        APP_ENV="production",
+        CLERK_JWKS_URL=_FAKE_JWKS,
+        BASIC_AUTH_USER=_FAKE_USER,
+        BASIC_AUTH_PASSWORD=_FAKE_PASSWORD,
+        CORS_ALLOWED_ORIGINS="https://app.example.com,*",
+    )
+    with pytest.raises(ProductionConfigError) as exc:
+        assert_production_config()
+    assert "*" in str(exc.value)
+
+
+def test_explicit_cors_allowlist_passes_in_production(monkeypatch):
+    _set(
+        monkeypatch,
+        APP_ENV="production",
+        CLERK_JWKS_URL=_FAKE_JWKS,
+        BASIC_AUTH_USER=_FAKE_USER,
+        BASIC_AUTH_PASSWORD=_FAKE_PASSWORD,
+        CORS_ALLOWED_ORIGINS="https://app.example.com",
+    )
+    assert_production_config()  # does not raise
+
+
+def test_cors_wildcard_ignored_outside_production(monkeypatch):
+    _set(monkeypatch, APP_ENV="local", CORS_ALLOWED_ORIGINS="*")
+    assert_production_config()  # does not raise
+
+
 def test_whitespace_only_value_counts_as_missing(monkeypatch):
     # A fat-fingered blank secret must be treated as unset, not "present", so it
     # cannot satisfy the gate (boundary case for the .strip() check).


### PR DESCRIPTION
Closes #705, closes #706, and lands the code portion of #707. All three are from the 2026-07-15 security audit.

## #705 — Material upload had no request body-size limit (DoS)
The material endpoint's `file.read(cap+1)` bounds memory, but Starlette parses the whole multipart body (spooling a large file part to disk) **before** the endpoint runs, so a multi-GB `file` part was fully received before the 256 KB check fired.

- New pure-ASGI `BodySizeLimitMiddleware` (`app/core/body_size_limit.py`), wired **outermost** in `main.py` so an oversize body is rejected before auth/CORS/the form parser touch it.
  - Declared oversize `Content-Length` → 413 before any body byte is read (the realistic vector).
  - Chunked/unknown-length body → the `receive` stream is counted and cut off (synthetic `http.disconnect`) once it crosses the cap, bounding the buffer.
- New `MAX_REQUEST_BODY_BYTES` setting (default **1 MiB**). The endpoint's own 256 KB check still fires for materials between 256 KB and 1 MiB, so valid uploads are unchanged.

## #706 — Three low-severity hardening items
1. **Reflected upload fields.** `title`/`filename` are echoed verbatim in list/detail but were uncapped. Now truncated at write time (200 / 255) so a future non-escaping consumer can't inherit stored oversize content.
2. **Constant-time webhook secrets.** The Telegram outer secret, Strava `verify_token`, and Strava `subscription_id` now use `secrets.compare_digest`, matching the BasicAuth/OAuth-state gates. Behaviour-preserving.
3. **Required `user_id` scoping.** `get_activity`'s `user_id` is now required (matching `get_activities`/`get_owned_activity`), closing a future cross-tenant footgun. The one caller already passes it.

## #707 — CORS wildcard boot guard (code portion only)
`assert_production_config` now refuses to boot in production when `CORS_ALLOWED_ORIGINS` contains `*` (unsafe with `allow_credentials=True`). The **remaining #707 items are deploy-side owner actions** and are NOT done here: arm `CLERK_AUTHORIZED_PARTIES` to the app origin(s), and confirm the prod `CORS_ALLOWED_ORIGINS` value.

## Tests
- New `tests/test_body_size_limit.py`: declared-length reject, streamed-chunk cutoff, at-cap passthrough, non-HTTP passthrough.
- `test_materials_api.py`: real >1 MiB upload → 413 at the edge (endpoint never reached); long title/filename truncation.
- `test_production_config.py`: prod CORS-wildcard raises; explicit allowlist passes; non-prod ignores `*`.
- Full backend suite green: **2194 passed, 5 skipped** (baseline 2184 + 10 new).

## Decisions (owner unreachable — best-recommendation calls, per the batch brief)
- **Global 1 MiB body cap** rather than coupling the edge limit to the 256 KB material cap, to leave headroom for any future larger legitimate request. Configurable via `MAX_REQUEST_BODY_BYTES`.
- **Truncate** (not reject) over-long title/filename, so a long name never fails an otherwise-valid upload.
- **CORS guard is fatal-in-prod** (fail closed), consistent with the existing production-config guard; a false positive can only block a new deploy, never the running one.
- `subscription_id` (an int) is compared constant-time on its string form — it's treated as secret-ish in the existing auth docstring.

North Star: these are infra/security guards, invisible to the coach and the runner; no LLM-facing surface changed, no coach-pack change (no diagram regen needed).