### PR TITLE
Arm Clerk azp validation from existing origin config (partially addresses #707)

### DIFF
--- a/backend/app/core/clerk_auth.py
+++ b/backend/app/core/clerk_auth.py
@@ -70,7 +70,9 @@ class ClerkVerifier:
         jwk_client: Optional[object] = None,
     ) -> None:
         self._issuer = issuer
-        self._authorized_parties = tuple(authorized_parties)
+        # Normalise (strip trailing slash) so an operator- or config-supplied
+        # origin with a trailing "/" still matches the bare-origin azp Clerk mints.
+        self._authorized_parties = tuple(p.rstrip("/") for p in authorized_parties)
         self._leeway = leeway
         # PyJWKClient caches signing keys in-process after the first fetch.
         self._jwk_client = jwk_client or jwt.PyJWKClient(jwks_url)
@@ -102,8 +104,15 @@ class ClerkVerifier:
             raise ClerkAuthError(f"could not verify session token: {exc}") from exc
 
         if self._authorized_parties:
+            # Clerk sets `azp` to the frontend origin that minted the token, so a
+            # token issued by the SAME instance for a DIFFERENT app/origin carries
+            # that other origin here and is rejected (the #707 threat: a valid
+            # same-instance token from a foreign frontend). A token with NO azp is
+            # allowed, per Clerk's documented guidance to skip the check when the
+            # claim is absent; our browser-minted sessions always carry it, so an
+            # absent azp is not the foreign-origin case this guards against.
             azp = claims.get("azp")
-            if azp not in self._authorized_parties:
+            if azp is not None and str(azp).rstrip("/") not in self._authorized_parties:
                 raise ClerkAuthError("token authorized party not allowed")
 
         return claims

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -352,7 +352,12 @@ class Settings(BaseSettings):
     # instance; set explicitly only to override.
     CLERK_ISSUER: str = ""
     # Optional comma-separated allowlist of authorized parties (the `azp` claim,
-    # the frontend origin Clerk issued the token to). Empty disables the check.
+    # the frontend origin Clerk issued the token to). When set it wins outright.
+    # When EMPTY the allowlist is DERIVED from the app's own frontend origins
+    # already in config (CORS_ALLOWED_ORIGINS + APP_BASE_URL), so azp validation
+    # is armed by default with no new required env var (#707); see
+    # clerk_authorized_parties_list. Set this explicitly only to override that
+    # derivation (e.g. to add a satellite origin Clerk mints tokens for).
     CLERK_AUTHORIZED_PARTIES: str = ""
     # Clock-skew tolerance (seconds) for token exp/nbf/iat checks.
     CLERK_LEEWAY_SECONDS: int = 30
@@ -439,7 +444,31 @@ class Settings(BaseSettings):
 
     @property
     def clerk_authorized_parties_list(self) -> list[str]:
-        return [p.strip() for p in self.CLERK_AUTHORIZED_PARTIES.split(",") if p.strip()]
+        """The authorized-party (``azp``) allowlist for Clerk token verification.
+
+        An explicit ``CLERK_AUTHORIZED_PARTIES`` wins. When it is unset the list
+        is DERIVED from the app's own frontend origins already in config -- the
+        CORS allowlist plus ``APP_BASE_URL`` -- so azp validation is ARMED by
+        default from existing config with no new required env var (#707),
+        mirroring how ``STRAVA_OAUTH_STATE_SECRET`` falls back to existing
+        secrets. A token minted by the SAME Clerk instance for a DIFFERENT
+        frontend origin then carries that other origin in ``azp`` and is
+        rejected, while the real frontend -- which must be a CORS-allowed origin
+        to reach the backend at all -- always matches, so a correctly-configured
+        deploy sees no false 401s. Origins are normalised (trailing slash
+        stripped) and de-duplicated, order-stable. Empty only if every source is
+        blank (never in a real deploy), which leaves the check inert.
+        """
+        if self.CLERK_AUTHORIZED_PARTIES.strip():
+            raw = self.CLERK_AUTHORIZED_PARTIES.split(",")
+        else:
+            raw = [*self.cors_allowed_origins_list, self.APP_BASE_URL]
+        deduped: dict[str, None] = {}
+        for origin in raw:
+            norm = origin.strip().rstrip("/")
+            if norm:
+                deduped.setdefault(norm, None)
+        return list(deduped)
 
     @property
     def clerk_enabled(self) -> bool:

