### PR TITLE
Cache the coach system prompt (prompt caching) (#629)

### DIFF
--- a/backend/app/services/coach/llm.py
+++ b/backend/app/services/coach/llm.py
@@ -76,9 +76,16 @@ def _rate_limit_backoff_seconds(exc: Any, retry_index: int) -> float:
 
 @dataclass
 class Usage:
-    """Token usage for the per-user budget gate (#472). 0 when none was returned."""
+    """Token usage for the per-user budget gate (#472). 0 when none was returned.
+
+    `cache_read_input_tokens` / `cache_creation_input_tokens` (#629) are captured
+    for verification of prompt-cache hits; they are NOT billed on the budget gate
+    (which bills the uncached `input_tokens` only — a conservative under-estimate,
+    since caching strictly lowers real cost)."""
     input_tokens: int = 0
     output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
 
 
 def _usage_from_response(response: Any) -> Usage:
@@ -87,7 +94,25 @@ def _usage_from_response(response: Any) -> Usage:
     return Usage(
         input_tokens=getattr(usage, "input_tokens", 0) or 0,
         output_tokens=getattr(usage, "output_tokens", 0) or 0,
+        cache_read_input_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
+        cache_creation_input_tokens=getattr(usage, "cache_creation_input_tokens", 0) or 0,
     )
+
+
+def _cacheable_system(system: str) -> List[Dict[str, Any]]:
+    """Wrap the system prompt as a single cacheable content block (#629).
+
+    The Anthropic prompt cache is a prefix match, and our coach system prompt is
+    byte-identical across every activity for a given prompt id + voice, so caching
+    it takes the ~7k-10k input tok/report system prefix from full price to ~0.1x on
+    a cache read. `tools` render before `system` in cache order and our tool schema
+    is deterministic too, so this one breakpoint caches tools + system together.
+
+    Behaviour-preserving: same prompt, same params, same output. A no-op when the
+    prefix is under the model's minimum cacheable length (the API silently ignores
+    the breakpoint), so it never harms the shorter aux-path prompts that also route
+    through the create-based methods."""
+    return [{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}]
 
 
 @dataclass
@@ -103,6 +128,9 @@ class MessageResult:
     # Usage for the per-user budget gate (P2.2); 0 when no usage was returned.
     input_tokens: int = 0
     output_tokens: int = 0
+    # Prompt-cache verification (#629); not billed on the budget gate.
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
 
 
 @dataclass
@@ -146,7 +174,7 @@ class AnthropicClient:
                     model=self.model,
                     max_tokens=max_tokens,
                     temperature=0.2,
-                    system=system,
+                    system=_cacheable_system(system),  # #629 prompt caching
                     messages=[{"role": "user", "content": user}],
                     timeout=_TIMEOUT_SECONDS,
                 )
@@ -230,7 +258,7 @@ class AnthropicClient:
                     model=self.model,
                     max_tokens=max_tokens,
                     temperature=0,
-                    system=system,
+                    system=_cacheable_system(system),  # #629 prompt caching
                     messages=[{"role": "user", "content": user}],
                     tools=[tool],
                     tool_choice={"type": "tool", "name": tool_name},
@@ -314,7 +342,7 @@ class AnthropicClient:
                 async with self.client.messages.stream(
                     model=self.model,
                     max_tokens=max_tokens,
-                    system=system,
+                    system=_cacheable_system(system),  # #629 prompt caching
                     messages=[{"role": "user", "content": user}],
                     thinking={"type": "adaptive"},
                     output_config={"effort": _COACH_EFFORT},
@@ -324,11 +352,23 @@ class AnthropicClient:
                 ) as stream:
                     final = await stream.get_final_message()
                 usage = getattr(final, "usage", None)
