### PR TITLE
Wire the past-session recorded-laps rule into the coach prompt (#712)

### DIFF
--- a/backend/app/schemas/coach_context.py
+++ b/backend/app/schemas/coach_context.py
@@ -1030,6 +1030,7 @@ class RecentWeeksActivity(BaseModel):
     hr_drift: Optional[float] = None      # within-run cardiac drift, HR-bearing runs/rides only
     structure: Optional[str] = None       # continuous | intervals (runs only)
     shape: Optional[str] = None           # e.g. "6x800m" (interval runs only)
+    source: Optional[str] = None     # "recorded_laps" when the runner pressed the lap button on this past session (so a later report must NOT advise the lap button on it), else None; reuses the exact metrics.interval_structure.source vocabulary the subject-run rule keys on. Null-dropped, so packs stored before this change still validate on strict re-parse.
     long_run: Optional[bool] = None       # runner-relative long-run verdict, surfaced only when long
     pain: Optional[int] = None            # check-in pain score, surfaced only when present
     notes: Optional[str] = None           # bounded check-in notes, surfaced only when present

--- a/backend/app/services/coach/prompt_features.py
+++ b/backend/app/services/coach/prompt_features.py
@@ -338,6 +338,28 @@ PROMPT_FEATURES: dict[str, frozenset[PromptFeature]] = {
             _F.PACK_COACH_VIEW,
         }
     ),
+    # #712: grouped_v6 = grouped_v5 + the past-session recorded-laps prose clause. NO new
+    # capability (same feature set as grouped_v5), so its pack is byte-identical to grouped_v5's;
+    # only the system-prompt TEXT differs. Ships INERT (flip target: grouped_v5 -> grouped_v6).
+    "coach_message_lean_grouped_v6": frozenset(
+        {
+            _F.TWO_STAGE,
+            _F.VOICE,
+            _F.CORPUS,
+            _F.STANCE,
+            _F.READINESS,
+            _F.USER_MATERIALS,
+            _F.RECENT_WEEKS,
+            _F.STREAM_VIEW,
+            _F.TRAINING_HISTORY_2WK,
+            _F.MEMORY,
+            _F.INTENSITY_READ,
+            _F.INTENSITY_MIX,
+            _F.METRICS_COACH_FRAMED,
+            _F.SALIENCE_DROPPED,
+            _F.PACK_COACH_VIEW,
+        }
+    ),
 }
 
 

--- a/backend/app/services/coach/prompts.py
+++ b/backend/app/services/coach/prompts.py
@@ -1116,16 +1116,18 @@ SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V3_OPENER = _regroup_lean_opener_prompt(
 )
 
 # ADR 0026 follow-up (#712): grouped_v6 = grouped_v5's prose (grouped_v3 base + v3