--- a/backend/tests/test_clerk_auth.py
+++ b/backend/tests/test_clerk_auth.py
@@ -189,6 +189,67 @@ class TestVerifierCrypto:
         assert verifier.verify(ok)["azp"] == "https://app.example.com"
 
 
+class TestAuthorizedParties:
+    """azp allowlist arming (#707): a same-instance token minted for a FOREIGN
+    frontend origin is rejected, trailing slashes are normalised so a
+    config-supplied ``origin/`` still matches the bare-origin azp, and a token
+    with NO azp is allowed (Clerk's documented skip-when-absent guidance)."""
+
+    def _verifier(self, pub, parties):
+        return ClerkVerifier(
+            TEST_JWKS_URL,
+            issuer=TEST_ISSUER,
+            authorized_parties=parties,
+            jwk_client=_FakeJWKClient(pub),
+            leeway=30,
+        )
+
+    def test_foreign_azp_rejected(self, rsa_keys):
+        priv, pub = rsa_keys
+        verifier = self._verifier(pub, ("https://app.example.com",))
+        token = _make_token(priv, claims={"azp": "https://evil.example.com"})
+        with pytest.raises(ClerkAuthError):
+            verifier.verify(token)
+
+    def test_trailing_slash_normalised_both_sides(self, rsa_keys):
+        priv, pub = rsa_keys
+        # Configured party carries a trailing slash; the token's azp does not.
+        verifier = self._verifier(pub, ("https://app.example.com/",))
+        token = _make_token(priv, claims={"azp": "https://app.example.com"})
+        assert verifier.verify(token)["azp"] == "https://app.example.com"
+
+    def test_missing_azp_allowed(self, rsa_keys):
+        # No azp claim -> the check is skipped (Clerk guidance). A foreign token
+        # always carries its own origin in azp, so absence is not the threat.
+        priv, pub = rsa_keys
+        verifier = self._verifier(pub, ("https://app.example.com",))
+        token = _make_token(priv)  # no azp in the default payload
+        assert "azp" not in verifier.verify(token)
+
+    def test_empty_allowlist_disables_check(self, rsa_keys):
+        priv, pub = rsa_keys
+        verifier = self._verifier(pub, ())
+        token = _make_token(priv, claims={"azp": "https://anything.example.com"})
+        assert verifier.verify(token)["azp"] == "https://anything.example.com"
+
+    def test_get_verifier_arms_from_derived_settings(self, monkeypatch, rsa_keys):
+        # The production wiring: with CLERK_AUTHORIZED_PARTIES unset, get_verifier
+        # derives the allowlist from CORS_ALLOWED_ORIGINS + APP_BASE_URL, so azp
+        # validation is armed by default from existing config (no new env var).
+        monkeypatch.setattr(settings, "CLERK_JWKS_URL", TEST_JWKS_URL)
+        monkeypatch.setattr(settings, "CLERK_AUTHORIZED_PARTIES", "")
+        monkeypatch.setattr(
+            settings, "CORS_ALLOWED_ORIGINS", "https://app.example.com/"
+        )
+        monkeypatch.setattr(settings, "APP_BASE_URL", "https://app.example.com")
+        clerk_auth.reset_verifier_cache()
+        try:
+            verifier = clerk_auth.get_verifier()
+            assert verifier._authorized_parties == ("https://app.example.com",)
+        finally:
+            clerk_auth.reset_verifier_cache()
+
+
 # --- dependency enforcement over HTTP (TestClient) -------------------------
 
 class TestSessionEnforcement:
@@ -225,6 +286,25 @@ class TestSessionEnforcement:
         # runner like strava_login, so it requires the session (401 without a
         # token). The bare OAuth callback stays the only session-exempt handshake.
         assert client.get("/api/auth/strava/status").status_code == 401
+
+    def test_foreign_azp_token_denied_over_http(self, client, monkeypatch, rsa_keys):
+        # End-to-end #707: a signature-valid token minted by the same Clerk
+        # instance for a DIFFERENT frontend origin is rejected by the dependency
+        # (401), not just at the verifier unit level.
+        priv, pub = rsa_keys
+        monkeypatch.setattr(settings, "CLERK_JWKS_URL", TEST_JWKS_URL)
+        armed = ClerkVerifier(
+            TEST_JWKS_URL,
+            issuer=TEST_ISSUER,
+            authorized_parties=("https://app.example.com",),
+            jwk_client=_FakeJWKClient(pub),
+            leeway=30,
+        )
+        monkeypatch.setattr(clerk_auth, "get_verifier", lambda: armed)
+        foreign = _make_token(priv, claims={"azp": "https://evil.example.com"})
+        assert client.get("/api/profile", headers={HEADER: foreign}).status_code == 401
+        good = _make_token(priv, claims={"azp": "https://app.example.com"})
+        assert client.get("/api/profile", headers={HEADER: good}).status_code == 200
 
 
 # --- email resolution (claim + Clerk API fallback) -------------------------

