### PR TITLE
Carry interval detection source in recent-session markers (#661)

### DIFF
--- a/backend/app/schemas/coach_context.py
+++ b/backend/app/schemas/coach_context.py
@@ -646,6 +646,13 @@ class RecentActivityItem(BaseModel):
     weekday: Optional[str] = None
     structure: Optional[str] = None  # continuous | intervals (the classifier verdict)
     interval_shape: Optional[str] = None  # e.g. "7x400m"; None for a continuous run
+    # #661: how this past session's interval structure was detected — "recorded_laps"
+    # when the runner pressed the lap button (so a later report must NOT advise the lap
+    # button on this session), else None (stream-detected or not an interval session).
+    # Reuses the exact `metrics.interval_structure.source` vocabulary the subject-run
+    # rule already keys on, so the coach reads a past session the same way. Optional and
+    # null-dropped, so packs stored before #661 still validate on strict re-parse.
+    source: Optional[str] = None
     # #650: the classifier's runner-RELATIVE "long run" verdict, surfaced only when long
     # (None otherwise) so the coach recognises a past long run without guessing a
     # per-runner distance threshold. The symmetric case to the interval marker.
@@ -1838,7 +1845,7 @@ def _drop_recent_training_dedup(rt: Dict[str, Any], _data: Dict[str, Any]) -> No
         # weekday is always populated (from the date), so it stays. Re-parse safe: both
         # default to None when absent.
         for act in win.get("activities", []):
-            for k in ("structure", "interval_shape", "long_run"):
+            for k in ("structure", "interval_shape", "source", "long_run"):
                 if act.get(k) is None:
                     act.pop(k, None)
 

--- a/backend/app/services/coach/recent_training.py
+++ b/backend/app/services/coach/recent_training.py
@@ -92,6 +92,18 @@ def _interval_shape(interval_structure: Any) -> Optional[str]:
     return f"{n}x{rounded}m"
 
 
+def _interval_source(interval_structure: Any) -> Optional[str]:
+    """#661: how a past session's interval structure was detected. Returns
+    "recorded_laps" when the runner pressed the lap button (the stored
+    `interval_structure.source`), so a later report knows not to advise the lap
+    button on that session. Returns None for a stream-detected interval session or
+    a non-interval session — the same absence-means-not-lap-recorded reading the
+    subject-run rule uses (`metrics.interval_structure.source == "recorded_laps"`)."""
+    if not isinstance(interval_structure, dict):
+        return None
+    return interval_structure.get("source")
+
+
 def _by_type(window_facts: List[Any]) -> List[RecentTypeBreakdown]:
     """Per-activity-type counts + totals + the type's session share of the window,
     most-frequent type first (ties broken by type name for determinism)."""
@@ -144,6 +156,9 @@ def _recent_activities(window_facts: List[Any]) -> List[RecentActivityItem]:
             weekday=f.local_date.strftime("%a"),
             structure=getattr(f, "structure", None),
             interval_shape=_interval_shape(getattr(f, "interval_structure", None)),
+            # #661: carry the lap-button provenance so a later report engaging this
+            # past session's thread never advises the lap button on a recorded-laps run.
+            source=_interval_source(getattr(f, "interval_structure", None)),
             long_run=True if getattr(f, "duration_class", None) == "long" else None,
         )
         for f in ordered

--- a/backend/tests/test_recent_training.py
+++ b/backend/tests/test_recent_training.py
@@ -137,6 +137,43 @@ def test_recent_session_carries_weekday_structure_and_shape():
     assert easy.interval_shape is None  # a continuous run has no rep shape
 
 
