### PR TITLE
Make the coach North Star check durable in-context (#717)

### DIFF
--- a/north-star.md
+++ b/north-star.md
@@ -1,0 +1,10 @@
+# The North Star (coach decisions)
+
+Every decision about what the coach LLM receives or is told — a context-pack field, a prompt clause, a new signal, the way a number is framed — passes two questions before any mechanical one:
+
+1. **What does a good coach actually need here?** Feed the coach the read that serves the runner, not everything that happens to be computable. A good coach's judgment is already latent in the model; give it the signal, not a raw dump.
+2. **Could an LLM misread it?** Whatever is ambiguous will eventually be read wrong. Frame, label, or tier a signal so its meaning is unmistakable — and prefer fixing the framing over withholding the fact.
+
+This is a test, not a rulebook. It sits *above* the specific coaching rules — the prompt disciplines, the policy validator, the evals — which enforce the particular cases it implies. A change can pass every mechanical check and still be coach-wrong; when it fails either question, it is wrong, however green the tests.
+
+*The hard case.* `effort_score` is cumulative training LOAD — it grows with duration, so a long easy run scores high. Handed to the coach raw it fails both questions at once: a good coach does not need a bare load number, and an LLM reads "high load" as "high intensity." The fix is not to hide the number but to frame it — labelled as load, with the intensity read taken from the effort axis and RPE. That is the #168 discipline, and the pattern generalizes to every signal the coach sees: name what it means, or the model will guess.

--- a/project-context.md
+++ b/project-context.md
@@ -1,4 +1,7 @@
+@north-star.md
+
 > Domain vocabulary lives in `CONTEXT.md`. This file describes the current implementation; the glossary describes the language.
+> The North Star above is the standing test for every coach-LLM decision (loaded via this file's import); apply it alongside the workflow whenever a change touches what the coach receives or is told.
 
 ## Product Summary
 


### PR DESCRIPTION
Closes #717.

Promotes the **North Star** test for coach-LLM decisions from session prompts + agent memory to a durable project instruction the next agent reads into context automatically.

## What
- **New `north-star.md`** (repo root, tracked), written through `aiw-prompt-smith`:
  - A two-question **test**, not a rulebook — pitched at the altitude where it sits *above* the specific coaching rules (prompt disciplines / policy validator / evals) that enforce its particular cases:
    1. What does a good coach actually need here?
    2. Could an LLM misread it?
  - Leading phrases that surface in reasoning ("a good coach", "could an LLM misread it", "a test, not a rulebook"), positive framing, and **one hard worked example** (`effort_score` is cumulative load, not intensity — the #168 discipline, generalized): the fix is to *frame* a signal so its meaning is unmistakable, not to withhold it.
- **Import routing:** `@north-star.md` is added to the tracked `project-context.md`. `CLAUDE.md` already imports `project-context.md`, so the chain `CLAUDE.md → project-context.md → north-star.md` loads it every session.

## Why routed through project-context.md (not CLAUDE.md)
`CLAUDE.md` and `ai-workflow.md` are **gitignored** (local-only by design), so an `@`-import added to `CLAUDE.md` would not ship with the repo — a fresh clone would get `north-star.md` but nothing importing it. Importing from the **tracked** `project-context.md` makes the whole chain reproducible from a clone. `ai-workflow.md` is untouched — per the request, the North Star is a coach-decision lens, not a process rule.

## Notes
- Both files land in one commit (`ac37f7b`) — the intended two-commit split collapsed when an earlier `git add` of the gitignored `CLAUDE.md` broke the chain; the content is complete and correct (branch diff = exactly these two files, +13 lines).
- No code change; docs/instructions only.