### PR TITLE
fix(coach): non-destructive coach-report Re-run (re-analyze + preserve original + stamp) (#646)

### DIFF
--- a/backend/alembic/versions/c3f8a1d0e527_coach_report_non_destructive_regen.py
+++ b/backend/alembic/versions/c3f8a1d0e527_coach_report_non_destructive_regen.py
@@ -1,0 +1,64 @@
+"""coach_report non-destructive regeneration (superseded_at + partial unique index)
+
+Revision ID: c3f8a1d0e527
+Revises: b7d4e9f2a1c8
+Create Date: 2026-07-21 00:00:00.000000
+
+#646 non-destructive "Re-run": a force regeneration no longer overwrites the active
+coach_reports row in place. It sets `superseded_at` on the prior current row (an
+immutable audit copy of what the coach saw, including its point-in-time context_pack)
+and inserts the regenerated report as a NEW current row.
+
+"Current" = superseded_at IS NULL, so the cache uniqueness moves from a FULL unique
+constraint on (activity_id, prompt_id, schema_version) to a PARTIAL unique index over
+the same columns scoped to current rows — exactly one current row per key, unlimited
+archived copies.
+
+Backward-safety (previews share the production DB, so this can run against prod while
+prod still runs the old code): the new column is nullable, so old-code INSERTs that
+omit it still work. Existing rows get superseded_at = NULL, i.e. all become "current"
+— correct, since each key currently has exactly one generation (the old full unique
+constraint guaranteed no duplicates), so the partial index enforces the identical
+uniqueness for the existing data. The old code path still does an in-place UPDATE of
+the current row, which is fine under the partial index.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c3f8a1d0e527"
+down_revision: Union[str, None] = "b7d4e9f2a1c8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_OLD_UNIQUE = "uq_coach_reports_activity_version"
+_NEW_INDEX = "uq_coach_reports_activity_version_current"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "coach_reports",
+        sa.Column("superseded_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Swap the full unique constraint for a partial unique index over the current rows.
+    op.drop_constraint(_OLD_UNIQUE, "coach_reports", type_="unique")
+    op.create_index(
+        _NEW_INDEX,
+        "coach_reports",
+        ["activity_id", "prompt_id", "schema_version"],
+        unique=True,
+        postgresql_where=sa.text("superseded_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_NEW_INDEX, table_name="coach_reports")
+    op.create_unique_constraint(
+        _OLD_UNIQUE,
+        "coach_reports",
+        ["activity_id", "prompt_id", "schema_version"],
+    )
+    op.drop_column("coach_reports", "superseded_at")

--- a/backend/app/jobs/process_new_activity.py
+++ b/backend/app/jobs/process_new_activity.py
@@ -37,6 +37,7 @@ from app.core.queue import queue
 from app.db.session import SessionLocal
 from app.models import Activity, Block, Exchange, StravaAccount
 from app.models.coaching_relationship import CoachingRelationship
+from app.jobs.reanalyze_history import reanalyze_activity_if_streams
 from app.services.analysis import analyze_with_streams
 from app.services.analysis.classifier import Classification, compose_headline
 from app.services.blocks import activity_end, assign_activity_to_block, is_run_activity
@@ -764,11 +765,29 @@ def regenerate_report_job(activity_id: str) -> None:
     LLM call (30-120s) never blocks the HTTP request or exceeds the gateway timeout
     — the request only enqueues this job and the frontend polls for the result.
 
-    Delegates to the same force path the synchronous endpoint used, so the result
-    is identical; only the place it runs changes. Idempotent enough for a double
-    click: a second run just replaces the active-version row again."""
+    #646 fix-refresh: re-derive analysis from the activity's ALREADY-STORED streams
+    first (cheap, local, NO Strava call), so the regenerated report reflects the
+    current deployed analysis code rather than a stale `DerivedMetric`. Skips
+    gracefully when there are no stored streams, and a re-analysis failure never
+    blocks the regeneration (it proceeds with the existing metrics). The force regen
+    itself is non-destructive: it archives the prior report and mints a new current
+    row stamped with the regeneration date + memory as-of date."""
     db = SessionLocal()
     try:
+        try:
+            reanalyzed = reanalyze_activity_if_streams(db, str(activity_id))
+            logger.info(
+                "regenerate_report_job re-analysis %s for activity %s",
+                "ran" if reanalyzed else "skipped (no stored streams)",
+                activity_id,
+            )
+        except Exception:  # noqa: BLE001 — re-analysis must never block the regen
+            db.rollback()
+            logger.exception(
+                "regenerate_report_job re-analysis failed for activity %s; "
+                "proceeding with existing metrics",
+                activity_id,
+            )
         asyncio.run(get_or_generate_coach_report(db, str(activity_id), force=True))
     finally:
         db.close()

--- a/backend/app/jobs/reanalyze_history.py
+++ b/backend/app/jobs/reanalyze_history.py
@@ -83,6 +83,34 @@ def count_eligible(
     return len(db.execute(_eligible_stmt(cursor=cursor, user_id=user_id)).scalars().all())
 
 
+def reanalyze_activity_if_streams(db: Session, activity_id) -> bool:
+    """Re-derive ONE activity's analysis from its ALREADY-STORED streams (no Strava
+    call) — the single-activity form of the bulk re-analysis (#646).
+
+    The coach-report "Re-run" calls this before regenerating so the report reflects
+    the current deployed analysis code instead of a stale/buggy `DerivedMetric` frozen
+    at the activity's original analysis. `analyze` upserts the `DerivedMetric` and
+    commits, so it is idempotent and safe to repeat.
+
+    Returns True when analysis ran, False when it was skipped because the activity has
+    no stored streams (a summary-only import) — the caller then proceeds with the
+    existing metrics rather than failing or reaching out to Strava.
+    """
+    activity_uuid = (
+        activity_id if isinstance(activity_id, uuid.UUID) else uuid.UUID(str(activity_id))
+    )
+    has_streams = (
+        db.query(ActivityStream.id)
+        .filter(ActivityStream.activity_id == activity_uuid)
+        .first()
+        is not None
+    )
+    if not has_streams:
+        return False
+    analyze(db, str(activity_uuid))
+    return True
+
+
 @dataclass
 class ReanalyzeBatchResult:
     processed: list[int] = field(default_factory=list)  # strava_activity_ids

--- a/backend/app/jobs/reanalyze_history.py
+++ b/backend/app/jobs/reanalyze_history.py
@@ -26,6 +26,7 @@ the single worker to webhooks/self-heal between batches.
 """
 
 import logging
+import uuid
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -36,7 +37,7 @@ from app.core.config import settings
 from app.core.queue import queue
 from app.db.session import SessionLocal
 from app.jobs import batch_chain
-from app.models import Activity
+from app.models import Activity, ActivityStream
 from app.services.analysis import analyze
 from app.services.analysis.baseline import recompute_runner_baseline
 

--- a/backend/app/models/coach_report.py
+++ b/backend/app/models/coach_report.py
@@ -2,9 +2,9 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Boolean, ForeignKey, DateTime, JSON, String, Uuid, Text, UniqueConstraint
+from sqlalchemy import Boolean, ForeignKey, DateTime, Index, JSON, String, Uuid, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.sql import func
+from sqlalchemy.sql import func, text
 
 from app.db.base import Base
 from app.models.base import generate_uuid
@@ -13,16 +13,27 @@ from app.models.base import generate_uuid
 class CoachReport(Base):
     __tablename__ = "coach_reports"
 
-    # Cache identity is (activity_id, prompt_id, schema_version): one report per
-    # activity per report shape. A version bump retains prior versions rather
+    # Cache identity is (activity_id, prompt_id, schema_version): one CURRENT report
+    # per activity per report shape. A version bump retains prior versions rather
     # than overwriting them, so report history is comparable across prompt/schema
     # changes (the seam the M5 eval harness relies on). prompt_id/schema_version
     # are nullable so old code (during the deploy window on the preview-shared
     # production DB) can still insert; new code always populates them.
+    #
+    # #646 non-destructive regen: a force regeneration no longer overwrites the
+    # active row in place. It sets `superseded_at` on the prior current row (an
+    # immutable audit copy of what the coach saw) and inserts the regenerated report
+    # as a new CURRENT row. "Current" = superseded_at IS NULL, so the uniqueness is
+    # a PARTIAL unique index scoped to the current rows (unlimited archived copies,
+    # exactly one current row per key). Expressed for both Postgres (prod) and SQLite
+    # (tests build from the model via create_all); both support partial indexes.
     __table_args__ = (
-        UniqueConstraint(
+        Index(
+            "uq_coach_reports_activity_version_current",
             "activity_id", "prompt_id", "schema_version",
-            name="uq_coach_reports_activity_version",
+            unique=True,
+            postgresql_where=text("superseded_at IS NULL"),
+            sqlite_where=text("superseded_at IS NULL"),
         ),
     )
 
@@ -44,6 +55,16 @@ class CoachReport(Base):
 
     is_fallback: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default="false", default=False
+    )
+
+    # #646 non-destructive regeneration: NULL for the CURRENT report, a timestamp for
+    # an ARCHIVED (superseded) audit copy. A force "Re-run" sets this on the prior
+    # current row and inserts a fresh current row, so the original report + its
+    # point-in-time context_pack snapshot survive for comparison instead of being
+    # overwritten. All display/active/digest/eval read paths filter to superseded_at
+    # IS NULL; archived rows are audit-only and never served as the report.
+    superseded_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )
 
     # P1.1 voice freshness (not cache IDENTITY): the fingerprint of the runner's

