### PR TITLE
Add manual resting_hr profile field (#555)

### DIFF
--- a/backend/alembic/versions/e1a2b3c4d5f6_add_resting_hr_to_user_profile.py
+++ b/backend/alembic/versions/e1a2b3c4d5f6_add_resting_hr_to_user_profile.py
@@ -1,0 +1,32 @@
+"""add resting_hr to user_profiles
+
+Revision ID: e1a2b3c4d5f6
+Revises: a3f1c9d7e208
+Create Date: 2026-07-17 00:00:00.000000
+
+Manual resting HR (bpm) is the interim data source for the referral red-flag set
+(#555), ahead of a device integration. The coach referral layer abstains while
+it is null; #166's sustained-rise detection activates once a trend source lands.
+
+Backward-safety (previews share the production DB, so this can run against prod
+while prod still runs the old code): the column is nullable, so old-code INSERTs
+that omit it still work and existing rows are simply left NULL.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e1a2b3c4d5f6"
+down_revision: Union[str, None] = "a3f1c9d7e208"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("user_profiles", sa.Column("resting_hr", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("user_profiles", "resting_hr")

--- a/backend/app/models/user_profile.py
+++ b/backend/app/models/user_profile.py
@@ -21,6 +21,10 @@ class UserProfile(Base):
     current_weekly_km: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     max_hr: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     max_hr_source: Mapped[Optional[str]] = mapped_column(String, nullable=True)  # "user_entered", "race_estimate", "lab_test"
+    # Manual resting HR (bpm), the interim source ahead of a device integration
+    # (#555). Null until the runner enters it; the referral layer abstains while
+    # absent, and #166's sustained-rise red flag activates once a trend source lands.
+    resting_hr: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     # The runner's own HR-zone lower bounds (5 ascending bpm values), pulled from
     # their Strava athlete zones so time-in-zone matches what Strava shows (#297).
     # Null until first synced; analysis then falls back to the %-of-max-HR scheme.

--- a/backend/app/schemas/profile.py
+++ b/backend/app/schemas/profile.py
@@ -13,6 +13,7 @@ class UserProfileBase(BaseModel):
     current_weekly_km: Optional[int] = None
     max_hr: Optional[int] = None
     max_hr_source: Optional[str] = None  # "user_entered", "race_estimate", "lab_test"
+    resting_hr: Optional[int] = None  # manual resting HR (bpm), interim source for #555
     upcoming_races: List[Dict[str, Any]] = []
     injury_notes: Optional[str] = None
     stimulant_use: Optional[bool] = None

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -15,18 +15,23 @@ def test_get_and_update_profile(client: TestClient, db):
         "experience_level": "advanced",
         "weekly_days_available": 5,
         "current_weekly_km": 60,
+        "max_hr": 188,
+        "resting_hr": 48,
         "upcoming_races": [{"name": "Boston 2026", "date": "2026-04-20", "distance_km": 42.2}],
         "injury_notes": "Left knee soreness"
     }
-    
+
     response = client.put("/api/profile", json=updated_payload)
     assert response.status_code == 200
     res_data = response.json()
     assert res_data["goal_type"] == "marathon"
     assert res_data["current_weekly_km"] == 60
+    assert res_data["resting_hr"] == 48
     assert len(res_data["upcoming_races"]) == 1
     assert res_data["upcoming_races"][0]["name"] == "Boston 2026"
 
     # 3. Verify persistence
     response = client.get("/api/profile")
-    assert response.json()["injury_notes"] == "Left knee soreness"
+    body = response.json()
+    assert body["injury_notes"] == "Left knee soreness"
+    assert body["resting_hr"] == 48

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -30,7 +30,8 @@ export default function ProfilePage() {
     // upcoming_races handling skipped for simple MVP form, 
     // but field exists in backend schema
     upcoming_races: [],
-    max_hr: 0 // New field state
+    max_hr: 0, // New field state
+    resting_hr: 0
   });
 
   useEffect(() => {
@@ -47,7 +48,8 @@ export default function ProfilePage() {
             current_weekly_km: data.current_weekly_km || 0,
             injury_notes: data.injury_notes || '',
             upcoming_races: data.upcoming_races || [],
-            max_hr: data.max_hr || 0
+            max_hr: data.max_hr || 0,
+            resting_hr: data.resting_hr || 0
         });
         setLoading(false);
       })
@@ -77,7 +79,7 @@ export default function ProfilePage() {
     const { name, value } = e.target;
     setFormData(prev => ({
         ...prev,
-        [name]: name === 'weekly_days_available' || name === 'current_weekly_km' || name === 'max_hr' ? Number(value) : value
+        [name]: name === 'weekly_days_available' || name === 'current_weekly_km' || name === 'max_hr' || name === 'resting_hr' ? Number(value) : value
     }));
   };
 
@@ -155,6 +157,21 @@ export default function ProfilePage() {
                 />
                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     Used to calculate zones. If unknown, estimate with 220 minus age.
+                </p>
+            </div>
+
+            <div>
+                <label className="block text-sm font-medium mb-1">Resting Heart Rate (bpm)</label>
+                <input
+                    type="number" min="30" max="120"
+                    name="resting_hr"
+                    value={formData.resting_hr || ''}
+                    onChange={handleChange}
+                    placeholder="e.g. 50"
+                    className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
+                />
+                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    Your typical morning resting HR. Helps the coach read fatigue trends.
                 </p>
             </div>
 

--- a/frontend/lib/types/profile.ts
+++ b/frontend/lib/types/profile.ts
@@ -7,6 +7,7 @@ export interface UserProfile {
   current_weekly_km?: number;
   max_hr?: number;
   max_hr_source?: string | null;  // "user_entered" | "race_estimate" | "lab_test"
+  resting_hr?: number;  // manual resting HR (bpm), interim source for #555
   upcoming_races: { name: string; date: string; distance_km: number }[];
   injury_notes?: string;
   updated_at: string;


### PR DESCRIPTION
Closes #555 (partially — see scope note).

## What
Adds a manual, nullable `resting_hr` (bpm) to the runner's profile as the **interim** resting-HR data source, ahead of a device (Garmin) integration. It surfaces on the profile form beside Max HR and flows through the existing profile GET/PUT round-trip.

## Why
#555 unblocks #166's non-diagnostic referral red flags, which need resting HR — a metric Strava does not provide. The owner's call: manual entry now via a profile field, device integration later.

## Scope (honest partial-unblock)
This lands the **data + surface only**. `calibration.assess_referral` is deliberately untouched — it already abstains, so wiring a resting-HR parameter now would be dead code with no trend data to read. A single profile scalar is a **baseline anchor**, not a time series, so #166's *sustained resting-HR rise* red flag activates once a trend source (Garmin) lands. HR **recovery** (post-exercise) remains unsourced — it needs a continuous device stream.

## Changes
- `models/user_profile.py`, `schemas/profile.py` — nullable `Optional[int]`; flows through the `model_dump(exclude_unset=True)` setattr write loop and both read/write (Create = Base).
- `alembic/e1a2b3c4d5f6` — additive nullable column (safe against old code on the shared prod DB).
- `frontend/lib/types/profile.ts` + `app/profile/page.tsx` — type, formData init/hydration, numeric-coercion ternary, input JSX (range 30–120).
- `tests/test_profile.py` — `resting_hr` round-trip assertion.

## Verification
- Backend suite green: 2207 passed.
- Migration applied → rolled back → re-applied against local Postgres; column confirmed `integer / nullable`.
- Frontend `tsc --noEmit` + `next lint` clean.
- Live browser round-trip on the local stack: entered 52 → saved → reloaded → persisted; backend API confirms `resting_hr = 52`.

## Follow-on
- #166 referral rise-detection, once a trend source lands.
- Garmin (or other device) integration as the durable source — the remaining part of #555's original design.
