### PR TITLE
refactor(coach): make exchange_lifecycle the sole owner of Exchange transitions (#697)

### DIFF
--- a/backend/app/jobs/process_new_activity.py
+++ b/backend/app/jobs/process_new_activity.py
@@ -207,7 +207,7 @@ def _is_run_activity(activity: Activity) -> bool:
 def _exchange_for_activity(db: Session, activity: Activity) -> Optional[Exchange]:
     """The exchange owning this activity's block, via lazy block assignment."""
     block = _ensure_block(db, activity)
-    return db.query(Exchange).filter(Exchange.block_id == block.id).first()
+    return lifecycle.get_exchange_for_block(db, block.id)
 
 
 def _receipt_templates_for(db: Session, user_id) -> Optional[dict]:
@@ -283,7 +283,7 @@ async def _send_receipt(
 
     # Open the exchange on the first receipt, independent of delivery (A4 posture):
     # the reply window anchors here and must work even for a NoOp local notifier.
-    exchange = db.query(Exchange).filter(Exchange.block_id == block.id).first()
+    exchange = lifecycle.get_exchange_for_block(db, block.id)
     if exchange is not None:
         lifecycle.open_exchange(db, exchange)
 
@@ -393,11 +393,7 @@ def _resolve_completed_block(
         )
         return None
 
-    exchange = db.query(Exchange).filter(Exchange.block_id == block.id).first()
-    if exchange is None:  # defensive: blocks are created with their exchange
-        exchange = Exchange(user_id=block.user_id, block_id=block.id)
-        db.add(exchange)
-        db.commit()
+    exchange = lifecycle.ensure_exchange_for_block(db, block)
 
     primary = db.query(Activity).filter(Activity.id == block.primary_activity_id).one()
 
@@ -542,7 +538,7 @@ def _enqueue_reply_fuller(db: Session, activity_id) -> bool:
         return False  # no activity, or never grouped (nothing to advance)
 
     block = db.query(Block).filter(Block.id == activity.block_id).first()
-    exchange = db.query(Exchange).filter(Exchange.block_id == activity.block_id).first()
+    exchange = lifecycle.get_exchange_for_block(db, activity.block_id)
     if block is None or exchange is None:
         return False
     # Open (opener generated, not closed) and within the reply window: a closed or
@@ -589,14 +585,16 @@ def _record_done_and_schedule(db: Session, activity_id) -> bool:
         return False
 
     block = db.query(Block).filter(Block.id == activity.block_id).first()
-    exchange = db.query(Exchange).filter(Exchange.block_id == activity.block_id).first()
+    exchange = lifecycle.get_exchange_for_block(db, activity.block_id)
     if block is None or exchange is None:
         return False
-    if lifecycle.is_closed(exchange):
-        return False  # closed: the full report already went
-    # A "done" tap cannot resurrect a stale exchange (an unopened one is allowed —
-    # the receipt opens it on ingest, but a defensive mark_done opens it anyway).
-    if exchange.opened_at is not None and not lifecycle.within_reply_window(exchange):
+    # A "done" tap acts only on an OPEN, in-window exchange — the SAME guard the reply
+    # path uses (`can_fire_reply_fuller`), so the "reply/done may act only on an open,
+    # in-window exchange" invariant has one implementation, not two (#697). The receipt
+    # opens the exchange on ingest, so a delivered receipt (the only surface carrying the
+    # "done" button) always sees an opened exchange; a closed/stale one never re-fires
+    # (AC3/AC4). `mark_done` still opens defensively.
+    if not lifecycle.can_fire_reply_fuller(exchange):
         return False
 
     # Record the explicit completion signal (idempotent), opening the exchange if

--- a/backend/app/services/coach/exchange_lifecycle.py
+++ b/backend/app/services/coach/exchange_lifecycle.py
@@ -45,7 +45,7 @@ from sqlalchemy import func, update
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
-from app.models import Activity, Exchange
+from app.models import Activity, Block, Exchange
 
 logger = logging.getLogger(__name__)
 
@@ -87,9 +87,33 @@ def within_reply_window(exchange: Exchange, *, now: Optional[datetime] = None) -
 
 
 def can_fire_reply_fuller(exchange: Exchange, *, now: Optional[datetime] = None) -> bool:
-    """Whether a runner reply may early-fire the fuller turn: the exchange is open,
-    not closed, and within the reply window (A4 reply path)."""
+    """Whether a runner action (a reply OR a "done" tap) may early-fire the fuller/full
+    report: the exchange is open, not closed, and within the reply window. The SINGLE
+    act-guard shared by the A4 reply path and the #296 "done" path, so "reply/done may
+    act only on an open, in-window exchange" has one implementation, not two."""
     return is_open(exchange) and within_reply_window(exchange, now=now)
+
+
+# --- block -> exchange resolution ---------------------------------------------
+
+
+def get_exchange_for_block(db: Session, block_id) -> Optional[Exchange]:
+    """The Exchange owning this block, or None (A1: one exchange per block, `block_id`
+    UNIQUE). The single block->exchange lookup, so the job layer never re-implements the
+    query at each call site."""
+    return db.query(Exchange).filter(Exchange.block_id == block_id).first()
+
+
+def ensure_exchange_for_block(db: Session, block: Block) -> Exchange:
+    """The block's Exchange, creating one if it is somehow missing (defensive: blocks are
+    created WITH their exchange in `blocks.py`, A1). Idempotent get-or-create, so a
+    block-complete check that finds no row still resolves an exchange rather than crashing."""
+    exchange = get_exchange_for_block(db, block.id)
+    if exchange is None:
+        exchange = Exchange(user_id=block.user_id, block_id=block.id)
+        db.add(exchange)
+        db.commit()
+    return exchange
 
 
 # --- state transitions (each guarded, idempotent, committing) -----------------

--- a/backend/tests/test_exchange_lifecycle.py
+++ b/backend/tests/test_exchange_lifecycle.py
@@ -120,6 +120,43 @@ def test_can_fire_reply_fuller_requires_open_and_in_window(db, window):
         _exchange(db, opened_at=now - timedelta(days=3))) is False  # stale
 
 
+# --- block -> exchange resolution (#697) --------------------------------------
+
+
+def test_get_exchange_for_block_returns_the_row(db):
+    ex = _exchange(db)
+    assert lifecycle.get_exchange_for_block(db, ex.block_id) is ex
+
+
+def test_get_exchange_for_block_returns_none_when_absent(db):
+    assert lifecycle.get_exchange_for_block(db, uuid4()) is None
+
+
+def test_ensure_exchange_for_block_returns_existing(db):
+    ex = _exchange(db)
+    block = ex.block
+    # blocks are created WITH their exchange, so ensure resolves the existing one
+    # without creating a duplicate.
+    assert lifecycle.ensure_exchange_for_block(db, block) is ex
+    assert (
+        db.query(Exchange).filter(Exchange.block_id == block.id).count() == 1
+    )
+
+
+def test_ensure_exchange_for_block_creates_when_missing(db):
+    ex = _exchange(db)
+    block = ex.block
+    db.delete(ex)
+    db.commit()
+    assert lifecycle.get_exchange_for_block(db, block.id) is None
+
+    created = lifecycle.ensure_exchange_for_block(db, block)
+    assert created.block_id == block.id
+    assert created.user_id == block.user_id
+    db.refresh(block)
+    assert lifecycle.get_exchange_for_block(db, block.id) is created
+
+
 # --- open transition ----------------------------------------------------------
 
 

--- a/backend/tests/test_receipt_cadence_pipeline.py
+++ b/backend/tests/test_receipt_cadence_pipeline.py
@@ -294,6 +294,26 @@ async def test_done_tap_noops_when_exchange_closed(db, configured, notifier):
     sched.assert_not_called()
 
 
+async def test_done_tap_noops_when_exchange_stale(db, configured, notifier, monkeypatch):
+    # #697: the "done" path now shares the reply path's act-guard
+    # (`can_fire_reply_fuller`), so a tap on a STALE exchange (opener older than the
+    # reply window) no-ops exactly as a stale reply does — one guard, not two. It also
+    # must NOT record done (no state transition on a guard failure).
+    from datetime import timedelta
+
+    monkeypatch.setattr(settings, "EXCHANGE_REPLY_WINDOW_SECONDS", 86400)
+    activity = _seed(db)
+    ex = _exchange_of(db, activity)
+    ex.opened_at = datetime.now(timezone.utc) - timedelta(days=3)  # opened, but stale
+    db.add(ex)
+    db.commit()
+    with patch.object(pna, "_schedule_block_complete") as sched:
+        assert mark_done_and_schedule(db, activity.id) is False
+    sched.assert_not_called()
+    ex = _exchange_of(db, activity)
+    assert ex.done_at is None
+
+
 # --- rollback inertness -------------------------------------------------------
 
 


### PR DESCRIPTION
Addresses #697.

## What
`exchange_lifecycle.py` (#494) documents itself as the single owner of every legal Exchange transition, but the job layer still open-coded three of them. This makes the module the actual owner.

Two new lifecycle verbs, and the job layer routes through them:
- `get_exchange_for_block(db, block_id)` — the single block->exchange lookup, replacing five identical inline `db.query(Exchange).filter(Exchange.block_id == ...).first()` copies (`_exchange_for_activity`, `_send_receipt`, `_resolve_completed_block`, `_enqueue_reply_fuller`, `_record_done_and_schedule`).
- `ensure_exchange_for_block(db, block)` — the defensive get-or-create, replacing the inline `Exchange(...)` construction + commit in `_resolve_completed_block`.
- The done path (`_record_done_and_schedule`) now guards on `lifecycle.can_fire_reply_fuller(exchange)` — the **same** predicate the reply path (`_enqueue_reply_fuller`) already used — so "reply/done may act only on an open, in-window exchange" has one implementation, not two divergent copies.

After this, the job layer contains no `db.query(Exchange)` or `Exchange(...)` at all; `Exchange` stays imported only for type annotations.

## Acceptance criteria
- [x] Exchange creation, block->exchange lookup, and the reply/done act-guard go through the lifecycle module.
- [x] The reply and done paths share one guard predicate (no divergent copies) — both call `can_fire_reply_fuller`.
- [x] The at-most-once notification invariant is enforced/tested in one place (already centralized in `NOTIFICATION_SENTINELS` + `notification_already_sent`/`mark_notification_sent`, pinned by `test_exchange_lifecycle.py`; unchanged here).
- [x] Behaviour-preserving for existing exchange/pipeline/reply/receipt tests.

## The divergence the issue flagged
The issue asked to verify the divergent done-tap vs reply guard for a latent bug. The prior done guard was `not closed AND (unopened OR in-window)`; the reply guard is `is_open AND in-window` (`can_fire_reply_fuller`). They differ only on the **unopened** case: the old done guard acted on it (relying on `mark_done`'s defensive open), the reply guard rejects it. Under the receipt cadence the receipt opens the exchange on ingest — and the "done" button only ever rides a delivered receipt — so an unopened exchange is unreachable at the done path. Unifying to `can_fire_reply_fuller` is therefore behaviour-preserving for every reachable state; `mark_done` keeps its defensive open as belt-and-suspenders.

## Behaviour-preserving, how proven
- The five lookups and the get-or-create are verbatim moves (identical query / identical create+commit).
- The guard delta is confined to the unreachable unopened-done case (reasoned above; every existing done test seeds via `_send_receipt`, which opens the exchange first).
- Full backend suite green with CI-parity env overrides: **2245 passed, 5 skipped**. Targeted exchange/reply/receipt/pipeline/telegram/blocks suites all green.

## Tests added
- Unit: `get_exchange_for_block` (row / None), `ensure_exchange_for_block` (returns existing without duplicating, creates when missing).
- Behavioural: `test_done_tap_noops_when_exchange_stale` — pins that the done path now shares the reply-window guard (no-op **and** no `done_at` write on a stale exchange).

## Decisions noted
- Kept the name `can_fire_reply_fuller` (rather than renaming to a neutral term) to avoid churning a public symbol and its existing test; its docstring now states it guards both reply and done.
- Scope held to the job layer per the issue. `blocks.py` also creates the Exchange row (on block assignment / split) and open-codes sentinel inheritance on merge — those are the A1 block-correction concern, out of this issue's scope. Noted as a possible follow-up.
- The at-most-once claim/release notify orchestration (`_notify`'s `presend_claimed` + `claim_fuller`/`release_fuller_claim`) is already lifecycle-owned at the row level; consolidating its job-layer orchestration is a larger change left as a follow-up.

## Not verified
No live Strava/Telegram end-to-end run (no local OAuth app). This is internal row-resolution + guard plumbing with no new external behaviour; the async pipeline/reply/receipt tests drive the real functions and are the appropriate evidence tier. No context-pack or system-prompt change, so no diagram regeneration needed.