-# orientation) with the recorded-laps discipline EXTENDED to past sessions. #661 added the
-# `source == "recorded_laps"` marker to recent-session data; this teaches the coach to apply
-# the same "do not advise the lap button they already pressed" rule when it engages a past
-# session from `recent_weeks`. Text-only change to one clause; every prior prompt byte-
-# identical; ships INERT (flip target: grouped_v5 -> grouped_v6, zero code change).
-_LEAN_LAPS_RULE_SUBJECT_ONLY = "never tell them to use the lap button they already pressed."
+# orientation) with the recorded-laps discipline RAISED from the subject run to the CLASS.
+# #661 added the `source == "recorded_laps"` marker to recent-session data; rather than bolt a
+# second, parallel past-session sentence onto the existing rule, this rewrites the one clause to
+# cover ANY session whose laps were runner-recorded — this run or a past one the coach revisits
+# from recent_weeks — so the rule is stated once at the right altitude. One clause replaced;
+# every prior prompt byte-identical; ships INERT (flip target: grouped_v5 -> grouped_v6).
+_LEAN_LAPS_RULE_SUBJECT_ONLY = (
+    "if the laps were runner-recorded, never tell them to use the lap button they already pressed."
+)
 _LEAN_LAPS_RULE_WITH_PAST = (
-    "never tell them to use the lap button they already pressed. The same holds for any past "
-    "session you bring up from their recent weeks — if its laps were runner-recorded, never "
-    "point them to the lap button there either."
+    "if a session's laps were runner-recorded — this run or an earlier one you're revisiting — "
+    "never tell them to use the lap button they already pressed."
 )
 assert _LEAN_LAPS_RULE_SUBJECT_ONLY in SYSTEM_PROMPT_MESSAGE_LEAN_V1  # guard: fail loudly if the base clause wording drifts
 SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V6 = _regroup_lean_prompt(

--- a/backend/app/services/coach/prompts.py
+++ b/backend/app/services/coach/prompts.py
@@ -1115,6 +1115,24 @@ SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V3_OPENER = _regroup_lean_opener_prompt(
     SYSTEM_PROMPT_MESSAGE_LEAN_V1_OPENER
 )
 
+# ADR 0026 follow-up (#712): grouped_v6 = grouped_v5's prose (grouped_v3 base + v3
+# orientation) with the recorded-laps discipline EXTENDED to past sessions. #661 added the
+# `source == "recorded_laps"` marker to recent-session data; this teaches the coach to apply
+# the same "do not advise the lap button they already pressed" rule when it engages a past
+# session from `recent_weeks`. Text-only change to one clause; every prior prompt byte-
+# identical; ships INERT (flip target: grouped_v5 -> grouped_v6, zero code change).
+_LEAN_LAPS_RULE_SUBJECT_ONLY = "never tell them to use the lap button they already pressed."
+_LEAN_LAPS_RULE_WITH_PAST = (
+    "never tell them to use the lap button they already pressed. The same holds for any past "
+    "session you bring up from their recent weeks — if its laps were runner-recorded, never "
+    "point them to the lap button there either."
+)
+assert _LEAN_LAPS_RULE_SUBJECT_ONLY in SYSTEM_PROMPT_MESSAGE_LEAN_V1  # guard: fail loudly if the base clause wording drifts
+SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V6 = _regroup_lean_prompt(
+    SYSTEM_PROMPT_MESSAGE_LEAN_V1.replace(_LEAN_LAPS_RULE_SUBJECT_ONLY, _LEAN_LAPS_RULE_WITH_PAST),
+    _GROUP_ORIENTATION_V3,
+)
+
 
 PROMPT_VERSIONS = {
     "coach_report_v1": SYSTEM_PROMPT_V1,
@@ -1189,6 +1207,10 @@ PROMPT_VERSIONS = {
     # fuller prose never named salience), so it reuses grouped_v3's system prompt. The
     # disposition-first prose tune lands as a later commit on this id. Ships INERT.
     "coach_message_lean_grouped_v5": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V3,
+    # #712 — grouped_v6 = grouped_v5 + the past-session recorded-laps prose clause. Same
+    # feature set as grouped_v5 (identical pack); only the fuller system-prompt TEXT differs.
+    # Ships INERT (flip target: grouped_v5 -> grouped_v6, zero code change).
+    "coach_message_lean_grouped_v6": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V6,
 }
 
 # Prompt-id prefixes that select the A3 prose-message output family (schema 2.x).
@@ -1234,6 +1256,9 @@ _OPENER_PROMPTS = {
     # carries salience.novelty and the opener prose (which reads it) stays byte-identical to
     # grouped_v3. Prod never runs the opener (receipt cadence), so this path is defensive.
     "coach_message_lean_grouped_v5": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V3_OPENER,
+    # #712: the past-session laps rule is a fuller-only prose clause; the opener carries no lap
+    # advice, so grouped_v6's opener is byte-identical to grouped_v3/v5.
+    "coach_message_lean_grouped_v6": SYSTEM_PROMPT_MESSAGE_LEAN_GROUPED_V3_OPENER,
 }
 
 # ADR 0026 Slice 1: the prompt ids that receive the GROUPED pack serialization
@@ -1248,6 +1273,7 @@ GROUPED_PACK_PROMPT_IDS: frozenset[str] = frozenset(
         "coach_message_lean_grouped_v3",
         "coach_message_lean_grouped_v4",
         "coach_message_lean_grouped_v5",
+        "coach_message_lean_grouped_v6",
     }
 )
 

--- a/backend/app/services/coach/recent_weeks.py
+++ b/backend/app/services/coach/recent_weeks.py
@@ -143,6 +143,16 @@ def _totals(window_facts: List[Any]) -> RecentWeeksTotals:
     )
 
 