--- a/backend/app/schemas/coach.py
+++ b/backend/app/schemas/coach.py
@@ -102,6 +102,15 @@ class CoachReportMeta(BaseModel):
     # by the read endpoint; defaults False so stored meta (which never carries it) and
     # every non-voice prompt validate unchanged.
     voice_stale: bool = False
+    # #646 non-destructive-regen provenance stamp — STORED, set only when this report
+    # was produced by a force "Re-run" that superseded a prior report (not on a first
+    # generation, where both stay None). `regenerated_at` is when the Re-run ran;
+    # `memory_as_of` is the runner-memory profile's grounded-through date at that time.
+    # Runner memory is intentionally current + unversioned, so the stamp is how a
+    # regenerated old report's hindsight is made honest (the preserved original carries
+    # the point-in-time memory). Optional/defaulted so pre-#646 stored meta validates.
+    regenerated_at: Optional[datetime] = None
+    memory_as_of: Optional[datetime] = None
 
 
 class CoachReportContent(BaseModel):

--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -450,7 +450,10 @@ async def stream_chat_response(
     # (`_validate_chat_text`) runs regardless and already tolerates an empty pack.
     report_row = get_active_report_row(db, activity_id) or (
         db.query(CoachReport)
-        .filter(CoachReport.activity_id == activity_id)
+        .filter(
+            CoachReport.activity_id == activity_id,
+            CoachReport.superseded_at.is_(None),  # #646: current rows only, not audit copies
+        )
         .order_by(CoachReport.created_at.desc())
         .first()
     )

--- a/backend/app/services/coach/eval/harness.py
+++ b/backend/app/services/coach/eval/harness.py
@@ -149,7 +149,9 @@ def score_db_reports(
         # the active output shape across the cutover (AC5).
         schema_version = active_schema_version(prompt_id)
 
-    query = db.query(CoachReport)
+    # #646: score CURRENT rows only; superseded audit copies would double-count the
+    # same activity's regenerated report into the scorecard.
+    query = db.query(CoachReport).filter(CoachReport.superseded_at.is_(None))
     if not all_versions:
         query = query.filter(
             CoachReport.prompt_id == prompt_id,
@@ -230,7 +232,9 @@ async def judge_db_reports(
     if schema_version is None:
         schema_version = active_schema_version(prompt_id)
 
-    query = db.query(CoachReport)
+    # #646: score CURRENT rows only; superseded audit copies would double-count the
+    # same activity's regenerated report into the scorecard.
+    query = db.query(CoachReport).filter(CoachReport.superseded_at.is_(None))
     if not all_versions:
         query = query.filter(
             CoachReport.prompt_id == prompt_id,

--- a/backend/app/services/coach/retrieval.py
+++ b/backend/app/services/coach/retrieval.py
@@ -152,6 +152,7 @@ def fetch_prior_digests(
             Activity.is_deleted == False,  # noqa: E712
             Activity.start_date < activity.start_date,
             CoachReport.is_fallback == False,  # noqa: E712
+            CoachReport.superseded_at.is_(None),  # #646: current rows only, not audit copies
         )
         # start_date orders by exchange recency; created_at picks the latest
         # version per activity; id is a stable final tiebreaker.
@@ -222,6 +223,7 @@ def fetch_prior_commitments(db: Session, activity: Activity) -> Optional[PriorCo
             Activity.is_deleted == False,  # noqa: E712
             Activity.start_date < activity.start_date,
             CoachReport.is_fallback == False,  # noqa: E712
+            CoachReport.superseded_at.is_(None),  # #646: current rows only, not audit copies
         )
         .order_by(
             Activity.start_date.desc(),
@@ -265,6 +267,7 @@ def fetch_recent_user_digests(
             Activity.user_id == _as_uuid(user_id),
             Activity.is_deleted == False,  # noqa: E712
             CoachReport.is_fallback == False,  # noqa: E712
+            CoachReport.superseded_at.is_(None),  # #646: current rows only, not audit copies
         )
         .order_by(
             Activity.start_date.desc(),

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -31,6 +31,7 @@ from app.schemas.coach import (
 )
 from app.schemas.coach_context import CoachContextPack, ContinuityContext
 from app.services.coach.budget import over_budget as budget_over, record as budget_record
+from app.services.coach.memory_store import get_memory
 from app.services.coach.memory_update import enqueue_memory_update
 from app.services.coach.context import build_context_pack
 from app.services.coach.coach_framing import coach_llm_view
@@ -272,6 +273,9 @@ def get_active_report_row(db: Session, activity_id) -> Optional[CoachReport]:
             CoachReport.activity_id == activity_uuid,
             CoachReport.prompt_id == prompt_id,
             CoachReport.schema_version == active_schema_version(prompt_id),
+            # #646: only the CURRENT row is the active report; superseded audit copies
+            # of the same key are never served.
+            CoachReport.superseded_at.is_(None),
         )
         .first()
     )
@@ -297,7 +301,12 @@ def get_displayable_report_row(db: Session, activity_id) -> Optional[CoachReport
     activity_uuid = _coerce_uuid(activity_id)
     return (
         db.query(CoachReport)
-        .filter(CoachReport.activity_id == activity_uuid)
+        .filter(
+            CoachReport.activity_id == activity_uuid,
+            # #646: never fall back to a superseded audit copy; only current rows
+            # (of any prompt/schema version) are displayable.
+            CoachReport.superseded_at.is_(None),
+        )
         .order_by(CoachReport.created_at.desc())
         .first()
     )
@@ -680,6 +689,23 @@ async def generate_fuller(
     )
 
 
+def _memory_as_of(db: Session, user_id) -> Optional[datetime]:
+    """The runner-memory profile's as-of date, for the #646 regeneration stamp.
+
+    Reads the (current, unversioned) runner memory row's `grounded_through` — the
+    date of the most recent source the profile was rewritten from — falling back to
+    when the row was last written. None when memory is disabled or no profile exists
+    yet. This is provenance only (never grounds a fact); it makes a regenerated old
+    report honest about the vantage point its memory speaks from.
+    """
+    if not settings.COACH_MEMORY_ENABLED:
+        return None
+    row = get_memory(db, user_id)
+    if row is None:
+        return None
+    return row.grounded_through or row.updated_at
+
+
 def _persist_report(
     db: Session,
     *,
@@ -694,9 +720,21 @@ def _persist_report(
     fire_learning_loop: bool,
     voice=None,
 ) -> Optional[CoachReportRead]:
-    """Build the meta + digest, persist the report (in-place UPDATE of `existing`
-    or a fresh INSERT), and optionally fire the learning loop. Shared by the
-    single-shot path, the opener, and the fuller turn so storage is identical.
+    """Build the meta + digest, persist the report, and optionally fire the learning
+    loop. Shared by the single-shot path, the opener, and the fuller turn so storage
+    is identical.
+
+    Three persistence shapes:
+    - INSERT (existing is None): a first generation.
+    - in-place UPDATE (existing is an opener-only row, or a fallback replacing a
+      fallback): the opener->fuller fill evolves ONE logical report on the same row,
+      so it is not a supersede.
+    - #646 SUPERSEDE (existing is a COMPLETE report and the new outcome is good): a
+      force "Re-run" archives the prior current row (superseded_at = now, an immutable
+      audit copy of what the coach saw) and INSERTS the regenerated report as the new
+      current row, in ONE transaction (flush the archive first so the partial unique
+      index has room). The original report + its point-in-time context_pack snapshot
+      survive; the new row carries the regenerated-on + memory-as-of stamp.
 
     The digest is stored only for a COMPLETE non-fallback report — an opener-only
     row (is_opener_only) and any fallback carry no digest, so they never feed the
@@ -736,6 +774,24 @@ def _persist_report(
             prompt_id,
         )
 
+    # #646: a force "Re-run" over a COMPLETE existing report is a non-destructive
+    # supersede (archive + insert), not an in-place overwrite. An opener->fuller fill
+    # (existing is opener-only) and a fallback outcome stay in-place: they evolve the
+    # one logical report, not a regeneration. The #279 guard above already returned
+    # for a fallback-over-good, so a supersede is always a good report replacing a
+    # complete prior one.
+    supersede = (
+        existing is not None
+        and not is_opener_only(existing.report)
+        and not outcome.is_fallback
+    )
+
+    # The provenance stamp rides only a supersede (a true Re-run); a first generation
+    # or an opener->fuller fill leaves both None, so the normal path's meta is
+    # unchanged bar the two None-defaulted keys.
+    regenerated_at = datetime.now(timezone.utc) if supersede else None
+    memory_as_of = _memory_as_of(db, activity.user_id) if supersede else None
+
     meta = CoachReportMeta(
         confidence=pack.metrics.confidence,
         model_id=settings.COACH_MODEL_ID,
@@ -745,6 +801,8 @@ def _persist_report(
         generated_at=datetime.now(timezone.utc),
         policy_violations=outcome.policy_violations,
         tail_degraded=outcome.tail_degraded,
+        regenerated_at=regenerated_at,
+        memory_as_of=memory_as_of,
     )
 
     # P1.1 voice freshness: stamp the voice this report speaks in, so a later voice
@@ -771,10 +829,12 @@ def _persist_report(
                 "exchange digest projection failed for activity %s", activity_uuid
             )
 
-    if existing is not None:
-        # A4 in-place UPDATE: the fuller turn fills the opener's evolving row. The
-        # cache identity (activity_id, prompt_id, schema_version) is unchanged — it
-        # is the same physical row — so the M0 versioned cache is preserved.
+    if existing is not None and not supersede:
+        # A4 in-place UPDATE: the fuller turn fills the opener's evolving row (or a
+        # fallback replaces a fallback). The cache identity (activity_id, prompt_id,
+        # schema_version) is unchanged — it is the same physical row — so the M0
+        # versioned cache is preserved and no audit copy is minted (there is no prior
+        # complete report to preserve; the opener is one half of this same report).
         existing.report = outcome.report_dump
         existing.meta = meta.model_dump(mode="json")
         existing.context_pack = pack_dict
@@ -787,6 +847,15 @@ def _persist_report(
         db.refresh(existing)
         row = existing
     else:
+        if supersede:
+            # #646: archive the prior current row as an immutable audit copy, then
+            # insert the regenerated report as the new current row — one transaction,
+            # so a crash leaves the prior report intact (#273) and the partial unique
+            # index never sees two current rows for the key. Flush the archive first
+            # so the UPDATE lands before the INSERT under that index.
+            existing.superseded_at = regenerated_at
+            db.add(existing)
+            db.flush()
         db_report = CoachReport(
             activity_id=activity_uuid,
             prompt_id=prompt_id,
@@ -803,9 +872,10 @@ def _persist_report(
         try:
             db.commit()
         except IntegrityError:
-            # A concurrent request generated the active-version row first. Yield to
-            # the row that landed (and do NOT fire the learning loop — the winner's
-            # generation owns it).
+            # A concurrent request generated the active-version row first (and, on a
+            # supersede, archived the same prior row). Roll back — which also reverts
+            # our archive — and yield to the row that landed (do NOT fire the learning
+            # loop; the winner's generation owns it).
             db.rollback()
             winner = get_active_report_row(db, activity_uuid)
             if winner is not None:

--- a/backend/tests/test_async_regenerate.py
+++ b/backend/tests/test_async_regenerate.py
@@ -144,17 +144,37 @@ class TestRegenerateEnqueueFailure:
 
 
 class TestRegenerateJob:
-    def test_job_delegates_to_force_regeneration(self):
+    def test_job_reanalyzes_then_delegates_to_force_regeneration(self):
+        # #646: the Re-run job re-derives analysis from stored streams FIRST (so the
+        # report reflects current deployed analysis code), then force-regenerates.
         from app.jobs import process_new_activity as job_mod
 
         fake_db = MagicMock()
         with patch.object(job_mod, "SessionLocal", return_value=fake_db), \
+             patch.object(job_mod, "reanalyze_activity_if_streams", return_value=True) as reanalyze, \
              patch.object(job_mod, "get_or_generate_coach_report", new=AsyncMock(return_value=None)) as gen:
             job_mod.regenerate_report_job("11111111-1111-1111-1111-111111111111")
+        # re-analysis runs before the regen, against the same activity/session.
+        reanalyze.assert_called_once()
+        assert reanalyze.call_args.args[1] == "11111111-1111-1111-1111-111111111111"
         gen.assert_awaited_once()
         # force=True is the whole point: it regenerates the active-version row.
         assert gen.await_args.kwargs.get("force") is True
         fake_db.close.assert_called_once()  # session is always closed
+
+    def test_job_proceeds_when_reanalysis_fails(self):
+        # #646: re-analysis is best-effort — a failure must NOT block the regen.
+        from app.jobs import process_new_activity as job_mod
+
+        fake_db = MagicMock()
+        with patch.object(job_mod, "SessionLocal", return_value=fake_db), \
+             patch.object(job_mod, "reanalyze_activity_if_streams",
+                          side_effect=RuntimeError("analysis blew up")), \
+             patch.object(job_mod, "get_or_generate_coach_report", new=AsyncMock(return_value=None)) as gen:
+            job_mod.regenerate_report_job("11111111-1111-1111-1111-111111111111")
+        gen.assert_awaited_once()  # regen still ran with existing metrics
+        assert gen.await_args.kwargs.get("force") is True
+        fake_db.close.assert_called_once()
 
 
 class TestJobTimeouts:

--- a/backend/tests/test_coach_report_versioning.py
+++ b/backend/tests/test_coach_report_versioning.py
@@ -158,7 +158,10 @@ async def test_version_bump_regenerates_and_retains_old_version(db):
 # --- force ----------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_force_regenerates_active_and_retains_prior_versions(db):
+async def test_force_regenerates_nondestructively_archiving_prior(db):
+    # #646: a force "Re-run" over a complete report is NON-DESTRUCTIVE. It archives
+    # the prior current row (superseded_at set — an immutable audit copy of what the
+    # coach saw) and inserts the regenerated report as a NEW current row.
     activity = _seed_activity(db)
     old = _insert_report(db, activity.id, ACTIVE_PROMPT_ID, "1.0")
     active = _insert_report(db, activity.id, ACTIVE_PROMPT_ID, SCHEMA_VERSION)
@@ -169,16 +172,29 @@ async def test_force_regenerates_active_and_retains_prior_versions(db):
     fake.generate_json.assert_called_once()
     # Prior (1.0) version survives the force.
     assert db.query(CoachReport).filter(CoachReport.id == old.id).first() is not None
-    # Exactly one active-version row, regenerated IN PLACE (#273 generate-then-swap:
-    # the active row is held and its content swapped atomically, so the row id is
-    # stable and a crash mid-regen can never leave zero rows). Content is refreshed.
-    active_rows = db.query(CoachReport).filter(
+
+    # The prior active row is preserved AS AN ARCHIVE (superseded_at set, original
+    # content intact) — the point-in-time snapshot the audit/review loop relies on.
+    archived = db.query(CoachReport).filter(CoachReport.id == active_id).first()
+    assert archived is not None
+    assert archived.superseded_at is not None
+    assert archived.report["key_takeaways"][0]["text"] == "Cached takeaway one."
+
+    # Exactly ONE current active-version row, and it is the freshly generated one
+    # (a new physical row, not the archived original).
+    current_rows = db.query(CoachReport).filter(
         CoachReport.activity_id == activity.id,
         CoachReport.schema_version == SCHEMA_VERSION,
+        CoachReport.superseded_at.is_(None),
     ).all()
-    assert len(active_rows) == 1
-    assert active_rows[0].id == active_id  # same physical row, swapped in place
+    assert len(current_rows) == 1
+    assert current_rows[0].id != active_id  # new row, original preserved
     assert result.report.key_takeaways[0].text == "Freshly generated one."
+    # Two schema-2.0-family rows now coexist for this activity: 1 archived + 1 current.
+    assert db.query(CoachReport).filter(
+        CoachReport.activity_id == activity.id,
+        CoachReport.schema_version == SCHEMA_VERSION,
+    ).count() == 2
 
 
 def test_force_via_api_does_not_destroy_prior_versions(client, db):

--- a/backend/tests/test_regen_nondestructive_646.py
+++ b/backend/tests/test_regen_nondestructive_646.py
@@ -1,0 +1,181 @@
+"""#646: coach-report "Re-run" is a non-destructive fix-refresh.
+
+Three coupled defects fixed here:
+1. RE-ANALYZE FIRST — the regen job re-derives analysis from the activity's
+   already-stored streams (no Strava call) so the report reflects current deployed
+   analysis code, skipping gracefully when there are no stored streams.
+2. PRESERVE THE ORIGINAL — a force regen archives the prior current row
+   (superseded_at set, its report + context_pack snapshot immutable) and inserts a
+   new current row, instead of overwriting in place.
+3. STAMP — the regenerated (current) report carries a regenerated-on timestamp and
+   the runner-memory as-of date, so a report regenerated with hindsight is honest.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from app.core.config import settings
+from app.jobs.reanalyze_history import reanalyze_activity_if_streams
+from app.models import ActivityStream, RunnerMemory
+from app.models.coach_report import CoachReport
+from app.services.coach.service import (
+    SCHEMA_VERSION,
+    get_active_report_row,
+    get_displayable_report_row,
+    get_or_generate_coach_report,
+)
+
+# Reuse the structured single-shot seed + LLM mock (schema 1.2, easy to drive).
+from tests.test_coach_report_versioning import _mock_llm, _seed_activity
+
+ACTIVE_PROMPT_ID = "coach_report_v10"
+
+
+@pytest.fixture(autouse=True)
+def _pin_structured_prompt(monkeypatch):
+    monkeypatch.setattr(settings, "COACH_PROMPT_ID", ACTIVE_PROMPT_ID)
+
+
+def _seed_original_report(db, activity, *, context_pack) -> CoachReport:
+    """A complete, non-fallback current report with a distinctive context_pack — the
+    point-in-time snapshot a Re-run must preserve."""
+    row = CoachReport(
+        activity_id=activity.id,
+        prompt_id=ACTIVE_PROMPT_ID,
+        schema_version=SCHEMA_VERSION,
+        report={
+            "key_takeaways": [{"text": "Original takeaway."}],
+            "next_steps": [{"action": "Rest", "details": "Easy", "why": "Recovery"}],
+            "risks": [],
+            "questions": [],
+        },
+        meta={
+            "confidence": "medium", "model_id": "test-model",
+            "prompt_id": ACTIVE_PROMPT_ID, "schema_version": SCHEMA_VERSION,
+            "input_hash": "deadbeef",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "policy_violations": [],
+        },
+        context_pack=context_pack,
+        is_fallback=False,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+# --- (c) re-analyze from stored streams --------------------------------------
+
+
+def test_reanalyze_runs_when_streams_present(db):
+    activity = _seed_activity(db)
+    db.add(ActivityStream(activity_id=activity.id, stream_type="heartrate", data=[120, 130, 140]))
+    db.commit()
+    with patch("app.jobs.reanalyze_history.analyze") as analyze:
+        ran = reanalyze_activity_if_streams(db, str(activity.id))
+    assert ran is True
+    analyze.assert_called_once()
+    assert analyze.call_args.args[1] == str(activity.id)  # re-derive THIS activity
+
+
+def test_reanalyze_skips_gracefully_without_streams(db):
+    activity = _seed_activity(db)  # summary-only import: no ActivityStream rows
+    with patch("app.jobs.reanalyze_history.analyze") as analyze:
+        ran = reanalyze_activity_if_streams(db, str(activity.id))
+    assert ran is False
+    analyze.assert_not_called()  # never fabricate analysis / never call Strava
+
+
+# --- (a) preserve the original + (b) exactly one current row ------------------
+
+
+@pytest.mark.asyncio
+async def test_force_regen_preserves_original_context_pack_as_archive(db):
+    activity = _seed_activity(db)
+    snapshot = {"memory": {"lately": "as of the original vantage point"}}
+    original = _seed_original_report(db, activity, context_pack=snapshot)
+    original_id = original.id
+
+    ctx, _ = _mock_llm()
+    with ctx:
+        await get_or_generate_coach_report(db, str(activity.id), force=True)
+
+    # The original survives as an immutable audit copy: superseded_at set, its
+    # report + point-in-time context_pack snapshot intact.
+    archived = db.query(CoachReport).filter(CoachReport.id == original_id).first()
+    assert archived is not None
+    assert archived.superseded_at is not None
+    assert archived.context_pack == snapshot
+    assert archived.report["key_takeaways"][0]["text"] == "Original takeaway."
+
+
+@pytest.mark.asyncio
+async def test_after_regen_exactly_one_current_row_is_served(db):
+    activity = _seed_activity(db)
+    original = _seed_original_report(db, activity, context_pack={"v": "orig"})
+    original_id = original.id
+
+    ctx, _ = _mock_llm()
+    with ctx:
+        await get_or_generate_coach_report(db, str(activity.id), force=True)
+
+    # Exactly one CURRENT row, and it is the fresh one — not the archived original.
+    current = db.query(CoachReport).filter(
+        CoachReport.activity_id == activity.id,
+        CoachReport.superseded_at.is_(None),
+    ).all()
+    assert len(current) == 1
+    assert current[0].id != original_id
+
+    # Both the active and displayable read paths serve the current row, never the archive.
+    assert get_active_report_row(db, activity.id).id == current[0].id
+    assert get_displayable_report_row(db, activity.id).id == current[0].id
+    assert get_active_report_row(db, activity.id).id != original_id
+
+
+# --- (d) the regeneration stamp ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_current_report_carries_regeneration_stamp(db):
+    activity = _seed_activity(db)
+    _seed_original_report(db, activity, context_pack={"v": "orig"})
+    # A runner-memory profile grounded through a known date — the "memory as of" the
+    # regenerated report should stamp, so its hindsight is made honest.
+    grounded = datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
+    db.add(RunnerMemory(user_id=activity.user_id, profile={}, grounded_through=grounded))
+    db.commit()
+
+    ctx, _ = _mock_llm()
+    with ctx:
+        await get_or_generate_coach_report(db, str(activity.id), force=True)
+
+    read = get_active_report_row(db, activity.id)
+    meta = read.meta
+    from app.schemas.coach import CoachReportMeta
+    parsed = CoachReportMeta.model_validate(meta)
+    assert parsed.regenerated_at is not None  # stamped as a Re-run
+    assert parsed.memory_as_of is not None
+    assert parsed.memory_as_of.date() == grounded.date()  # memory as-of date carried
+
+
+# --- (e) the normal first-generation path is unchanged -----------------------
+
+
+@pytest.mark.asyncio
+async def test_first_generation_has_no_archive_and_no_stamp(db):
+    activity = _seed_activity(db)  # no prior report
+    ctx, _ = _mock_llm()
+    with ctx:
+        await get_or_generate_coach_report(db, str(activity.id))
+
+    rows = db.query(CoachReport).filter(CoachReport.activity_id == activity.id).all()
+    assert len(rows) == 1
+    assert rows[0].superseded_at is None  # exactly one current row, nothing archived
+    from app.schemas.coach import CoachReportMeta
+    parsed = CoachReportMeta.model_validate(rows[0].meta)
+    assert parsed.regenerated_at is None  # a first generation is not a regeneration
+    assert parsed.memory_as_of is None

--- a/frontend/components/CoachReportPanel.tsx
+++ b/frontend/components/CoachReportPanel.tsx
@@ -659,6 +659,23 @@ export default function CoachReportPanel({ activityId, hasMetrics, onStartChat }
             minute: '2-digit',
           })}
         </span>
+        {/* #646: honesty stamp on a re-run report — memory is current + unversioned,
+            so a report re-generated later speaks with hindsight; the original is
+            preserved and this stamp makes the vantage point explicit. */}
+        {report.meta.regenerated_at && (
+          <span title="This report was re-run after its original generation. Runner memory is always current, so it may reflect knowledge gained since the run.">
+            {'· Regenerated '}
+            {new Date(report.meta.regenerated_at).toLocaleDateString(undefined, {
+              month: 'short',
+              day: 'numeric',
+            })}
+            {report.meta.memory_as_of &&
+              `, memory as of ${new Date(report.meta.memory_as_of).toLocaleDateString(undefined, {
+                month: 'short',
+                day: 'numeric',
+              })}`}
+          </span>
+        )}
       </div>
 
       {/* Debug: opt-in via NEXT_PUBLIC_SHOW_DEBUG_PANEL=true (or "1"). Off in

--- a/frontend/lib/types/coach.ts
+++ b/frontend/lib/types/coach.ts
@@ -40,6 +40,12 @@ export interface CoachReportMeta {
   // current one, so it should regenerate to honour the new voice. A read-time flag
   // set by the backend; the panel auto-triggers the async regen once when it is true.
   voice_stale?: boolean;
+  // #646: non-destructive-regen provenance. Set only when this report was produced by
+  // a "Re-run" that superseded a prior report. `regenerated_at` is when it re-ran;
+  // `memory_as_of` is the runner-memory as-of date it spoke from. The panel shows a
+  // "Regenerated ..., memory as of ..." stamp so a report re-run with hindsight is honest.
+  regenerated_at?: string | null;
+  memory_as_of?: string | null;
 }
 
 export interface CoachReportContent {


### PR DESCRIPTION
Addresses #646 (frontend stamp shipped; see "Remaining" for the one deferred check).

## Owner-decided semantics (built exactly)
"Re-run" = a full, non-destructive fix-refresh:
1. **Re-analyze first** from the activity's already-stored streams (cheap, local, no Strava call), so the report reflects current deployed analysis code.
2. **Preserve the original** as an immutable audit copy; write the regenerated report as a new current row (schema change, owner-approved).
3. **Stamp** the current report with a regenerated-on date + the runner-memory as-of date. Memory stays current + unversioned; the preserved original + the stamp are how the hindsight is made honest.

## What changed
- **Re-analyze on Re-run** — `regenerate_report_job` now calls a new `reanalyze_activity_if_streams` (single-activity form of the `reanalyze_history` stored-streams path) before `get_or_generate_coach_report(force=True)`. No stored streams → skipped gracefully (never calls Strava); a re-analysis failure is caught and the regen proceeds with existing metrics.
- **Non-destructive supersede** — in `_persist_report`, a force regen over a *complete* report archives the prior current row (`superseded_at = now`, its `report`/`context_pack`/`meta` intact) and INSERTs the regenerated report as the new current row, in one transaction (flush the archive first). Opener→fuller fills and fallback-over-opener stay in-place (one logical report, not a regeneration). The #279 fallback-preserve and #273 crash-safety guarantees are retained.
- **Provenance stamp** — `CoachReportMeta` gains `regenerated_at` + `memory_as_of` (grounded_through of the runner-memory profile), set only on a supersede. Surfaced in the coach report footer ("Regenerated <date>, memory as of <date>").

## History-model decision + rationale
Chose the **nullable `superseded_at` timestamp + partial unique index** (`WHERE superseded_at IS NULL`) over an integer `generation` discriminator. Rationale: "current = superseded_at IS NULL" is a single clean predicate every read path shares; the timestamp doubles as audit provenance; and both Postgres (prod) and modern SQLite (tests build from the model via `create_all`) support partial indexes, so no dialect split. Expressed in the model with `postgresql_where=`/`sqlite_where=` so `create_all` builds it; the migration swaps the old full unique constraint for the partial index. Verified the SQLite partial index enforces one-current-row (the existing duplicate-rejection test still raises `IntegrityError`).

## CoachReport read paths audited (exhaustive grep)
9 query sites; 8 filtered to `superseded_at IS NULL` (current-only), 1 intentionally left as any-history:
1. `service.get_active_report_row` — **filtered** (the M0 active cache row).
2. `service.get_displayable_report_row` (both the active call and the any-version fallback) — **filtered**.
3. `service.get_block_primary_report_row` — delegates to `get_displayable_report_row` (covered, no own query).
4. `chat.py` fallback report row — **filtered**.
5. `retrieval.fetch_prior_digests` — **filtered**.
6. `retrieval.fetch_prior_commitments` — **filtered**.
7. `retrieval.fetch_recent_user_digests` — **filtered**.
8. `eval/harness.score_db_reports` — **filtered** (archived copies would double-count the scorecard).
9. `eval/harness.judge_db_reports` — **filtered** (same population as the scorer).
- `blocks._primary_has_report` — **intentionally NOT filtered**: the block-primary freeze invariant wants "a report was ever keyed to the primary", and an archived copy still means one existed. `api/coach.py` has no direct CoachReport queries.

Normal first-generation is behaviourally identical (one current row, no archive, no stamp) — pinned by a new test. The #260 frontend poll still works: the new current row carries a newer `generated_at`.

## Alembic
One migration `c3f8a1d0e527` (down_revision `b7d4e9f2a1c8`): add nullable `superseded_at`, drop the full unique constraint, create the partial unique index. `python -m alembic heads` → **single head** `c3f8a1d0e527`. Safe on the populated prod table (existing rows → `superseded_at` NULL = current; no dupes exist under the old constraint, so the partial index enforces identical uniqueness). Exercised up → down → up against local Postgres; downgrade restores the original constraint.

## Tests
- New `test_regen_nondestructive_646.py`: re-analysis runs with streams / skips without; force regen preserves the original's `context_pack` as an archive; exactly one current row served by active+displayable reads; the current report carries the regen + memory-as-of stamp; first-generation has no archive and no stamp.
- Updated `test_coach_report_versioning` (in-place → archive+insert semantics) and the `test_async_regenerate` job-delegation tests (re-analysis then force; proceeds when re-analysis fails).
- Full CI baseline `make backend-test` (`-m "not integration"`, with the CI-green COACH_* env): **2237 passed, 3 skipped, 12 deselected**. Diagram drift guard passes (coach pack unchanged; the stamp is report metadata, not a pack field). Frontend `tsc --noEmit` + `next lint` clean.

## Remaining / unverified
- **Frontend full `next build` not run**: a `next dev` server was live on :3000 (building corrupts its `.next` chunks). Validated via `tsc --noEmit` + `next lint` instead.
- Live-deploy migration run and visual confirmation of the stamp in a browser are left for the human.
- The one failing test locally (`test_models.py::test_create_user_and_activity`) is `integration`-marked (excluded from CI baseline) and fails identically on the clean tree — a pre-existing local-Postgres env issue, not this change.