### PR TITLE
chore: gitignore all installed AI-workflow tool artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,14 +46,17 @@ frontend/tsconfig.tsbuildinfo
 
 # IDE
 .idea/
-.vscode/
 
 # AI workflow and skills (tooling config, not product code)
+# The installer only ignores the last-installed tool's paths in its managed
+# block below; these keep every installed tool's artifacts local-only.
 .agents/
 .gemini/
 .github/*
 !.github/workflows/
 claude.md
+CLAUDE.md
+.claude/
 .codex/
 AGENTS.md
 .vercel
@@ -69,6 +72,8 @@ docs/audit/coach-*
 ai-workflow.md
 .ai-policy/
 .githooks/
-CLAUDE.md
-.claude/
+.github/copilot-instructions.md
+.github/hooks/
+.vscode/
+.agents/skills/
 # <<< ai-workflow <<<


### PR DESCRIPTION
The workflow updater (3.10.0 -> 3.12.0) rewrites a single per-tool managed .gitignore block, so running it across claude/codex/copilot left only the last tool's paths ignored. Keep every installed tool's vendored artifacts local-only in the hand-maintained section, outside the managed block.