+def _interval_source(interval_structure: Any) -> Optional[str]:
+    """How this past session's interval structure was detected — "recorded_laps" when
+    the runner pressed the lap button, else None. Mirrors recent_training._interval_source,
+    reusing the exact `metrics.interval_structure.source` vocabulary the subject-run rule
+    keys on, so the coach reads a past session the same way (#712)."""
+    if not isinstance(interval_structure, dict):
+        return None
+    return interval_structure.get("source")
+
+
 def _activity(fact: Any, checkins: dict) -> RecentWeeksActivity:
     ci: Optional[CheckInFacts] = checkins.get(getattr(fact, "activity_id", None))
     is_run = _is_run(fact)
@@ -165,6 +175,7 @@ def _activity(fact: Any, checkins: dict) -> RecentWeeksActivity:
         ),
         structure=(getattr(fact, "structure", None) if is_run else None),
         shape=(_interval_shape(getattr(fact, "interval_structure", None)) if is_run else None),
+        source=(_interval_source(getattr(fact, "interval_structure", None)) if is_run else None),
         long_run=(True if (is_run and getattr(fact, "duration_class", None) == "long") else None),
         pain=ci.pain_score if ci else None,
         notes=note,

--- a/backend/tests/test_message_prompt_lean_grouped.py
+++ b/backend/tests/test_message_prompt_lean_grouped.py
@@ -108,3 +108,23 @@ def test_grouped_builds_for_both_modes():
 
 def test_grouped_ships_inert():
     assert settings.COACH_PROMPT_ID != GROUPED
+
+
+def test_message_prompt_lean_grouped_v6_extends_laps_rule_to_past_sessions():
+    """#712: grouped_v6 = grouped_v5's fuller prose with the recorded-laps discipline
+    extended to a past session pulled from recent_weeks. It differs from grouped_v5 ONLY
+    in that one laps clause; the opener is byte-identical; it serves the grouped pack."""
+    v5 = prompts.PROMPT_VERSIONS["coach_message_lean_grouped_v5"]
+    v6 = prompts.PROMPT_VERSIONS["coach_message_lean_grouped_v6"]
+    # v6 differs from v5 ONLY by the extended past-session laps clause.
+    assert v6 != v5
+    assert v6.replace(prompts._LEAN_LAPS_RULE_WITH_PAST, prompts._LEAN_LAPS_RULE_SUBJECT_ONLY) == v5
+    assert "past session you bring up from their recent weeks" in v6
+    assert "past session you bring up from their recent weeks" not in v5
+    # opener byte-identical (no lap clause in the opener).
+    assert (
+        prompts._OPENER_PROMPTS["coach_message_lean_grouped_v6"]
+        == prompts._OPENER_PROMPTS["coach_message_lean_grouped_v5"]
+    )
+    # grouped serialization + feature parity with the flip target.
+    assert "coach_message_lean_grouped_v6" in prompts.GROUPED_PACK_PROMPT_IDS

