### PR TITLE
chore(coach): remove runtime-dead symbols and fold relationship resolvers

### DIFF
--- a/backend/app/schemas/coach_context.py
+++ b/backend/app/schemas/coach_context.py
@@ -1720,7 +1720,9 @@ class CoachContextPack(BaseModel):
         return _nest_flat(self.to_serializable_dict())
 
     def fingerprint(self) -> str:
-        """Deterministic SHA-256 cache key. Byte-identical to the legacy hash_context_pack output."""
+        """Deterministic SHA-256 cache key: the canonical hash of the serialized pack
+        (sorted-key JSON with `default=str`), which the versioned-cache identity is
+        defined against."""
         serialised = json.dumps(self.to_serializable_dict(), sort_keys=True, default=str)
         return hashlib.sha256(serialised.encode()).hexdigest()
 

--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -14,12 +14,10 @@ view) is reachable through the retrieval seam on demand, not forced into the
 default pack.
 """
 
-import hashlib
-import json
 import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Dict, Optional
+from typing import Optional
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, joinedload, undefer
@@ -59,7 +57,6 @@ from app.services.coach.intensity_read import build_intensity_mix, build_intensi
 from app.services.readiness import build_readiness
 from app.services.coach.retrieval import (
     fetch_corpus,
-    fetch_latest_user_reply,
     fetch_prior_commitments,
     fetch_prior_digests,
     fetch_stream_view,
@@ -1485,19 +1482,19 @@ def _novelty_axis_history(db: Session, activity: Activity) -> list[AxisSnapshot]
     ]
 
 
-# --- The read-time history-scan signal registry (#492) ----------------------
-# The five signals reached through the one `ReadTimeSignal` seam. Each pairs a
+# --- The read-time history-scan signals (#492) ------------------------------
+# The signals reached through the one `ReadTimeSignal` seam. Each pairs a
 # `_build_*_context` adapter (the bounded scan + thin-history abstention) with its
 # optional prompt-feature gate, so `gather` applies gating + dispatch uniformly and
 # `build_context_pack` / `build_b_baseline` never repeat a private convention.
 #
-# Two are ALWAYS-EMITTED (gate_feature=None — calibration and adherence live in the
-# B baseline and always produce a section, possibly empty/degraded). Three are
-# PROMPT-GATED (the section is dropped from serialization when the active prompt does
-# not carry the feature, keeping the pack byte-stable elsewhere).
+# The ALWAYS-EMITTED signals (gate_feature=None — calibration and adherence live in
+# the B baseline and always produce a section, possibly empty/degraded) run on every
+# prompt; the PROMPT-GATED signals are dropped from serialization when the active
+# prompt does not carry the feature, keeping the pack byte-stable elsewhere.
 #
-# #203 slots a stored-artifact adapter in by re-registering the same `name` with a
-# read-stored compute of the SAME (db, activity, as_of) shape — no `context.py` change.
+# #203 slots a stored-artifact adapter in by swapping a signal's compute for a
+# read-stored one of the SAME (db, activity, as_of) shape — no call-site change.
 _CALIBRATION_SIGNAL = ReadTimeSignal("calibration", _build_calibration_context)
 _ADHERENCE_SIGNAL = ReadTimeSignal("adherence", _build_adherence_context)
 _TRAINING_LOAD_SIGNAL = ReadTimeSignal(
@@ -1533,34 +1530,3 @@ _INTENSITY_SIGNAL = ReadTimeSignal(
     "intensity", _build_intensity_context, PromptFeature.INTENSITY
 )
 
-# All read-time signals, keyed by name — the registry a stored-artifact adapter
-# (#203) would look up and swap an entry in without touching the call sites above.
-# `memory` (ADR 0025) is itself the stored-artifact adapter the seam was designed
-# for: it reads a written profile rather than scanning history.
-READ_TIME_SIGNALS: Dict[str, ReadTimeSignal] = {
-    s.name: s
-    for s in (
-        _CALIBRATION_SIGNAL,
-        _ADHERENCE_SIGNAL,
-        _TRAINING_LOAD_SIGNAL,
-        _TRAINING_VOLUME_SIGNAL,
-        _RECENT_TRAINING_SIGNAL,
-        _READINESS_SIGNAL,
-        _RECENT_WEEKS_SIGNAL,
-        _TRAINING_HISTORY_SIGNAL,
-        _TRAINING_HISTORY_2WK_SIGNAL,
-        _MEMORY_SIGNAL,
-        _INTENSITY_SIGNAL,
-    )
-}
-
-
-def hash_context_pack(pack: Dict[str, Any]) -> str:
-    """Deterministic SHA-256 hash of a legacy dict-shaped pack.
-
-    Retained for migration safety (tests pin the typed model's fingerprint against this);
-    new code should call CoachContextPack.fingerprint() instead.
-    """
-    return hashlib.sha256(
-        json.dumps(pack, sort_keys=True, default=str).encode()
-    ).hexdigest()

--- a/backend/app/services/coach/memory_store.py
+++ b/backend/app/services/coach/memory_store.py
@@ -2,18 +2,15 @@
 
 The runner memory profile: one rewritten-from-source per-runner profile, written
 by the background update pass (M2) and read into the coach pack (M3). This layer
-only persists and retrieves the row and renders it to markdown; the authority
-boundary (memory yields to measured data, never lowers the safety floor) is
-enforced elsewhere (the v13 prompt addendum + the medical-scope validator). No
-LLM here.
+only persists and retrieves the row; the authority boundary (memory yields to
+measured data, never lowers the safety floor) is enforced elsewhere (the v13
+prompt addendum + the medical-scope validator). No LLM here.
 
-Three entry points:
+Two entry points:
 - `get_memory(db, user_id)`: the user's memory row, or None.
 - `upsert_memory(db, user_id, ...)`: create or wholesale-replace the single
   per-user row (the update pass rewrites it from scratch each run, so this is a
   full replace, not a merge). Best-effort against the UNIQUE(user_id) race.
-- `render_profile_markdown(profile)`: a pure projection of a profile to markdown
-  for surfacing/debug — emits all five headings even when a section is empty.
 
 All reads/writes are user-scoped.
 """
@@ -29,11 +26,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.runner_memory import RunnerMemory
-from app.schemas.coach_memory import (
-    MEMORY_SECTION_FIELDS,
-    MEMORY_SECTION_TITLES,
-    RunnerMemoryProfile,
-)
+from app.schemas.coach_memory import RunnerMemoryProfile
 
 logger = logging.getLogger(__name__)
 
@@ -107,22 +100,3 @@ def upsert_memory(
             raise
     db.refresh(row)
     return row
-
-
-def render_profile_markdown(profile: RunnerMemoryProfile) -> str:
-    """Render a profile to markdown for surfacing/debug.
-
-    Pure (no DB, no LLM). Always emits all five section headings in canonical
-    order, even when a section is empty, so the shape is constant for every runner
-    ("same sections everyone").
-    """
-    blocks: list[str] = []
-    for field in MEMORY_SECTION_FIELDS:
-        lines = [f"## {MEMORY_SECTION_TITLES[field]}"]
-        items = getattr(profile, field)
-        if items:
-            lines.extend(f"- {item}" for item in items)
-        else:
-            lines.append("_(nothing yet)_")
-        blocks.append("\n".join(lines))
-    return "\n\n".join(blocks) + "\n"

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -172,24 +172,34 @@ def is_receipt_cadence(prompt_id: str) -> bool:
     return settings.COACH_RECEIPT_CADENCE and is_two_stage_prompt(prompt_id)
 
 
-def _resolve_voice_for_activity(db: Session, activity: Activity):
-    """Resolve the runner's declared coach voice for this activity's owner (P1.1).
+def _relationship_for_activity(
+    db: Session, activity: Activity
+) -> Optional[CoachingRelationship]:
+    """Load the runner's thin CoachingRelationship row, or None.
 
-    Loads the thin CoachingRelationship row (the row may not exist yet — a runner
-    who never opened their profile) and resolves it to a VoiceProfile; a missing
-    row or an undeclared voice resolves to the moderate default. This only affects
-    voice-aware prompts (coach_message_v3) — render_voice_block is a no-op for every
-    other prompt id, so the resolved voice is harmless under any other prompt."""
-    # #522: COACH_RELATIONSHIP_ENABLED off => never read the relationship; resolve to
-    # the moderate default voice (the runner's declared voice has no effect).
+    Returns None both when the row does not exist yet (a runner who never opened
+    their profile) and when COACH_RELATIONSHIP_ENABLED is off (#522: never read the
+    relationship, so the runner's declared voice/stance has no effect). In both cases
+    the caller's resolver maps None to its moderate/default profile, so a missing row
+    and a disabled input are indistinguishable by design."""
     if not settings.COACH_RELATIONSHIP_ENABLED:
-        return resolve_voice(None)
-    relationship = (
+        return None
+    return (
         db.query(CoachingRelationship)
         .filter(CoachingRelationship.user_id == activity.user_id)
         .first()
     )
-    return resolve_voice(relationship)
+
+
+def _resolve_voice_for_activity(db: Session, activity: Activity):
+    """Resolve the runner's declared coach voice for this activity's owner (P1.1).
+
+    Resolves the thin CoachingRelationship row to a VoiceProfile; a missing row, an
+    undeclared voice, or a disabled relationship input resolves to the moderate
+    default. This only affects voice-aware prompts (coach_message_v3) —
+    render_voice_block is a no-op for every other prompt id, so the resolved voice is
+    harmless under any other prompt."""
+    return resolve_voice(_relationship_for_activity(db, activity))
 
 
 def report_voice_stale(db: Session, row: Optional[CoachReport]) -> bool:
@@ -224,23 +234,14 @@ def report_voice_stale(db: Session, row: Optional[CoachReport]) -> bool:
 def _resolve_stance_for_activity(db: Session, activity: Activity):
     """Resolve the runner's declared coaching stance for this activity's owner (P1.3).
 
-    Loads the thin CoachingRelationship row (may not exist yet) and resolves it to a
-    StanceProfile (selected school + the two emphasis axes); a missing row or an
-    undeclared stance resolves to the default school (aerobic-base) + balanced
+    Resolves the thin CoachingRelationship row to a StanceProfile (selected school +
+    the two emphasis axes); a missing row, an undeclared stance, or a disabled
+    relationship input resolves to the default school (aerobic-base) + balanced
     emphasis. This only takes effect under a stance-aware prompt (coach_message_v5):
     build_context_pack threads the school into the corpus section and the emphasis
     into the stance section only under v5, so the resolved stance is harmless under
     any other prompt id (the P1.2/voice precedent)."""
-    # #522: COACH_RELATIONSHIP_ENABLED off => never read the relationship; resolve to
-    # the default school + balanced emphasis (the runner's declared stance has no effect).
-    if not settings.COACH_RELATIONSHIP_ENABLED:
-        return resolve_stance(None)
-    relationship = (
-        db.query(CoachingRelationship)
-        .filter(CoachingRelationship.user_id == activity.user_id)
-        .first()
-    )
-    return resolve_stance(relationship)
+    return resolve_stance(_relationship_for_activity(db, activity))
 
 
 def active_schema_version(prompt_id: str) -> str:

--- a/backend/tests/test_coach_context_pack.py
+++ b/backend/tests/test_coach_context_pack.py
@@ -1,17 +1,33 @@
 """Characterisation tests for the typed CoachContextPack schema.
 
-These tests pin the migration's load-bearing invariant: a typed pack must produce
-the byte-identical cache hash the legacy dict-based pack produced, and round-trip
-through model_validate / model_dump without losing or reordering fields.
+These tests pin the migration's load-bearing invariant: a typed pack's fingerprint
+must equal the canonical SHA-256 of its serialized dict form (the cache identity the
+legacy dict-based pack produced), and round-trip through model_validate / model_dump
+without losing or reordering fields.
 """
 
+import hashlib
+import json
 import uuid
 from datetime import datetime, timezone
 
 from app.models import Activity, DerivedMetric, UserProfile
 from app.models.user import User
 from app.schemas.coach_context import CoachContextPack
-from app.services.coach.context import build_context_pack, hash_context_pack
+from app.services.coach.context import build_context_pack
+
+
+def _canonical_pack_hash(pack: dict) -> str:
+    """The canonical dict-hash the versioned cache identity is defined against.
+
+    This is the formula `CoachContextPack.fingerprint()` must stay byte-identical to
+    (previously the app-side `hash_context_pack`, removed once `fingerprint()` became
+    the sole caller). Kept here as the migration cross-check oracle: if `fingerprint()`
+    ever changes its canonical form, these tests catch the drift in the cache key.
+    """
+    return hashlib.sha256(
+        json.dumps(pack, sort_keys=True, default=str).encode()
+    ).hexdigest()
 
 
 def _legacy_full_pack() -> dict:
@@ -482,16 +498,16 @@ def test_load_accepts_both_flat_and_grouped_shapes():
     assert from_flat.fingerprint() == from_grouped.fingerprint()
 
 
-def test_fingerprint_matches_legacy_hash_full():
+def test_fingerprint_matches_canonical_hash_full():
     pack_dict = _legacy_full_pack()
-    expected = hash_context_pack(pack_dict)
+    expected = _canonical_pack_hash(pack_dict)
     pack = CoachContextPack.load(pack_dict)
     assert pack.fingerprint() == expected
 
 
-def test_fingerprint_matches_legacy_hash_sparse():
+def test_fingerprint_matches_canonical_hash_sparse():
     pack_dict = _legacy_sparse_pack()
-    expected = hash_context_pack(pack_dict)
+    expected = _canonical_pack_hash(pack_dict)
     pack = CoachContextPack.load(pack_dict)
     assert pack.fingerprint() == expected
 
@@ -557,8 +573,8 @@ def test_real_fixture_pack_roundtrips_through_typed_schema(db):
 
     # Round-trip through model_validate preserves the dict shape.
     assert CoachContextPack.load(pack_dict).to_serializable_dict() == pack_dict
-    # The typed fingerprint matches the legacy dict-based hash byte-for-byte.
-    assert pack.fingerprint() == hash_context_pack(pack_dict)
+    # The typed fingerprint matches the canonical dict-based hash byte-for-byte.
+    assert pack.fingerprint() == _canonical_pack_hash(pack_dict)
 
 
 # --- The #493 gated-pack-section registry --------------------------------------

--- a/backend/tests/test_memory_store.py
+++ b/backend/tests/test_memory_store.py
@@ -1,21 +1,16 @@
-"""M1 — runner memory store (DB layer over `runner_memory`) + markdown render.
+"""M1 — runner memory store (DB layer over `runner_memory`).
 
 The thin store: round-trip a profile, upsert replaces the single per-user row in
-place, get returns None for an unknown user, and the pure markdown render emits
-all five headings even when empty. No LLM here.
+place, and get returns None for an unknown user. No LLM here.
 """
 
 import uuid
 
 from app.models.runner_memory import RunnerMemory
 from app.models.user import User
-from app.schemas.coach_memory import (
-    MEMORY_SECTION_TITLES,
-    RunnerMemoryProfile,
-)
+from app.schemas.coach_memory import RunnerMemoryProfile
 from app.services.coach.memory_store import (
     get_memory,
-    render_profile_markdown,
     upsert_memory,
 )
 
@@ -65,19 +60,3 @@ def test_upsert_accepts_string_user_id(db):
     uid = _user(db)
     upsert_memory(db, str(uid), profile=RunnerMemoryProfile(who_you_are=["runs early"]))
     assert get_memory(db, str(uid)) is not None
-
-
-def test_render_emits_all_five_headings_when_empty():
-    markdown = render_profile_markdown(RunnerMemoryProfile())
-    for title in MEMORY_SECTION_TITLES.values():
-        assert f"## {title}" in markdown
-    # An empty section renders a placeholder, not a phantom bullet.
-    assert "_(nothing yet)_" in markdown
-
-
-def test_render_lists_section_lines():
-    markdown = render_profile_markdown(
-        RunnerMemoryProfile(limits_and_constraints=["Left knee niggle, mentioned once"])
-    )
-    assert "## Limits & constraints" in markdown
-    assert "- Left knee niggle, mentioned once" in markdown

--- a/backend/tests/test_read_time_signals.py
+++ b/backend/tests/test_read_time_signals.py
@@ -22,11 +22,14 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from app.services.coach.context import (
-    READ_TIME_SIGNALS,
     _ADHERENCE_SIGNAL,
     _CALIBRATION_SIGNAL,
+    _INTENSITY_SIGNAL,
     _MEMORY_SIGNAL,
     _RECENT_TRAINING_SIGNAL,
+    _RECENT_WEEKS_SIGNAL,
+    _READINESS_SIGNAL,
+    _TRAINING_HISTORY_2WK_SIGNAL,
     _TRAINING_HISTORY_SIGNAL,
     _TRAINING_LOAD_SIGNAL,
     _TRAINING_VOLUME_SIGNAL,
@@ -36,19 +39,36 @@ from app.services.coach.read_time_signals import ReadTimeSignal, gather
 
 _AS_OF = datetime(2026, 3, 20, 8, 0, tzinfo=timezone.utc)
 
+# Every read-time signal, reached at its call site through the one `ReadTimeSignal`
+# seam. There is no aggregate registry object — each signal is wired directly at its
+# `gather(...)` call site — so this tuple is the test's own enumeration.
+_ALL_SIGNALS = (
+    _CALIBRATION_SIGNAL,
+    _ADHERENCE_SIGNAL,
+    _TRAINING_LOAD_SIGNAL,
+    _TRAINING_VOLUME_SIGNAL,
+    _RECENT_TRAINING_SIGNAL,
+    # ADR 0026 Slice 2 (#670): the redefined right_now content signals + the rebased
+    # training-history ladder (PR 2), which coexists with the original for byte-stability.
+    _READINESS_SIGNAL,
+    _RECENT_WEEKS_SIGNAL,
+    _TRAINING_HISTORY_SIGNAL,
+    _TRAINING_HISTORY_2WK_SIGNAL,
+    _MEMORY_SIGNAL,
+    _INTENSITY_SIGNAL,
+)
 
-# --- registry shape ----------------------------------------------------------
+
+# --- signal shape ------------------------------------------------------------
 
 
-def test_all_signals_registered_under_one_interface():
-    assert set(READ_TIME_SIGNALS) == {
+def test_all_signals_share_one_interface():
+    assert {s.name for s in _ALL_SIGNALS} == {
         "calibration",
         "adherence",
         "training_load",
         "training_volume",
         "recent_training",
-        # ADR 0026 Slice 2 (#670): the redefined right_now content signals + the rebased
-        # training-history ladder (PR 2), which coexists with the original for byte-stability.
         "readiness",
         "recent_weeks",
         "training_history",
@@ -56,7 +76,7 @@ def test_all_signals_registered_under_one_interface():
         "memory",
         "intensity",
     }
-    assert all(isinstance(s, ReadTimeSignal) for s in READ_TIME_SIGNALS.values())
+    assert all(isinstance(s, ReadTimeSignal) for s in _ALL_SIGNALS)
 
 
 def test_always_emitted_vs_gated_split_is_explicit():


### PR DESCRIPTION
Cleanup tail from the 2026-07-15 audits. Ships the genuinely-safe pure-subtraction subset; the two dependency-gated items stay deferred by design.

## Changes

**Deletions** (verified no app callers via whole-repo dependency search incl. dynamic/string refs):
- `hash_context_pack` (`context.py`) — superseded by `CoachContextPack.fingerprint()`. Its migration cross-check oracle moves test-local (`_canonical_pack_hash` in `test_coach_context_pack.py`), so `fingerprint()`'s canonical-form invariant is still pinned.
- `render_profile_markdown` (`memory_store.py`) — no app caller; capability dropped with its two tests.
- `READ_TIME_SIGNALS` dict (`context.py`) — dead aggregate, zero app consumers. The individual `_*_SIGNAL` constants stay live (wired directly at their `gather(...)` call sites); the registry-shape test re-enumerates them locally.
- Stray unused `fetch_latest_user_reply` import in `context.py` (pre-existing; the function itself stays, live in `service.py`).

**Refactor** (behaviour-preserving):
- Fold `_resolve_voice_for_activity` / `_resolve_stance_for_activity` onto one `_relationship_for_activity` helper. Byte-identical: flag-off → `None` → `resolve_*(None)`, exactly as before.

**Kept by justification** (satisfies #699's "removed **or justified**"): the `*_PROMPT_IDS` / `is_*_prompt` derived views are a documented, drift-proof, one-per-feature surface over the `PROMPT_FEATURES` manifest. Deleting the test-only subset would leave an asymmetric surface; wholesale inlining fights the documented readability intent and enlarges the diff past "safe subtraction."

## Deferred (unchanged, by design)
- #704's `_build_training_load_context` / `_build_readiness_context` fold — blocked until the old `training_load` pack key is retired (both keys still coexist by prompt feature).
- #699 part (b) — collapsing the `ReadTimeSignal` seam itself folds into #203 (its second adapter).

## Verification
- Delete modality: whole-repo dependency search clean (only a history note remains).
- Refactor: full backend suite green at **2230 passed** (baseline 2232; delta = the two intentionally-removed render tests). Coach pack byte-stable — the fingerprint/serialization, voice/stance resolution (both flag states), and #522 kill-switch tests all pass. Net −42 lines. Pyflakes clean on touched files.

Partially addresses #704 (two gated items remain open). Addresses #699 part (a) (part b deferred to #203).