### PR TITLE
Per-runner configurable week start (#676)

### DIFF
--- a/backend/alembic/versions/b7d4e9f2a1c8_add_week_starts_on_to_user_profile.py
+++ b/backend/alembic/versions/b7d4e9f2a1c8_add_week_starts_on_to_user_profile.py
@@ -1,0 +1,33 @@
+"""add week_starts_on to user_profiles
+
+Revision ID: b7d4e9f2a1c8
+Revises: e1a2b3c4d5f6
+Create Date: 2026-07-17 00:00:00.000000
+
+Per-runner week start (#676): the day the runner's week begins, in Python
+weekday() space (0=Monday, 6=Sunday). Null resolves to Monday, so every coach
+pack and Trends surface keeps byte-identical "this week" framing for existing
+runners; a runner may choose Sunday to shift the boundary.
+
+Backward-safety (previews share the production DB, so this can run against prod
+while prod still runs the old code): the column is nullable, so old-code INSERTs
+that omit it still work and existing rows are simply left NULL (= Monday).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b7d4e9f2a1c8"
+down_revision: Union[str, None] = "e1a2b3c4d5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("user_profiles", sa.Column("week_starts_on", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("user_profiles", "week_starts_on")

--- a/backend/app/models/user_profile.py
+++ b/backend/app/models/user_profile.py
@@ -35,6 +35,12 @@ class UserProfile(Base):
     # Opt-in medication/physiology flag (N4 confounder stage reads it). Nullable:
     # unset means "unknown", not "no stimulant use".
     stimulant_use: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    # The day the runner's week starts, in Python weekday() space (0=Monday,
+    # 6=Sunday). Null resolves to Monday, so every pre-existing row and every
+    # runner who has not chosen keeps byte-identical "this week" framing across
+    # the coach pack and the Trends API (#676). The product offers only Monday or
+    # Sunday; the single week-boundary definition in services/weeks.py is general.
+    week_starts_on: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/app/schemas/profile.py
+++ b/backend/app/schemas/profile.py
@@ -2,7 +2,9 @@ from datetime import date, datetime
 from typing import Optional, List, Dict, Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from app.services.weeks import MONDAY, SUNDAY
 
 
 class UserProfileBase(BaseModel):
@@ -17,6 +19,15 @@ class UserProfileBase(BaseModel):
     upcoming_races: List[Dict[str, Any]] = []
     injury_notes: Optional[str] = None
     stimulant_use: Optional[bool] = None
+    # Week start: Monday (0) or Sunday (6); null resolves to Monday (#676).
+    week_starts_on: Optional[int] = None
+
+    @field_validator("week_starts_on")
+    @classmethod
+    def _week_start_is_monday_or_sunday(cls, v: Optional[int]) -> Optional[int]:
+        if v is not None and v not in (MONDAY, SUNDAY):
+            raise ValueError("week_starts_on must be 0 (Monday) or 6 (Sunday)")
+        return v
 
 
 class UserProfileCreate(UserProfileBase):

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -52,6 +52,7 @@ from app.services.coach.stance import StanceProfile, resolve_stance
 from app.services.coach.volume import build_training_volume
 from app.services.coach.recent_training import build_recent_training
 from app.services.coach.recent_weeks import CheckInFacts, build_recent_weeks
+from app.services.weeks import resolve_week_start
 from app.services.coach.training_history import build_training_history
 from app.services.coach.intensity import build_intensity
 from app.services.coach.intensity_read import build_intensity_mix, build_intensity_read
@@ -485,7 +486,8 @@ def _build_training_volume_context(
     facts = _query_activity_facts(
         db, local_day - timedelta(days=91), local_day + timedelta(days=1), user_id=activity.user_id
     )
-    return build_training_volume(facts, local_day)
+    week_starts_on = resolve_week_start(_load_profile(db, activity.user_id))
+    return build_training_volume(facts, local_day, week_starts_on)
 
 
 def _build_recent_training_context(
@@ -591,7 +593,8 @@ def _build_recent_weeks_context(
         if f.local_date >= local_day - timedelta(days=14)
     ]
     checkins = _query_recent_checkins(db, recent_ids)
-    return build_recent_weeks(facts, checkins, local_day)
+    week_starts_on = resolve_week_start(_load_profile(db, activity.user_id))
+    return build_recent_weeks(facts, checkins, local_day, week_starts_on)
 
 
 # The wide fetch span for the multi-year history scan: ~10 years, so the deep ladder

--- a/backend/app/services/coach/query_tools.py
+++ b/backend/app/services/coach/query_tools.py
@@ -42,13 +42,14 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
-from app.models import Activity
+from app.models import Activity, UserProfile
 from app.models.derived_metric import DerivedMetric
 from app.services.coach import coach_units
 from app.services.analysis.splits import calculate_splits
 from app.services.coach.recent_training import _interval_shape
 from app.services.coach.volume import build_volume_report
 from app.services.trends import _query_activity_facts
+from app.services.weeks import MONDAY, resolve_week_start, week_start
 
 logger = logging.getLogger(__name__)
 
@@ -101,10 +102,21 @@ def _first_of_month(d: date) -> date:
     return d.replace(day=1)
 
 
-def resolve_window(window: str, today: date) -> Optional[ResolvedWindow]:
+def _owner_week_start(db: Session, owner_user_id) -> int:
+    """The owner's chosen week start (0=Monday default, 6=Sunday), for the calendar
+    windows resolve_window computes (#676)."""
+    return resolve_week_start(
+        db.query(UserProfile).filter(UserProfile.user_id == owner_user_id).first()
+    )
+
+
+def resolve_window(
+    window: str, today: date, week_starts_on: int = MONDAY
+) -> Optional[ResolvedWindow]:
     """Resolve a named window to a concrete date range as of `today`, or None if the
     name is unknown. Rolling windows end today inclusive; calendar windows follow the
-    runner's local calendar; all_time has no start."""
+    runner's local calendar; all_time has no start. `week_starts_on` (0=Monday default,
+    6=Sunday) sets the boundary for the this_week/last_week windows (#676)."""
     end_excl = today + timedelta(days=1)  # inclusive of today
 
     if window in _ROLLING_DAYS_RANGEKEY:
@@ -119,12 +131,12 @@ def resolve_window(window: str, today: date) -> Optional[ResolvedWindow]:
         start = end_excl - timedelta(days=14)
         return ResolvedWindow(start, end_excl, f"the last 14 days ({start.isoformat()} to {today.isoformat()})", None)
     if window == "this_week":
-        start = today - timedelta(days=today.weekday())  # Monday
+        start = week_start(today, week_starts_on)
         return ResolvedWindow(start, end_excl, f"this week ({start.isoformat()} to {today.isoformat()})", None)
     if window == "last_week":
-        this_mon = today - timedelta(days=today.weekday())
-        start = this_mon - timedelta(days=7)
-        return ResolvedWindow(start, this_mon, f"last week ({start.isoformat()} to {(this_mon - timedelta(days=1)).isoformat()})", None)
+        this_start = week_start(today, week_starts_on)
+        start = this_start - timedelta(days=7)
+        return ResolvedWindow(start, this_start, f"last week ({start.isoformat()} to {(this_start - timedelta(days=1)).isoformat()})", None)
     if window == "this_month":
         start = _first_of_month(today)
         return ResolvedWindow(start, end_excl, f"this month ({start.isoformat()} to {today.isoformat()})", None)
@@ -227,7 +239,7 @@ def list_activities_in_range(
     window. Each entry carries the per-run distance/pace/effort the frozen pack omits,
     plus the #650 shape markers, and the `activity_id` the coach passes to
     get_session_detail for depth."""
-    resolved = resolve_window(window, today)
+    resolved = resolve_window(window, today, _owner_week_start(db, owner_user_id))
     if resolved is None:
         return {"error": "unknown_window", "window": window, "allowed": list(LIST_WINDOWS)}
 
@@ -348,7 +360,8 @@ def get_training_summary(
     rather than summing rows itself. vs-typical reuses `build_volume_report`'s rolling
     framing (canonical norm, no drift) and is present only for a rolling window with no
     type filter (the norm is holistic)."""
-    resolved = resolve_window(window, today)
+    week_starts_on = _owner_week_start(db, owner_user_id)
+    resolved = resolve_window(window, today, week_starts_on)
     if resolved is None or window not in SUMMARY_WINDOWS:
         return {"error": "unknown_window", "window": window, "allowed": list(SUMMARY_WINDOWS)}
 
@@ -366,7 +379,7 @@ def get_training_summary(
         # so it can establish the baseline, ask for this window's rolling framing.
         all_facts = _query_activity_facts(db, None, resolved.end, user_id=owner_user_id)
         try:
-            report = build_volume_report(all_facts, today, resolved.range_key)
+            report = build_volume_report(all_facts, today, resolved.range_key, week_starts_on)
             vs_typical = _vs_typical(report)
         except Exception as exc:  # a norm failure must never fail the whole tool
             logger.warning("training_summary vs_typical failed: %s", exc)

--- a/backend/app/services/coach/recent_weeks.py
+++ b/backend/app/services/coach/recent_weeks.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import Any, List, NamedTuple, Optional, Union
 
+from app.services.weeks import MONDAY, days_into_week, is_last_day_of_week, week_start
+
 from app.schemas.coach_context import (
     RecentWeeksActivity,
     RecentWeeksAllTotal,
@@ -245,12 +247,16 @@ def _vs_typical(
 
 
 def build_recent_weeks(
-    facts: List[Any], checkins: dict, as_of: date
+    facts: List[Any], checkins: dict, as_of: date, week_starts_on: int = MONDAY
 ) -> RecentWeeksContext:
     """Build the day-resolved recent-weeks read as of `as_of` (the runner's local day)
     from facts spanning at least the trailing ~91 days (the two weeks of structure plus
     the ~12-week norm baseline). Facts are duck-typed `ActivityFact`s; `checkins` maps
-    `activity_id -> CheckInFacts` for the per-activity felt-effort signals."""
+    `activity_id -> CheckInFacts` for the per-activity felt-effort signals.
+
+    `week_starts_on` (0=Monday default, 6=Sunday) sets the calendar-week boundary so
+    "this week" / "last week" match the runner's chosen week start (#676); the rolling
+    7d lane is week-start-independent."""
     # rolling 7d — the load-verdict lane (full 7 days, directly comparable).
     roll_start = as_of - timedelta(days=6)
     roll_facts = [f for f in facts if roll_start <= f.local_date <= as_of]
@@ -264,16 +270,17 @@ def build_recent_weeks(
         vs_your_typical=_vs_typical(roll_facts, facts, as_of - timedelta(days=7)),
     )
 
-    # this week — Monday to the run's day (partial unless the run is on a Sunday).
-    this_start = as_of - timedelta(days=as_of.weekday())
-    this_complete = as_of.weekday() == 6  # Sunday
+    # this week — week start to the run's day (partial unless the run is the last day
+    # of the runner's week).
+    this_start = week_start(as_of, week_starts_on)
+    this_complete = is_last_day_of_week(as_of, week_starts_on)
     this_facts = [f for f in facts if this_start <= f.local_date <= as_of]
     this_week = RecentWeeksCalendar(
         start=_endpoint(this_start),
         end=_endpoint(as_of),
         label="This week" if this_complete else "This week, in progress",
         complete=this_complete,
-        days_elapsed=as_of.weekday() + 1,
+        days_elapsed=days_into_week(as_of, week_starts_on),
         days=_days(this_start, as_of, this_facts, checkins),
         week_totals=_totals(this_facts),
         # A partial week carries NO verdict (the #653 fix); a complete Sunday week does.
@@ -284,7 +291,7 @@ def build_recent_weeks(
         ),
     )
 
-    # last week — the previous Monday-Sunday block (complete).
+    # last week — the previous complete week block (ends the day before this_start).
     last_end = this_start - timedelta(days=1)
     last_start = last_end - timedelta(days=6)
     last_facts = [f for f in facts if last_start <= f.local_date <= last_end]

--- a/backend/app/services/coach/volume.py
+++ b/backend/app/services/coach/volume.py
@@ -48,6 +48,7 @@ from app.schemas.coach_context import (
     VolumeWindow,
 )
 from app.schemas.trends import VolumeFraming, VolumeMetricVsNorm, VolumeReport
+from app.services.weeks import MONDAY, days_into_week, week_start
 
 # The metrics compared, in a fixed order (byte-stable pack).
 _METRICS = ("sessions", "distance_m", "moving_time_s", "effort_score")
@@ -148,17 +149,23 @@ def _window(
     )
 
 
-def build_training_volume(facts: List[Any], as_of: date) -> TrainingVolumeContext:
+def build_training_volume(
+    facts: List[Any], as_of: date, week_starts_on: int = MONDAY
+) -> TrainingVolumeContext:
     """Build the volume-vs-norm signal as of `as_of` from facts spanning at least
     the trailing ~91 days. Facts are duck-typed: each needs `local_date`,
-    `activity_type`, `distance_m`, `moving_time_s`, `effort_score`."""
+    `activity_type`, `distance_m`, `moving_time_s`, `effort_score`.
+
+    `week_starts_on` (0=Monday default, 6=Sunday) sets the calendar-week boundary
+    so it matches the runner's chosen week start (#676); rolling_7d is
+    week-start-independent."""
     # Current windows.
     rolling_start = as_of - timedelta(days=6)  # 7 days ending on as_of inclusive
     rolling_facts = [f for f in facts if rolling_start <= f.local_date <= as_of]
 
-    week_start = as_of - timedelta(days=as_of.weekday())  # Monday of this week
-    week_facts = [f for f in facts if week_start <= f.local_date <= as_of]
-    week_days_elapsed = as_of.weekday() + 1  # Mon=1 .. Sun=7
+    wk_start = week_start(as_of, week_starts_on)  # first day of this week
+    week_facts = [f for f in facts if wk_start <= f.local_date <= as_of]
+    week_days_elapsed = days_into_week(as_of, week_starts_on)
 
     # Norm baselines: the runner's own per-day training rate over history strictly
     # BEFORE the current 7-day window, projected to a weekly figure (#451). This is the
@@ -318,11 +325,14 @@ def _report_framing(
     )
 
 
-def _calendar_period(range_key: str, as_of: date) -> Tuple[date, date, int, str]:
+def _calendar_period(
+    range_key: str, as_of: date, week_starts_on: int = MONDAY
+) -> Tuple[date, date, int, str]:
     """The current calendar period for a range: (start, last_day, length_days, label).
-    The period runs from `start` to `last_day`; the caller compares to-date (start..as_of)."""
+    The period runs from `start` to `last_day`; the caller compares to-date (start..as_of).
+    Only the weekly (7D) period depends on `week_starts_on` (#676)."""
     if range_key == "7D":
-        start = as_of - timedelta(days=as_of.weekday())  # Monday
+        start = week_start(as_of, week_starts_on)
         last = start + timedelta(days=6)
         label = "This week"
     elif range_key == "30D":
@@ -347,7 +357,9 @@ def _calendar_period(range_key: str, as_of: date) -> Tuple[date, date, int, str]
     return start, last, (last - start).days + 1, label
 
 
-def build_volume_report(facts: List[Any], as_of: date, range_key: str) -> VolumeReport:
+def build_volume_report(
+    facts: List[Any], as_of: date, range_key: str, week_starts_on: int = MONDAY
+) -> VolumeReport:
     """The Trends-page volume-vs-norm report for `range_key` (7D/30D/3M/6M/1Y) as of
     `as_of`. Two framings — rolling (trailing N days) and calendar (current period to
     date) — each metric vs the runner's norm for a FULL period of that length (#436):
@@ -362,7 +374,7 @@ def build_volume_report(facts: List[Any], as_of: date, range_key: str) -> Volume
         facts, "rolling", f"{n}-day rolling", roll_start, as_of, n, True, baseline_days
     )
 
-    p_start, p_last, p_days, p_label = _calendar_period(range_key, as_of)
+    p_start, p_last, p_days, p_label = _calendar_period(range_key, as_of, week_starts_on)
     calendar = _report_framing(
         facts, "calendar", p_label, p_start, as_of, p_days, as_of >= p_last, baseline_days
     )

--- a/backend/app/services/training_load.py
+++ b/backend/app/services/training_load.py
@@ -20,9 +20,11 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from app.models import Activity, DerivedMetric
+from app.models import Activity, DerivedMetric, UserProfile
 from app.schemas.trends import LoadActivityPoint, LoadResponse, LoadWeek
 from app.services.analysis.classifier import Classification, compose_headline
+from app.services.weeks import MONDAY, resolve_week_start
+from app.services.weeks import week_start as _shared_week_start
 
 # The chronic baseline window and the optimal band around it.
 CHRONIC_WEEKS = 4
@@ -44,8 +46,10 @@ class LoadFact:
     headline: Optional[str] = None
 
 
-def week_start(d: date) -> date:
-    return d - timedelta(days=d.weekday())
+def week_start(d: date, starts_on: int = MONDAY) -> date:
+    # Delegates to the single week-boundary definition (#676); default Monday
+    # keeps every existing caller byte-identical.
+    return _shared_week_start(d, starts_on)
 
 
 def _status(score: float, target_min: Optional[float], target_max: Optional[float]) -> str:
@@ -62,6 +66,7 @@ def build_load_report(
     facts: list[LoadFact],
     today: date,
     series_start: Optional[date] = None,
+    week_starts_on: int = MONDAY,
 ) -> LoadResponse:
     """Pure aggregation: facts -> chronological weekly report ending this week.
 
@@ -70,21 +75,25 @@ def build_load_report(
     the series length matches an unbounded build). When None, the first week is
     derived from ``facts`` as before. Either way it is clamped to the
     MAX_WEEKS floor.
+
+    ``week_starts_on`` (0=Monday default, 6=Sunday) sets the week boundary the
+    weekly buckets align to (#676). The within-week day-of-week breakdown array
+    (``daily`` below) stays weekday-indexed (Mon=0) regardless.
     """
-    current_week = week_start(today)
+    current_week = week_start(today, week_starts_on)
     # Bound the series so per-request cost stays flat as history grows.
     earliest_served = current_week - timedelta(weeks=MAX_WEEKS - 1)
     if series_start is not None:
         first_week = series_start
     elif facts:
-        first_week = min(week_start(f.day) for f in facts)
+        first_week = min(week_start(f.day, week_starts_on) for f in facts)
     else:
         first_week = current_week
     first_week = max(first_week, earliest_served)
 
     by_week: dict[date, list[LoadFact]] = {}
     for f in facts:
-        by_week.setdefault(week_start(f.day), []).append(f)
+        by_week.setdefault(week_start(f.day, week_starts_on), []).append(f)
 
     n_weeks = (current_week - first_week).days // 7 + 1
     starts = [first_week + timedelta(weeks=i) for i in range(n_weeks)]
@@ -138,7 +147,10 @@ def get_load_report(
     # full-history scan. We compute `today` once and reuse it for both the SQL
     # bound and the pure report build so a midnight rollover can't disagree.
     resolved_today = today or date.today()
-    earliest_served = week_start(resolved_today) - timedelta(weeks=MAX_WEEKS - 1)
+    week_starts_on = resolve_week_start(
+        db.query(UserProfile).filter(UserProfile.user_id == user_id).first()
+    )
+    earliest_served = week_start(resolved_today, week_starts_on) - timedelta(weeks=MAX_WEEKS - 1)
 
     # Project only the columns the report needs instead of materializing full
     # Activity + DerivedMetric ORM objects. This avoids loading the per-row
@@ -223,4 +235,6 @@ def get_load_report(
                 headline=compose_headline(activity, Classification.from_metrics(metrics)),
             )
         )
-    return build_load_report(facts, resolved_today, series_start=series_start)
+    return build_load_report(
+        facts, resolved_today, series_start=series_start, week_starts_on=week_starts_on
+    )

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -11,7 +11,8 @@ from typing import List, Optional
 from sqlalchemy import select, and_
 from sqlalchemy.orm import Session
 
-from app.models import Activity, DerivedMetric
+from app.models import Activity, DerivedMetric, UserProfile
+from app.services.weeks import MONDAY, resolve_week_start, week_start
 from app.schemas.trends import (
     TrendsResponse,
     TrendsSummary,
@@ -232,20 +233,25 @@ class WeekBucket:
 _EPOCH_MONDAY = date(1970, 1, 5)
 
 
-def _period_start(d: date, period: str) -> date:
+def _period_start(d: date, period: str, week_starts_on: int = MONDAY) -> date:
     """First local day of the coarse bucket that ``d`` falls in.
 
-    - ``biweekly``: 14-day bins aligned to ``_EPOCH_MONDAY`` (Monday start).
+    - ``biweekly``: 14-day bins aligned to the week-start grid (fortnight parity).
     - ``monthly``: the first of the calendar month.
+
+    ``week_starts_on`` (0=Monday default, 6=Sunday) shifts the biweekly grid so
+    it aligns with the weekly bars (#676); monthly is unaffected.
     """
     if period == "monthly":
         return d.replace(day=1)
-    # biweekly: snap to the bin's starting Monday by fortnight parity.
-    monday = d - timedelta(days=d.weekday())
-    weeks = (monday - _EPOCH_MONDAY).days // 7
+    # biweekly: snap to the bin's starting week boundary by fortnight parity. The
+    # parity epoch is the week-start grid's own epoch so weekly and biweekly agree.
+    epoch = week_start(_EPOCH_MONDAY, week_starts_on)
+    start = week_start(d, week_starts_on)
+    weeks = (start - epoch).days // 7
     if weeks % 2 == 1:
-        monday -= timedelta(days=7)
-    return monday
+        start -= timedelta(days=7)
+    return start
 
 
 def _next_period_start(start: date, period: str) -> date:
@@ -598,6 +604,7 @@ def build_weekly_buckets(
     until: Optional[date] = None,
     pre_window_daily: Optional[List[DailyFact]] = None,
     rolling_anchor: Optional[date] = None,
+    week_starts_on: int = MONDAY,
 ) -> List[WeekBucket]:
     """
     Roll daily facts into 7-day buckets.
@@ -619,7 +626,7 @@ def build_weekly_buckets(
     def _key(d: date) -> date:
         if rolling_anchor is not None:
             return _rolling_bin_start(d, rolling_anchor, 7)
-        return d - timedelta(days=d.weekday())
+        return week_start(d, week_starts_on)
 
     # Build buckets from actual data first
     buckets: dict[date, WeekBucket] = {}
@@ -674,6 +681,7 @@ def build_period_buckets(
     until: Optional[date] = None,
     pre_window_daily: Optional[List[DailyFact]] = None,
     rolling_anchor: Optional[date] = None,
+    week_starts_on: int = MONDAY,
 ) -> List[PeriodBucket]:
     """Roll daily facts into coarse buckets (#432) for ``biweekly`` or ``monthly``.
 
@@ -692,7 +700,7 @@ def build_period_buckets(
     def _key(d: date) -> date:
         if rolling_anchor is not None:
             return _rolling_bin_start(d, rolling_anchor, bin_days)
-        return _period_start(d, period)
+        return _period_start(d, period, week_starts_on)
 
     def _advance(cur: date) -> date:
         if rolling_anchor is not None:
@@ -861,6 +869,7 @@ def build_zone_load_weekly(
     activity_facts: List[ActivityFact],
     weekly_buckets: List["WeekBucket"],
     rolling_anchor: Optional[date] = None,
+    week_starts_on: int = MONDAY,
 ) -> List[dict]:
     """
     Aggregate per-activity time_in_zones into weekly 3-zone buckets.
@@ -878,7 +887,7 @@ def build_zone_load_weekly(
         if rolling_anchor is not None:
             key = _rolling_bin_start(af.local_date, rolling_anchor, 7)
         else:
-            key = af.local_date - timedelta(days=af.local_date.weekday())
+            key = week_start(af.local_date, week_starts_on)
         easy_s, mod_s, hard_s = _collapse_to_3_zones(af.time_in_zones)
         prev = zone_by_week.get(key, (0, 0, 0))
         zone_by_week[key] = (
@@ -937,6 +946,7 @@ def build_zone_load_period(
     period_buckets: List["PeriodBucket"],
     period: str,
     rolling_anchor: Optional[date] = None,
+    week_starts_on: int = MONDAY,
 ) -> List[dict]:
     """Per-coarse-bucket 3-zone minutes (#432), continuous over ``period_buckets``.
 
@@ -951,7 +961,7 @@ def build_zone_load_period(
         if rolling_anchor is not None:
             ps = _rolling_bin_start(af.local_date, rolling_anchor, _ROLLING_BIN_DAYS[period])
         else:
-            ps = _period_start(af.local_date, period)
+            ps = _period_start(af.local_date, period, week_starts_on)
         easy_s, mod_s, hard_s = _collapse_to_3_zones(af.time_in_zones)
         prev = zone_by_period.get(ps, (0, 0, 0))
         zone_by_period[ps] = (
@@ -1055,6 +1065,15 @@ def get_trends_report(
     # comparison spans [prev_start, prev_end). Calendar mode shifts both.
     since, prev_start, prev_end = _resolve_window(range_upper, mode)
 
+    # The runner's chosen week start (0=Monday default, 6=Sunday), which the
+    # calendar-mode weekly/biweekly bars align to (#676). Rolling mode buckets by
+    # today-anchored blocks, so it is week-start-independent there.
+    week_starts_on = resolve_week_start(
+        db.query(UserProfile).filter(UserProfile.user_id == user_id).first()
+        if user_id is not None
+        else None
+    )
+
     # Rolling mode buckets the bars in fixed-width blocks rolling back from today
     # rather than snapping to the calendar grid (#630). None keeps the calendar
     # keying (ISO-Monday weeks / calendar months / the fortnight grid).
@@ -1067,7 +1086,7 @@ def get_trends_report(
     if mode == "calendar" and range_upper in _RANGE_DAYS and _RANGE_DAYS[range_upper]:
         from app.services.coach.volume import _calendar_period
 
-        _, until, _, _ = _calendar_period(range_upper, date.today())
+        _, until, _, _ = _calendar_period(range_upper, date.today(), week_starts_on)
 
     # 1. Activity-level facts (filtered by types if provided)
     activity_facts = build_activity_facts(
@@ -1155,6 +1174,7 @@ def get_trends_report(
     weekly = build_weekly_buckets(
         daily_facts, range_key=range_upper, since=since, until=until,
         pre_window_daily=pre_window_daily, rolling_anchor=rolling_anchor,
+        week_starts_on=week_starts_on,
     )
 
     weekly_distance = [
@@ -1196,10 +1216,12 @@ def get_trends_report(
     biweekly = build_period_buckets(
         daily_facts, "biweekly", range_key=range_upper, since=since, until=until,
         pre_window_daily=pre_window_daily, rolling_anchor=rolling_anchor,
+        week_starts_on=week_starts_on,
     )
     monthly = build_period_buckets(
         daily_facts, "monthly", range_key=range_upper, since=since, until=until,
         pre_window_daily=pre_window_daily, rolling_anchor=rolling_anchor,
+        week_starts_on=week_starts_on,
     )
 
     def _period_distance(buckets: List[PeriodBucket]) -> List[PeriodDistancePoint]:
@@ -1269,7 +1291,9 @@ def get_trends_report(
     # 9. Zone load (3-zone stacked bar)
     weekly_zone_load = [
         ZoneLoadWeekPoint(**p)
-        for p in build_zone_load_weekly(activity_facts, weekly, rolling_anchor=rolling_anchor)
+        for p in build_zone_load_weekly(
+            activity_facts, weekly, rolling_anchor=rolling_anchor, week_starts_on=week_starts_on
+        )
     ]
     daily_zone_load = [
         DailyZoneLoadPoint(**p)
@@ -1277,11 +1301,17 @@ def get_trends_report(
     ]
     biweekly_zone_load = [
         PeriodZoneLoadPoint(**p)
-        for p in build_zone_load_period(activity_facts, biweekly, "biweekly", rolling_anchor=rolling_anchor)
+        for p in build_zone_load_period(
+            activity_facts, biweekly, "biweekly", rolling_anchor=rolling_anchor,
+            week_starts_on=week_starts_on,
+        )
     ]
     monthly_zone_load = [
         PeriodZoneLoadPoint(**p)
-        for p in build_zone_load_period(activity_facts, monthly, "monthly", rolling_anchor=rolling_anchor)
+        for p in build_zone_load_period(
+            activity_facts, monthly, "monthly", rolling_anchor=rolling_anchor,
+            week_starts_on=week_starts_on,
+        )
     ]
 
     return TrendsResponse(
@@ -1334,13 +1364,18 @@ def get_volume_report(
     )
 
     resolved = as_of or date.today()
+    week_starts_on = resolve_week_start(
+        db.query(UserProfile).filter(UserProfile.user_id == user_id).first()
+        if user_id is not None
+        else None
+    )
     key = range_key if range_key in _RANGE_WINDOW_DAYS else "7D"
     n = _RANGE_WINDOW_DAYS[key]
     roll_start = resolved - timedelta(days=n - 1)
-    period_start, _, _, _ = _calendar_period(key, resolved)
+    period_start, _, _, _ = _calendar_period(key, resolved, week_starts_on)
     # Fetch back to the earliest window start plus the term-scaled norm baseline.
     earliest = min(roll_start, period_start) - timedelta(days=_BASELINE_DAYS_BY_RANGE[key] + 1)
     facts = _query_activity_facts(
         db, earliest, resolved + timedelta(days=1), types, user_id=user_id
     )
-    return build_volume_report(facts, resolved, key)
+    return build_volume_report(facts, resolved, key, week_starts_on)

--- a/backend/app/services/weeks.py
+++ b/backend/app/services/weeks.py
@@ -1,0 +1,52 @@
+"""The single definition of "the week" (#676).
+
+Historically every coach-pack and Trends surface open-coded the same
+hardcoded-Monday idiom (`d - timedelta(days=d.weekday())`). That made the
+week boundary impossible to change per-runner without editing six places and
+risking drift between the coach pack and the Trends API. This module is the
+one place that turns a date into its week boundary, parameterized by the
+runner's chosen `week_starts_on`.
+
+`week_starts_on` is an int in Python's `weekday()` space: 0=Monday .. 6=Sunday.
+`starts_on=MONDAY` (the default) reproduces the prior idiom byte-for-byte, so a
+runner who has not chosen otherwise sees byte-identical output. The product only
+offers Monday or Sunday, but the arithmetic here is general (any weekday) so the
+math is trivially testable and carries no special-cases.
+"""
+
+from datetime import date, timedelta
+from typing import Any
+
+MONDAY = 0
+SUNDAY = 6
+
+
+def resolve_week_start(profile: Any) -> int:
+    """The effective week start for a runner, from their profile.
+
+    Null (unset) or a missing profile resolves to Monday, keeping every existing
+    runner's output byte-identical. Duck-typed on ``.week_starts_on`` so the pure
+    week-math module stays free of an ORM import.
+    """
+    value = getattr(profile, "week_starts_on", None)
+    return MONDAY if value is None else value
+
+
+def _offset(d: date, starts_on: int) -> int:
+    """Days from d back to the start of its week (0..6)."""
+    return (d.weekday() - starts_on) % 7
+
+
+def week_start(d: date, starts_on: int = MONDAY) -> date:
+    """The first day of the week containing d, given the week starts on `starts_on`."""
+    return d - timedelta(days=_offset(d, starts_on))
+
+
+def days_into_week(d: date, starts_on: int = MONDAY) -> int:
+    """1-based position of d within its week (1 = the week's first day .. 7 = its last)."""
+    return _offset(d, starts_on) + 1
+
+
+def is_last_day_of_week(d: date, starts_on: int = MONDAY) -> bool:
+    """True when d is the final day of its week (the day before the next week_start)."""
+    return _offset(d, starts_on) == 6

--- a/backend/tests/test_week_start_configurable.py
+++ b/backend/tests/test_week_start_configurable.py
@@ -1,0 +1,173 @@
+"""Per-runner week start actually shifts the week boundary (#676).
+
+The default (Monday / null) path is pinned byte-identical by the existing volume,
+recent_weeks, and trends suites. These tests cover the NET-NEW behavior: a Sunday
+week start moves the calendar-week boundary in every surface, and the profile
+setting threads all the way through the Trends API entry point.
+"""
+
+import uuid
+from datetime import date, datetime, time, timedelta
+
+from app.models import Activity, DerivedMetric, User, UserProfile
+from app.services.coach.query_tools import resolve_window
+from app.services.coach.recent_weeks import build_recent_weeks
+from app.services.coach.volume import build_training_volume, build_volume_report
+from app.services.trends import build_weekly_buckets, get_volume_report
+from app.services.trends import DailyFact
+from app.services.weeks import MONDAY, SUNDAY
+
+# Wednesday 2024-01-03. Its Monday week starts 2024-01-01 (Mon); its Sunday week
+# starts 2023-12-31 (Sun).
+WED = date(2024, 1, 3)
+THAT_MONDAY = date(2024, 1, 1)
+THAT_SUNDAY = date(2023, 12, 31)
+
+
+class TestRecentWeeksBoundary:
+    def test_default_this_week_starts_monday(self):
+        ctx = build_recent_weeks([], {}, WED)
+        assert ctx.this_week.start.weekday == "Mon"
+        assert ctx.this_week.days_elapsed == 3  # Mon, Tue, Wed
+
+    def test_sunday_this_week_starts_sunday(self):
+        ctx = build_recent_weeks([], {}, WED, SUNDAY)
+        assert ctx.this_week.start.weekday == "Sun"
+        assert ctx.this_week.days_elapsed == 4  # Sun, Mon, Tue, Wed
+        # Last week is the prior complete Sunday-Saturday block.
+        assert ctx.last_week.start.weekday == "Sun"
+        assert ctx.last_week.end.weekday == "Sat"
+
+
+class TestVolumeBoundary:
+    def test_default_calendar_week_days_elapsed(self):
+        ctx = build_training_volume([], WED)
+        assert ctx.calendar_week.days_elapsed == 3  # Mon, Tue, Wed
+
+    def test_sunday_calendar_week_days_elapsed(self):
+        ctx = build_training_volume([], WED, SUNDAY)
+        assert ctx.calendar_week.days_elapsed == 4  # Sun, Mon, Tue, Wed
+
+    def test_report_7d_calendar_period_start_shifts(self):
+        default = build_volume_report([], WED, "7D")
+        sunday = build_volume_report([], WED, "7D", SUNDAY)
+        assert default.calendar.period_start == THAT_MONDAY
+        assert sunday.calendar.period_start == THAT_SUNDAY
+
+
+class TestTrendsWeeklyBucketBoundary:
+    def _daily(self, d: date) -> DailyFact:
+        return DailyFact(d)
+
+    def test_calendar_mode_buckets_align_to_week_start(self):
+        # Calendar mode (rolling_anchor=None) keys buckets on the week boundary.
+        facts = [self._daily(WED)]
+        default = build_weekly_buckets(
+            facts, since=THAT_SUNDAY, until=WED, rolling_anchor=None
+        )
+        sunday = build_weekly_buckets(
+            facts, since=THAT_SUNDAY, until=WED, rolling_anchor=None, week_starts_on=SUNDAY
+        )
+        assert all(b.week_start.weekday() == MONDAY for b in default)
+        assert all(b.week_start.weekday() == SUNDAY for b in sunday)
+
+
+class TestResolveWindow:
+    def test_this_week_default_monday(self):
+        w = resolve_window("this_week", WED)
+        assert w.start == THAT_MONDAY
+
+    def test_this_week_sunday(self):
+        w = resolve_window("this_week", WED, SUNDAY)
+        assert w.start == THAT_SUNDAY
+
+    def test_last_week_sunday(self):
+        w = resolve_window("last_week", WED, SUNDAY)
+        assert w.start == THAT_SUNDAY - timedelta(days=7)
+        assert w.end == THAT_SUNDAY  # exclusive end == this week's start
+
+
+# ---------------------------------------------------------------------------
+# The profile setting threads through the Trends API entry point end to end.
+# ---------------------------------------------------------------------------
+
+def _user_with_week_start(db, week_starts_on) -> uuid.UUID:
+    user = User(email=f"{uuid.uuid4()}@example.com")
+    db.add(user)
+    db.flush()
+    profile = UserProfile(
+        user_id=user.id,
+        goal_type="general",
+        experience_level="intermediate",
+        weekly_days_available=4,
+    )
+    if week_starts_on is not None:
+        profile.week_starts_on = week_starts_on
+    db.add(profile)
+    db.flush()
+    return user.id
+
+
+def _activity_on(db, user_id, on: date) -> Activity:
+    activity = Activity(
+        user_id=user_id,
+        strava_activity_id=int(uuid.uuid4().int % 1_000_000_000),
+        start_date=datetime.combine(on, time(12, 0)),
+        start_date_local=datetime.combine(on, time(12, 0)),
+        type="Run",
+        name="Run",
+        distance_m=5000,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=0.0,
+        raw_summary={},
+    )
+    db.add(activity)
+    db.flush()
+    db.add(
+        DerivedMetric(
+            id=uuid.uuid4(),
+            activity_id=activity.id,
+            effort_score=1.0,
+            confidence="high",
+            flags=[],
+            confidence_reasons=[],
+        )
+    )
+    db.flush()
+    return activity
+
+
+def test_get_volume_report_uses_profile_week_start(db):
+    """A Sunday-week-start profile shifts the 7D calendar period start; a default
+    (null) profile keeps Monday. Proves the profile -> builder thread on the API path."""
+    monday_user = _user_with_week_start(db, None)  # null -> Monday
+    sunday_user = _user_with_week_start(db, SUNDAY)
+    _activity_on(db, monday_user, WED)
+    _activity_on(db, sunday_user, WED)
+
+    monday_report = get_volume_report(db, monday_user, "7D", as_of=WED)
+    sunday_report = get_volume_report(db, sunday_user, "7D", as_of=WED)
+
+    assert monday_report.calendar.period_start == THAT_MONDAY
+    assert sunday_report.calendar.period_start == THAT_SUNDAY
+
+
+def test_recent_weeks_context_uses_profile_week_start(db):
+    """The coach-pack recent_weeks builder loads the profile via _load_profile and
+    threads the runner's week start, so this_week shifts to Sunday for a Sunday runner."""
+    from datetime import time as _time
+
+    from app.services.coach.context import _build_recent_weeks_context
+
+    monday_user = _user_with_week_start(db, MONDAY)
+    sunday_user = _user_with_week_start(db, SUNDAY)
+    monday_activity = _activity_on(db, monday_user, WED)
+    sunday_activity = _activity_on(db, sunday_user, WED)
+    as_of = datetime.combine(WED, _time(12, 0))
+
+    monday_ctx = _build_recent_weeks_context(db, monday_activity, as_of)
+    sunday_ctx = _build_recent_weeks_context(db, sunday_activity, as_of)
+
+    assert monday_ctx.this_week.start.weekday == "Mon"
+    assert sunday_ctx.this_week.start.weekday == "Sun"

--- a/backend/tests/test_weeks.py
+++ b/backend/tests/test_weeks.py
@@ -1,0 +1,120 @@
+"""Unit tests for the single week-boundary definition (#676).
+
+The whole point of `services/weeks.py` is that every coach-pack and Trends
+surface derives "the week" from ONE place, parameterized by the runner's
+`week_starts_on` (0=Monday .. 6=Sunday). `starts_on=0` must reproduce the
+prior hardcoded-Monday idiom byte-for-byte; `starts_on=6` is the net-new
+Sunday behavior.
+"""
+
+from datetime import date
+
+from app.services.weeks import (
+    MONDAY,
+    SUNDAY,
+    days_into_week,
+    is_last_day_of_week,
+    resolve_week_start,
+    week_start,
+)
+
+
+# A known week: Mon 2024-01-01 .. Sun 2024-01-07, then Mon 2024-01-08.
+MON = date(2024, 1, 1)
+TUE = date(2024, 1, 2)
+WED = date(2024, 1, 3)
+THU = date(2024, 1, 4)
+FRI = date(2024, 1, 5)
+SAT = date(2024, 1, 6)
+SUN = date(2024, 1, 7)
+NEXT_MON = date(2024, 1, 8)
+
+
+class TestConstants:
+    def test_monday_is_zero_sunday_is_six(self):
+        assert MONDAY == 0
+        assert SUNDAY == 6
+
+
+class TestWeekStartMonday:
+    """starts_on defaults to Monday and reproduces `d - timedelta(days=d.weekday())`."""
+
+    def test_default_is_monday(self):
+        assert week_start(WED) == MON
+
+    def test_every_day_maps_to_its_monday(self):
+        for d in (MON, TUE, WED, THU, FRI, SAT, SUN):
+            assert week_start(d, MONDAY) == MON
+
+    def test_next_monday_starts_new_week(self):
+        assert week_start(NEXT_MON, MONDAY) == NEXT_MON
+
+    def test_matches_weekday_idiom(self):
+        # The exact idiom every surface used before the reconcile.
+        from datetime import timedelta
+
+        for offset in range(400):
+            d = MON + timedelta(days=offset)
+            assert week_start(d, MONDAY) == d - timedelta(days=d.weekday())
+
+
+class TestWeekStartSunday:
+    """starts_on=Sunday shifts the boundary back a day."""
+
+    def test_sunday_is_its_own_start(self):
+        assert week_start(SUN, SUNDAY) == SUN
+
+    def test_monday_belongs_to_the_prior_sunday(self):
+        # Sun 2023-12-31 is the start of the week containing Mon 2024-01-01.
+        assert week_start(MON, SUNDAY) == date(2023, 12, 31)
+
+    def test_saturday_still_in_the_sunday_week(self):
+        assert week_start(SAT, SUNDAY) == date(2023, 12, 31)
+
+    def test_next_sunday_starts_new_week(self):
+        assert week_start(NEXT_MON, SUNDAY) == SUN
+
+
+class TestDaysIntoWeek:
+    """1-based position of d within its week (Mon=1..Sun=7 for a Monday week)."""
+
+    def test_monday_week(self):
+        assert days_into_week(MON, MONDAY) == 1
+        assert days_into_week(SUN, MONDAY) == 7
+        assert days_into_week(WED, MONDAY) == 3
+
+    def test_sunday_week(self):
+        assert days_into_week(SUN, SUNDAY) == 1
+        assert days_into_week(MON, SUNDAY) == 2
+        assert days_into_week(SAT, SUNDAY) == 7
+
+
+class _Profile:
+    def __init__(self, week_starts_on):
+        self.week_starts_on = week_starts_on
+
+
+class TestResolveWeekStart:
+    def test_none_profile_is_monday(self):
+        assert resolve_week_start(None) == MONDAY
+
+    def test_null_setting_is_monday(self):
+        assert resolve_week_start(_Profile(None)) == MONDAY
+
+    def test_explicit_monday(self):
+        assert resolve_week_start(_Profile(MONDAY)) == MONDAY
+
+    def test_explicit_sunday(self):
+        assert resolve_week_start(_Profile(SUNDAY)) == SUNDAY
+
+
+class TestIsLastDayOfWeek:
+    def test_monday_week_last_day_is_sunday(self):
+        assert is_last_day_of_week(SUN, MONDAY) is True
+        assert is_last_day_of_week(SAT, MONDAY) is False
+        assert is_last_day_of_week(MON, MONDAY) is False
+
+    def test_sunday_week_last_day_is_saturday(self):
+        assert is_last_day_of_week(SAT, SUNDAY) is True
+        assert is_last_day_of_week(SUN, SUNDAY) is False
+        assert is_last_day_of_week(FRI, SUNDAY) is False

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -31,7 +31,8 @@ export default function ProfilePage() {
     // but field exists in backend schema
     upcoming_races: [],
     max_hr: 0, // New field state
-    resting_hr: 0
+    resting_hr: 0,
+    week_starts_on: 0 // 0=Monday (default), 6=Sunday (#676)
   });
 
   useEffect(() => {
@@ -49,7 +50,8 @@ export default function ProfilePage() {
             injury_notes: data.injury_notes || '',
             upcoming_races: data.upcoming_races || [],
             max_hr: data.max_hr || 0,
-            resting_hr: data.resting_hr || 0
+            resting_hr: data.resting_hr || 0,
+            week_starts_on: data.week_starts_on ?? 0
         });
         setLoading(false);
       })
@@ -79,7 +81,7 @@ export default function ProfilePage() {
     const { name, value } = e.target;
     setFormData(prev => ({
         ...prev,
-        [name]: name === 'weekly_days_available' || name === 'current_weekly_km' || name === 'max_hr' || name === 'resting_hr' ? Number(value) : value
+        [name]: name === 'weekly_days_available' || name === 'current_weekly_km' || name === 'max_hr' || name === 'resting_hr' || name === 'week_starts_on' ? Number(value) : value
     }));
   };
 
@@ -177,13 +179,29 @@ export default function ProfilePage() {
 
             <div>
                 <label className="block text-sm font-medium mb-1">Current Weekly Volume (km)</label>
-                <input 
+                <input
                     type="number" min="0"
                     name="current_weekly_km"
                     value={formData.current_weekly_km}
                     onChange={handleChange}
                     className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
                 />
+            </div>
+
+            <div>
+                <label className="block text-sm font-medium mb-1">Week Starts On</label>
+                <select
+                    name="week_starts_on"
+                    value={formData.week_starts_on}
+                    onChange={handleChange}
+                    className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
+                >
+                    <option value={0}>Monday</option>
+                    <option value={6}>Sunday</option>
+                </select>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    Sets which day your training week begins, for &ldquo;this week&rdquo; on the coach and Trends.
+                </p>
             </div>
         </div>
 

--- a/frontend/lib/types/profile.ts
+++ b/frontend/lib/types/profile.ts
@@ -8,6 +8,7 @@ export interface UserProfile {
   max_hr?: number;
   max_hr_source?: string | null;  // "user_entered" | "race_estimate" | "lab_test"
   resting_hr?: number;  // manual resting HR (bpm), interim source for #555
+  week_starts_on?: number;  // 0=Monday (default), 6=Sunday (#676)
   upcoming_races: { name: string; date: string; distance_km: number }[];
   injury_notes?: string;
   updated_at: string;


### PR DESCRIPTION
Partially addresses #676 — lands the config + one-definition plumbing (default Monday = behavior-preserving). Issue stays open for any deferred follow-ups (see below).

## What

Makes the Monday/Sunday week boundary a per-runner setting, threaded through a single shared definition so the coach pack and the Trends API agree on "the week." Default (unset) resolves to Monday, so all current output is byte-identical.

## Changes

- **`services/weeks.py`** (new) — the single week-boundary definition: `week_start` / `days_into_week` / `is_last_day_of_week` / `resolve_week_start`. General over any start day; `starts_on=MONDAY` (the default) reproduces the prior hardcoded `d - timedelta(days=d.weekday())` idiom byte-for-byte.
- **`user_profiles.week_starts_on`** — nullable int (0=Mon default, 6=Sun), migration `b7d4e9f2a1c8` (nullable, preview-safe), validated to `{0,6}` on `PUT /profile`, plus a Monday/Sunday `<select>` on the profile page.
- **Threaded through the six week-boundary surfaces**, sourced from the runner's profile: coach `recent_weeks` + `training_volume`; Trends `get_volume_report` / `get_trends_report` (weekly + biweekly + zone-load buckets) / `get_load_report`; and coach-chat `query_tools.resolve_window`.

## Deliberately out of scope

- `analysis/baseline.py` `isocalendar()` weekly norm — an internal aggregation the runner never sees as "this week"; kept ISO/Monday (shifting a stat with a display preference would be coach-wrong).
- `readiness.py` — per-day EWMA, already week-start-agnostic.
- The v9–v14 / `lean_v1` VOLUME addendum still says "Monday-Sunday" in prose. Not in the live prompt (`grouped_v5`), which reads the boundary from the self-describing weekday-stamped `recent_weeks` section, so the live coach is correct. Left as rollback-only hygiene per owner call.

## Verification

- Full backend suite green at default Monday: **2232 passed** (baseline 2204 + 28 new) — the existing byte-stable pack/trends tests are the behavior-preservation oracle.
- `test_weeks.py` pins the shared helper (incl. a 400-day equivalence check vs the old idiom). `test_week_start_configurable.py` covers Sunday behavior across every surface, with DB-backed tests exercising both profile→builder threads (`get_volume_report` and `_build_recent_weeks_context`) end to end.
- Migration verified against real Postgres: applies, reverses, re-applies.
- Frontend `next lint` + `tsc --noEmit` clean (`next build` runs in CI).