### PR TITLE
feat(chat): coach-chat tool trace shows what was fetched, not just that a tool ran (#664)

### DIFF
--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -435,6 +435,12 @@ async def post_chat(
                     # frame), so the client renders it as status instead of appending
                     # it to the reply.
                     yield f"data: {json.dumps({'type': 'status', 'label': event.status_label, 'tool': event.status_tool})}\n\n"
+                elif event.trace_entry is not None:
+                    # #664: the post-fetch trace record of WHAT a tool fetched (window +
+                    # count). A JSON OBJECT payload tagged `tool_trace`, distinct from
+                    # both the string content frames and the status affordance, so the
+                    # client banks it into the persistent trace instead of the reply.
+                    yield f"data: {json.dumps({'type': 'tool_trace', 'entry': event.trace_entry})}\n\n"
                 else:
                     yield _sse_data(event.text)
         except Exception:

--- a/backend/app/models/coach_chat_message.py
+++ b/backend/app/models/coach_chat_message.py
@@ -17,10 +17,13 @@ class CoachChatMessage(Base):
     activity_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("activities.id"), index=True)
     role: Mapped[str] = mapped_column(String(16))  # "user" or "assistant"
     content: Mapped[str] = mapped_column(Text)
-    # #648 follow-up: the on-demand data tools the coach ran to produce this
-    # assistant turn (ordered, de-duplicated tool names), so the UI can show a
-    # persistent "looked up …" trace that survives a reload. Null on user turns and
-    # on assistant turns that answered without a fetch.
+    # #648 follow-up / #664: the on-demand data tools the coach ran to produce this
+    # assistant turn, one record per call ({tool, label, detail, count}) describing
+    # WHAT each fetched (resolved window + result count), so the UI can show a
+    # persistent "looked up …" trace that survives a reload. Null on user turns and on
+    # assistant turns that answered without a fetch. Pre-#664 rows hold a bare list of
+    # tool-name strings; the read schema coerces those into records on load, so no
+    # data migration is needed for this generic JSON column.
     tools_used: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -1,12 +1,24 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class ChatMessageSend(BaseModel):
     message: str
+
+
+class ToolTraceEntry(BaseModel):
+    """One tool call's compact trace of WHAT it fetched (#664): the tool name, a
+    past-tense friendly label, the resolved window, and a result count. Rendered as
+    one chip so the runner can sanity-check the data the coach reasoned over. Every
+    field is server-derived; no model prose enters the trace."""
+
+    tool: str
+    label: Optional[str] = None
+    detail: Optional[str] = None
+    count: Optional[int] = None
 
 
 class ChatMessageRead(BaseModel):
@@ -14,12 +26,34 @@ class ChatMessageRead(BaseModel):
     activity_id: UUID
     role: str
     content: str
-    # #648 f/u: the on-demand data tools the coach ran for this turn (null when none),
-    # so the UI can render a persistent "looked up …" trace after a reload.
-    tools_used: Optional[List[str]] = None
+    # #648 f/u / #664: the on-demand data tools the coach ran for this turn (null when
+    # none), as one record per call describing what each fetched, so the UI can render
+    # a persistent "looked up …" trace after a reload.
+    tools_used: Optional[List[ToolTraceEntry]] = None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("tools_used", mode="before")
+    @classmethod
+    def _coerce_tools_used(cls, value: Any) -> Any:
+        """Normalise the stored `tools_used` JSON into `ToolTraceEntry` records.
+
+        Pre-#664 rows stored a bare list of tool-name strings; coerce each into a
+        record (filling the friendly label from the server-owned verb map) so a
+        reloaded UI renders legacy turns uniformly with no client-side legacy branch.
+        New rows already store the record dicts and pass through unchanged."""
+        if not value:
+            return value
+        from app.services.coach.query_tools import trace_label
+
+        coerced = []
+        for item in value:
+            if isinstance(item, str):
+                coerced.append({"tool": item, "label": trace_label(item)})
+            else:
+                coerced.append(item)
+        return coerced
 
 
 class ChatHistoryResponse(BaseModel):

--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -35,6 +35,7 @@ from app.services.coach.query_tools import (
     CHAT_TOOLS,
     TOOL_STATUS_LABELS,
     execute_chat_tool,
+    summarize_tool_call,
 )
 from app.services.coach.validator import (
     PolicyViolation,
@@ -100,9 +101,11 @@ def _slice_for_stream(text: str) -> List[str]:
 @dataclass
 class ChatStreamEvent:
     """One item the route renders to SSE: a content slice (a `data:` frame), a
-    content-free heartbeat (an SSE comment frame the client ignores), or an ephemeral
+    content-free heartbeat (an SSE comment frame the client ignores), an ephemeral
     status affordance (#648: a JSON-object `data:` frame the client shows while a tool
-    round runs, distinct from the string content frames).
+    round runs, distinct from the string content frames), or a tool-trace record
+    (#664: the post-fetch `{tool,label,detail,count}` of WHAT was fetched, banked by
+    the client into the persistent "looked up …" trace).
 
     #375: #340's buffer-then-validate left a long silent gap between the route's
     `: ok` frame and the post-generation content, where token streaming used to keep
@@ -112,6 +115,10 @@ class ChatStreamEvent:
     is_heartbeat: bool = False
     status_label: str = ""  # #648: ephemeral "fetching data" affordance
     status_tool: str = ""   # the tool name behind that affordance (for the persistent trace)
+    # #664: a completed tool call's compact, server-derived trace record (window +
+    # count). Emitted AFTER the fetch, so it carries the result summary the pre-fetch
+    # status frame cannot. None on every non-trace event.
+    trace_entry: Optional[dict] = None
 
 
 # How often a keepalive heartbeat is emitted while the reply is being buffered
@@ -607,7 +614,11 @@ async def stream_chat_response(
     stream_failed = False
     # The message served if the stream fails; the except may specialise it (#625).
     stream_fail_message = "Sorry, I encountered an error. Please try again."
-    tools_used: List[str] = []  # ordered, de-duped tool names, persisted for the trace
+    # #664: ordered, one-record-per-CALL trace of WHAT each tool fetched (tool name,
+    # friendly label, resolved window, result count), persisted for the UI's
+    # "looked up …" trace. NOT de-duped by name, so a multi-window turn shows every
+    # fetch rather than collapsing to one chip (the #648 f/u the issue asks for).
+    tool_trace: List[dict] = []
     last_heartbeat = time.monotonic()
     try:
         for round_idx in range(_MAX_TOOL_ROUNDS):
@@ -651,18 +662,22 @@ async def stream_chat_response(
                 tool_results = []
                 for blk in tool_uses:
                     name = _block_attr(blk, "name")
-                    if name and name not in tools_used:
-                        tools_used.append(name)
-                    # Show the ephemeral affordance BEFORE the fetch runs (#648). Carry
-                    # the tool name so the client can build the persistent trace too.
+                    tool_input = _block_attr(blk, "input") or {}
+                    # Show the ephemeral affordance BEFORE the fetch runs (#648): the
+                    # spinner cannot yet know the result, so it stays present-tense.
                     yield ChatStreamEvent(
                         status_label=TOOL_STATUS_LABELS.get(name, "Looking that up…"),
                         status_tool=name or "",
                     )
                     last_heartbeat = time.monotonic()
-                    result = execute_chat_tool(
-                        db, owner_user_id, name, _block_attr(blk, "input") or {}
-                    )
+                    result = execute_chat_tool(db, owner_user_id, name, tool_input)
+                    # #664: AFTER the fetch, derive the compact trace record of what it
+                    # returned (resolved window + count, all server-derived) and both
+                    # bank it and stream it, so the persistent trace shows what was
+                    # fetched, not just that a tool ran. One record per call.
+                    entry = summarize_tool_call(name, tool_input, result)
+                    tool_trace.append(entry)
+                    yield ChatStreamEvent(trace_entry=entry)
                     tool_results.append({
                         "type": "tool_result",
                         "tool_use_id": _block_attr(blk, "id"),
@@ -724,12 +739,13 @@ async def stream_chat_response(
         yield ChatStreamEvent(text=piece)
 
     # Save the validated assistant response (never the raw gated text), tagged with
-    # the data tools this turn ran so the UI can show a persistent trace (#648 f/u).
+    # the trace of what the data tools fetched this turn so the UI can show a
+    # persistent "looked up …" trace that survives a reload (#648 f/u, #664).
     assistant_msg = CoachChatMessage(
         activity_id=activity_id,
         role="assistant",
         content=assistant_text,
-        tools_used=tools_used or None,
+        tools_used=tool_trace or None,
     )
     db.add(assistant_msg)
     db.commit()

--- a/backend/app/services/coach/query_tools.py
+++ b/backend/app/services/coach/query_tools.py
@@ -449,6 +449,78 @@ TOOL_STATUS_LABELS = {
 }
 
 
+# The past-tense verb shown on the PERSISTENT trace of a finished turn (#664, the
+# #663 follow-up). Owned here alongside the present-tense spinner labels so the two
+# tenses live in ONE module instead of being duplicated across the backend spinner
+# and the frontend trace (the #663 friendly-label duplication). An unknown key falls
+# back to a generic phrasing so a new tool never renders a raw identifier.
+TOOL_TRACE_LABELS = {
+    "list_activities_in_range": "Looked up your training history",
+    "get_session_detail": "Pulled up a past session",
+    "get_training_summary": "Tallied your recent training",
+}
+_DEFAULT_TRACE_LABEL = "Looked up your training data"
+
+
+# Compact, human-readable renderings of each named window, for the trace's `detail`
+# (#664). These are SHORT ("last 30 days") rather than the tool result's verbose
+# `window.label` ("the last 30 days (2026-06-21 to 2026-07-21)"), which is meant for
+# the coach to reason over. Keyed by the window enum value the model supplied, so the
+# label is server-derived from a server-known token, never from model prose.
+WINDOW_TRACE_LABELS = {
+    "last_7_days": "last 7 days",
+    "last_14_days": "last 14 days",
+    "last_30_days": "last 30 days",
+    "last_90_days": "last 90 days",
+    "last_180_days": "last 180 days",
+    "last_365_days": "last year",
+    "this_week": "this week",
+    "last_week": "last week",
+    "this_month": "this month",
+    "last_month": "last month",
+    "this_year": "this year",
+    "all_time": "all time",
+}
+
+
+def trace_label(name: Optional[str]) -> str:
+    """The past-tense trace verb for a tool name (or the generic fallback)."""
+    return TOOL_TRACE_LABELS.get(name or "", _DEFAULT_TRACE_LABEL)
+
+
+def summarize_tool_call(
+    name: Optional[str], tool_input: Optional[Dict[str, Any]], result: Optional[dict]
+) -> dict:
+    """Derive one compact, safe trace record from a completed tool call (#664).
+
+    Produces `{tool, label, detail, count}` describing WHAT was fetched — the resolved
+    window and a result count — so the runner can sanity-check the data the coach
+    reasoned over instead of seeing only that a tool ran. Every field is SERVER-derived
+    (the past-tense verb, the window enum humanised, counts computed by the tool); no
+    model-authored prose enters the trace, so it needs no policy gate (it is not the
+    coach's reply). One record per tool CALL, so a genuine multi-window turn no longer
+    collapses to a single chip. Never raises: a malformed or error result degrades to a
+    label-only record."""
+    tool_input = tool_input or {}
+    result = result or {}
+    entry: dict = {"tool": name or "", "label": trace_label(name), "detail": None, "count": None}
+
+    def _int(value):
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+    if name in ("list_activities_in_range", "get_training_summary"):
+        entry["detail"] = WINDOW_TRACE_LABELS.get(tool_input.get("window"))
+        if name == "list_activities_in_range":
+            entry["count"] = _int(result.get("count"))
+        else:  # get_training_summary: the session total is the natural count
+            entry["count"] = _int((result.get("totals") or {}).get("sessions"))
+    elif name == "get_session_detail":
+        # A single named session: its local date is the useful "what", no count.
+        d = result.get("date")
+        entry["detail"] = d if isinstance(d, str) else None
+    return entry
+
+
 CHAT_TOOLS: List[Dict[str, Any]] = [
     {
         "name": "list_activities_in_range",

--- a/backend/tests/test_chat_query_tools.py
+++ b/backend/tests/test_chat_query_tools.py
@@ -232,3 +232,59 @@ def test_execute_dispatch_reaches_each_tool(db):
         db, u.id, "list_activities_in_range", {"window": "last_7_days"}, today=TODAY)
     assert "totals" in qt.execute_chat_tool(
         db, u.id, "get_training_summary", {"window": "last_7_days"}, today=TODAY)
+
+
+# --- #664: summarize_tool_call, the persistent-trace record derivation ------------
+
+def test_summarize_list_call_carries_window_and_count():
+    entry = qt.summarize_tool_call(
+        "list_activities_in_range",
+        {"window": "last_30_days"},
+        {"count": 12, "showing": 12, "activities": []},
+    )
+    assert entry == {
+        "tool": "list_activities_in_range",
+        "label": "Looked up your training history",
+        "detail": "last 30 days",
+        "count": 12,
+    }
+
+
+def test_summarize_summary_call_uses_session_total_as_count():
+    entry = qt.summarize_tool_call(
+        "get_training_summary",
+        {"window": "last_7_days"},
+        {"totals": {"sessions": 4}, "by_type": [], "vs_typical": None},
+    )
+    assert entry["detail"] == "last 7 days"
+    assert entry["count"] == 4
+    assert entry["label"] == "Tallied your recent training"
+
+
+def test_summarize_session_detail_uses_date_no_count():
+    entry = qt.summarize_tool_call(
+        "get_session_detail", {"activity_id": "x"}, {"date": "2026-07-08", "type": "Run"},
+    )
+    assert entry["detail"] == "2026-07-08"
+    assert entry["count"] is None
+    assert entry["label"] == "Pulled up a past session"
+
+
+def test_summarize_error_result_degrades_to_label_only():
+    entry = qt.summarize_tool_call(
+        "list_activities_in_range", {"window": "nonsense"}, {"error": "unknown_window"},
+    )
+    # unknown window -> no humanised detail, no count, but the label still renders
+    assert entry["detail"] is None
+    assert entry["count"] is None
+    assert entry["label"] == "Looked up your training history"
+
+
+def test_summarize_unknown_tool_uses_generic_label():
+    entry = qt.summarize_tool_call("something_new", {}, {})
+    assert entry == {
+        "tool": "something_new",
+        "label": "Looked up your training data",
+        "detail": None,
+        "count": None,
+    }

--- a/backend/tests/test_chat_tool_loop.py
+++ b/backend/tests/test_chat_tool_loop.py
@@ -136,9 +136,10 @@ async def test_direct_answer_without_a_tool_call(db):
 
 @pytest.mark.asyncio
 async def test_tools_used_persisted_and_returned_in_history(db):
-    """#648 f/u: a turn that runs data tools banks their names on the assistant
-    message and every status frame carries the tool name, so the UI can render a
-    persistent trace that survives a reload."""
+    """#648 f/u / #664: a turn that runs data tools banks a trace record per call on
+    the assistant message — the resolved window and result count, not just the tool
+    name — so the UI can render a persistent "looked up …" trace that survives a
+    reload."""
     activity = _seed_activity_with_report(db)
     _past_run(db, activity.user_id, days_ago=5, distance_m=12000)
 
@@ -149,22 +150,95 @@ async def test_tools_used_persisted_and_returned_in_history(db):
     with patch.object(AnthropicClient, "stream_chat_turn", new=stub):
         events = await _drain(db, activity.id, "how far was my longest run?")
 
-    # the status frame carries the tool name for the live/persistent trace
-    assert any(ev.status_tool == "list_activities_in_range" for ev in events)
+    # a tool_trace event carries WHAT was fetched: resolved window + count (#664),
+    # all server-derived, so the runner can sanity-check the coach's data.
+    traces = [ev.trace_entry for ev in events if ev.trace_entry is not None]
+    assert traces == [{
+        "tool": "list_activities_in_range",
+        "label": "Looked up your training history",
+        "detail": "last 30 days",
+        "count": 1,
+    }]
 
-    # the assistant row banked the tool it ran
+    # the assistant row banked that same record
     saved = (
         db.query(CoachChatMessage)
         .filter(CoachChatMessage.activity_id == activity.id,
                 CoachChatMessage.role == "assistant")
         .one()
     )
-    assert saved.tools_used == ["list_activities_in_range"]
+    assert saved.tools_used == [{
+        "tool": "list_activities_in_range",
+        "label": "Looked up your training history",
+        "detail": "last 30 days",
+        "count": 1,
+    }]
 
     # and the history read surfaces it (from_attributes) for a reloaded UI
     history = get_chat_history(db, str(activity.id))
     assistant = [m for m in history if m.role == "assistant"][-1]
-    assert assistant.tools_used == ["list_activities_in_range"]
+    assert assistant.tools_used is not None
+    entry = assistant.tools_used[0]
+    assert entry.tool == "list_activities_in_range"
+    assert entry.detail == "last 30 days"
+    assert entry.count == 1
+    assert entry.label == "Looked up your training history"
+
+
+@pytest.mark.asyncio
+async def test_multi_window_fetch_shows_one_record_per_call(db):
+    """#664: two list calls over different windows no longer collapse to one chip —
+    the trace banks one record per CALL, so a genuine multi-window turn is honest."""
+    activity = _seed_activity_with_report(db)
+    _past_run(db, activity.user_id, days_ago=3, distance_m=9000)
+    _past_run(db, activity.user_id, days_ago=40, distance_m=15000)
+
+    stub = chat_tool_loop_stub([
+        [{"name": "list_activities_in_range", "input": {"window": "last_7_days"}}],
+        [{"name": "list_activities_in_range", "input": {"window": "last_90_days"}}],
+        "You did one run this week and two in the last 90 days.",
+    ])
+    with patch.object(AnthropicClient, "stream_chat_turn", new=stub):
+        await _drain(db, activity.id, "how much have I run lately?")
+
+    saved = (
+        db.query(CoachChatMessage)
+        .filter(CoachChatMessage.activity_id == activity.id,
+                CoachChatMessage.role == "assistant")
+        .one()
+    )
+    # last_7_days sees only the 3-days-ago run; last_90_days also sweeps in the
+    # 40-days-ago run and the seeded subject activity (~55 days ago). The point is
+    # that the two windows are BOTH recorded, with their own counts, rather than
+    # collapsing to one chip.
+    assert saved.tools_used == [
+        {"tool": "list_activities_in_range", "label": "Looked up your training history",
+         "detail": "last 7 days", "count": 1},
+        {"tool": "list_activities_in_range", "label": "Looked up your training history",
+         "detail": "last 90 days", "count": 3},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_legacy_string_tools_used_coerced_on_read(db):
+    """#664: a pre-#664 assistant row stored bare tool-name strings; the history read
+    coerces them into records (filling the label) so a reloaded UI needs no legacy
+    branch."""
+    activity = _seed_activity_with_report(db)
+    db.add(CoachChatMessage(
+        activity_id=activity.id, role="assistant", content="old turn",
+        tools_used=["list_activities_in_range", "get_training_summary"],
+    ))
+    db.commit()
+
+    history = get_chat_history(db, str(activity.id))
+    assistant = [m for m in history if m.role == "assistant"][-1]
+    assert [e.tool for e in assistant.tools_used] == [
+        "list_activities_in_range", "get_training_summary"]
+    assert assistant.tools_used[0].label == "Looked up your training history"
+    # legacy rows have no stored window/count
+    assert assistant.tools_used[0].detail is None
+    assert assistant.tools_used[0].count is None
 
 
 @pytest.mark.asyncio

--- a/frontend/components/CoachChat.tsx
+++ b/frontend/components/CoachChat.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, forwardRef, useImperativeHandle } from 'react';
-import { ChatMessage, CoachReport, isMessageReport } from '@/lib/types';
+import { ChatMessage, CoachReport, ToolTraceEntry, isMessageReport } from '@/lib/types';
 import { MessageCircle, Send, Loader2, RotateCcw, Sparkles, Search } from 'lucide-react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -10,32 +10,40 @@ interface Props {
   activityId: string;
 }
 
-// #648 f/u: friendly past-tense labels for the persistent tool-use trace shown on
-// an assistant turn that fetched data. Keyed by the backend tool name carried on
-// each status frame (and persisted to CoachChatMessage.tools_used). An unknown key
-// falls back to a generic phrasing so a new tool never renders a raw identifier.
-const TOOL_TRACE_LABELS: Record<string, string> = {
-  list_activities_in_range: 'Looked up your training history',
-  get_session_detail: 'Pulled up a past session',
-  get_training_summary: 'Tallied your recent training',
-};
+// #664: the friendly past-tense label is now server-owned (query_tools.TOOL_TRACE_LABELS,
+// carried on each trace entry), consolidating the #663 duplication. This is only a
+// defensive fallback for an entry that somehow arrives without one.
+const toolTraceLabel = (entry: ToolTraceEntry): string =>
+  entry.label ?? 'Looked up your training data';
 
-const toolTraceLabel = (name: string): string =>
-  TOOL_TRACE_LABELS[name] ?? 'Looked up your training data';
+// #664: render one trace chip's "what was fetched" tail — the resolved window and a
+// result count — from the server-derived entry. e.g. "· last 30 days (12 sessions)".
+const toolTraceDetail = (entry: ToolTraceEntry): string => {
+  const parts: string[] = [];
+  if (entry.detail) parts.push(entry.detail);
+  if (entry.count != null) parts.push(`${entry.count} ${entry.count === 1 ? 'session' : 'sessions'}`);
+  if (!parts.length) return '';
+  // "last 30 days (12 sessions)" when both present; either alone otherwise.
+  return entry.detail && entry.count != null
+    ? ` · ${entry.detail} (${entry.count} ${entry.count === 1 ? 'session' : 'sessions'})`
+    : ` · ${parts.join(' ')}`;
+};
 
 // The persistent "looked up …" trace rendered above an assistant turn that ran one
 // or more data tools. Survives a reload because tools_used is stored on the message.
-function ToolTrace({ tools }: { tools: string[] }) {
+// #664: one chip PER tool call (no name de-dup), each showing what it fetched, so a
+// multi-window turn no longer collapses to a single chip.
+function ToolTrace({ tools }: { tools: ToolTraceEntry[] }) {
   if (!tools.length) return null;
   return (
     <div className="mb-1.5 flex flex-wrap gap-1.5">
-      {tools.map((name, i) => (
+      {tools.map((entry, i) => (
         <span
-          key={`${name}-${i}`}
+          key={`${entry.tool}-${i}`}
           className="inline-flex items-center gap-1 rounded-full bg-blue-50 dark:bg-blue-900/30 px-2 py-0.5 text-[11px] font-medium text-blue-600 dark:text-blue-300"
         >
           <Search className="w-2.5 h-2.5 shrink-0" />
-          {toolTraceLabel(name)}
+          {toolTraceLabel(entry)}{toolTraceDetail(entry)}
         </span>
       ))}
     </div>
@@ -193,10 +201,11 @@ const CoachChat = forwardRef<CoachChatHandle, Props>(function CoachChat({ activi
 
       const decoder = new TextDecoder();
       let fullResponse = '';
-      // #648 f/u: accumulate the data tools the coach ran this turn (ordered,
-      // de-duplicated) so we can attach them to the finalized assistant message
-      // and render a persistent "looked up …" trace that survives a reload.
-      const toolsUsed: string[] = [];
+      // #648 f/u / #664: accumulate the trace records of what the coach fetched this
+      // turn (one per tool call, describing the resolved window + count) so we can
+      // attach them to the finalized assistant message and render a persistent
+      // "looked up …" trace that survives a reload.
+      const toolsUsed: ToolTraceEntry[] = [];
       // SSE events are delimited by a blank line. Buffer across reads so an
       // event split over two network chunks is reassembled before parsing.
       let buffer = '';
@@ -210,13 +219,16 @@ const CoachChat = forwardRef<CoachChatHandle, Props>(function CoachChat({ activi
             // The backend JSON-encodes each chunk so multi-line markdown
             // survives the SSE protocol intact. A content frame is a JSON string;
             // a status frame (#648) is a JSON object {type:'status',label,tool}
-            // shown as an ephemeral "fetching" affordance (label), whose tool name
-            // is banked for the persistent trace, not appended to the reply.
+            // shown as an ephemeral "fetching" affordance (label); a tool_trace
+            // frame (#664) is {type:'tool_trace',entry:{tool,label,detail,count}}
+            // banked into the persistent trace, not appended to the reply.
             const parsed = JSON.parse(data);
             if (parsed && typeof parsed === 'object' && parsed.type === 'status') {
               setFetchingLabel(parsed.label ?? '');
-              const tool = typeof parsed.tool === 'string' ? parsed.tool : '';
-              if (tool && !toolsUsed.includes(tool)) toolsUsed.push(tool);
+            } else if (parsed && typeof parsed === 'object' && parsed.type === 'tool_trace') {
+              if (parsed.entry && typeof parsed.entry === 'object') {
+                toolsUsed.push(parsed.entry as ToolTraceEntry);
+              }
             } else if (typeof parsed === 'string') {
               fullResponse += parsed;
               setStreamingText(fullResponse);

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -48,7 +48,7 @@ export type {
   CoachReportMeta,
 } from "./types/coach";
 export { isMessageReport, isOpenerOnly } from "./types/coach";
-export type { ChatMessage } from "./types/chat";
+export type { ChatMessage, ToolTraceEntry } from "./types/chat";
 export type {
   VoiceDials,
   VoiceAxisInfo,

--- a/frontend/lib/types/chat.ts
+++ b/frontend/lib/types/chat.ts
@@ -1,11 +1,28 @@
+// #648 f/u / #664: one on-demand data tool the coach ran for an assistant turn,
+// describing WHAT it fetched (resolved window + result count), not just that it ran.
+// Every field is server-derived (the friendly label, the window, the count); the
+// UI renders it as one chip. Pre-#664 rows persisted only tool-name strings; the
+// backend read schema coerces those into this record shape on load, so the client
+// always sees objects.
+export interface ToolTraceEntry {
+  tool: string;
+  // Past-tense friendly verb (e.g. "Looked up your training history"), server-owned.
+  label?: string | null;
+  // Compact "what": the resolved window ("last 30 days") or a session date.
+  detail?: string | null;
+  // Result count where meaningful (sessions found / totalled); null for a single
+  // session lookup.
+  count?: number | null;
+}
+
 export interface ChatMessage {
   id: string;
   activity_id: string;
   role: "user" | "assistant";
   content: string;
-  // #648 f/u: the on-demand data tools the coach ran for this assistant turn
+  // #648 f/u / #664: the on-demand data tools the coach ran for this assistant turn
   // (null/absent when none), so the UI can show a persistent "looked up …" trace
   // that survives a reload. User turns never carry it.
-  tools_used?: string[] | null;
+  tools_used?: ToolTraceEntry[] | null;
   created_at: string;
 }


### PR DESCRIPTION
Addresses #664.

## What

Enriches the persistent coach-chat tool-use trace (the "Looked up your training history" chip from #648 / PR #663) from a de-duplicated list of tool NAMES into one structured record per tool CALL describing **what** was fetched.

- **Shows the resolved window + count.** A `list_activities_in_range` over 30 days that returned 12 sessions now renders `Looked up your training history · last 30 days (12 sessions)` instead of a bare `Looked up your training history`.
- **Un-collapses same-tool multi-fetch.** Two `list_activities_in_range` calls with different windows now show two chips (each with its own window/count) rather than one, so a genuine multi-window turn is honest.
- **Consolidates the #663 friendly-label duplication.** The past-tense trace verb moves from the frontend into `query_tools.TOOL_TRACE_LABELS`, co-located with the present-tense spinner labels, so the two tenses live in one module.

## Trace shape (technical decision)

Each tool call yields a compact record `{tool, label, detail, count}`:
- `tool` — stable tool key (icon/fallback).
- `label` — server-owned past-tense verb ("Looked up your training history").
- `detail` — humanised resolved window ("last 30 days") or a session date; `null` when unknown.
- `count` — sessions found (list) / totalled (summary); `null` for a single-session lookup.

Rationale: structured (not a pre-baked sentence) so the frontend controls chip layout, but with the friendly verb server-owned to kill the #663 duplication. One record **per call** (not de-duped by name) is what un-collapses the multi-window case. All fields are server-derived (window enum humanised via a static map, counts computed by the tools) so **no model-authored prose enters the trace** — it needs no policy gate and is not the coach's reply.

## How it flows

- Backend `summarize_tool_call` (in `query_tools.py`) derives each record from the tool input + result the loop already produces — the tool contract, result payloads, system prompt, and context pack are all untouched.
- `chat.py` banks one record per call and streams it as a **new `tool_trace` SSE frame** (distinct from the `#648` pre-fetch `status` spinner frame and from content frames), so the live UI and the persisted trace share one shape. The pre-fetch spinner is unchanged.
- Persisted to `CoachChatMessage.tools_used` (generic JSON column, so no DDL migration). Pre-#664 rows (bare name strings) are coerced into records on read (`ChatMessageRead` validator fills the label), so a reloaded UI needs no legacy branch and no data backfill.
- Frontend `ToolTrace` renders label + detail + count; the live SSE handler banks entries from `tool_trace` frames.

## What is NOT changed

Confirmed I did not touch what the LLM receives: `CHAT_TOOLS` schemas, `execute_chat_tool`, the tool result payloads fed back to the model, the system prompt, and the context pack are all byte-unchanged (the `query_tools.py` diff is purely additive). The medical-scope/policy validation of the actual reply text (#340) and the keepalive heartbeats (#375) are untouched; the trace frame is metadata only.

## Tests

- `backend`: full suite green with the CI-parity env (`2247 passed, 5 skipped`). Added coverage for the trace frame carrying resolved window + count, one-record-per-call on a multi-window turn, legacy string-row coercion on read, and unit tests for `summarize_tool_call` across all three tools + error/unknown-tool degradation. Updated the existing `tools_used` persistence test to the new record shape.
- `frontend`: `tsc --noEmit` and `next lint` both clean. **A full production `next build` was intentionally skipped** because a `next dev` server was running on port 3000 (building while it is up corrupts shared `.next` chunks); type-check + lint stand in.

## For the human to verify

I cannot visually confirm the rendered chip on real data. Please eyeball, in the live chat, that a data-fetching turn shows e.g. "Looked up your training history · last 30 days (N sessions)", that a two-window turn shows two chips, and that older chats still render their legacy name-only chips after reload.