--- a/backend/tests/test_clerk_authorized_parties.py
+++ b/backend/tests/test_clerk_authorized_parties.py
@@ -1,0 +1,83 @@
+"""Clerk authorized-parties (`azp`) allowlist derivation (#707).
+
+Security-first coverage (aiw-security-testing): the point is that azp validation
+is ARMED by default from existing frontend/origin config, with no new required
+env var, and that a foreign same-instance origin is rejected while the real
+frontend always passes. These pin the derivation and normalisation logic on the
+`Settings.clerk_authorized_parties_list` property; the token-level enforcement
+lives in test_clerk_auth.py (TestAuthorizedParties).
+"""
+
+from app.core.config import settings
+
+
+def _set(monkeypatch, **kwargs):
+    for key, value in kwargs.items():
+        monkeypatch.setattr(settings, key, value)
+
+
+def test_explicit_value_wins(monkeypatch):
+    # An explicit allowlist is used verbatim (normalised), ignoring the derived
+    # origins, so an operator can widen/narrow it deliberately.
+    _set(
+        monkeypatch,
+        CLERK_AUTHORIZED_PARTIES="https://app.example.com, https://satellite.example.com",
+        CORS_ALLOWED_ORIGINS="https://ignored.example.com",
+        APP_BASE_URL="https://also-ignored.example.com",
+    )
+    assert settings.clerk_authorized_parties_list == [
+        "https://app.example.com",
+        "https://satellite.example.com",
+    ]
+
+
+def test_derived_from_cors_and_app_base_url_when_unset(monkeypatch):
+    # The default-armed path: with no explicit setting the allowlist is the union
+    # of the CORS origins and APP_BASE_URL, so azp validation is on by default
+    # from config the operator already set.
+    _set(
+        monkeypatch,
+        CLERK_AUTHORIZED_PARTIES="",
+        CORS_ALLOWED_ORIGINS="https://app.example.com,https://www.example.com",
+        APP_BASE_URL="https://app.example.com",
+    )
+    parties = settings.clerk_authorized_parties_list
+    assert "https://app.example.com" in parties
+    assert "https://www.example.com" in parties
+
+
+def test_real_frontend_origin_is_always_present(monkeypatch):
+    # The frontend must be a CORS-allowed origin to reach the backend, so its
+    # azp is guaranteed to be in the derived allowlist -- no false 401s for a
+    # correctly-configured deploy.
+    _set(
+        monkeypatch,
+        CLERK_AUTHORIZED_PARTIES="",
+        CORS_ALLOWED_ORIGINS="https://frontend.example.com,http://localhost:8000",
+        APP_BASE_URL="https://frontend.example.com",
+    )
+    assert "https://frontend.example.com" in settings.clerk_authorized_parties_list
+
+
+def test_derived_list_deduped_and_slash_normalised(monkeypatch):
+    # A trailing-slash origin and a duplicate collapse to one bare-origin entry,
+    # so the membership test matches the bare-origin azp Clerk mints.
+    _set(
+        monkeypatch,
+        CLERK_AUTHORIZED_PARTIES="",
+        CORS_ALLOWED_ORIGINS="https://app.example.com/,https://app.example.com",
+        APP_BASE_URL="https://app.example.com/",
+    )
+    assert settings.clerk_authorized_parties_list == ["https://app.example.com"]
+
+
+def test_all_sources_blank_yields_empty_inert_list(monkeypatch):
+    # Degenerate (not a real deploy): every source blank -> empty list, which
+    # leaves the token-level check inert rather than rejecting everything.
+    _set(
+        monkeypatch,
+        CLERK_AUTHORIZED_PARTIES="",
+        CORS_ALLOWED_ORIGINS="",
+        APP_BASE_URL="",
+    )
+    assert settings.clerk_authorized_parties_list == []


### PR DESCRIPTION
## What

Completes the code side of the #707 security-config hardening by **arming Clerk authorized-party (`azp`) validation by default**, derived from the app's own frontend/origin config. No new required env var.

