### PR TITLE
Offline eval harness for the runner-memory writer (#658)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test seed-local coach-review eval eval-selftest diagram-check verify-local deployed-handshake-smoke post-deploy-verify preflight-env-check
+.PHONY: smoke backend-smoke frontend-smoke test backend-test frontend-test seed-local coach-review eval eval-selftest eval-memory eval-memory-selftest diagram-check verify-local deployed-handshake-smoke post-deploy-verify preflight-env-check
 
 # Prefer the project venv interpreter when it exists, fall back to bare python.
 # Path is relative to backend/ since the targets cd there first. CI has no
@@ -82,6 +82,17 @@ eval:
 # no API key required, so this is safe to run in CI.
 eval-selftest:
 	cd backend && $(BACKEND_PY) -m scripts.eval_coach_reports --self-test
+
+# Offline runner-memory eval harness (#658) — the durable-memory counterpart to
+# `eval`. Scores memory writes against ADR 0025 rubric assertions.
+#   make eval-memory EVAL_MEMORY_ARGS="--scan"   # score stored profiles (needs DB)
+eval-memory:
+	cd backend && $(BACKEND_PY) -m scripts.eval_runner_memory $(EVAL_MEMORY_ARGS)
+
+# Validate the runner-memory rubric against its synthetic good/bad fixtures. No DB
+# and no API key required, so this is safe to run in CI.
+eval-memory-selftest:
+	cd backend && $(BACKEND_PY) -m scripts.eval_runner_memory --self-test
 
 # Deployed-only smoke for the Strava + Telegram handshake auth gates (#540).
 # NOT a CI gate: needs a live deployment (real APP_ENV/secrets). Non-mutating —

--- a/backend/app/services/coach/eval/memory/__init__.py
+++ b/backend/app/services/coach/eval/memory/__init__.py
@@ -1,0 +1,27 @@
+"""Offline runner-memory eval harness (#658) — the durable-memory counterpart to
+the M5 coach-report eval.
+
+It scores a runner-memory WRITE against deterministic ADR 0025 assertions, so a
+change to the memory writer (sources, prompt, or graduation) has a repeatable
+quality gate instead of a one-off human read — the same way ``make eval`` guards
+the coach reports.
+
+Deterministic in v1, on purpose: an LLM judge would reintroduce the drift the
+gate exists to catch. The semantic assertions #658 lists (a genuine elliptical
+commitment IS captured; a reworded verdict; newer-supersedes-older) need a judge
+and are a documented opt-in follow-up, not part of this deterministic core.
+"""
+
+from app.services.coach.eval.memory.rubric import (
+    MEMORY_ASSERTIONS,
+    MemoryScore,
+    score_memory,
+    score_stored_profile,
+)
+
+__all__ = [
+    "MEMORY_ASSERTIONS",
+    "MemoryScore",
+    "score_memory",
+    "score_stored_profile",
+]

--- a/backend/app/services/coach/eval/memory/fixtures.py
+++ b/backend/app/services/coach/eval/memory/fixtures.py
@@ -1,0 +1,83 @@
+"""Synthetic good / deliberately-bad memory-write fixtures (#658).
+
+SYNTHETIC, NOT production data (ground-truth trust level 5): hand-authored to
+exercise the rubric, co-designed so the good fixture passes every applicable
+assertion and the bad fixture fails every one. The numbered comments on the bad
+fixture map each violation to the assertion it trips, the same inverted-oracle
+idiom the coach-report eval's `deliberately_bad_report` uses.
+
+Each fixture returns the scored triple `(MemorySources, [MemoryCandidate],
+RunnerMemoryProfile)`: the writer's input, its raw candidate proposal, and the
+stored profile graduation produced.
+"""
+
+from typing import List, Tuple
+
+from app.schemas.coach_memory import RunnerMemoryProfile
+from app.services.coach.memory_update import MemoryCandidate, MemorySources, SourceItem
+
+_Triple = Tuple[MemorySources, List[MemoryCandidate], RunnerMemoryProfile]
+
+
+def known_good_memory() -> _Triple:
+    """A clean write: stated facts and soft character only, every durable line on
+    the runner's own words, the plan on a committed goal, the safety niggle held."""
+    sources = MemorySources(
+        sources=(
+            SourceItem(id="rc1", kind="check_in_note", text="Knee felt tight after Sunday's long run", durable=True),
+            SourceItem(id="rr1", kind="chat", text="yeah let's lock in the October half", durable=True, role="runner"),
+            SourceItem(id="rc2", kind="check_in_note", text="signed up for the October half marathon", durable=True),
+            SourceItem(id="rr2", kind="chat", text="i always wear my vaporflys for workouts", durable=True, role="runner"),
+            SourceItem(id="rc3", kind="check_in_note", text="did the workout in vaporflys again, felt great", durable=True),
+            SourceItem(id="rr3", kind="chat", text="i mostly train on my own, prefer it that way", durable=True, role="runner"),
+            SourceItem(id="rc4", kind="check_in_note", text="solo long run again this week", durable=True),
+            SourceItem(id="cc1", kind="coach_chat", text="want to lock in the October half?", durable=False, role="coach"),
+        )
+    )
+    candidates = [
+        MemoryCandidate(text="Trains mostly solo, prefers it that way", section="who_you_are", supporting_source_ids=["rr3", "rc4"]),
+        MemoryCandidate(text="Possible right-knee niggle, mentioned once", section="limits_and_constraints", supporting_source_ids=["rc1"], safety_relevant=True),
+        MemoryCandidate(text="Racing a half marathon in October", section="goals_and_plans", supporting_source_ids=["rr1", "rc2"]),
+        MemoryCandidate(text="Vaporflys for workouts", section="what_works_for_you", supporting_source_ids=["rr2", "rc3"]),
+        MemoryCandidate(text="Agreed: locking in the October half", section="lately", supporting_source_ids=["rr1", "cc1"]),
+    ]
+    profile = RunnerMemoryProfile(
+        who_you_are=["Trains mostly solo, prefers it that way"],
+        limits_and_constraints=["Possible right-knee niggle, mentioned once"],
+        goals_and_plans=["Racing a half marathon in October"],
+        what_works_for_you=["Vaporflys for workouts"],
+        lately=["Agreed: locking in the October half"],
+    )
+    return sources, candidates, profile
+
+
+def deliberately_bad_memory() -> _Triple:
+    """A write that trips every assertion, one violation each."""
+    sources = MemorySources(
+        sources=(
+            SourceItem(id="rr1", kind="chat", text="i mostly run solo", durable=True, role="runner"),
+            SourceItem(id="rc1", kind="check_in_note", text="left shin has been sore this week", durable=True),
+            SourceItem(id="cc1", kind="coach_chat", text="you'd respond well to 100-mile weeks", durable=False, role="coach"),
+            SourceItem(id="cc2", kind="coach_chat", text="how about a 50k ultra next month?", durable=False, role="coach"),
+        )
+    )
+    candidates = [
+        # (1) no_inferred_verdict: an inferred training-compliance verdict. Grounded
+        #     on a durable source so it trips ONLY the verdict sensor, not grounding.
+        MemoryCandidate(text="Ignores easy-day guidance and runs them too hard", section="who_you_are", supporting_source_ids=["rr1"]),
+        # (2) durable_lines_grounded: a durable preference grounded ONLY on a coach
+        #     turn (anti-echo violation) — the coach's opinion as the runner's fact.
+        MemoryCandidate(text="Responds well to 100-mile weeks", section="what_works_for_you", supporting_source_ids=["cc1"]),
+        # (3) plan_from_commitment: a plan the COACH proposed, no runner commitment.
+        MemoryCandidate(text="Doing a 50k ultra next month", section="goals_and_plans", supporting_source_ids=["cc2"]),
+        # (4) safety_limit_held: a grounded safety limit that the profile DROPPED.
+        MemoryCandidate(text="Sore left shin, mentioned once", section="limits_and_constraints", supporting_source_ids=["rc1"], safety_relevant=True),
+    ]
+    profile = RunnerMemoryProfile(
+        who_you_are=["Ignores easy-day guidance and runs them too hard"],  # (1)
+        limits_and_constraints=[],  # (4) the grounded shin limit was dropped
+        goals_and_plans=["Doing a 50k ultra next month"],  # (3)
+        what_works_for_you=["Responds well to 100-mile weeks"],  # (2)
+        lately=[],
+    )
+    return sources, candidates, profile

--- a/backend/app/services/coach/eval/memory/harness.py
+++ b/backend/app/services/coach/eval/memory/harness.py
@@ -1,0 +1,131 @@
+"""Aggregation + self-test + stored-profile scan for the runner-memory eval (#658).
+
+Mirrors the coach-report eval's `harness.py`: a `MemoryScorecard` that
+micro-averages assertion pass rates, a `run_self_test()` that validates the
+rubric against the synthetic good/bad fixtures with NO DB and NO API key, and a
+`scan_stored_profiles()` that runs the profile-only verdict floor over the stored
+`runner_memory` rows (needs a DB, no key).
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from app.services.coach.eval.memory.fixtures import (
+    deliberately_bad_memory,
+    known_good_memory,
+)
+from app.services.coach.eval.memory.rubric import (
+    MEMORY_ASSERTIONS,
+    MemoryScore,
+    score_memory,
+    score_stored_profile,
+)
+from app.services.coach.eval.rubric import AssertionStatus
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MemoryScorecard:
+    scores: List[MemoryScore] = field(default_factory=list)
+    errors: int = 0
+
+    def assertion_summary(self) -> Dict[str, Dict[str, Any]]:
+        """Per-assertion {applicable, passed, failed, pass_rate}, micro-averaged,
+        skipping NOT_APPLICABLE — the coach-eval shape."""
+        summary: Dict[str, Dict[str, Any]] = {}
+        for score in self.scores:
+            for a in score.assertions:
+                bucket = summary.setdefault(
+                    a.name, {"applicable": 0, "passed": 0, "failed": 0}
+                )
+                if a.status is AssertionStatus.NOT_APPLICABLE:
+                    continue
+                bucket["applicable"] += 1
+                if a.status is AssertionStatus.PASS:
+                    bucket["passed"] += 1
+                elif a.status is AssertionStatus.FAIL:
+                    bucket["failed"] += 1
+        for bucket in summary.values():
+            applicable = bucket["applicable"]
+            bucket["pass_rate"] = (bucket["passed"] / applicable) if applicable else 1.0
+        return summary
+
+    @property
+    def overall_pass_rate(self) -> float:
+        applicable = sum(s.applicable_count for s in self.scores)
+        passed = sum(s.passed_count for s in self.scores)
+        return (passed / applicable) if applicable else 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "profiles_scored": len(self.scores),
+            "errors": self.errors,
+            "overall_pass_rate": self.overall_pass_rate,
+            "assertions": self.assertion_summary(),
+            "scores": [s.to_dict() for s in self.scores],
+        }
+
+
+def _all_assertion_names() -> set:
+    """Every assertion name in the full rubric (derived by running it once on the
+    good fixture, so the set never drifts from `MEMORY_ASSERTIONS`)."""
+    sources, candidates, profile = known_good_memory()
+    return {a.name for a in score_memory(sources, candidates, profile).assertions}
+
+
+def run_self_test() -> bool:
+    """Validate the rubric against its synthetic fixtures. No DB, no API key.
+
+    The good fixture must fail nothing (and apply at least one assertion); the bad
+    fixture must FAIL every assertion name. Returns True on success. This is the
+    inverted-oracle gate: it proves each assertion can both pass a clean write and
+    catch its violation, so a later real-data scan is trustworthy."""
+    ok = True
+
+    good = score_memory(*known_good_memory())
+    if good.applicable_count == 0:
+        logger.error("memory_selftest_good_no_applicable_assertions")
+        ok = False
+    if good.failed_count != 0:
+        failed = [a.name for a in good.assertions if a.status is AssertionStatus.FAIL]
+        logger.error("memory_selftest_good_unexpected_failures", extra={"failed": failed})
+        ok = False
+
+    bad = score_memory(*deliberately_bad_memory())
+    failed_names = {a.name for a in bad.assertions if a.status is AssertionStatus.FAIL}
+    expected = _all_assertion_names()
+    missing = expected - failed_names
+    if missing:
+        logger.error(
+            "memory_selftest_bad_did_not_fail_all", extra={"not_failed": sorted(missing)}
+        )
+        ok = False
+
+    return ok
+
+
+def scan_stored_profiles(db) -> MemoryScorecard:
+    """Run the profile-only verdict floor over every stored `runner_memory` profile.
+
+    A real-data sensor with no candidates/sources on hand, so only the ADR 0025
+    rule-1 verdict floor (`no_inferred_verdict`) applies. Each row is guarded so one
+    malformed profile becomes an error, never a crash."""
+    from app.models.runner_memory import RunnerMemory
+    from app.schemas.coach_memory import RunnerMemoryProfile
+
+    scorecard = MemoryScorecard()
+    for row in db.query(RunnerMemory).all():
+        if not row.profile:
+            continue
+        try:
+            profile = RunnerMemoryProfile(**row.profile)
+        except Exception:
+            logger.exception("memory_scan_unparseable_profile", extra={"user_id": str(row.user_id)})
+            scorecard.errors += 1
+            continue
+        scorecard.scores.append(
+            score_stored_profile(profile, label=f"user:{row.user_id}")
+        )
+    return scorecard

--- a/backend/app/services/coach/eval/memory/rubric.py
+++ b/backend/app/services/coach/eval/memory/rubric.py
@@ -1,0 +1,314 @@
+"""The deterministic runner-memory rubric (#658).
+
+The unit scored is the triple ``(sources, candidates, profile)``:
+
+- ``sources`` (``MemorySources``): what the writer was handed this pass.
+- ``candidates`` (``list[MemoryCandidate]``): the writer's RAW proposed lines,
+  pre-graduation, each carrying its ``supporting_source_ids`` citations and the
+  ``safety_relevant`` flag. This is where provenance lives.
+- ``profile`` (``RunnerMemoryProfile``): what ``apply_graduation`` stored.
+
+The stored profile keeps only line text (graduation discards provenance), so the
+grounding / anti-echo sensors read the candidates, matched back to a profile line
+by ``(section, text)``. This mirrors the coach-report eval scoring ``(content,
+pack)``: ``candidates`` are the memory analogue of the LLM ``content``, ``sources``
+the analogue of the ``pack``.
+
+Each assertion returns an ``AssertionResult`` (PASS / FAIL / NOT_APPLICABLE),
+reusing the coach-eval vocabulary so both harnesses speak one language.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+from app.schemas.coach_memory import MEMORY_SECTION_FIELDS, RunnerMemoryProfile
+from app.services.coach.eval.rubric import AssertionResult, AssertionStatus
+from app.services.coach.memory_update import MemoryCandidate, MemorySources
+
+# ADR 0025 §1-4 durable sections: a line here must rest on the runner's OWN words.
+# `lately` is the probationary holding pen and may rest on any source (incl. a
+# coach digest), so it is excluded from the grounding sensors.
+_PLAIN_DURABLE_SECTIONS = ("who_you_are", "limits_and_constraints", "what_works_for_you")
+_PLAN_SECTION = "goals_and_plans"
+
+# Narrow, high-precision markers of an INFERRED BEHAVIOURAL VERDICT about the
+# runner's TRAINING COMPLIANCE (ADR 0025 rule 1 — the rest-day-fixation incident's
+# symptom). Memory holds STATED facts and soft character only; whether the runner
+# follows advice or trains easy enough is re-derived live from data and is NEVER a
+# memory line. Deliberately narrow (like the coach nag sensor), so a legitimately
+# STATED preference or limit ("no morning runs", "gels make me sick", "prefers
+# evening runs") never trips it — only an unambiguous compliance judgment does.
+_VERDICT_MARKERS = (
+    "ignores easy",
+    "ignores rest",
+    "ignores advice",
+    "ignores the plan",
+    "ignores coaching",
+    "doesn't follow",
+    "does not follow",
+    "won't follow",
+    "never follows",
+    "doesn't run easy",
+    "does not run easy",
+    "won't run easy",
+    "overcooks easy",
+    "overcooks the easy",
+    "runs easy days too hard",
+    "runs easy too hard",
+    "fixated on rest",
+    "fixated on",
+    "consistently ignores",
+    "keeps ignoring",
+    "keeps blowing past",
+    "tends to overcook",
+    "struggles to run easy",
+    "can't run easy",
+    "refuses to run easy",
+)
+
+
+def _candidate_index(
+    candidates: List[MemoryCandidate],
+) -> Dict[tuple, MemoryCandidate]:
+    """Map (section, text) -> candidate, so a profile line can be traced back to
+    the candidate (and thus the source ids) that produced it. Graduation preserves
+    candidate text verbatim, so the match is exact."""
+    return {(c.section, c.text.strip()): c for c in candidates}
+
+
+# --------------------------------------------------------------------------- #
+# Assertions
+# --------------------------------------------------------------------------- #
+def assert_no_inferred_verdict(
+    sources: MemorySources,
+    candidates: List[MemoryCandidate],
+    profile: RunnerMemoryProfile,
+) -> AssertionResult:
+    """ADR 0025 rule 1: no section holds an inferred behavioural verdict about the
+    runner's training compliance (the rest-day-fixation floor). FAIL on any
+    `_VERDICT_MARKERS` hit; PASS otherwise. Always applicable — this is the floor.
+    Reads the profile text only, so it also scores a stored profile with no
+    sources/candidates on hand."""
+    hits: List[Dict[str, Any]] = []
+    for section in MEMORY_SECTION_FIELDS:
+        for line in getattr(profile, section):
+            low = line.lower()
+            for marker in _VERDICT_MARKERS:
+                if marker in low:
+                    hits.append({"section": section, "line": line, "marker": marker})
+    if hits:
+        return AssertionResult(
+            "no_inferred_verdict",
+            AssertionStatus.FAIL,
+            "A memory line renders an inferred behavioural verdict about the runner's "
+            "training compliance — the retired belief loop's symptom. Memory holds "
+            "stated facts and soft character only; compliance is re-derived live.",
+            {"hits": hits},
+        )
+    return AssertionResult(
+        "no_inferred_verdict",
+        AssertionStatus.PASS,
+        "No section renders an inferred behavioural verdict about the runner.",
+    )
+
+
+def assert_durable_lines_grounded(
+    sources: MemorySources,
+    candidates: List[MemoryCandidate],
+    profile: RunnerMemoryProfile,
+) -> AssertionResult:
+    """ADR 0025 rule 6 (anti-echo): every line in a plain durable section
+    (who_you_are / limits_and_constraints / what_works_for_you) must rest on at
+    least one of the runner's OWN (durable) sources. A line grounded only on the
+    coach's words, or on no matching candidate at all, FAILS — that is the coach's
+    opinion echoed as the runner's stated fact. NOT_APPLICABLE when there are no
+    such lines."""
+    durable_ids = sources.durable_source_ids
+    index = _candidate_index(candidates)
+    lines = [
+        (section, line)
+        for section in _PLAIN_DURABLE_SECTIONS
+        for line in getattr(profile, section)
+    ]
+    if not lines:
+        return AssertionResult(
+            "durable_lines_grounded",
+            AssertionStatus.NOT_APPLICABLE,
+            "No durable character/limit/preference lines to check.",
+        )
+    bad: List[Dict[str, Any]] = []
+    for section, line in lines:
+        candidate = index.get((section, line.strip()))
+        if candidate is None:
+            bad.append({"section": section, "line": line, "reason": "no matching candidate (fabricated)"})
+            continue
+        if not (set(candidate.supporting_source_ids) & durable_ids):
+            bad.append({"section": section, "line": line, "reason": "grounded only on non-durable (coach) sources"})
+    if bad:
+        return AssertionResult(
+            "durable_lines_grounded",
+            AssertionStatus.FAIL,
+            "A durable memory line does not rest on the runner's own words (it is "
+            "ungrounded or echoes a coach turn as the runner's stated fact).",
+            {"violations": bad},
+        )
+    return AssertionResult(
+        "durable_lines_grounded",
+        AssertionStatus.PASS,
+        "Every durable character/limit/preference line rests on the runner's own words.",
+    )
+
+
+def assert_plan_from_commitment(
+    sources: MemorySources,
+    candidates: List[MemoryCandidate],
+    profile: RunnerMemoryProfile,
+) -> AssertionResult:
+    """The #657 regression sensor: every `goals_and_plans` line must trace to a
+    runner COMMITMENT — a candidate grounded on at least one durable (runner)
+    source. A plan the coach only PROPOSED (grounded on coach turns alone), or a
+    plan the runner merely weighed, must not graduate. NOT_APPLICABLE when there
+    are no plan lines."""
+    durable_ids = sources.durable_source_ids
+    index = _candidate_index(candidates)
+    plans = profile.goals_and_plans
+    if not plans:
+        return AssertionResult(
+            "plan_from_commitment",
+            AssertionStatus.NOT_APPLICABLE,
+            "No goals_and_plans lines to check.",
+        )
+    bad: List[Dict[str, Any]] = []
+    for line in plans:
+        candidate = index.get((_PLAN_SECTION, line.strip()))
+        if candidate is None:
+            bad.append({"line": line, "reason": "no matching candidate (fabricated)"})
+            continue
+        if not (set(candidate.supporting_source_ids) & durable_ids):
+            bad.append({"line": line, "reason": "no runner commitment — coach-proposed / weighed only"})
+    if bad:
+        return AssertionResult(
+            "plan_from_commitment",
+            AssertionStatus.FAIL,
+            "A goals_and_plans line has no runner commitment behind it (a coach "
+            "proposal or an option the runner only weighed graduated as a plan).",
+            {"violations": bad},
+        )
+    return AssertionResult(
+        "plan_from_commitment",
+        AssertionStatus.PASS,
+        "Every plan rests on a runner commitment.",
+    )
+
+
+def assert_safety_limit_held(
+    sources: MemorySources,
+    candidates: List[MemoryCandidate],
+    profile: RunnerMemoryProfile,
+) -> AssertionResult:
+    """ADR 0025 rule 4: a `safety_relevant` limit grounded on the runner's own
+    words is HELD in limits_and_constraints on a single mention (never silently
+    dropped). FAIL when such a grounded safety candidate is missing from the stored
+    limits. NOT_APPLICABLE when there is no grounded safety candidate to hold."""
+    durable_ids = sources.durable_source_ids
+    grounded_safety = [
+        c
+        for c in candidates
+        if c.safety_relevant and (set(c.supporting_source_ids) & durable_ids)
+    ]
+    if not grounded_safety:
+        return AssertionResult(
+            "safety_limit_held",
+            AssertionStatus.NOT_APPLICABLE,
+            "No grounded safety-relevant limit to hold.",
+        )
+    stored = {line.strip() for line in profile.limits_and_constraints}
+    dropped = [c.text for c in grounded_safety if c.text.strip() not in stored]
+    if dropped:
+        return AssertionResult(
+            "safety_limit_held",
+            AssertionStatus.FAIL,
+            "A safety-relevant limit grounded on the runner's own words was dropped "
+            "from limits_and_constraints instead of being held on first mention.",
+            {"dropped": dropped},
+        )
+    return AssertionResult(
+        "safety_limit_held",
+        AssertionStatus.PASS,
+        "Every grounded safety-relevant limit is held in limits_and_constraints.",
+    )
+
+
+# The full triple-scored rubric.
+MEMORY_ASSERTIONS: List[
+    Callable[[MemorySources, List[MemoryCandidate], RunnerMemoryProfile], AssertionResult]
+] = [
+    assert_no_inferred_verdict,
+    assert_durable_lines_grounded,
+    assert_plan_from_commitment,
+    assert_safety_limit_held,
+]
+
+# The subset scoreable from a stored profile alone (no candidates/sources): the
+# verdict floor reads profile text only, so a real-data scan can run it.
+PROFILE_ONLY_ASSERTIONS: List[
+    Callable[[MemorySources, List[MemoryCandidate], RunnerMemoryProfile], AssertionResult]
+] = [assert_no_inferred_verdict]
+
+
+@dataclass
+class MemoryScore:
+    assertions: List[AssertionResult]
+    label: Optional[str] = None
+
+    @property
+    def applicable_count(self) -> int:
+        return sum(1 for a in self.assertions if a.status is not AssertionStatus.NOT_APPLICABLE)
+
+    @property
+    def passed_count(self) -> int:
+        return sum(1 for a in self.assertions if a.status is AssertionStatus.PASS)
+
+    @property
+    def failed_count(self) -> int:
+        return sum(1 for a in self.assertions if a.status is AssertionStatus.FAIL)
+
+    @property
+    def pass_rate(self) -> float:
+        """Passed over applicable. Vacuously 1.0 when nothing applies."""
+        applicable = self.applicable_count
+        if applicable == 0:
+            return 1.0
+        return self.passed_count / applicable
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "label": self.label,
+            "applicable_count": self.applicable_count,
+            "passed_count": self.passed_count,
+            "failed_count": self.failed_count,
+            "pass_rate": self.pass_rate,
+            "assertions": [a.to_dict() for a in self.assertions],
+        }
+
+
+def score_memory(
+    sources: MemorySources,
+    candidates: List[MemoryCandidate],
+    profile: RunnerMemoryProfile,
+    *,
+    label: Optional[str] = None,
+) -> MemoryScore:
+    """Score one memory WRITE (the full triple) against the deterministic rubric."""
+    results = [assertion(sources, candidates, profile) for assertion in MEMORY_ASSERTIONS]
+    return MemoryScore(assertions=results, label=label)
+
+
+def score_stored_profile(
+    profile: RunnerMemoryProfile, *, label: Optional[str] = None
+) -> MemoryScore:
+    """Score a STORED profile with the profile-only subset (no candidates/sources
+    on hand). Only the ADR 0025 rule-1 verdict floor applies here."""
+    empty_sources = MemorySources()
+    results = [assertion(empty_sources, [], profile) for assertion in PROFILE_ONLY_ASSERTIONS]
+    return MemoryScore(assertions=results, label=label)

--- a/backend/scripts/eval_runner_memory.py
+++ b/backend/scripts/eval_runner_memory.py
@@ -1,0 +1,62 @@
+"""Offline runner-memory eval harness CLI (#658).
+
+The durable-memory counterpart to `scripts/eval_coach_reports.py`. Two modes:
+
+  --self-test   Validate the rubric against its synthetic good/bad fixtures.
+                No DB, no API key. Exit 0 on pass, 1 on failure. This is the
+                CI-friendly gate (the `make eval-memory-selftest` target).
+
+  --scan        Score every STORED runner_memory profile against the profile-only
+                verdict floor (ADR 0025 rule 1). Needs a DB (no key). Exit 0, or
+                1 if any profile fails the floor.
+
+The full triple-scored rubric (grounding / anti-echo / plan-commitment / safety-
+hold) needs the writer's raw candidates + sources, which are not stored, so it is
+exercised offline via the fixtures (self-test) and — as a follow-up — a
+`--regenerate` path that runs the real writer over a conversation fixture set,
+mirroring `eval_coach_reports.py --regenerate`. See docs/testing/coach-memory-eval.md.
+"""
+
+import argparse
+import json
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Offline runner-memory eval harness (#658)")
+    parser.add_argument("--self-test", action="store_true", help="validate the rubric against synthetic fixtures (no DB/key)")
+    parser.add_argument("--scan", action="store_true", help="score stored runner_memory profiles' verdict floor (needs DB)")
+    parser.add_argument("--output", help="write the JSON scorecard to this path")
+    args = parser.parse_args()
+
+    if args.self_test:
+        from app.services.coach.eval.memory.harness import run_self_test
+
+        ok = run_self_test()
+        print(f"runner-memory eval self-test: {'PASS' if ok else 'FAIL'}")
+        return 0 if ok else 1
+
+    if args.scan:
+        from app.db.session import SessionLocal
+        from app.services.coach.eval.memory.harness import scan_stored_profiles
+
+        db = SessionLocal()
+        try:
+            scorecard = scan_stored_profiles(db)
+        finally:
+            db.close()
+        payload = scorecard.to_dict()
+        text = json.dumps(payload, indent=2, default=str)
+        if args.output:
+            with open(args.output, "w") as fh:
+                fh.write(text)
+        print(text)
+        floor = payload["assertions"].get("no_inferred_verdict", {})
+        return 0 if floor.get("failed", 0) == 0 else 1
+
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_memory_eval.py
+++ b/backend/tests/test_memory_eval.py
@@ -1,0 +1,123 @@
+"""#658: the offline runner-memory eval rubric + self-test.
+
+Validates that each deterministic assertion both passes a clean write and catches
+its own violation (the inverted-oracle gate), and that the harness self-test
+agrees. No DB, no API key.
+"""
+
+from app.schemas.coach_memory import RunnerMemoryProfile
+from app.services.coach.eval.memory.fixtures import (
+    deliberately_bad_memory,
+    known_good_memory,
+)
+from app.services.coach.eval.memory.harness import run_self_test
+from app.services.coach.eval.memory.rubric import (
+    AssertionStatus,
+    MemoryScore,
+    score_memory,
+    score_stored_profile,
+)
+from app.services.coach.memory_update import MemoryCandidate, MemorySources, SourceItem
+
+
+def _status(score: MemoryScore, name: str) -> AssertionStatus:
+    for a in score.assertions:
+        if a.name == name:
+            return a.status
+    raise AssertionError(f"assertion {name} not present")
+
+
+def test_self_test_passes():
+    assert run_self_test() is True
+
+
+def test_good_fixture_fails_nothing_and_applies_all():
+    score = score_memory(*known_good_memory())
+    assert score.failed_count == 0
+    # Every assertion is applicable in the good fixture (it has lines in every
+    # durable section, a plan, and a grounded safety limit).
+    assert score.applicable_count == 4
+    assert score.pass_rate == 1.0
+
+
+def test_bad_fixture_fails_every_assertion():
+    score = score_memory(*deliberately_bad_memory())
+    failed = {a.name for a in score.assertions if a.status is AssertionStatus.FAIL}
+    assert failed == {
+        "no_inferred_verdict",
+        "durable_lines_grounded",
+        "plan_from_commitment",
+        "safety_limit_held",
+    }
+
+
+def test_verdict_floor_catches_inferred_verdict():
+    profile = RunnerMemoryProfile(who_you_are=["Ignores easy days and overcooks the easy runs"])
+    score = score_stored_profile(profile)
+    assert _status(score, "no_inferred_verdict") is AssertionStatus.FAIL
+
+
+def test_verdict_floor_allows_stated_constraint():
+    # A legitimately STATED preference/limit must not trip the narrow verdict floor.
+    profile = RunnerMemoryProfile(
+        limits_and_constraints=["No morning runs — works early shifts"],
+        what_works_for_you=["Prefers evening runs", "Gels make me nauseous"],
+    )
+    score = score_stored_profile(profile)
+    assert _status(score, "no_inferred_verdict") is AssertionStatus.PASS
+
+
+def test_coach_proposed_plan_is_not_a_commitment():
+    sources = MemorySources(
+        sources=(
+            SourceItem(id="cc1", kind="coach_chat", text="want to try a 50k?", durable=False, role="coach"),
+        )
+    )
+    candidates = [
+        MemoryCandidate(text="Doing a 50k", section="goals_and_plans", supporting_source_ids=["cc1"]),
+    ]
+    profile = RunnerMemoryProfile(goals_and_plans=["Doing a 50k"])
+    score = score_memory(sources, candidates, profile)
+    assert _status(score, "plan_from_commitment") is AssertionStatus.FAIL
+
+
+def test_committed_plan_passes():
+    sources = MemorySources(
+        sources=(
+            SourceItem(id="rr1", kind="chat", text="yeah I'm doing the 50k", durable=True, role="runner"),
+        )
+    )
+    candidates = [
+        MemoryCandidate(text="Doing a 50k", section="goals_and_plans", supporting_source_ids=["rr1"]),
+    ]
+    profile = RunnerMemoryProfile(goals_and_plans=["Doing a 50k"])
+    score = score_memory(sources, candidates, profile)
+    assert _status(score, "plan_from_commitment") is AssertionStatus.PASS
+
+
+def test_dropped_safety_limit_fails():
+    sources = MemorySources(
+        sources=(
+            SourceItem(id="rc1", kind="check_in_note", text="knee is sore", durable=True),
+        )
+    )
+    candidates = [
+        MemoryCandidate(text="Possible knee niggle", section="limits_and_constraints", supporting_source_ids=["rc1"], safety_relevant=True),
+    ]
+    profile = RunnerMemoryProfile(limits_and_constraints=[])  # dropped
+    score = score_memory(sources, candidates, profile)
+    assert _status(score, "safety_limit_held") is AssertionStatus.FAIL
+
+
+def test_coach_echoed_durable_fact_fails_anti_echo():
+    sources = MemorySources(
+        sources=(
+            SourceItem(id="cc1", kind="coach_chat", text="you love long tempos", durable=False, role="coach"),
+        )
+    )
+    candidates = [
+        MemoryCandidate(text="Loves long tempo blocks", section="what_works_for_you", supporting_source_ids=["cc1"]),
+    ]
+    profile = RunnerMemoryProfile(what_works_for_you=["Loves long tempo blocks"])
+    score = score_memory(sources, candidates, profile)
+    assert _status(score, "durable_lines_grounded") is AssertionStatus.FAIL

--- a/docs/testing/coach-memory-eval.md
+++ b/docs/testing/coach-memory-eval.md
@@ -1,0 +1,83 @@
+# Runner-memory eval harness (#658)
+
+The durable-memory counterpart to the coach-report eval (`docs/testing/coach-report-eval.md`).
+It scores a runner-memory WRITE against deterministic ADR 0025 assertions, so a
+change to the memory writer (`services/coach/memory_update.py` — its sources,
+prompt, or graduation) has a repeatable quality gate instead of a one-off human
+read of the resulting profile.
+
+## What it scores
+
+The memory writer is an LLM (`claude-haiku-4-5`) that rebuilds the whole profile
+from source each pass, so its behaviour cannot be pinned by deterministic unit
+tests. The unit the harness scores is the triple:
+
+- **`sources`** (`MemorySources`) — what the writer was handed this pass.
+- **`candidates`** (`list[MemoryCandidate]`) — the writer's RAW proposed lines,
+  before graduation, each carrying its `supporting_source_ids` citations and the
+  `safety_relevant` flag. Provenance lives here.
+- **`profile`** (`RunnerMemoryProfile`) — what `apply_graduation` stored.
+
+The stored profile keeps only line text (graduation discards provenance), so the
+grounding sensors read the candidates, matched back to a profile line by
+`(section, text)`. `candidates` are the memory analogue of the coach-report eval's
+LLM `content`; `sources` the analogue of its `pack`.
+
+## The rubric (deterministic v1)
+
+`app/services/coach/eval/memory/rubric.py`. Each returns PASS / FAIL /
+NOT_APPLICABLE, reusing the coach-eval `AssertionResult` vocabulary.
+
+| Assertion | ADR 0025 rule | What it catches |
+|---|---|---|
+| `no_inferred_verdict` | Rule 1 | An inferred behavioural verdict about training compliance ("ignores easy days") — the rest-day-fixation floor. Narrow, high-precision markers, so a legitimately STATED constraint ("no morning runs") never trips it. |
+| `durable_lines_grounded` | Rule 6 (anti-echo) | A durable character/limit/preference line that rests only on the coach's words, or on no candidate at all — the coach's opinion echoed as the runner's stated fact. |
+| `plan_from_commitment` | — (#657 regression) | A `goals_and_plans` line with no runner commitment behind it (a coach proposal, or an option the runner only weighed, graduated as a plan). |
+| `safety_limit_held` | Rule 4 | A grounded `safety_relevant` limit dropped from `limits_and_constraints` instead of being held on first mention. |
+
+### Deliberately deterministic
+
+An LLM judge would reintroduce the drift the gate exists to detect. The semantic
+judgments #658 also lists — a genuine *elliptical* commitment ("yeah, do that")
+IS captured, a *reworded* verdict, and newer-supersedes-older — need a judge to
+score reliably and are a documented opt-in follow-up (mirroring the coach eval's
+off-by-default `judge.py`), not part of this deterministic core.
+
+## Running it
+
+```
+make eval-memory-selftest      # validate the rubric against its fixtures (no DB, no key)
+make eval-memory EVAL_MEMORY_ARGS="--scan"   # score stored runner_memory profiles (needs a seeded DB)
+```
+
+- **Self-test** (`--self-test`): validates the rubric against the synthetic
+  good/bad fixtures in `fixtures.py`. The good fixture must fail nothing; the bad
+  fixture must FAIL every assertion. This is the inverted-oracle gate — it proves
+  each assertion can both pass a clean write and catch its violation. CI-safe.
+  Also exercised by `tests/test_memory_eval.py` in the normal suite.
+- **Scan** (`--scan`): runs the profile-only verdict floor (`no_inferred_verdict`)
+  over every stored `runner_memory` profile. Only the floor applies, because a
+  stored profile has no candidates/sources on hand. Seed real data first
+  (`make seed-local`).
+
+## Why each layer is trustworthy
+
+- The fixtures are SYNTHETIC (ground-truth trust level 5), co-designed so the
+  inverted-oracle self-test is meaningful: the bad fixture trips each assertion by
+  exactly one authored violation.
+- The grounding sensors re-derive support from the current source set (the same
+  contract `apply_graduation` enforces), so a hallucinated citation contributes
+  nothing.
+- The verdict floor reuses the same narrow, high-precision-over-recall discipline
+  as the coach report's `coached_direction_not_nagged` sensor.
+
+## Follow-ups (not in #658's first cut)
+
+- An opt-in LLM-judge layer for the semantic assertions above.
+- A `--regenerate` path that runs the real writer over a conversation fixture set
+  and scores the full triple, mirroring `eval_coach_reports.py --regenerate`
+  (this is the generalisation of #657's real-conversation fixtures into the
+  harness).
+
+Related: ADR 0025 (`docs/adr/0025-runner-memory-is-a-rewritten-profile.md`),
+#657 (the writer change this harness guards).


### PR DESCRIPTION
Closes #658.

The durable-memory counterpart to the M5 coach-report eval (`app/services/coach/eval/`). It scores a runner-memory WRITE against deterministic ADR 0025 assertions, so a change to the memory writer (`memory_update.py` — sources, prompt, or graduation) has a repeatable quality gate instead of a one-off human read of the resulting profile.

## What it scores
The unit is the triple `(sources, candidates, profile)`: what the writer saw, its RAW proposed candidate lines (pre-graduation, carrying `supporting_source_ids` + `safety_relevant`), and the stored profile graduation produced. The stored profile discards provenance, so the grounding sensors read the candidates, matched to a profile line by `(section, text)`. This mirrors the coach-report eval scoring `(content, pack)`.

## Rubric (deterministic v1)
| Assertion | ADR 0025 | Catches |
|---|---|---|
| `no_inferred_verdict` | Rule 1 | An inferred training-compliance verdict ("ignores easy days") — the rest-day-fixation floor. Narrow markers, so a STATED constraint ("no morning runs") never trips it. |
| `durable_lines_grounded` | Rule 6 | A durable line resting only on the coach's words (anti-echo) or on no candidate at all. |
| `plan_from_commitment` | #657 sensor | A `goals_and_plans` line with no runner commitment (a coach proposal / weighed option graduated as a plan). |
| `safety_limit_held` | Rule 4 | A grounded `safety_relevant` limit dropped instead of held on first mention. |

## Deliverables
- `app/services/coach/eval/memory/` (rubric / fixtures / harness)
- `scripts/eval_runner_memory.py` — `--self-test` (no DB/key) and `--scan` (stored profiles' verdict floor, needs DB)
- `make eval-memory-selftest` / `make eval-memory`
- `docs/testing/coach-memory-eval.md`
- `tests/test_memory_eval.py` — 9 tests pinning each assertion's pass + fail cases + the self-test

## Verification
New/additive modality. The inverted-oracle self-test proves each assertion both passes a clean write and catches its violation (good fails nothing, bad fails all four). `make eval-memory-selftest` passes; full backend suite green (**2193 passed, 5 skipped**; baseline + 9).

## Decisions (owner unreachable — best-recommendation calls)
- **Deterministic v1, no LLM judge.** An LLM judge would reintroduce the drift the gate exists to detect (matching the coach eval's off-by-default `judge.py`). The semantic assertions #658 also lists — a genuine *elliptical* commitment IS captured, a *reworded* verdict, newer-supersedes-older — need a judge and are documented follow-ups.
- **`--regenerate` (run the real writer over conversation fixtures and score the full triple) is a documented follow-up**, not in this first cut. This slice is the fixture-based harness + real-data verdict-floor scan, which is CI-safe and immediately useful; #657's real-conversation fixtures generalise into the `--regenerate` path later.
- The grounding sensors check the anti-echo invariant (a durable line rests on ≥1 *durable/runner* source) rather than re-implementing `apply_graduation`'s exact ≥2 count, which is already deterministic and unit-tested — the eval's job is to catch the *writer* echoing a coach turn, not to re-test graduation.

North Star: this is a quality gate that guards what a good coach's memory should and shouldn't hold (stated facts, not inferred verdicts); it changes no runtime coach behaviour and no coach-pack (no diagram regen).