--- a/backend/tests/test_message_prompt_lean_grouped.py
+++ b/backend/tests/test_message_prompt_lean_grouped.py
@@ -116,11 +116,12 @@ def test_message_prompt_lean_grouped_v6_extends_laps_rule_to_past_sessions():
     in that one laps clause; the opener is byte-identical; it serves the grouped pack."""
     v5 = prompts.PROMPT_VERSIONS["coach_message_lean_grouped_v5"]
     v6 = prompts.PROMPT_VERSIONS["coach_message_lean_grouped_v6"]
-    # v6 differs from v5 ONLY by the extended past-session laps clause.
+    # v6 differs from v5 ONLY by raising the laps clause from this-run to the class
+    # (any runner-recorded session, this run or a past one revisited).
     assert v6 != v5
     assert v6.replace(prompts._LEAN_LAPS_RULE_WITH_PAST, prompts._LEAN_LAPS_RULE_SUBJECT_ONLY) == v5
-    assert "past session you bring up from their recent weeks" in v6
-    assert "past session you bring up from their recent weeks" not in v5
+    assert "an earlier one you're revisiting" in v6
+    assert "an earlier one you're revisiting" not in v5
     # opener byte-identical (no lap clause in the opener).
     assert (
         prompts._OPENER_PROMPTS["coach_message_lean_grouped_v6"]

--- a/backend/tests/test_message_prompt_v10.py
+++ b/backend/tests/test_message_prompt_v10.py
@@ -42,6 +42,7 @@ def test_v10_registered_carries_every_v9_capability_plus_stream_view():
         "coach_message_lean_grouped_v3",  # ADR 0026 Slice 3 keeps STREAM_VIEW
         "coach_message_lean_grouped_v4",  # ADR 0026 Slice 4 keeps STREAM_VIEW
         "coach_message_lean_grouped_v5",  # ADR 0026 Slice 5 keeps STREAM_VIEW
+        "coach_message_lean_grouped_v6",  # #712 keeps STREAM_VIEW
     }
     assert V10 in _OPENER_PROMPTS  # has a distinct opener form (two-stage)
     # same schema family as v9 (so v10 reports regenerate, prior history retained).

--- a/backend/tests/test_prompt_features.py
+++ b/backend/tests/test_prompt_features.py
@@ -227,6 +227,26 @@ EXPECTED_CAPABILITIES = {
         F.SALIENCE_DROPPED,
         F.PACK_COACH_VIEW,
     },
+    # #712 — grouped_v6 = grouped_v5 + a past-session recorded-laps prose clause. NO new
+    # capability (identical feature set to grouped_v5, so its pack is byte-identical);
+    # only the fuller system-prompt TEXT differs. Ships INERT (flip target: v5 -> v6).
+    "coach_message_lean_grouped_v6": {
+        F.TWO_STAGE,
+        F.VOICE,
+        F.CORPUS,
+        F.STANCE,
+        F.READINESS,
+        F.USER_MATERIALS,
+        F.RECENT_WEEKS,
+        F.STREAM_VIEW,
+        F.TRAINING_HISTORY_2WK,
+        F.MEMORY,
+        F.INTENSITY_READ,
+        F.INTENSITY_MIX,
+        F.METRICS_COACH_FRAMED,
+        F.SALIENCE_DROPPED,
+        F.PACK_COACH_VIEW,
+    },
 }
 
 # Ids that must carry NO capabilities (the inert-under-rollback set).
@@ -279,7 +299,7 @@ def test_memory_feature_is_active_on_v13():
         "coach_message_v13", "coach_message_v14", "coach_message_lean_v1",
         "coach_message_lean_grouped_v1", "coach_message_lean_grouped_v2",
         "coach_message_lean_grouped_v3", "coach_message_lean_grouped_v4",
-        "coach_message_lean_grouped_v5",
+        "coach_message_lean_grouped_v5", "coach_message_lean_grouped_v6",
     }
     assert prompts.is_memory_prompt("coach_message_v13") is True
     assert prompts.is_memory_prompt("coach_message_v12") is False
@@ -309,32 +329,35 @@ def test_derived_sets_match_captured_membership():
     # SALIENCE_DROPPED (a view-only section removal), so it joins exactly the same derived
     # sets as grouped_v4 and is the sole member of the new SALIENCE_DROPPED set.
     GROUPED5 = "coach_message_lean_grouped_v5"
+    # #712: grouped_v6 = grouped_v5 + a fuller-prose laps clause; SAME feature set as
+    # grouped_v5, so it joins exactly the same derived sets grouped_v5 belongs to.
+    GROUPED6 = "coach_message_lean_grouped_v6"
     assert prompts.TWO_STAGE_PROMPT_IDS == {
         "coach_message_v2", "coach_message_v3", "coach_message_v4",
         "coach_message_v5", "coach_message_v6", "coach_message_v7", "coach_message_v8",
         "coach_message_v9", "coach_message_v10", "coach_message_v11", "coach_message_v12",
         "coach_message_v13", "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4,
-        GROUPED5,
+        GROUPED5, GROUPED6,
     }
     assert prompts.VOICE_PROMPT_IDS == {
         "coach_message_v3", "coach_message_v4", "coach_message_v5",
         "coach_message_v6", "coach_message_v7", "coach_message_v8", "coach_message_v9",
         "coach_message_v10", "coach_message_v11", "coach_message_v12", "coach_message_v13",
-        "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4, GROUPED5,
+        "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4, GROUPED5, GROUPED6,
     }
     assert prompts.CORPUS_PROMPT_IDS == {
         "coach_message_v4", "coach_message_v5", "coach_message_v6",
         "coach_message_v7", "coach_message_v8", "coach_message_v9", "coach_message_v10",
         "coach_message_v11", "coach_message_v12", "coach_message_v13", "coach_message_v14",
-        LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4, GROUPED5,
+        LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4, GROUPED5, GROUPED6,
     }
     assert prompts.STANCE_PROMPT_IDS == {
         "coach_message_v5", "coach_message_v6", "coach_message_v7", "coach_message_v8",
         "coach_message_v9", "coach_message_v10", "coach_message_v11", "coach_message_v12",
         "coach_message_v13", "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4,
-        GROUPED5,
+        GROUPED5, GROUPED6,
     }
-    # Slice 2: grouped_v2/v3 REPLACE training_load with readiness, so they are NOT here.
+    # Slice 2: grouped_v2..v6 REPLACE training_load with readiness, so they are NOT here.
     assert prompts.TRAINING_LOAD_PROMPT_IDS == {
         "coach_message_v6", "coach_message_v7", "coach_message_v8", "coach_message_v9",
         "coach_message_v10", "coach_message_v11", "coach_message_v12", "coach_message_v13",
@@ -343,9 +366,9 @@ def test_derived_sets_match_captured_membership():
     assert prompts.USER_MATERIALS_PROMPT_IDS == {
         "coach_message_v7", "coach_message_v8", "coach_message_v9", "coach_message_v10",
         "coach_message_v11", "coach_message_v12", "coach_message_v13", "coach_message_v14",
-        LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4, GROUPED5,
+        LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4, GROUPED5, GROUPED6,
     }
-    # Slice 2: grouped_v2/v3 REPLACE volume + recent_training with recent_weeks, so they
+    # Slice 2: grouped_v2..v6 REPLACE volume + recent_training with recent_weeks, so they
     # are absent from both of these sets.
     assert prompts.VOLUME_PROMPT_IDS == {
         "coach_message_v9", "coach_message_v10", "coach_message_v11", "coach_message_v12",
@@ -353,35 +376,35 @@ def test_derived_sets_match_captured_membership():
     }
     assert prompts.STREAM_VIEW_PROMPT_IDS == {
         "coach_message_v10", "coach_message_v11", "coach_message_v12", "coach_message_v13",
-        "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4, GROUPED5,
+        "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4, GROUPED5, GROUPED6,
     }
     assert prompts.RECENT_TRAINING_PROMPT_IDS == {
         "coach_message_v11", "coach_message_v12", "coach_message_v13", "coach_message_v14",
         LEAN, GROUPED,
     }
-    # Slice 2 PR 2: grouped_v2/v3 REBASE training_history (carry TRAINING_HISTORY_2WK
+    # Slice 2 PR 2: grouped_v2..v6 REBASE training_history (carry TRAINING_HISTORY_2WK
     # instead), so they drop OUT of the original-ladder set and are the members of the new.
     assert prompts.TRAINING_HISTORY_PROMPT_IDS == {
         "coach_message_v12", "coach_message_v13", "coach_message_v14", LEAN, GROUPED,
     }
-    assert prompts.TRAINING_HISTORY_2WK_PROMPT_IDS == {GROUPED2, GROUPED3, GROUPED4, GROUPED5}
+    assert prompts.TRAINING_HISTORY_2WK_PROMPT_IDS == {GROUPED2, GROUPED3, GROUPED4, GROUPED5, GROUPED6}
     assert prompts.MEMORY_PROMPT_IDS == {
         "coach_message_v13", "coach_message_v14", LEAN, GROUPED, GROUPED2, GROUPED3, GROUPED4,
-        GROUPED5,
+        GROUPED5, GROUPED6,
     }
-    # Slice 3: grouped_v3/v4/v5 REPLACE INTENSITY with INTENSITY_READ + INTENSITY_MIX, so they
+    # Slice 3: grouped_v3..v6 REPLACE INTENSITY with INTENSITY_READ + INTENSITY_MIX, so they
     # drop OUT of the intensity set and are the members of the two new ones.
     assert prompts.INTENSITY_PROMPT_IDS == {"coach_message_v14", LEAN, GROUPED, GROUPED2}
-    assert prompts.INTENSITY_READ_PROMPT_IDS == {GROUPED3, GROUPED4, GROUPED5}
-    assert prompts.INTENSITY_MIX_PROMPT_IDS == {GROUPED3, GROUPED4, GROUPED5}
-    # Slice 2's two sets: grouped_v2/v3/v4/v5 are the members.
-    assert prompts.READINESS_PROMPT_IDS == {GROUPED2, GROUPED3, GROUPED4, GROUPED5}
-    assert prompts.RECENT_WEEKS_PROMPT_IDS == {GROUPED2, GROUPED3, GROUPED4, GROUPED5}
-    # Slice 4: grouped_v4/v5 carry the metrics-coach-framed view flag.
-    assert prompts.METRICS_COACH_FRAMED_PROMPT_IDS == {GROUPED4, GROUPED5}
-    # Slice 5: grouped_v5 is the sole carrier of the salience-dropped + coach-view flags (the flip target).
-    assert prompts.SALIENCE_DROPPED_PROMPT_IDS == {GROUPED5}
-    assert prompts.PACK_COACH_VIEW_PROMPT_IDS == {GROUPED5}
+    assert prompts.INTENSITY_READ_PROMPT_IDS == {GROUPED3, GROUPED4, GROUPED5, GROUPED6}
+    assert prompts.INTENSITY_MIX_PROMPT_IDS == {GROUPED3, GROUPED4, GROUPED5, GROUPED6}
+    # Slice 2's two sets: grouped_v2..v6 are the members.
+    assert prompts.READINESS_PROMPT_IDS == {GROUPED2, GROUPED3, GROUPED4, GROUPED5, GROUPED6}
+    assert prompts.RECENT_WEEKS_PROMPT_IDS == {GROUPED2, GROUPED3, GROUPED4, GROUPED5, GROUPED6}
+    # Slice 4: grouped_v4..v6 carry the metrics-coach-framed view flag.
+    assert prompts.METRICS_COACH_FRAMED_PROMPT_IDS == {GROUPED4, GROUPED5, GROUPED6}
+    # Slice 5: grouped_v5 (flip target) + grouped_v6 carry the salience-dropped + coach-view flags.
+    assert prompts.SALIENCE_DROPPED_PROMPT_IDS == {GROUPED5, GROUPED6}
+    assert prompts.PACK_COACH_VIEW_PROMPT_IDS == {GROUPED5, GROUPED6}
 
 
 def test_predicates_agree_with_has_feature():

--- a/backend/tests/test_recent_weeks.py
+++ b/backend/tests/test_recent_weeks.py
@@ -222,3 +222,41 @@ def test_notes_are_bounded():
     rw = _build(checkins)
     wed = rw.this_week.days[2].activities[0]
     assert wed.notes is not None and len(wed.notes) <= 200
+
+
+def test_recorded_laps_source_carried_on_recent_weeks():
+    """#712: a past session whose interval structure came from the runner's own recorded
+    laps carries source=='recorded_laps', so a later report knows not to advise the lap
+    button on it. Mirrors the subject-run `metrics.interval_structure.source` reading."""
+    lap_run = FakeFact(
+        "lap_run", date(2026, 7, 14), distance_m=8000, moving_time_s=2400,
+        effort_score=120.0, effort="hard", structure="intervals",
+        interval_structure={
+            "source": "recorded_laps",
+            "work_segments": [{"distance_m": 400}] * 8,
+        },
+    )
+    facts = _baseline_history() + [lap_run]
+    rw = build_recent_weeks(facts, {}, AS_OF)
+    act = next(a for d in rw.this_week.days for a in d.activities if a.type == "Run")
+    assert act.source == "recorded_laps"
+    # It survives the section's null-strip serialization (byte present when it applies).
+    from app.schemas.coach_context import _strip_nulls_in_place
+    dumped = act.model_dump()
+    _strip_nulls_in_place(dumped)
+    assert dumped.get("source") == "recorded_laps"
+
+
+def test_stream_detected_and_continuous_runs_have_no_source_marker():
+    """A stream-detected interval run (interval_structure without a `source` key) and a
+    continuous run (no interval_structure) both carry source is None, so it is dropped
+    from serialization — byte-stable when absent. The shared fixture's l_fri/t_wed carry
+    interval_structure with NO source, and the walk is a non-run."""
+    from app.schemas.coach_context import _strip_nulls_in_place
+    rw = _build()
+    for d in list(rw.last_week.days) + list(rw.this_week.days):
+        for a in d.activities:
+            assert a.source is None
+            dumped = a.model_dump()
+            _strip_nulls_in_place(dumped)
+            assert "source" not in dumped


### PR DESCRIPTION
Closes #712.

## The scope correction (please read)

#712 was filed as a prompt-only follow-up to #661: "#661 added the `source` marker to the recent-session shape data, now teach the coach to apply the recorded-laps rule to a past session too." Tracing it before implementing surfaced a gap the issue did not anticipate, so I made a call under the delegated coaching-decision authority:

**#661 added `source` to `recent_training` (`RecentTrainingActivity`). But production runs the GROUPED prompt `coach_message_lean_grouped_v5`, which reads past sessions via `recent_weeks` (`RecentWeeksActivity`) — a section that carried no `source` field.** (ADR 0026 Slice 2 merged `training_volume` + `recent_training` into the new day-resolved `recent_weeks`; the grouped prompt consumes that, not `recent_training`.) So on prod the recorded-laps marker never reached the coach, and a prompt-only rule would have referenced data the coach cannot see. #661's substrate lands the marker for the FLAT prompt chain; the grouped (prod) line needed its own substrate.

So this PR closes #712 on the production line by doing both halves:

## Substrate — carry `source` on `recent_weeks`
- `RecentWeeksActivity` gains `source: Optional[str] = None`, populated in `recent_weeks._activity` from the session's `interval_structure` (a local `_interval_source` mirroring `recent_training._interval_source`, same `"recorded_laps"` vocabulary).
- Recursively null-dropped by the existing `_drop_recent_weeks_nulls`, so **only a recorded-laps session carries it** — byte-stable when absent, and the strict `extra="forbid"` re-parse (chat + eval load stored packs) still validates pre-change packs. This mirrors #661's exact ungated-but-null-dropped pattern.

## Prompt — new **inert** `coach_message_lean_grouped_v6`
- `grouped_v6` = `grouped_v5`'s prose with the recorded-laps discipline **raised from the subject run to the class**, via `aiw-prompt-smith`. The first cut bolted on a second parallel past-session sentence (an instance patch that duplicated the subject-run logic and named the `recent_weeks` section against the lean prompt's no-JSON-keys style); the shipped version instead rewrites the one existing clause to cover the class:
  > *"…and if a session's laps were runner-recorded — this run or an earlier one you're revisiting — never tell them to use the lap button they already pressed."*
- Built by re-grouping the lean base with **exactly that one clause replaced** (guarded by an import-time `assert` that fails loudly if the base wording drifts). Same feature set, opener, and grouped serialization as `grouped_v5`.
- **Ships INERT.** Flip target: `COACH_PROMPT_ID` `coach_message_lean_grouped_v5` → `coach_message_lean_grouped_v6`, zero code change, rollback = flip back.

### North-Star / prompt-smith note
The clause is conditional and keyed on the same `"recorded_laps"` vocabulary as the working subject-run rule, so it cannot over-suppress lap-button advice on a stream-detected session. Stating it once at the class altitude (rather than one rule per surface) is shorter and matches the disposition-first prose. A good coach shouldn't tell a runner to press the lap button on a session where they already did — this run or a remembered one.

## Verification
- Byte-stability: every prior prompt (`grouped_v1..v5`, `lean_v1`, `v1..v14`) is byte-identical. The `grouped_v6` prose pin is `v6.replace(with_past, subject_only) == v5`; every exact-set (`==`) membership assertion in `test_prompt_features.py` now pins `grouped_v6` to exactly the sets `grouped_v5` joins (feature parity, no capability added/dropped).
- New tests: `recent_weeks` carries `source` for a recorded-laps run and drops it (byte-stable) otherwise; the `grouped_v6` prompt pin.
- **71 oracle + 651 broad** prompt/pack/chat/eval tests green (run with the prod-parity coach flags at defaults; local `.env` otherwise skews byte-stable tests, CI without `.env` is authoritative).

No new dependency, no schema-breaking change (additive Optional field), no live-prompt behaviour change (grouped_v6 is inert), tests strengthened not weakened.