The CORS-never-wildcard boot guard (the other half of #707) already landed in #708. This PR closes the second control.

## Problem

`ClerkVerifier` validated `azp` only when `CLERK_AUTHORIZED_PARTIES` was set, and it defaults empty. Signature, `exp/iat/sub`, and (in prod) `iss` are all verified, so this was never a forgery path, but a token minted by the **same Clerk instance for a different frontend origin** was accepted (a missing origin allowlist / CSRF-adjacent gap the 2026-07-15 audit flagged).

## Change

- `Settings.clerk_authorized_parties_list` now falls back, when `CLERK_AUTHORIZED_PARTIES` is unset, to the **union of `CORS_ALLOWED_ORIGINS` + `APP_BASE_URL`** (normalised, de-duplicated). This mirrors the `STRAVA_OAUTH_STATE_SECRET` secure-by-existing-config fallback pattern. An explicit `CLERK_AUTHORIZED_PARTIES` still wins.
- `ClerkVerifier` normalises trailing slashes on both the configured parties and the token `azp`, and adopts Clerk's documented semantics: **reject a present-but-foreign `azp`, allow a missing one** (our browser-minted sessions always carry it; Clerk's own guidance is to skip the check when the claim is absent).

### Why this is safe by construction

The legitimate frontend origin **must** be a CORS-allowed origin to reach the backend at all, so it is always in the derived allowlist. A correctly-configured deploy therefore sees no false 401s, while a foreign same-instance origin (which is in neither CORS nor `APP_BASE_URL`) is rejected. That is exactly the threat.

## Decisions (noted per workflow)

- **Reused existing config instead of a new required env var.** The task allowed a new setting but preferred deriving from existing origin config; `CORS_ALLOWED_ORIGINS ∪ APP_BASE_URL` is precisely "the app's own origin(s)" and guarantees the real frontend passes. `CLERK_AUTHORIZED_PARTIES` remains an explicit override (e.g. to add a satellite origin).
- **`azp`-absent is allowed, not rejected**, matching Clerk's documented "skip when the claim is absent" guidance. A foreign token always carries its origin in `azp`, so absence is not the guarded case.

## Behaviour change to be aware of

Arming `azp` will now reject any authenticated call whose `azp` is **not** one of the app's own origins. In particular a **Vercel preview** frontend (a different origin, not in `CORS_ALLOWED_ORIGINS`) calling the prod backend through its server-side proxy would be rejected. That is arguably desirable (preview writes mutating prod data is a documented hazard), but flagging it explicitly.

## Tests (aiw-security-testing, negative paths)

- `test_clerk_authorized_parties.py`: explicit wins; derived from CORS + `APP_BASE_URL`; real frontend origin always present; dedup + slash-normalisation; all-blank -> inert.
- `test_clerk_auth.py::TestAuthorizedParties`: foreign `azp` rejected; trailing-slash normalised both sides; missing `azp` allowed; empty allowlist disables; `get_verifier` arms from derived settings.
- `test_clerk_auth.py::TestSessionEnforcement::test_foreign_azp_token_denied_over_http`: end-to-end 401 for a foreign-origin token, 200 for the matching origin, through the real dependency.

Scoped run green: `test_clerk_auth.py test_clerk_authorized_parties.py test_production_config.py` (51 passed) plus `test_basic_auth_middleware.py test_observability.py test_oauth_state.py` (50 passed, 3 skipped). Full local `make backend-test` has ~90 pre-existing `.env` prod-parity failures unrelated to this change (CI is the truth).

## Required owner action (post-merge, runtime-only, cannot be done in code)

- **Confirm at runtime that the deployed Clerk instance's `azp` equals the configured frontend origin** (`APP_BASE_URL` / a `CORS_ALLOWED_ORIGINS` entry). The derivation is safe by construction, but the exact string equality (scheme/host/port, apex vs www) is a live-deploy confirmation I cannot perform. AC: a cross-origin same-instance token is rejected; the real frontend still signs in. If prod ever needs an origin that is intentionally *not* CORS-allowed, set `CLERK_AUTHORIZED_PARTIES` explicitly.
- The #707 CORS confirmation (prod `CORS_ALLOWED_ORIGINS` is an explicit allowlist, not `*`) is now enforced at boot by the #708 guard; no action beyond keeping the value explicit.

Leaving #707 open for the owner runtime-verification action above.