### PR TITLE
Make the per-user budget counter cache-aware (#709)

### DIFF
--- a/backend/app/services/coach/budget.py
+++ b/backend/app/services/coach/budget.py
@@ -46,11 +46,37 @@ PRICE_PER_MTOK: Dict[str, tuple[float, float]] = {
 }
 _DEFAULT_PRICE = (5.0, 25.0)  # conservative: assume Opus tier when unknown
 
+# Prompt-caching price multipliers on the INPUT price (#709/#629). Anthropic
+# bills a cache read at ~0.1x the base input price and a cache write at ~1.25x
+# for the 5-minute ephemeral TTL the coach uses (llm.py sets `cache_control:
+# {"type": "ephemeral"}` with no `ttl`, i.e. the 5-min default). A 1-hour TTL
+# would be 2.0x; if the coach ever switches TTL, bump _CACHE_WRITE_MULTIPLIER.
+_CACHE_READ_MULTIPLIER = 0.1
+_CACHE_WRITE_MULTIPLIER = 1.25
 
-def cost_usd(model: str, input_tokens: int, output_tokens: int) -> float:
-    """List-price cost of one call in USD."""
+
+def cost_usd(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_input_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
+) -> float:
+    """List-price cost of one call in USD, cache-aware (#709).
+
+    With prompt caching active the API reports `input_tokens` as only the
+    *uncached* input; the cached portion arrives as `cache_read_input_tokens`
+    (billed ~0.1x) and `cache_creation_input_tokens` (billed ~1.25x). The three
+    input buckets are disjoint, so their costs add. Callers that pass no cache
+    counts (the pre-caching path) are byte-stable with the old 3-arg pricing.
+    """
     price_in, price_out = PRICE_PER_MTOK.get(model, _DEFAULT_PRICE)
-    return (input_tokens * price_in + output_tokens * price_out) / 1_000_000
+    return (
+        input_tokens * price_in
+        + cache_read_input_tokens * price_in * _CACHE_READ_MULTIPLIER
+        + cache_creation_input_tokens * price_in * _CACHE_WRITE_MULTIPLIER
+        + output_tokens * price_out
+    ) / 1_000_000
 
 
 def _now() -> datetime:
@@ -193,9 +219,23 @@ class BudgetGate:
             logger.warning("llm_budget_check_failed", extra={"error": str(exc)})
             return False
 
-    def record(self, user_id, model: str, input_tokens: int, output_tokens: int) -> None:
+    def record(
+        self,
+        user_id,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_input_tokens: int = 0,
+        cache_creation_input_tokens: int = 0,
+    ) -> None:
         """Add one call's list-price cost to the user's and the global windows."""
-        amount = cost_usd(model, input_tokens, output_tokens)
+        amount = cost_usd(
+            model,
+            input_tokens,
+            output_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+        )
         if amount <= 0:
             return
         today = _now().date()
@@ -268,5 +308,19 @@ def over_budget(user_id) -> bool:
     return get_gate().over_budget(user_id)
 
 
-def record(user_id, model: str, input_tokens: int, output_tokens: int) -> None:
-    get_gate().record(user_id, model, input_tokens, output_tokens)
+def record(
+    user_id,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_input_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
+) -> None:
+    get_gate().record(
+        user_id,
+        model,
+        input_tokens,
+        output_tokens,
+        cache_read_input_tokens=cache_read_input_tokens,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+    )

--- a/backend/app/services/coach/material_distiller.py
+++ b/backend/app/services/coach/material_distiller.py
@@ -173,7 +173,14 @@ async def _distill_with_one_retry(
         max_tokens=_MAX_TOKENS,
     )
     if user_id is not None:
-        budget_record(user_id, client.model, usage.input_tokens, usage.output_tokens)
+        budget_record(
+            user_id,
+            client.model,
+            usage.input_tokens,
+            usage.output_tokens,
+            cache_read_input_tokens=usage.cache_read_input_tokens,
+            cache_creation_input_tokens=usage.cache_creation_input_tokens,
+        )
     try:
         return DistilledMaterial.model_validate(raw)
     except ValidationError as exc:
@@ -193,7 +200,14 @@ async def _distill_with_one_retry(
         max_tokens=_MAX_TOKENS,
     )
     if user_id is not None:
-        budget_record(user_id, client.model, usage.input_tokens, usage.output_tokens)
+        budget_record(
+            user_id,
+            client.model,
+            usage.input_tokens,
+            usage.output_tokens,
+            cache_read_input_tokens=usage.cache_read_input_tokens,
+            cache_creation_input_tokens=usage.cache_creation_input_tokens,
+        )
     return DistilledMaterial.model_validate(raw)
 
 

--- a/backend/app/services/coach/memory_update.py
+++ b/backend/app/services/coach/memory_update.py
@@ -567,7 +567,14 @@ async def update_memory(
 
     # Record the Haiku spend on the per-user budget counter (#472). Best-effort;
     # record() is a no-op when budgets are unconfigured.
-    budget_record(user_id, client.model, usage.input_tokens, usage.output_tokens)
+    budget_record(
+        user_id,
+        client.model,
+        usage.input_tokens,
+        usage.output_tokens,
+        cache_read_input_tokens=usage.cache_read_input_tokens,
+        cache_creation_input_tokens=usage.cache_creation_input_tokens,
+    )
 
     try:
         output = RunnerMemoryWriterOutput.model_validate(raw)

--- a/backend/app/services/coach/receipt_voice.py
+++ b/backend/app/services/coach/receipt_voice.py
@@ -261,7 +261,14 @@ async def generate_receipt_templates(
             max_tokens=_MAX_TOKENS,
         )
         if user_id is not None:
-            budget_record(user_id, client.model, usage.input_tokens, usage.output_tokens)
+            budget_record(
+                user_id,
+                client.model,
+                usage.input_tokens,
+                usage.output_tokens,
+                cache_read_input_tokens=usage.cache_read_input_tokens,
+                cache_creation_input_tokens=usage.cache_creation_input_tokens,
+            )
         record = GeneratedReceiptTemplates.model_validate(raw)
     except Exception:  # noqa: BLE001 — fail-visible to logs, never crash; floor stands
         logger.exception("receipt-voice generation failed; house-default floor stands")

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -952,7 +952,14 @@ async def _call_message(
     # P2.2: count EVERY sub-call's spend (the retry/escalation fan-out is the
     # cost lever the going-live doc flags), keyed by activity-owner user_id.
     if user_id is not None:
-        budget_record(user_id, client.model, result.input_tokens, result.output_tokens)
+        budget_record(
+            user_id,
+            client.model,
+            result.input_tokens,
+            result.output_tokens,
+            cache_read_input_tokens=result.cache_read_input_tokens,
+            cache_creation_input_tokens=result.cache_creation_input_tokens,
+        )
     return result
 
 

--- a/backend/tests/test_llm_budget.py
+++ b/backend/tests/test_llm_budget.py
@@ -36,6 +36,38 @@ def test_cost_usd_matches_price_table():
     assert budget.cost_usd("mystery-model", 1_000_000, 0) == pytest.approx(5.0)
 
 
+def test_cost_usd_prices_cache_tokens():
+    # #709: with prompt caching, usage.input_tokens is only the UNCACHED portion;
+    # the cached portion is billed separately — cache reads at ~0.1x the input
+    # price, cache creation at ~1.25x (the 5-min ephemeral TTL the coach uses).
+    # The three input buckets are disjoint, so their costs sum.
+    assert budget.cost_usd(
+        "claude-opus-4-8", 0, 0, cache_read_input_tokens=1_000_000
+    ) == pytest.approx(0.5)  # 1M * $5 * 0.1
+    assert budget.cost_usd(
+        "claude-opus-4-8", 0, 0, cache_creation_input_tokens=1_000_000
+    ) == pytest.approx(6.25)  # 1M * $5 * 1.25
+    assert budget.cost_usd(
+        "claude-opus-4-8",
+        1_000_000,
+        1_000_000,
+        cache_read_input_tokens=1_000_000,
+        cache_creation_input_tokens=1_000_000,
+    ) == pytest.approx(5.0 + 25.0 + 0.5 + 6.25)
+    # Backwards-compatible: omitting the cache args is byte-stable with the old
+    # 3-arg pricing (the default code path when caching reports zero cache tokens).
+    assert budget.cost_usd("claude-opus-4-8", 1_000_000, 1_000_000) == pytest.approx(30.0)
+
+
+def test_record_bills_cache_tokens(monkeypatch):
+    # Cache-creation spend alone accrues on the counter (1M Opus creation tokens
+    # = $6.25, over the $1 cap) — the counter is now honest about cached cost.
+    monkeypatch.setattr(settings, "LLM_BUDGET_USER_DAILY_USD", 1.0)
+    gate = budget.new_in_memory_gate()
+    gate.record("user-A", "claude-opus-4-8", 0, 0, cache_creation_input_tokens=1_000_000)
+    assert gate.over_budget("user-A") is True
+
+
 def test_over_budget_is_per_user(monkeypatch):
     monkeypatch.setattr(settings, "LLM_BUDGET_USER_DAILY_USD", 1.0)
     gate = budget.new_in_memory_gate()

--- a/backend/tests/test_material_distiller.py
+++ b/backend/tests/test_material_distiller.py
@@ -107,7 +107,14 @@ async def test_distill_records_haiku_spend_for_the_user(db):
     with patch.object(md, "budget_record", MagicMock()) as rec:
         await md.distill_material(db, material.id, client=client)
 
-    rec.assert_called_once_with(material.user_id, "claude-haiku-4-5", 100, 50)
+    rec.assert_called_once_with(
+        material.user_id,
+        "claude-haiku-4-5",
+        100,
+        50,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_receipt_voice.py
+++ b/backend/tests/test_receipt_voice.py
@@ -159,7 +159,14 @@ async def test_refresh_records_haiku_spend_for_the_user(db):
     with patch.object(RV, "budget_record", MagicMock()) as rec:
         await RV.refresh_receipt_templates(db, rel.user_id, client=_client(payload))
 
-    rec.assert_called_once_with(rel.user_id, "claude-haiku-4-5", 100, 50)
+    rec.assert_called_once_with(
+        rel.user_id,
+        "claude-haiku-4-5",
+        100,
+        50,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #709.

## What
Makes `cost_usd` / `budget.record` cache-aware so the per-user LLM spend counter reflects the true billed cost under prompt caching (#629).

With caching active, the API reports `usage.input_tokens` as **only the uncached** input; the cached portion arrives separately as `cache_read_input_tokens` (billed ~0.1×) and `cache_creation_input_tokens` (billed ~1.25×). The counter previously billed the uncached `input_tokens` only, so it under-estimated true spend — safe for the cap (never lets more real dollars through than baseline) but the project otherwise values an honest cost counter (#472).

## Change
- `cost_usd(model, input, output, cache_read_input_tokens=0, cache_creation_input_tokens=0)` — the three input buckets are disjoint (`total = input + cache_read + cache_creation`), so their costs add. Cache read priced at `0.1×` the input price, cache creation at `1.25×`.
- `record(...)` gains the same two optional args and threads them to `cost_usd`.
- All five `budget_record` call sites (`service`, `receipt_voice`, `memory_update`, `material_distiller`×2) now pass `usage.cache_read_input_tokens` / `usage.cache_creation_input_tokens` — already captured on `Usage`/`MessageResult` by #629.

The cache args default to `0`, so the pre-caching / zero-cache path is **byte-stable** with the old 3-arg pricing (pinned by a test).

## Cache-write multiplier decision
`1.25×` matches the **5-minute ephemeral TTL** the coach uses (`llm.py` sets `cache_control: {"type": "ephemeral"}` with no `ttl`). A 1-hour TTL would be `2.0×`; a module comment flags this so the constant moves with the TTL if it ever changes. Multipliers confirmed against Anthropic's current documented cache pricing.

## Tests
- New: `test_cost_usd_prices_cache_tokens` (exact-dollar pricing of each bucket + backwards-compat), `test_record_bills_cache_tokens`.
- Updated two existing spend-recording assertions to match the new call signature (mocked usage carries zero cache tokens).
- Green: `test_llm_budget`, `test_budget_cap_guard`, `test_material_distiller`, `test_memory_update`, `test_receipt_voice`, `test_message_service` (82 passed).

Note: coach **chat** streaming still doesn't record spend at all — that's the separate #625, out of scope here.