### PR TITLE
refactor(jobs): extract shared self-pacing batch-chain module (#698)

### DIFF
--- a/backend/app/jobs/backfill_streams.py
+++ b/backend/app/jobs/backfill_streams.py
@@ -19,9 +19,8 @@ worker free between batches and the combined Strava call rate under the
 
 import asyncio
 import logging
-import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Optional
 
 from sqlalchemy import select
@@ -30,7 +29,8 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.core.queue import queue
 from app.db.session import SessionLocal
-from app.models import Activity, ActivityStream
+from app.jobs import batch_chain
+from app.models import Activity
 from app.services.analysis import analyze_with_streams
 from app.services.strava_ingestion import strava_budget
 from app.services.strava_ingestion.port import StravaRateLimited
@@ -56,28 +56,18 @@ def _eligible_stmt(*, user_id: Optional[str] = None):
     opened. When `user_id` is given the set is scoped to that runner (#470), so a
     user's trigger only backfills their own history; omit it for a global pass.
     """
-    has_streams = (
-        select(ActivityStream.id)
-        .where(ActivityStream.activity_id == Activity.id)
-        .exists()
-    )
     stmt = select(Activity).where(
         Activity.is_deleted.is_(False),
         Activity.streams_backfilled_at.is_(None),
-        ~has_streams,
+        ~batch_chain.has_streams_exists(),
     )
-    if user_id is not None:
-        # user_id rides through RQ as a string; coerce so the Uuid column
-        # comparison works on both Postgres and the SQLite test backend.
-        if isinstance(user_id, str):
-            user_id = uuid.UUID(user_id)
-        stmt = stmt.where(Activity.user_id == user_id)
+    stmt = batch_chain.scope_to_user(stmt, user_id)
     return stmt.order_by(Activity.start_date.desc())
 
 
 def count_eligible(db: Session, *, user_id: Optional[str] = None) -> int:
     """How many activities still need stream-derived analysis (optionally scoped)."""
-    return len(db.execute(_eligible_stmt(user_id=user_id)).scalars().all())
+    return batch_chain.count_eligible(db, _eligible_stmt(user_id=user_id))
 
 
 @dataclass
@@ -157,18 +147,11 @@ async def backfill_streams_batch(
 
 
 def _schedule_next_batch(user_id: Optional[str] = None) -> None:
-    """Schedule the next batch after the configured pause, so the single worker
-    stays free to process webhooks between batches. Carries `user_id` so the
-    self-paced chain stays scoped to the triggering runner (#470).
-
-    Uses RQ-native deferred scheduling (drained by the worker's `with_scheduler`),
-    so no separate rq-scheduler process is needed (#123/ADR 0006)."""
-    from app.core.queue import queue
-
-    queue.enqueue_in(
-        timedelta(seconds=settings.BACKFILL_BATCH_PAUSE_SECONDS),
-        backfill_streams_job,
-        user_id,
+    """Schedule the next batch after the configured pause (the normal, work-remains
+    path). Carries `user_id` so the self-paced chain stays scoped to the triggering
+    runner (#470). The chain mechanics live in `batch_chain.schedule_after` (#698)."""
+    batch_chain.schedule_after(
+        backfill_streams_job, settings.BACKFILL_BATCH_PAUSE_SECONDS, user_id
     )
 
 
@@ -176,12 +159,8 @@ def _reschedule_after_budget(user_id: Optional[str] = None) -> None:
     """Re-enqueue this batch after the Strava-budget backoff (#544), when the
     shared budget is exhausted, so the chain resumes once capacity frees rather
     than dropping the runner's backfill."""
-    from app.core.queue import queue
-
-    queue.enqueue_in(
-        timedelta(seconds=settings.STRAVA_BUDGET_BACKOFF_SECONDS),
-        backfill_streams_job,
-        user_id,
+    batch_chain.schedule_after(
+        backfill_streams_job, settings.STRAVA_BUDGET_BACKOFF_SECONDS, user_id
     )
 
 
@@ -233,32 +212,6 @@ def backfill_streams_job(user_id: Optional[str] = None) -> None:
         logger.info("Backfill complete: no eligible activities remain")
 
 
-def _acquire_enqueue_slot(user_id: str) -> bool:
-    """Best-effort guard: at most one backfill chain enqueued per user per
-    cooldown, so rapid re-triggers (a double Sync tap, or Sync racing the manual
-    backfill endpoint) don't spawn overlapping chains that double-fetch the same
-    activity's streams against the shared budget. Degrades OPEN on any Redis error
-    so a coordination outage never blocks a legitimate backfill."""
-    try:
-        from app.core.queue import redis_conn
-
-        return bool(
-            redis_conn.set(
-                f"backfill_enqueue:{user_id}",
-                "1",
-                nx=True,
-                ex=_BACKFILL_ENQUEUE_COOLDOWN_S,
-            )
-        )
-    except Exception as exc:  # Redis down / misconfigured: enqueue anyway
-        logger.warning(
-            "backfill_enqueue_guard_unavailable user=%s: %s; enqueuing anyway",
-            user_id,
-            exc,
-        )
-        return True
-
-
 def enqueue_backfill(db: Session, user_id) -> int:
     """Count the runner's eligible activities and enqueue their first backfill batch.
 
@@ -271,11 +224,13 @@ def enqueue_backfill(db: Session, user_id) -> int:
     idempotent, and the per-activity budget re-check (#601) bounds the cost."""
     user_id = str(user_id)
     eligible = count_eligible(db, user_id=user_id)
-    if eligible and _acquire_enqueue_slot(user_id):
+    if eligible and batch_chain.acquire_enqueue_slot(
+        f"backfill_enqueue:{user_id}", _BACKFILL_ENQUEUE_COOLDOWN_S
+    ):
         queue.enqueue(
             backfill_streams_job,
             user_id,
             job_id=f"{_BACKFILL_JOB_ID}_{user_id}",
-            result_ttl=3600,
+            result_ttl=batch_chain.CHAIN_RESULT_TTL,
         )
     return eligible

--- a/backend/app/jobs/batch_chain.py
+++ b/backend/app/jobs/batch_chain.py
@@ -1,0 +1,111 @@
+"""Shared self-pacing batch-chain mechanics for the maintenance jobs (#698).
+
+`backfill_streams` (#110) and `reanalyze_history` (#300) both walk a large
+eligible set in bounded batches, each batch scheduling its own successor via
+RQ-native deferred scheduling so the single worker stays free for live traffic,
+scoped per user (#470), never notifying. Only their eligibility predicate,
+per-batch work, and mark/advance strategy differ (backfill marks a DB flag and is
+rate-limit driven; reanalyze walks a `strava_activity_id` cursor with no Strava
+calls). This module owns the parts that do NOT differ, so pacing, idempotency,
+and cooldown behaviour are fixed in one place instead of two (or three):
+
+* the eligible-set query fragments both eligibility builders share
+  (`has_streams_exists`, `scope_to_user`) and the `count_eligible` mechanic;
+* the per-user enqueue-cooldown idiom (`acquire_enqueue_slot`), also used by the
+  self-heal trigger (#123);
+* the deferred successor scheduling (`schedule_after`).
+
+The mark/advance strategy stays in each job: it is expressed as the job's own
+eligibility filter (a `streams_backfilled_at` marker vs a cursor bound) plus how
+its entrypoint threads args into `schedule_after`.
+"""
+
+import logging
+import uuid
+from datetime import timedelta
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import Activity, ActivityStream
+
+logger = logging.getLogger(__name__)
+
+# result_ttl on the first-batch enqueue: keep the finished job result briefly so a
+# rapid re-trigger sees the per-user job id, then let it expire.
+CHAIN_RESULT_TTL = 3600
+
+
+def has_streams_exists():
+    """EXISTS(...) clause, true when the activity has stored ``ActivityStream`` rows.
+
+    Reanalyze REQUIRES it (only stored streams can be re-derived offline, no Strava
+    call); backfill NEGATES it (``~has_streams_exists()`` selects the summary-only
+    activities that still need streams fetched). One construction, opposite polarity.
+    """
+    return (
+        select(ActivityStream.id)
+        .where(ActivityStream.activity_id == Activity.id)
+        .exists()
+    )
+
+
+def scope_to_user(stmt, user_id: Optional[str]):
+    """Restrict an ``Activity`` query to one runner (#470); a ``None`` user is a global pass.
+
+    ``user_id`` rides through RQ as a string, so coerce it to ``UUID`` for the Uuid
+    column comparison to work on both Postgres and the SQLite test backend.
+    """
+    if user_id is None:
+        return stmt
+    if isinstance(user_id, str):
+        user_id = uuid.UUID(user_id)
+    return stmt.where(Activity.user_id == user_id)
+
+
+def count_eligible(db: Session, stmt) -> int:
+    """How many rows an eligibility statement selects."""
+    return len(db.execute(stmt).scalars().all())
+
+
+def acquire_enqueue_slot(
+    key: str, cooldown_seconds: int, *, degrade_open: bool = True
+) -> bool:
+    """Best-effort per-user cooldown: at most one chain enqueued per ``key`` per
+    ``cooldown_seconds`` via an atomic Redis ``SET NX EX``, so rapid re-triggers (a
+    double Sync tap, app-open spam) collapse into one chain rather than spawning
+    overlapping chains against the shared budget.
+
+    ``degrade_open`` picks the Redis-outage fallback: ``True`` enqueues anyway (a
+    coordination outage must never block a legitimate maintenance run — the job's
+    own marker/idempotency bounds any residual overlap), ``False`` skips (a
+    best-effort safety net can wait for the next trigger). The idiom lives here
+    once (#698); backfill (#601) and self-heal (#123) both call it.
+    """
+    try:
+        from app.core.queue import redis_conn
+
+        return bool(redis_conn.set(key, "1", nx=True, ex=cooldown_seconds))
+    except Exception as exc:  # noqa: BLE001 — Redis down / misconfigured
+        logger.warning(
+            "enqueue_cooldown_unavailable key=%s degrade_open=%s: %s; proceeding accordingly",
+            key,
+            degrade_open,
+            exc,
+        )
+        return degrade_open
+
+
+def schedule_after(job_func, pause_seconds: int, *args) -> None:
+    """Schedule the chain's successor after ``pause_seconds`` so the single worker
+    stays free to process webhooks between batches. Carries ``*args`` (cursor and/or
+    user) so the chain stays scoped to the triggering runner and resumes where it
+    left off.
+
+    Uses RQ-native deferred scheduling (drained by the worker's ``with_scheduler``),
+    so no separate rq-scheduler process is needed (#123/ADR 0006).
+    """
+    from app.core.queue import queue
+
+    queue.enqueue_in(timedelta(seconds=pause_seconds), job_func, *args)

--- a/backend/app/jobs/reanalyze_history.py
+++ b/backend/app/jobs/reanalyze_history.py
@@ -26,9 +26,7 @@ the single worker to webhooks/self-heal between batches.
 """
 
 import logging
-import uuid
 from dataclasses import dataclass, field
-from datetime import timedelta
 from typing import Optional
 
 from sqlalchemy import select
@@ -37,7 +35,8 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.core.queue import queue
 from app.db.session import SessionLocal
-from app.models import Activity, ActivityStream
+from app.jobs import batch_chain
+from app.models import Activity
 from app.services.analysis import analyze
 from app.services.analysis.baseline import recompute_runner_baseline
 
@@ -56,23 +55,13 @@ def _eligible_stmt(*, cursor: Optional[int] = None, user_id: Optional[str] = Non
     set is scoped to that runner (#470), so a user's trigger only re-analyzes
     their own history; omit it for a global pass (the offline eval rebuild).
     """
-    has_streams = (
-        select(ActivityStream.id)
-        .where(ActivityStream.activity_id == Activity.id)
-        .exists()
-    )
     stmt = select(Activity).where(
         Activity.is_deleted.is_(False),
-        has_streams,
+        batch_chain.has_streams_exists(),
     )
     if cursor is not None:
         stmt = stmt.where(Activity.strava_activity_id < cursor)
-    if user_id is not None:
-        # user_id rides through RQ as a string; coerce so the Uuid column
-        # comparison works on both Postgres and the SQLite test backend.
-        if isinstance(user_id, str):
-            user_id = uuid.UUID(user_id)
-        stmt = stmt.where(Activity.user_id == user_id)
+    stmt = batch_chain.scope_to_user(stmt, user_id)
     return stmt.order_by(Activity.strava_activity_id.desc())
 
 
@@ -80,7 +69,9 @@ def count_eligible(
     db: Session, *, cursor: Optional[int] = None, user_id: Optional[str] = None
 ) -> int:
     """How many activities are still eligible (optionally past the cursor / scoped)."""
-    return len(db.execute(_eligible_stmt(cursor=cursor, user_id=user_id)).scalars().all())
+    return batch_chain.count_eligible(
+        db, _eligible_stmt(cursor=cursor, user_id=user_id)
+    )
 
 
 @dataclass
@@ -163,19 +154,12 @@ def reanalyze_history_batch(
 
 
 def _schedule_next_batch(cursor: int, user_id: Optional[str] = None) -> None:
-    """Schedule the next batch after the configured pause, so the single worker
-    stays free to process webhooks between batches. Carries `user_id` so the
-    self-paced chain stays scoped to the triggering runner (#470).
-
-    Uses RQ-native deferred scheduling (drained by the worker's `with_scheduler`),
-    so no separate rq-scheduler process is needed (#123/ADR 0006)."""
-    from app.core.queue import queue
-
-    queue.enqueue_in(
-        timedelta(seconds=settings.REANALYZE_BATCH_PAUSE_SECONDS),
-        reanalyze_history_job,
-        cursor,
-        user_id,
+    """Schedule the next batch after the configured pause. Carries the advanced
+    `cursor` and `user_id` so the self-paced chain resumes strictly past where it
+    stopped and stays scoped to the triggering runner (#470). The chain mechanics
+    live in `batch_chain.schedule_after` (#698)."""
+    batch_chain.schedule_after(
+        reanalyze_history_job, settings.REANALYZE_BATCH_PAUSE_SECONDS, cursor, user_id
     )
 
 
@@ -222,6 +206,6 @@ def enqueue_reanalyze(db: Session, user_id) -> int:
             None,  # cursor: start from the newest activity
             user_id,
             job_id=f"{_REANALYZE_JOB_ID}_{user_id}",
-            result_ttl=3600,
+            result_ttl=batch_chain.CHAIN_RESULT_TTL,
         )
     return eligible

--- a/backend/app/jobs/self_heal.py
+++ b/backend/app/jobs/self_heal.py
@@ -21,8 +21,9 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 from app.core.config import settings
-from app.core.queue import queue, redis_conn
+from app.core.queue import queue
 from app.db.session import SessionLocal
+from app.jobs import batch_chain
 from app.models import Activity, StravaAccount
 from app.services.strava_ingestion import (
     ensure_valid_access_token,
@@ -42,18 +43,21 @@ _PER_PAGE = 30
 def maybe_enqueue_self_heal(user_id) -> bool:
     """Enqueue a self-heal check for ``user_id`` unless one ran very recently.
 
-    Bounded by an atomic Redis SET NX EX, so app-open spam and rapid Refresh taps
-    collapse to at most one check per ``SELF_HEAL_MIN_INTERVAL_SECONDS``. Returns
-    True when a check was enqueued, False when throttled or on any error — it is a
-    best-effort safety net and must never break the request that triggered it.
+    Bounded by the shared per-user enqueue cooldown (an atomic Redis SET NX EX,
+    #698), so app-open spam and rapid Refresh taps collapse to at most one check
+    per ``SELF_HEAL_MIN_INTERVAL_SECONDS``. ``degrade_open=False`` because this is a
+    best-effort safety net: a Redis outage skips the check (the next app-open
+    re-triggers it) rather than spending a scarce Strava call. Returns True when a
+    check was enqueued, False when throttled or on any error — it must never break
+    the request that triggered it.
     """
+    if not batch_chain.acquire_enqueue_slot(
+        f"self_heal:{user_id}",
+        settings.SELF_HEAL_MIN_INTERVAL_SECONDS,
+        degrade_open=False,
+    ):
+        return False
     try:
-        key = f"self_heal:{user_id}"
-        acquired = redis_conn.set(
-            key, "1", nx=True, ex=settings.SELF_HEAL_MIN_INTERVAL_SECONDS
-        )
-        if not acquired:
-            return False
         queue.enqueue(self_heal_job, str(user_id), job_id=f"self_heal_{user_id}")
         return True
     except Exception as exc:  # noqa: BLE001 — never propagate into the request

--- a/backend/tests/test_batch_chain.py
+++ b/backend/tests/test_batch_chain.py
@@ -1,0 +1,144 @@
+"""Shared self-pacing batch-chain mechanics (#698).
+
+Pins the harness both maintenance jobs (backfill #110, reanalyze #300) and the
+self-heal trigger (#123) now share: the eligible-set query fragments and count,
+the per-user enqueue-cooldown idiom (incl. its degrade-open/closed fallback), and
+the deferred successor scheduling. RQ scheduling itself is exercised via a fake
+queue (the real enqueue_in needs a live Redis/worker), so these assert the harness
+calls the queue correctly, not that RQ actually fires the job.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from sqlalchemy import select
+
+from app.jobs import batch_chain
+from app.models import Activity, ActivityStream, User
+
+
+def _seed_user(db) -> User:
+    user = User(email=f"u-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    return user
+
+
+def _seed_activity(db, user, strava_activity_id, *, with_streams: bool) -> Activity:
+    activity = Activity(
+        user_id=user.id,
+        strava_activity_id=strava_activity_id,
+        start_date=datetime(2026, 1, 15, 9, 0, 0, tzinfo=timezone.utc),
+        type="Run",
+        name="run",
+        distance_m=5000,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=10.0,
+        avg_hr=140,
+    )
+    db.add(activity)
+    db.commit()
+    if with_streams:
+        db.add(ActivityStream(activity_id=activity.id, stream_type="time", data=[0, 1, 2]))
+        db.commit()
+    return activity
+
+
+# --- eligible-set query fragments ----------------------------------------------
+
+def test_has_streams_exists_selects_only_stream_bearing_rows(db):
+    user = _seed_user(db)
+    streamed = _seed_activity(db, user, 101, with_streams=True)
+    streamless = _seed_activity(db, user, 102, with_streams=False)
+
+    with_streams = select(Activity).where(batch_chain.has_streams_exists())
+    without_streams = select(Activity).where(~batch_chain.has_streams_exists())
+
+    assert [a.id for a in db.execute(with_streams).scalars()] == [streamed.id]
+    assert [a.id for a in db.execute(without_streams).scalars()] == [streamless.id]
+
+
+def test_scope_to_user_filters_and_coerces_string_id(db):
+    user_a = _seed_user(db)
+    user_b = _seed_user(db)
+    a = _seed_activity(db, user_a, 201, with_streams=True)
+    _seed_activity(db, user_b, 202, with_streams=True)
+
+    base = select(Activity)
+    # user_id rides through RQ as a string; the helper must coerce it.
+    scoped = batch_chain.scope_to_user(base, str(user_a.id))
+    assert [row.id for row in db.execute(scoped).scalars()] == [a.id]
+
+
+def test_scope_to_user_none_is_a_global_pass(db):
+    user = _seed_user(db)
+    _seed_activity(db, user, 301, with_streams=True)
+    _seed_activity(db, user, 302, with_streams=False)
+
+    assert batch_chain.scope_to_user(select(Activity), None) is not None
+    all_rows = db.execute(batch_chain.scope_to_user(select(Activity), None)).scalars().all()
+    assert len(all_rows) == 2
+
+
+def test_count_eligible_counts_statement_rows(db):
+    user = _seed_user(db)
+    _seed_activity(db, user, 401, with_streams=True)
+    _seed_activity(db, user, 402, with_streams=True)
+    _seed_activity(db, user, 403, with_streams=False)
+
+    stmt = select(Activity).where(batch_chain.has_streams_exists())
+    assert batch_chain.count_eligible(db, stmt) == 2
+
+
+# --- the per-user enqueue-cooldown idiom ---------------------------------------
+
+def test_acquire_enqueue_slot_returns_true_when_slot_acquired():
+    fake_redis = MagicMock()
+    fake_redis.set.return_value = True
+    with patch("app.core.queue.redis_conn", fake_redis):
+        assert batch_chain.acquire_enqueue_slot("k", 120) is True
+    # Atomic SET NX EX with the cooldown TTL.
+    assert fake_redis.set.call_args.kwargs == {"nx": True, "ex": 120}
+
+
+def test_acquire_enqueue_slot_returns_false_when_throttled():
+    fake_redis = MagicMock()
+    fake_redis.set.return_value = None  # key already present within the window
+    with patch("app.core.queue.redis_conn", fake_redis):
+        assert batch_chain.acquire_enqueue_slot("k", 120) is False
+
+
+def test_acquire_enqueue_slot_degrades_open_on_redis_error():
+    """A Redis outage must not block a legitimate maintenance run: degrade OPEN."""
+    fake_redis = MagicMock()
+    fake_redis.set.side_effect = RuntimeError("redis down")
+    with patch("app.core.queue.redis_conn", fake_redis):
+        assert batch_chain.acquire_enqueue_slot("k", 120, degrade_open=True) is True
+
+
+def test_acquire_enqueue_slot_degrades_closed_on_redis_error():
+    """A best-effort safety net (self-heal) skips on a Redis outage: degrade CLOSED."""
+    fake_redis = MagicMock()
+    fake_redis.set.side_effect = RuntimeError("redis down")
+    with patch("app.core.queue.redis_conn", fake_redis):
+        assert batch_chain.acquire_enqueue_slot("k", 120, degrade_open=False) is False
+
+
+# --- deferred successor scheduling ---------------------------------------------
+
+def test_schedule_after_enqueues_deferred_with_args():
+    def _job(cursor, user_id):  # a stand-in chain entrypoint
+        return None
+
+    fake_queue = MagicMock()
+    with patch("app.core.queue.queue", fake_queue):
+        batch_chain.schedule_after(_job, 300, 42, "user-1")
+
+    fake_queue.enqueue_in.assert_called_once()
+    args = fake_queue.enqueue_in.call_args.args
+    # (timedelta(seconds=pause), job_func, *chain_args)
+    assert args[0].total_seconds() == 300
+    assert args[1] is _job
+    assert args[2:] == (42, "user-1")

--- a/backend/tests/test_self_heal.py
+++ b/backend/tests/test_self_heal.py
@@ -50,7 +50,9 @@ def test_maybe_enqueue_self_heal_is_bounded():
     fake_redis = MagicMock()
     fake_redis.set.side_effect = [True, None]  # first acquires, second throttled
     fake_queue = MagicMock()
-    with patch.object(self_heal, "redis_conn", fake_redis), \
+    # The cooldown idiom lives in batch_chain now (#698); it imports redis_conn
+    # from app.core.queue, so patch it there.
+    with patch("app.core.queue.redis_conn", fake_redis), \
          patch.object(self_heal, "queue", fake_queue):
         first = maybe_enqueue_self_heal("user-1")
         second = maybe_enqueue_self_heal("user-1")
@@ -67,7 +69,7 @@ def test_maybe_enqueue_self_heal_never_raises_into_request():
     request that triggered it — it is a best-effort safety net."""
     fake_redis = MagicMock()
     fake_redis.set.side_effect = RuntimeError("redis down")
-    with patch.object(self_heal, "redis_conn", fake_redis):
+    with patch("app.core.queue.redis_conn", fake_redis):
         assert maybe_enqueue_self_heal("user-1") is False
 
 


### PR DESCRIPTION
## What
Extracts the self-pacing batch-chain mechanics that `backfill_streams` (#110), `reanalyze_history` (#300), and the `self_heal` trigger (#123) each hand-wrote into one shared module, `backend/app/jobs/batch_chain.py`. Each job now reduces to its mark/advance strategy (a `streams_backfilled_at` marker vs a `strava_activity_id` cursor), its per-batch work, and its batch-size/pause settings. addresses #698.

## The shared module (`batch_chain.py`)
- `has_streams_exists()` / `scope_to_user(stmt, user_id)` / `count_eligible(db, stmt)` - the eligible-set query fragments both eligibility builders copied (the `ActivityStream` EXISTS subquery, used with opposite polarity; the string-to-UUID scoping coercion; the count mechanic).
- `acquire_enqueue_slot(key, cooldown_seconds, *, degrade_open=True)` - the per-user Redis SET-NX-EX enqueue-cooldown idiom, now defined once. `degrade_open` picks the Redis-outage fallback: `True` (backfill, #601) enqueues anyway so an outage never blocks a legitimate run; `False` (self-heal) skips so a best-effort safety net waits for the next trigger.
- `schedule_after(job_func, pause_seconds, *args)` - the RQ-native `enqueue_in` deferred successor scheduling.

Each job keeps its own `_eligible_stmt`, `count_eligible` wrapper, `_schedule_next_batch` / `_reschedule_after_budget`, first-batch `enqueue_*`, entrypoint, and result dataclass, delegating the common bits to `batch_chain`. Those module-level names stay in place (the job tests pin them).

## Behaviour-preserving - how it was proved
- Both existing job test suites (`test_backfill_streams_job.py`, `test_reanalyze_history_job.py`) and `test_self_heal.py` stay green unchanged in assertions.
- Ground truth = current behaviour: eligibility filters, per-user job-id format (`backfill_streams_{uid}` / `reanalyze_history_{uid}`), `result_ttl` (3600), cursor resumability, budget-yield reschedule branch, and the no-notify guarantee are all unchanged; the diff only relocates the shared mechanics.
- Added `tests/test_batch_chain.py` pinning the shared query fragments, the cooldown (acquire / throttle / degrade-open / degrade-closed), and the deferred-schedule call shape.
- Full backend suite green with the CI env overrides (`COACH_PROMPT_ID=coach_message_v8`, `COACH_RECEIPT_CADENCE=false`, all twelve `COACH_*_ENABLED=true`): **2249 passed, 5 skipped**.

## Decisions (noted per workflow)
- **Functions, not a class/strategy object.** The jobs are functions and the mark/advance difference is already carried by each job's eligibility predicate + how its entrypoint threads args into `schedule_after`; a strategy class would add indirection without removing more duplication.
- **First-batch `queue.enqueue` and the entrypoint orchestration stay in each job**, not in the harness. The reschedule *decision* genuinely differs (backfill has a 3-way budget-yield / work-remains / drained branch; reanalyze has a cursor-drain branch), and the job tests patch module-level `queue` / `SessionLocal` / `_schedule_next_batch` / `_reschedule_after_budget` / the batch fns - extracting those would break the pins for no net simplification. The harness owns the mechanics that are identical.
- **self_heal folded in** to satisfy "the cooldown idiom is defined once." Its cooldown's Redis handle moved into `batch_chain` (which imports `app.core.queue.redis_conn` at call time), so two `test_self_heal.py` tests now patch `app.core.queue.redis_conn` instead of `self_heal.redis_conn` - identical assertions, patch target follows the moved import. self_heal keeps its own try/except around `queue.enqueue` so a queue failure still degrades to `False` exactly as before.

## Deletions
- Removed the now-dead private `backfill_streams._acquire_enqueue_slot` (its body is the shared `acquire_enqueue_slot`; no external caller or test referenced it). No other deletions.
- Left untouched: `scripts/reanalyze_all.py` (the synchronous offline equivalent - reconciling it is tracked separately) and every public job entrypoint/signature.

## Verification scope
- Checked: unit behaviour via the four test files above + full suite; static import hygiene (pyflakes clean; removed now-unused `uuid`/`timedelta`/`ActivityStream`/`select`-subquery imports).
- NOT checked end-to-end: real RQ `enqueue_in` firing on a live worker/Redis. Scheduling is asserted only via a fake queue (unit level) - the same level the pre-existing job tests used; this refactor does not change the enqueue call shape.