### PR TITLE
refactor(analysis): typed composition intermediate + single interval-session gate (#701)

### DIFF
--- a/backend/app/services/analysis/_orchestrator.py
+++ b/backend/app/services/analysis/_orchestrator.py
@@ -11,6 +11,7 @@ from app.services.analysis.flags import generate_flags
 from app.services.analysis.intervals import detect_intervals, detect_intervals_from_laps
 from app.services.analysis.risk import compute_risk_score
 from app.services.analysis.workout_matching import match_planned_to_detected, build_interval_kpis
+from app.services.analysis.composition import DerivedMetricFields, IntervalSession
 
 logger = logging.getLogger(__name__)
 
@@ -71,9 +72,11 @@ def compute_confidence(activity, streams_dict, check_in, interval_structure=None
     # Interval-specific sanity checks. These reasons (no_intervals_detected,
     # rep variability, match mismatch) only describe an interval session, so
     # they must not lower the overall confidence of a non-interval activity
-    # (#169). The orchestrator nulls interval_structure when the structure axis
-    # did not resolve to intervals, so its presence is the "is interval session"
-    # gate; without it, workout_match's reasons stay confined to workout_match.
+    # (#169). `interval_structure` here is already the gated value from the
+    # single owner (IntervalSession, #701): it is non-None only for an interval
+    # session, so this function makes no independent session decision — its
+    # presence is the gate, and without it workout_match's reasons stay confined
+    # to workout_match.
     if interval_structure and workout_match:
         match_reasons = workout_match.get("confidence_reasons", [])
         for r in match_reasons:
@@ -156,15 +159,16 @@ def analyze(db: Session, activity_id: str, skip_baseline: bool = False) -> Optio
 
       A. Load phase (steps 1-4): activity, recent history, streams, check-in,
          profile-derived max_hr / HR zones. Pure DB reads.
-      B. Pre-commit metrics phase (steps 5-9.6): build the `metrics_data` dict
-         from the pure analysis stages, then upsert + commit it. This phase
+      B. Pre-commit metrics phase (steps 5-9.6): build the typed
+         `DerivedMetricFields` accumulator (`state`, #701) from the pure
+         analysis stages, then upsert + commit `state.to_columns()`. This phase
          carries the two real intra-phase ordering invariants, both flagged
          INVARIANT inline below:
            1. The interval-structure PROBE precedes classification, and the
               probed structure feeds the classifier's structure axis.
-           2. The kept `interval_structure` (nulled unless the structure axis
-              resolved to "intervals") GATES interval matching/KPIs and the
-              interval confidence checks.
+           2. The single interval-session gate (`IntervalSession.gate`, the ONE
+              owner of "is this an interval session") GATES interval
+              matching/KPIs and the interval confidence checks.
       C. Post-commit phase (step 11): the runner-baseline recompute, which by
          INVARIANT must follow the commit (see `_post_commit_baseline`).
 
@@ -212,12 +216,19 @@ def analyze(db: Session, activity_id: str, skip_baseline: bool = False) -> Optio
 
     # 5. Compute metrics. Pass the check-in RPE so the training-load primitive
     # (#186) can fall back to session-RPE on a strap-less run.
-    metrics_data = compute_derived_metrics_data(
-        activity,
-        streams_dict,
-        max_hr=max_hr,
-        rpe=check_in.rpe if check_in else None,
-        zone_boundaries=zone_boundaries,
+    #
+    # The pure metrics stage still returns its own dict (its external contract);
+    # the orchestrator seeds the typed accumulator (`state`, #701) from it and
+    # writes every subsequent stage's output as a typed attribute rather than a
+    # string key. `state.to_columns()` reproduces the exact upsert dict.
+    state = DerivedMetricFields.from_base_metrics(
+        compute_derived_metrics_data(
+            activity,
+            streams_dict,
+            max_hr=max_hr,
+            rpe=check_in.rpe if check_in else None,
+            zone_boundaries=zone_boundaries,
+        )
     )
 
     # 6. Classify into orthogonal axes (ADR 0007). Probe interval structure so
@@ -237,53 +248,52 @@ def analyze(db: Session, activity_id: str, skip_baseline: bool = False) -> Optio
     # recorded laps do not contain.
     lap_structure = detect_intervals_from_laps(activity.raw_summary, streams_dict, max_hr=max_hr)
     stream_structure = detect_intervals(streams_dict, "Intervals", max_hr=max_hr) if streams_dict else None
-    interval_structure = lap_structure or stream_structure
+    probed_structure = lap_structure or stream_structure
     classification = classify_activity(
         activity, history,
-        time_in_zones=metrics_data.get("time_in_zones"),
-        pace_variability=metrics_data.get("pace_variability"),
-        has_interval_structure=interval_structure is not None,
+        time_in_zones=state.time_in_zones,
+        pace_variability=state.pace_variability,
+        has_interval_structure=probed_structure is not None,
         max_hr=max_hr,
     )
-    metrics_data["effort"] = classification.effort
-    metrics_data["duration_class"] = classification.duration_class
-    metrics_data["structure"] = classification.structure
-    metrics_data["is_hilly"] = classification.is_hilly
-    metrics_data["is_race"] = classification.is_race
+    state.effort = classification.effort
+    state.duration_class = classification.duration_class
+    state.structure = classification.structure
+    state.is_hilly = classification.is_hilly
+    state.is_race = classification.is_race
 
-    # 6.5 Interval segmentation — keep the probed structure only when the
-    # structure axis resolved to intervals.
+    # 6.5 Interval segmentation — resolve the single "is this an interval
+    # session" gate (#701). IntervalSession.gate keeps the probed structure only
+    # when the classifier's structure axis resolved to intervals; it is the ONE
+    # owner of that concept.
     #
-    # ORDERING INVARIANT 2 (structure-axis gates interval KPIs): this null-out
-    # turns the post-classification `interval_structure` local into the single
-    # "is this an interval session" gate. Every downstream interval-only stage
-    # (6.6 workout matching, 6.7 KPIs, and the interval confidence checks in
-    # compute_confidence) keys off this gated value, so it must be applied here,
-    # AFTER classification and BEFORE those stages read it.
-    if classification.structure != "intervals":
-        interval_structure = None
-    metrics_data["interval_structure"] = interval_structure
+    # ORDERING INVARIANT 2 (structure-axis gates interval KPIs): the gate is the
+    # single source every downstream interval-only stage keys off — 6.6 workout
+    # matching, 6.7 KPIs, and the interval confidence checks in
+    # compute_confidence all read `interval_session.structure`. It must be
+    # resolved here, AFTER classification and BEFORE those stages read it.
+    interval_session = IntervalSession.gate(classification.structure, probed_structure)
+    state.interval_structure = interval_session.structure
 
     # 6.6 Workout matching — compare planned vs detected
     planned_workout = _extract_planned_workout(check_in)
-    workout_match = match_planned_to_detected(interval_structure, planned_workout)
-    metrics_data["workout_match"] = workout_match
+    workout_match = match_planned_to_detected(interval_session.structure, planned_workout)
+    state.workout_match = workout_match
 
     # 6.7 Interval-specific KPIs, gated on the structure axis via the
-    # interval_structure nulled at 6.5 (INVARIANT 2).
-    if interval_structure:
+    # interval_session gate (INVARIANT 2).
+    if interval_session.is_session:
         zones_calibrated = bool(
             profile and (profile.hr_zones or (profile.max_hr and profile.max_hr > 100))
         )
-        interval_kpis = build_interval_kpis(
-            interval_structure,
+        state.interval_kpis = build_interval_kpis(
+            interval_session.structure,
             max_hr=max_hr,
             zones_calibrated=zones_calibrated,
-            time_in_zones=metrics_data.get("time_in_zones"),
+            time_in_zones=state.time_in_zones,
         )
-        metrics_data["interval_kpis"] = interval_kpis
     else:
-        metrics_data["interval_kpis"] = None
+        state.interval_kpis = None
 
     # 7. Load history metrics for load spike detection
     history_metrics = (
@@ -293,12 +303,15 @@ def analyze(db: Session, activity_id: str, skip_baseline: bool = False) -> Optio
         if history else []
     )
 
-    # 8. Flags (all flag logic consolidated in flags.py)
+    # 8. Flags (all flag logic consolidated in flags.py). flags.py reads the
+    # accumulator as a dict; state.to_columns() presents the current typed
+    # values in that shape (later-stage fields are still at their defaults and
+    # unread here).
     all_flags = generate_flags(
-        activity, metrics_data, history, check_in,
+        activity, state.to_columns(), history, check_in,
         history_metrics=history_metrics,
     )
-    metrics_data["flags"] = all_flags
+    state.flags = all_flags
 
     # 8.5 Risk score (deterministic, based on flags + check-in + training context)
     check_in_data = {
@@ -309,29 +322,31 @@ def analyze(db: Session, activity_id: str, skip_baseline: bool = False) -> Optio
     # can read it instead of recomputing.
     from app.services.analysis._training_context import build_training_context
     training_ctx = build_training_context(db, activity)
-    metrics_data["training_context"] = training_ctx
+    state.training_context = training_ctx
     risk_result = compute_risk_score(all_flags, check_in_data, training_ctx)
-    metrics_data["risk_level"] = risk_result["risk_level"]
-    metrics_data["risk_score"] = risk_result["risk_score"]
-    metrics_data["risk_reasons"] = risk_result["risk_reasons"]
+    state.risk_level = risk_result["risk_level"]
+    state.risk_score = risk_result["risk_score"]
+    state.risk_reasons = risk_result["risk_reasons"]
 
-    # 9. Confidence (with interval sanity checks)
+    # 9. Confidence (with interval sanity checks). Consumes the gated structure
+    # from the single owner (interval_session), so the interval-only reasons
+    # stay confined to an interval session (#169/#701).
     confidence, confidence_reasons = compute_confidence(
         activity, streams_dict, check_in,
-        interval_structure=interval_structure,
+        interval_structure=interval_session.structure,
         workout_match=workout_match,
     )
-    metrics_data["confidence"] = confidence
-    metrics_data["confidence_reasons"] = confidence_reasons
+    state.confidence = confidence
+    state.confidence_reasons = confidence_reasons
 
     # 9.5 Discount signals (N4) — deterministic confounder annotation. Flags
     # when HR drift is likely inflated by heat/terrain/stimulant rather than
     # genuine fatigue. Reuses the profile loaded for max_hr above.
     from app.services.analysis.discount_signals import compute_discount_signals
-    metrics_data["discount_signals"] = compute_discount_signals(
+    state.discount_signals = compute_discount_signals(
         average_temp=activity.raw_summary.get("average_temp") if activity.raw_summary else None,
-        is_hilly=metrics_data.get("is_hilly"),
-        hr_drift=metrics_data.get("hr_drift"),
+        is_hilly=state.is_hilly,
+        hr_drift=state.hr_drift,
         stimulant_use=profile.stimulant_use if profile else None,
     )
 
@@ -341,17 +356,19 @@ def analyze(db: Session, activity_id: str, skip_baseline: bool = False) -> Optio
     # every analysis (self-heals on re-sync/backfill), a convenience view that
     # never overrides the re-derived metrics. Degrades to None without streams.
     from app.services.analysis.stream_view import build_stream_view
-    metrics_data["stream_view"] = build_stream_view(streams_dict)
+    state.stream_view = build_stream_view(streams_dict)
 
-    # 10. Upsert DerivedMetric
+    # 10. Upsert DerivedMetric. state.to_columns() reproduces the exact dict the
+    # upsert consumed before the typed-intermediate refactor (#701).
+    metric_columns = state.to_columns()
     existing_dm = db.query(DerivedMetric).filter(DerivedMetric.activity_id == activity.id).first()
 
     if existing_dm:
-        for k, v in metrics_data.items():
+        for k, v in metric_columns.items():
             setattr(existing_dm, k, v)
         dm = existing_dm
     else:
-        dm = DerivedMetric(activity_id=activity.id, **metrics_data)
+        dm = DerivedMetric(activity_id=activity.id, **metric_columns)
         db.add(dm)
 
     db.commit()

--- a/backend/app/services/analysis/composition.py
+++ b/backend/app/services/analysis/composition.py
@@ -1,0 +1,116 @@
+"""Typed intermediates for the analysis composition (#701).
+
+The orchestrator composes ~a dozen pure stages into one `DerivedMetric`. This
+module gives that composition two typed surfaces so the wiring — not just the
+individual stages — is expressible and testable:
+
+* :class:`IntervalSession` — the SINGLE owner of the "is this an interval
+  session" gate. Previously that concept was smeared across the classifier's
+  structure axis, an orchestrator null-out, and truthiness re-checks. It is now
+  derived once, here, from the classification structure axis plus the probed
+  interval structure; every downstream interval-only stage keys off this one
+  value.
+
+* :class:`DerivedMetricFields` — the typed stage-to-stage accumulator that
+  replaces the string-keyed ``metrics_data`` bag. Its field names match the
+  ``DerivedMetric`` columns exactly, so :meth:`DerivedMetricFields.to_columns`
+  reproduces the exact dict the upsert consumed before (same values, same
+  object identity — no copy), keeping the refactor behaviour-preserving.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class IntervalSession:
+    """The single owner of the "is this an interval session" gate.
+
+    `structure` is the kept interval structure (the probe's output) when the
+    classifier resolved the structure axis to ``"intervals"``, else ``None``.
+    Downstream interval-only stages (workout matching, KPIs, the interval
+    confidence sanity checks) gate on :attr:`structure` / :attr:`is_session`.
+    """
+
+    structure: Optional[dict]
+
+    @property
+    def is_session(self) -> bool:
+        return self.structure is not None
+
+    @classmethod
+    def gate(
+        cls, classification_structure: Optional[str], probed_structure: Optional[dict]
+    ) -> "IntervalSession":
+        """Apply the one gate: keep the probed structure only when the
+        classifier's structure axis resolved to intervals.
+
+        This is intentionally the ONLY place the gate is computed. It preserves
+        the prior orchestrator behaviour byte-for-byte: ``interval_structure``
+        (the ``lap_structure or stream_structure`` probe) was nulled unless
+        ``classification.structure == "intervals"``.
+        """
+        if classification_structure != "intervals":
+            return cls(structure=None)
+        return cls(structure=probed_structure)
+
+
+@dataclass
+class DerivedMetricFields:
+    """Typed accumulator for the fields that become a ``DerivedMetric`` row.
+
+    Field names and defaults mirror the ``DerivedMetric`` columns the
+    orchestrator writes, so :meth:`to_columns` yields exactly the dict the
+    upsert used to build directly.
+    """
+
+    # Base metrics (from compute_derived_metrics_data).
+    effort_score: float
+    pace_variability: Optional[float] = None
+    hr_drift: Optional[float] = None
+    time_in_zones: Optional[dict] = None
+    stops_analysis: Optional[dict] = None
+    efficiency_analysis: Optional[dict] = None
+
+    # Classification axes (ADR 0007).
+    effort: Optional[str] = None
+    duration_class: Optional[str] = None
+    structure: Optional[str] = None
+    is_hilly: Optional[bool] = None
+    is_race: Optional[bool] = None
+
+    # Interval session (gated by IntervalSession).
+    interval_structure: Optional[dict] = None
+    workout_match: Optional[dict] = None
+    interval_kpis: Optional[dict] = None
+
+    # Flags / risk / training context.
+    flags: list = field(default_factory=list)
+    training_context: Optional[dict] = None
+    risk_level: Optional[str] = None
+    risk_score: Optional[int] = None
+    risk_reasons: Optional[list] = None
+
+    # Confidence.
+    confidence: Optional[str] = None
+    confidence_reasons: list = field(default_factory=list)
+
+    # Deterministic annotations.
+    discount_signals: Optional[dict] = None
+    stream_view: Optional[dict] = None
+
+    @classmethod
+    def from_base_metrics(cls, metrics: dict[str, Any]) -> "DerivedMetricFields":
+        """Seed the accumulator from ``compute_derived_metrics_data``'s output."""
+        return cls(**metrics)
+
+    def to_columns(self) -> dict[str, Any]:
+        """The exact column dict the upsert consumes.
+
+        Shallow by design: values keep their identity (the JSON columns receive
+        the very objects the stages produced), matching the pre-refactor
+        ``DerivedMetric(**metrics_data)`` / ``setattr`` behaviour.
+        """
+        return {f.name: getattr(self, f.name) for f in fields(self)}

--- a/backend/tests/test_analysis_composition.py
+++ b/backend/tests/test_analysis_composition.py
@@ -1,0 +1,233 @@
+"""Characterisation tests for the analysis *composition* (#701).
+
+The individual analysis stages are unit-tested elsewhere; these tests pin how
+`_orchestrator.analyze` composes them — the stage-to-stage intermediate, the
+single "is this an interval session" gate, and the three documented ordering
+invariants. They are behaviour-preservation nets for the typed-intermediate /
+single-gate refactor: each asserts an observable consequence that a reordering
+or a re-smeared gate would break.
+
+Invariants under test (mirroring the orchestrator's composition contract):
+  1. probe-before-classify: the interval-structure probe runs BEFORE
+     classification and feeds the classifier's structure axis.
+  2. structure-axis-gates-KPIs: interval_structure is kept only when the
+     structure axis resolved to "intervals"; that one gated value drives
+     interval matching, KPIs, and the interval confidence reasons.
+  3. commit-before-baseline: the runner-baseline recompute runs AFTER the
+     DerivedMetric commit, so the just-analysed row is visible to it.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from app.models import Activity, User, UserProfile, DerivedMetric
+from app.models.activity_stream import ActivityStream
+from app.services.analysis import analyze
+from app.services.analysis import _orchestrator
+from app.services.analysis import baseline as baseline_mod
+
+
+BASE_DATE = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+
+
+def _seed_run(db, *, with_streams=True, avg_hr=160.0, user_intent=None):
+    """Seed one analysable run (and its user/profile). Returns the Activity."""
+    user_id = uuid.uuid4()
+    db.add(User(id=user_id, email=f"{user_id}@example.com"))
+    db.add(
+        UserProfile(
+            user_id=user_id,
+            goal_type="half",
+            experience_level="intermediate",
+            weekly_days_available=4,
+            current_weekly_km=40,
+            max_hr=190,
+            max_hr_source="user_entered",
+        )
+    )
+    db.flush()
+
+    activity = Activity(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        strava_activity_id=int(uuid.uuid4().int % (10**12)),
+        name="Test Run",
+        type="Run",
+        start_date=BASE_DATE,
+        distance_m=10000,
+        moving_time_s=3000,
+        elapsed_time_s=3100,
+        elev_gain_m=50.0,
+        avg_hr=avg_hr,
+        max_hr=175.0,
+        avg_cadence=170.0,
+        average_speed_mps=3.33,
+        user_intent=user_intent,
+    )
+    db.add(activity)
+    db.flush()
+
+    if with_streams:
+        n = 3000
+        db.add(ActivityStream(activity_id=activity.id, stream_type="heartrate", data=[int(avg_hr)] * n))
+        db.add(ActivityStream(activity_id=activity.id, stream_type="velocity_smooth", data=[3.3] * n))
+        db.add(ActivityStream(activity_id=activity.id, stream_type="time", data=list(range(n))))
+        db.add(ActivityStream(activity_id=activity.id, stream_type="distance", data=[i * 3.3 for i in range(n)]))
+
+    db.commit()
+    return activity
+
+
+# A recorded-laps interval structure the probe can return, with a
+# match-mismatch workout so the interval-only confidence reasons are visible
+# only when the session gate is open.
+_LAP_STRUCTURE = {
+    "source": "recorded_laps",
+    "summary": {"total_work_time_s": 600, "num_reps": 4},
+    "warmup_duration_s": 120,
+    "reps": [{"duration_s": 150}, {"duration_s": 150}, {"duration_s": 150}, {"duration_s": 150}],
+}
+
+
+# --- Invariant 1: probe-before-classify (the probe feeds the classifier) ---
+
+def test_probe_result_is_fed_to_classifier(db, monkeypatch):
+    """The classifier receives has_interval_structure=True exactly when the
+    probe found a structure — proving the probe ran first and fed it."""
+    activity = _seed_run(db)
+
+    captured = {}
+    real_classify = _orchestrator.classify_activity
+
+    def spy_classify(*args, **kwargs):
+        captured["has_interval_structure"] = kwargs.get("has_interval_structure")
+        return real_classify(*args, **kwargs)
+
+    monkeypatch.setattr(_orchestrator, "classify_activity", spy_classify)
+    monkeypatch.setattr(
+        _orchestrator, "detect_intervals_from_laps", lambda *a, **k: _LAP_STRUCTURE
+    )
+    monkeypatch.setattr(_orchestrator, "detect_intervals", lambda *a, **k: None)
+
+    analyze(db, activity.id)
+
+    assert captured["has_interval_structure"] is True
+
+
+def test_no_probe_structure_is_fed_as_false(db, monkeypatch):
+    activity = _seed_run(db)
+
+    captured = {}
+    real_classify = _orchestrator.classify_activity
+
+    def spy_classify(*args, **kwargs):
+        captured["has_interval_structure"] = kwargs.get("has_interval_structure")
+        return real_classify(*args, **kwargs)
+
+    monkeypatch.setattr(_orchestrator, "classify_activity", spy_classify)
+    monkeypatch.setattr(_orchestrator, "detect_intervals_from_laps", lambda *a, **k: None)
+    monkeypatch.setattr(_orchestrator, "detect_intervals", lambda *a, **k: None)
+
+    analyze(db, activity.id)
+
+    assert captured["has_interval_structure"] is False
+
+
+# --- Invariant 2: the structure axis gates interval KPIs + confidence ---
+
+def test_probe_structure_gated_out_when_axis_not_intervals(db, monkeypatch):
+    """A probe can find a structure, but if the classifier does not resolve the
+    structure axis to 'intervals' the gate closes: interval_structure /
+    interval_kpis are dropped and no interval-only confidence reason leaks."""
+    activity = _seed_run(db)
+
+    # Probe DOES find a (mismatching) structure...
+    monkeypatch.setattr(_orchestrator, "detect_intervals_from_laps", lambda *a, **k: _LAP_STRUCTURE)
+    monkeypatch.setattr(_orchestrator, "detect_intervals", lambda *a, **k: None)
+
+    # ...but the classifier resolves structure to continuous.
+    real_classify = _orchestrator.classify_activity
+
+    def force_continuous(*args, **kwargs):
+        c = real_classify(*args, **kwargs)
+        c.structure = "continuous"
+        return c
+
+    monkeypatch.setattr(_orchestrator, "classify_activity", force_continuous)
+
+    dm = analyze(db, activity.id)
+
+    assert dm.structure == "continuous"
+    assert dm.interval_structure is None
+    assert dm.interval_kpis is None
+    # The interval-only confidence reasons must not leak onto a non-interval run.
+    for reason in ("no_intervals_detected", "interval_structure_mismatch",
+                   "work_time_implausibly_high", "high_rep_distance_variability"):
+        assert reason not in (dm.confidence_reasons or [])
+
+
+def test_interval_session_keeps_structure_and_kpis(db, monkeypatch):
+    """When the axis resolves to intervals the gate is open: the probed
+    structure is kept and interval KPIs are computed from it."""
+    activity = _seed_run(db)
+
+    monkeypatch.setattr(_orchestrator, "detect_intervals_from_laps", lambda *a, **k: _LAP_STRUCTURE)
+    monkeypatch.setattr(_orchestrator, "detect_intervals", lambda *a, **k: None)
+
+    real_classify = _orchestrator.classify_activity
+
+    def force_intervals(*args, **kwargs):
+        c = real_classify(*args, **kwargs)
+        c.structure = "intervals"
+        return c
+
+    monkeypatch.setattr(_orchestrator, "classify_activity", force_intervals)
+
+    dm = analyze(db, activity.id)
+
+    assert dm.structure == "intervals"
+    assert dm.interval_structure == _LAP_STRUCTURE
+    assert dm.interval_kpis is not None
+
+
+# --- Invariant 3: commit-before-baseline ---
+
+def test_baseline_recompute_runs_after_derivedmetric_commit(db, monkeypatch):
+    """When the runner-baseline recompute runs, the just-analysed activity's
+    DerivedMetric row is already committed and visible."""
+    activity = _seed_run(db)
+
+    seen = {}
+    real_recompute = baseline_mod.recompute_runner_baseline
+
+    def spy_recompute(session, user_id):
+        row = (
+            session.query(DerivedMetric)
+            .filter(DerivedMetric.activity_id == activity.id)
+            .first()
+        )
+        seen["dm_visible"] = row is not None
+        return real_recompute(session, user_id)
+
+    monkeypatch.setattr(baseline_mod, "recompute_runner_baseline", spy_recompute)
+
+    analyze(db, activity.id)
+
+    assert seen.get("dm_visible") is True
+
+
+def test_skip_baseline_defers_recompute(db, monkeypatch):
+    """skip_baseline=True must not call the baseline recompute (the bulk-caller
+    contract), leaving the composition otherwise identical."""
+    activity = _seed_run(db)
+
+    called = {"n": 0}
+
+    def spy_recompute(session, user_id):
+        called["n"] += 1
+
+    monkeypatch.setattr(baseline_mod, "recompute_runner_baseline", spy_recompute)
+
+    analyze(db, activity.id, skip_baseline=True)
+
+    assert called["n"] == 0

--- a/backend/tests/test_analysis_composition_types.py
+++ b/backend/tests/test_analysis_composition_types.py
@@ -1,0 +1,97 @@
+"""Unit tests for the typed analysis-composition intermediates (#701).
+
+Covers the two new typed surfaces directly, independent of the orchestrator:
+the single interval-session gate (`IntervalSession`) and the typed accumulator
+(`DerivedMetricFields`) whose `to_columns()` must reproduce the exact upsert
+dict.
+"""
+
+from dataclasses import fields
+
+from app.models import DerivedMetric
+from app.services.analysis.composition import DerivedMetricFields, IntervalSession
+
+
+_PROBE = {"source": "recorded_laps", "summary": {"total_work_time_s": 600}}
+
+
+# --- IntervalSession: the single "is this an interval session" owner ---
+
+def test_gate_open_keeps_probed_structure_when_axis_is_intervals():
+    session = IntervalSession.gate("intervals", _PROBE)
+    assert session.is_session is True
+    assert session.structure is _PROBE
+
+
+def test_gate_closed_drops_structure_when_axis_not_intervals():
+    session = IntervalSession.gate("continuous", _PROBE)
+    assert session.is_session is False
+    assert session.structure is None
+
+
+def test_gate_closed_when_axis_intervals_but_no_probe():
+    # Defensive: the classifier only resolves "intervals" off a probed
+    # structure, but if it ever did without one, the gate stays closed.
+    session = IntervalSession.gate("intervals", None)
+    assert session.is_session is False
+    assert session.structure is None
+
+
+def test_gate_closed_for_none_axis():
+    session = IntervalSession.gate(None, _PROBE)
+    assert session.is_session is False
+
+
+# --- DerivedMetricFields: the typed accumulator ---
+
+def test_from_base_metrics_seeds_and_defaults():
+    base = {
+        "effort_score": 42.0,
+        "pace_variability": 3.1,
+        "hr_drift": 5.0,
+        "time_in_zones": {"Z2": 100},
+        "stops_analysis": None,
+        "efficiency_analysis": None,
+    }
+    state = DerivedMetricFields.from_base_metrics(base)
+
+    assert state.effort_score == 42.0
+    assert state.time_in_zones == {"Z2": 100}
+    # Later-stage fields start at their column defaults.
+    assert state.effort is None
+    assert state.structure is None
+    assert state.flags == []
+    assert state.confidence_reasons == []
+    assert state.interval_kpis is None
+
+
+def test_to_columns_preserves_object_identity():
+    """to_columns() must be shallow: the JSON columns receive the very objects
+    the stages produced (matching the pre-refactor **metrics_data upsert)."""
+    zones = {"Z2": 100}
+    structure = dict(_PROBE)
+    state = DerivedMetricFields.from_base_metrics({"effort_score": 1.0})
+    state.time_in_zones = zones
+    state.interval_structure = structure
+
+    cols = state.to_columns()
+
+    assert cols["time_in_zones"] is zones
+    assert cols["interval_structure"] is structure
+
+
+def test_to_columns_keys_are_all_derivedmetric_columns():
+    """Every accumulator field must map to a real DerivedMetric column, so
+    `DerivedMetric(**state.to_columns())` stays valid."""
+    state = DerivedMetricFields.from_base_metrics({"effort_score": 1.0})
+    cols = set(state.to_columns())
+
+    dm_columns = {c.name for c in DerivedMetric.__table__.columns}
+    missing = cols - dm_columns
+    assert not missing, f"accumulator fields not backed by a column: {missing}"
+
+
+def test_field_names_match_accumulator_columns_roundtrip():
+    # Guard against a field being renamed out of sync with to_columns().
+    state = DerivedMetricFields.from_base_metrics({"effort_score": 1.0})
+    assert set(state.to_columns()) == {f.name for f in fields(DerivedMetricFields)}


### PR DESCRIPTION
## What
Addresses #701. Makes the analysis *composition* (how `_orchestrator.analyze` wires the pure stages together) a typed, testable surface, without changing analysis behaviour.

New `backend/app/services/analysis/composition.py`:
- **`IntervalSession`** — the single owner of the "is this an interval session" gate. Previously that concept was smeared across the classifier's structure axis, an orchestrator null-out, and truthiness re-checks in `compute_confidence`. It is now derived once (`IntervalSession.gate(classification_structure, probed_structure)` keeps the probed structure only when the axis resolved to `intervals`), and every downstream interval-only stage (workout matching, KPIs, interval confidence reasons) reads that one value.
- **`DerivedMetricFields`** — the typed stage-to-stage accumulator that replaces the string-keyed `metrics_data` bag. Field names match the `DerivedMetric` columns; `to_columns()` reproduces the exact upsert dict.

`_orchestrator.analyze` now builds `state` (typed) stage by stage and upserts `state.to_columns()`. The pure `compute_derived_metrics_data` stage keeps its own dict contract (external, unit-tested) and seeds the accumulator; `generate_flags` still receives a dict via `state.to_columns()`, so no other stage changed.

## Behaviour-preserving — how it's proven
- The existing golden snapshot (`test_analysis_interface.py`) is **unchanged and green** (byte-identical `analyze` output for the representative fixture).
- `IntervalSession.gate` is a pure re-expression of the prior two-line null-out; `to_columns()` is shallow and identity-preserving (unit-tested), so the JSON columns receive the same objects as before.
- New `test_analysis_composition.py` (6 tests) written first against the current code, still green after the refactor, pins the three ordering invariants (probe-before-classify, structure-axis-gates-KPIs, commit-before-baseline) plus the gate and `skip_baseline`.
- New `test_analysis_composition_types.py` (8 tests) covers the gate and accumulator round-trip/column-mapping directly.
- Full backend suite: **2254 passed, 5 skipped** (CI-green env overrides).

## Acceptance criteria
- [x] Stage-to-stage intermediate is typed rather than a bag of string keys.
- [x] "Is this an interval session" has one owner (`IntervalSession`).
- [x] Ordering invariants covered by assertions (not only prose + one snapshot).
- [x] Behaviour-preserving: `analyze` output unchanged for existing fixtures.

## Decisions noted
- Kept `compute_derived_metrics_data`'s dict return (its unit-tested external contract) and seed the typed accumulator from it, rather than retyping every stage boundary — additive, no deletion.
- Kept `compute_confidence`'s `interval_structure=` parameter (directly unit-tested); it now provably receives the single gate's output rather than deciding independently. Retyping it to take an `IntervalSession` is a possible follow-up.
- Invariants are covered by tests rather than runtime `assert`s (an assert could raise on an edge input, which would not be strictly behaviour-preserving).

## Scope deliberately left out
- No code/function/module deleted (the issue's framing could imply further consolidation; that would be an ASK-first delete). This PR is purely additive + a behaviour-preserving rewrite of the accumulator wiring.

## Verification not done
- No reprocessing against a production data seed (no DB/Strava access here). The behaviour-preservation claim rests on the byte-identical golden snapshot, the identity-preserving `to_columns()` unit test, and the gate being a pure re-expression of the prior logic.