+def test_recent_session_carries_interval_source_when_lap_recorded():
+    """#661: a past interval session tags whether the runner pressed the lap button
+    (recorded_laps), so a later report never advises the lap button on it. A
+    stream-detected interval session and a continuous run carry no source (absence =
+    not lap-recorded), matching the subject-run rule's vocabulary."""
+    lap = {"source": "recorded_laps", "work_segments": [{"distance_m": 400.0} for _ in range(7)]}
+    stream = {"work_segments": [{"distance_m": 400.0} for _ in range(6)]}
+    facts = [
+        _fact(0, type="Run", structure="intervals", interval_structure=lap),
+        _fact(1, type="Run", structure="intervals", interval_structure=stream),
+        _fact(2, type="Run", structure="continuous"),
+    ]
+    ctx = build_recent_training(facts, _AS_OF)
+    assert ctx.last_7d.activities[0].source == "recorded_laps"
+    assert ctx.last_7d.activities[1].source is None  # stream-detected, not lap-recorded
+    assert ctx.last_7d.activities[2].source is None  # not an interval session
+
+
+def test_serialization_drops_null_interval_source_keeps_recorded_laps():
+    """#661: the null-drop trim omits a null `source` (costs no tokens) but keeps a
+    real "recorded_laps" marker so the coach can read it."""
+    from app.schemas.coach_context import _drop_recent_training_dedup
+
+    rt = {
+        "last_7d": {
+            "activities": [
+                {"date": "2026-06-01", "type": "Run", "structure": "intervals", "source": "recorded_laps"},
+                {"date": "2026-05-31", "type": "Run", "structure": "intervals", "source": None},
+            ]
+        }
+    }
+    _drop_recent_training_dedup(rt, {})
+    acts = rt["last_7d"]["activities"]
+    assert acts[0]["source"] == "recorded_laps"
+    assert "source" not in acts[1]  # null source dropped
+
+
 def test_recent_session_marks_long_run_only_when_long():
     """#650: a recent session carries a long-run marker ONLY when the classifier's
     runner-relative verdict is "long" — a standard run stays unmarked (no per-session


### PR DESCRIPTION
Closes #661 (substrate). The prompt-consumption slice is filed as #712.

## Problem
The recent-session shape markers (`recent_training.last_7d.activities[]`, added in #650/#444) carry `structure` + `interval_shape` + `weekday` + `distance` but NOT the interval detection `source`. So when a later report engages a PAST session's thread (#651), it can advise the lap button for a session that was already `recorded_laps` — the runner already pressed it. The prompt/validator enforce the recorded-laps rule only for THIS run's `interval_structure`.

## Change
Add an optional `source` to `RecentActivityItem`, read from the same stored `interval_structure` (`recent_training.py`). It carries `"recorded_laps"` when the runner pressed the lap button on that past session, else `None`. Added to the recent_training null-drop tuple so it costs no tokens when absent and pre-#661 packs still strict-parse under `extra="forbid"`. The shared `recent_weeks` markers inherit it too.

## Verification
- `test_recent_session_carries_interval_source_when_lap_recorded` — the marker carries `"recorded_laps"` for a lap session, `None` for a stream-detected interval and a continuous run.
- `test_serialization_drops_null_interval_source_keeps_recorded_laps` — null-drop trims a null `source`, keeps a real one.
- Diagram drift guard (`test_diagram_drift`) passes — no new pack section or DerivedMetric column.
- `recent_weeks` + pack tests + full backend suite green (**2186 passed, 5 skipped**).

## Decisions (owner unreachable — best-recommendation calls, per the batch brief)
- **Substrate only.** The prompt rule that makes the coach actually HONOR a past session's `recorded_laps` needs a new prompt version (prod runs `coach_message_lean_v1`; editing it in place breaks the pinned `test_message_prompt_lean_v1`). Shipping substrate-only keeps this low-risk and fully verifiable; the prompt-consumption slice is **#712**, to bundle with the next prompt iteration. Without it the field is available to the coach's general pack reasoning but not enforced.
- **`source` is positive-only** (`"recorded_laps"` or absent), matching the subject-run rule's exact vocabulary rather than synthesizing a `"stream"` value the codebase never stores — least ambiguous for the LLM (North Star: an LLM already reads `source == "recorded_laps"` this way for the subject run).
- **Diagram example DATA not regenerated.** The drift guard (the CI gate) passes because no new section/column is added. The committed example activity (`2c24b60…`) has no recorded-laps session in its recent window, so the field wouldn't appear in the example; and a blind regen would sweep in unrelated accumulated diagram drift (there is an open regen PR #687). Regenerating is left to the periodic regen.

North Star: a good coach must not tell a runner to press the lap button on a session where they already did — this carries the fact that makes that possible.