+                cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
+                cache_creation = getattr(usage, "cache_creation_input_tokens", 0) or 0
+                # Verify cache behaviour in prod (#629): ~0 read on the first report
+                # in a TTL window (a write instead), then the full system-prompt
+                # count on subsequent reports. A read that stays 0 across reports
+                # signals a silent prefix invalidator.
+                logger.info(
+                    "coach_prompt_cache",
+                    extra={"cache_read": cache_read, "cache_creation": cache_creation},
+                )
                 return MessageResult(
                     content_blocks=list(final.content),
                     stop_reason=final.stop_reason,
                     input_tokens=getattr(usage, "input_tokens", 0) or 0,
                     output_tokens=getattr(usage, "output_tokens", 0) or 0,
+                    cache_read_input_tokens=cache_read,
+                    cache_creation_input_tokens=cache_creation,
                 )
             except (
                 anthropic.APITimeoutError,

--- a/backend/tests/test_prompt_caching.py
+++ b/backend/tests/test_prompt_caching.py
@@ -1,0 +1,106 @@
+"""#629: the coach system prompt is passed as a cacheable content block, and the
+prompt-cache token counts are captured for verification.
+
+Behaviour-preserving change: these assert the request SHAPE (a single ephemeral
+cache_control block over the deterministic system prompt) and the usage capture,
+not model output. Driven via asyncio.run so no pytest-asyncio mode is assumed.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from app.services.coach.llm import AnthropicClient, _cacheable_system
+
+_EPHEMERAL = {"type": "ephemeral"}
+
+
+def _client():
+    # Constructs a real AsyncAnthropic (no network at construction); the message
+    # methods are then overridden with mocks, matching the existing test pattern.
+    return AnthropicClient(api_key="test-key-not-real", model="claude-sonnet-4-6")
+
+
+def test_cacheable_system_wraps_string_with_ephemeral_breakpoint():
+    assert _cacheable_system("SYSTEM PROMPT") == [
+        {"type": "text", "text": "SYSTEM PROMPT", "cache_control": _EPHEMERAL}
+    ]
+
+
+def test_generate_json_passes_cacheable_system_and_captures_cache_tokens():
+    client = _client()
+    resp = SimpleNamespace(
+        content=[SimpleNamespace(text="{}")],
+        usage=SimpleNamespace(
+            input_tokens=5,
+            output_tokens=2,
+            cache_read_input_tokens=10,
+            cache_creation_input_tokens=0,
+        ),
+    )
+    fake = AsyncMock(return_value=resp)
+    client.client.messages.create = fake
+    text, usage = asyncio.run(client.generate_json_with_usage(system="SYS", user="U"))
+    assert fake.call_args.kwargs["system"] == [
+        {"type": "text", "text": "SYS", "cache_control": _EPHEMERAL}
+    ]
+    assert usage.cache_read_input_tokens == 10
+    assert usage.cache_creation_input_tokens == 0
+
+
+def test_generate_structured_passes_cacheable_system_and_captures_cache_tokens():
+    client = _client()
+    resp = SimpleNamespace(
+        content=[SimpleNamespace(type="tool_use", name="record", input={"ok": 1})],
+        usage=SimpleNamespace(
+            input_tokens=5,
+            output_tokens=2,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=10,
+        ),
+    )
+    fake = AsyncMock(return_value=resp)
+    client.client.messages.create = fake
+    result, usage = asyncio.run(
+        client.generate_structured_with_usage(
+            system="SYS", user="U", tool={"name": "record"}
+        )
+    )
+    assert fake.call_args.kwargs["system"][0]["cache_control"] == _EPHEMERAL
+    assert result == {"ok": 1}
+    assert usage.cache_creation_input_tokens == 10
+
+
+def test_generate_coach_message_caches_system_and_captures_cache_tokens():
+    client = _client()
+    final = SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="Nice run.")],
+        stop_reason="end_turn",
+        usage=SimpleNamespace(
+            input_tokens=4406,
+            output_tokens=1469,
+            cache_read_input_tokens=10223,
+            cache_creation_input_tokens=0,
+        ),
+    )
+    captured = {}
+
+    @asynccontextmanager
+    async def fake_stream(**kwargs):
+        captured.update(kwargs)
+        stream = MagicMock()
+        stream.get_final_message = AsyncMock(return_value=final)
+        yield stream
+
+    client.client.messages.stream = fake_stream
+    result = asyncio.run(
+        client.generate_coach_message(system="SYS", user="U", tools=[])
+    )
+    assert captured["system"] == [
+        {"type": "text", "text": "SYS", "cache_control": _EPHEMERAL}
+    ]
+    assert result.cache_read_input_tokens == 10223
+    assert result.cache_creation_input_tokens == 0
+    # Behaviour-preserving: the parsed output is unchanged.
+    assert result.stop_reason == "end_turn"


### PR DESCRIPTION
Closes #629.

## What
Pass the coach system prompt as a single content block with `cache_control: {type: "ephemeral"}` instead of a bare string, at the three generation call sites in `llm.py`:
- `generate_coach_message` (the A3 fuller/opener path — the live prod path)
- `generate_json_with_usage`
- `generate_structured_with_usage`

The system prompt is deterministic per `prompt_id` + voice and byte-identical across every activity, so it is a textbook cache prefix. A cache read bills at ~0.1x, taking the ~7k–10k input-tok/report system prefix from full price to ~0.1x after the first write in each 5-min TTL window. `tools` render before `system` in cache order and our tool schema is deterministic, so the one breakpoint caches **tools + system** together.

## Verification hook
Captures `cache_read_input_tokens` / `cache_creation_input_tokens` onto `Usage` and `MessageResult`, and logs `coach_prompt_cache` on the live path. In prod: ~0 read on the first report in a TTL window (a write instead), then the full system-prompt count on later reports. A read stuck at 0 across reports signals a silent prefix invalidator. The recon confirmed the system prompt path injects no timestamps/UUIDs/RNG — all per-run data flows through the user message, not `system`.

## Behaviour-preserving
Same prompt, same params, same output. No eval/rubric or byte-stability impact; the deterministic validator is untouched. New tests assert the exact ephemeral-cache-control block shape at all three call sites and the cache-token capture; full backend suite green (**2188 passed, 5 skipped**; baseline 2184 + 4 new).

## Scope & decisions (owner unreachable — best-recommendation calls)
- **Coach generation path only.** Chat streaming (`chat.py`) and the aux Haiku paths are out of scope per the issue. The shared `create`-based methods (`generate_json`/`generate_structured`) do get the breakpoint, but it is a **no-op for prompts under the model's minimum cacheable length** (the API silently ignores it), so the shorter aux-path prompts (material distiller, etc.) are unaffected in practice. This was chosen over adding an opt-in flag, because the issue lists these exact methods as the change targets and the breakpoint is harmless where it doesn't apply.
- **Budget accounting left capture-only** (per the issue). With caching, the API reports only the uncached `input_tokens`, so the per-user budget counter now under-estimates true spend by the much-cheaper cache read/creation cost. This is **safe for the spend cap** (caching strictly lowers real cost), and making the counter cache-accurate is filed as a follow-up: **#709**.
- Anthropic SDK is `>=0.40.0` (0.92.0 installed); list-`system` + `cache_control` is supported with no beta header.

North Star: invisible to the coach and the runner (behaviour-neutral cost lever); no coach-pack change, so no diagram regen.