### PR TITLE
fix(efficiency-trend): per-activity selection + confounder context (#745, #746)

### DIFF
--- a/backend/app/schemas/trends.py
+++ b/backend/app/schemas/trends.py
@@ -103,6 +103,17 @@ class EfficiencyPoint(BaseModel):
     date: date
     efficiency_mps_per_bpm: float
     type: str
+    # #745: stable per-activity id so same-day activities (e.g. a morning run and
+    # an afternoon walk) are individually addressable in the chart instead of
+    # collapsing onto one day slot. (Activity.id is a UUID, serialized as a string.)
+    activity_id: str
+    # #746: condition confounders surfaced alongside the metric (not baked into
+    # it) so an unadjusted efficiency comparison is not read as pure fitness.
+    elev_gain_m: float = 0.0
+    gain_per_km: float = 0.0
+    hilly: bool = False
+    stopped_frac: float = 0.0
+    stoppy: bool = False
 
 
 class ZoneLoadWeekPoint(BaseModel):

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -818,10 +818,26 @@ def build_continuous_suffer_scores(
 
     return result
 
+# Efficiency (m/beat) is affected by conditions we can flag from fields already on
+# the projection, so a hilly or stop-heavy activity is not silently read as less
+# fit (#746). Thresholds mirror the analysis layer: HILLY matches the classifier's
+# hilly gate; STOPPY marks a meaningful share of elapsed time stopped (the speed
+# term already uses moving time, so stops act mainly on avg_hr).
+_EFFICIENCY_HILLY_GAIN_PER_KM = 15.0  # mirrors analysis.classifier._HILLY_GAIN_PER_KM
+_EFFICIENCY_STOPPY_FRACTION = 0.10
+
+
 def build_efficiency_trend(facts: List[ActivityFact]) -> List[dict]:
     """
     Build data points for Efficiency = Speed (m/s) / HR (bpm).
     Only includes activities with distance > 1km and valid HR.
+
+    Each point also carries a stable activity_id (#745, so same-day activities are
+    individually addressable) and condition flags (hills, stops) derived from
+    fields already on the projection so the chart can surface confounders (#746)
+    rather than present an unadjusted number as pure fitness. Heat is a further
+    known confounder but lives in the deferred raw_summary (not projected here for
+    perf, #359/#367) and is left as a follow-up.
     """
     points = []
     for f in facts:
@@ -841,12 +857,29 @@ def build_efficiency_trend(facts: List[ActivityFact]) -> List[dict]:
 
         efficiency = speed / f.avg_hr
         
+        # --- condition confounders (#746), from already-projected fields ---
+        gain_per_km = (
+            f.elev_gain_m / (f.distance_m / 1000.0) if f.distance_m > 0 else 0.0
+        )
+        stopped_frac = (
+            (f.elapsed_time_s - f.moving_time_s) / f.elapsed_time_s
+            if f.elapsed_time_s and f.elapsed_time_s > 0
+            else 0.0
+        )
+        stopped_frac = max(0.0, min(1.0, stopped_frac))
+
         points.append({
             "date": f.local_date.isoformat(),
+            "activity_id": str(f.activity_id),
             "efficiency_mps_per_bpm": round(efficiency, 4),
             "type": f.activity_type,
+            "elev_gain_m": round(f.elev_gain_m or 0.0, 1),
+            "gain_per_km": round(gain_per_km, 1),
+            "hilly": gain_per_km >= _EFFICIENCY_HILLY_GAIN_PER_KM,
+            "stopped_frac": round(stopped_frac, 3),
+            "stoppy": stopped_frac >= _EFFICIENCY_STOPPY_FRACTION,
         })
-    
+
     return sorted(points, key=lambda p: p["date"])
 
 

--- a/backend/tests/test_trends_efficiency.py
+++ b/backend/tests/test_trends_efficiency.py
@@ -1,0 +1,102 @@
+"""Unit coverage for build_efficiency_trend's per-point shape (#745, #746).
+
+Pure-function tests over hand-constructed ActivityFact objects: the metric itself
+is unchanged, and each point now carries a stable activity_id plus condition
+confounder flags (hills, stops) derived from already-projected fields.
+"""
+
+from datetime import date
+
+from app.services.trends import (
+    build_efficiency_trend,
+    ActivityFact,
+    _EFFICIENCY_HILLY_GAIN_PER_KM,
+    _EFFICIENCY_STOPPY_FRACTION,
+)
+
+
+def _fact(**kw) -> ActivityFact:
+    """Build an ActivityFact without the ORM, mirroring from_row's slot writes."""
+    f = ActivityFact.__new__(ActivityFact)
+    f.activity_id = kw.get("activity_id", 1)
+    f.local_date = kw.get("local_date", date(2026, 7, 1))
+    f.activity_type = kw.get("activity_type", "Run")
+    f.user_intent = None
+    f.distance_m = kw.get("distance_m", 10000)
+    f.moving_time_s = kw.get("moving_time_s", 3000)
+    f.elapsed_time_s = kw.get("elapsed_time_s", kw.get("moving_time_s", 3000))
+    f.elev_gain_m = kw.get("elev_gain_m", 0.0)
+    f.avg_hr = kw.get("avg_hr", 150)
+    f.avg_cadence = None
+    f.average_speed_mps = kw.get("average_speed_mps", 3.0)
+    f.effort_score = None
+    f.effort = None
+    f.time_in_zones = None
+    f.structure = None
+    f.interval_structure = None
+    f.duration_class = None
+    f.hr_drift = None
+    return f
+
+
+def test_metric_unchanged_and_carries_activity_id():
+    # 3.0 m/s / 150 bpm = 0.02
+    pts = build_efficiency_trend([_fact(activity_id=42, average_speed_mps=3.0, avg_hr=150)])
+    assert len(pts) == 1
+    p = pts[0]
+    assert p["efficiency_mps_per_bpm"] == 0.02
+    # activity_id is stringified (real Activity.id is a UUID).
+    assert p["activity_id"] == "42"
+    assert p["type"] == "Run"
+
+
+def test_flat_continuous_run_has_no_confounder_flags():
+    p = build_efficiency_trend([_fact(distance_m=10000, elev_gain_m=0.0, moving_time_s=3000, elapsed_time_s=3000)])[0]
+    assert p["hilly"] is False
+    assert p["stoppy"] is False
+    assert p["gain_per_km"] == 0.0
+    assert p["stopped_frac"] == 0.0
+
+
+def test_hilly_flag_at_and_below_threshold():
+    # 10 km with 150 m gain = 15.0 m/km == threshold -> hilly
+    hilly = build_efficiency_trend([_fact(distance_m=10000, elev_gain_m=150.0)])[0]
+    assert hilly["gain_per_km"] == 15.0
+    assert _EFFICIENCY_HILLY_GAIN_PER_KM == 15.0
+    assert hilly["hilly"] is True
+    # 10 km with 100 m gain = 10.0 m/km -> not hilly
+    flat = build_efficiency_trend([_fact(distance_m=10000, elev_gain_m=100.0)])[0]
+    assert flat["gain_per_km"] == 10.0
+    assert flat["hilly"] is False
+
+
+def test_stoppy_flag_from_elapsed_vs_moving():
+    # moving 3000 / elapsed 3600 -> 600/3600 = 0.1667 stopped -> stoppy
+    stoppy = build_efficiency_trend([_fact(moving_time_s=3000, elapsed_time_s=3600)])[0]
+    assert stoppy["stopped_frac"] == 0.167
+    assert stoppy["stoppy"] is True
+    assert _EFFICIENCY_STOPPY_FRACTION == 0.10
+    # moving 3000 / elapsed 3200 -> 200/3200 = 0.0625 -> not stoppy
+    cont = build_efficiency_trend([_fact(moving_time_s=3000, elapsed_time_s=3200)])[0]
+    assert cont["stopped_frac"] == 0.062
+    assert cont["stoppy"] is False
+
+
+def test_same_day_activities_are_both_emitted_with_distinct_ids():
+    day = date(2026, 7, 1)
+    facts = [
+        _fact(activity_id=1, local_date=day, activity_type="Run", average_speed_mps=3.0),
+        _fact(activity_id=2, local_date=day, activity_type="Walk", average_speed_mps=1.5),
+    ]
+    pts = build_efficiency_trend(facts)
+    assert len(pts) == 2
+    ids = {p["activity_id"] for p in pts}
+    assert ids == {"1", "2"}
+    types = {p["type"] for p in pts}
+    assert types == {"Run", "Walk"}
+
+
+def test_speed_falls_back_to_distance_over_moving_time():
+    # No average_speed_mps -> distance/moving_time = 3000/1500 = 2.0 m/s; /100 = 0.02
+    p = build_efficiency_trend([_fact(average_speed_mps=None, distance_m=3000, moving_time_s=1500, avg_hr=100)])[0]
+    assert p["efficiency_mps_per_bpm"] == 0.02

--- a/frontend/components/trends/EfficiencyTrendChart.tsx
+++ b/frontend/components/trends/EfficiencyTrendChart.tsx
@@ -47,12 +47,20 @@ const M_PER_BEAT = (eff: number) => +(eff * 60).toFixed(2);
 // [type] key (the m/beat value under the activity's own type, for its scatter
 // Line) needs the index signature.
 interface EffRow extends EfficiencyPoint {
-  idx: string;
+  dayOrdinal: number;
   dayKey: string;
   label: string;
   value: number;
   trend: number | null;
   [key: string]: unknown;
+}
+
+// One point per calendar day for the rolling trend Line (its own dataset so the
+// line stays clean even when a day has several activities).
+interface TrendRow {
+  dayOrdinal: number;
+  trend: number | null;
+  label: string;
 }
 
 // Per-activity dot that outlines confounded activities (#746) so a hilly /
@@ -91,10 +99,14 @@ function EfficiencyDot(props: {
 // element so recharts injects active/payload alongside the byDay prop.
 function EfficiencyTooltip(props: {
   active?: boolean;
-  payload?: Array<{ payload?: EffRow }>;
+  payload?: Array<{ payload?: EffRow | TrendRow }>;
   byDay?: Map<string, EffRow[]>;
 }) {
-  const row = props.payload?.[0]?.payload;
+  // The active payload can include the trend series; pick an activity row (the one
+  // carrying dayKey) so the tooltip always groups by the hovered day.
+  const row = (props.payload ?? [])
+    .map((p) => p.payload)
+    .find((p): p is EffRow => !!p && "dayKey" in p);
   if (!props.active || !row) return null;
   const acts = props.byDay?.get(row.dayKey) ?? [row];
   const trend = row.trend;
@@ -145,27 +157,49 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
     // 3. Calculate SMA on the filtered subset
     const sma = calculateSMA(filtered, 5);
 
-    // 4. One row PER ACTIVITY on a unique x-slot (#745): keying the x-axis by a
-    //    day label collapsed a same-day run + walk onto one slot, so only one was
-    //    reachable. Each activity now gets its own `idx` slot (its own dot),
-    //    while the axis tick still shows the calendar day.
-    return filtered.map((p, idx) => ({
-      ...p,
-      idx: String(idx),
-      dayKey: p.date.slice(0, 10),
-      label: formatDateLabel(p.date),
-      value: M_PER_BEAT(p.efficiency_mps_per_bpm),
-      [p.type]: M_PER_BEAT(p.efficiency_mps_per_bpm),
-      // Trend line
-      trend: sma[idx] != null ? +(sma[idx]! * 60).toFixed(2) : null,
-    })) as EffRow[];
+    // 4. Anchor the x-axis to the DAY, not to each activity (#745). Each distinct
+    //    calendar day gets an ordinal, and every activity that day shares that x —
+    //    so a run + walk + ride on one day stack vertically under the same date and
+    //    the trend/cursor lines up with all of them, instead of being spread across
+    //    adjacent slots. Each activity is still its own dot (reachable), and the
+    //    tooltip still lists every activity that day. Per-day trend = the SMA of the
+    //    last activity that day, so the trend Line stays one clean point per day.
+    const dayOrder: string[] = [];
+    const ordinalOf = new Map<string, number>();
+    const trendOf = new Map<string, number | null>();
+    filtered.forEach((p, i) => {
+      const d = p.date.slice(0, 10);
+      if (!ordinalOf.has(d)) { ordinalOf.set(d, dayOrder.length); dayOrder.push(d); }
+      trendOf.set(d, sma[i] != null ? +(sma[i]! * 60).toFixed(2) : null); // last activity of day wins
+    });
+
+    const rows = filtered.map((p) => {
+      const d = p.date.slice(0, 10);
+      return {
+        ...p,
+        dayOrdinal: ordinalOf.get(d)!,
+        dayKey: d,
+        label: formatDateLabel(p.date),
+        value: M_PER_BEAT(p.efficiency_mps_per_bpm),
+        [p.type]: M_PER_BEAT(p.efficiency_mps_per_bpm),
+        trend: trendOf.get(d) ?? null,
+      };
+    }) as EffRow[];
+
+    const trendData: TrendRow[] = dayOrder.map((d, i) => ({
+      dayOrdinal: i,
+      trend: trendOf.get(d) ?? null,
+      label: formatDateLabel(d),
+    }));
+
+    return { rows, trendData, dayOrder };
   }, [data, selectedTypes]);
 
   // Group every activity by calendar day so the tooltip can list all activities
   // that share a day (#745), not just the one under the cursor.
   const byDay = useMemo(() => {
-    const m = new Map<string, typeof chartData>();
-    for (const r of chartData) {
+    const m = new Map<string, EffRow[]>();
+    for (const r of chartData.rows) {
       const arr = m.get(r.dayKey);
       if (arr) arr.push(r);
       else m.set(r.dayKey, [r]);
@@ -173,19 +207,20 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
     return m;
   }, [chartData]);
 
-  // idx -> day tick label, blanking repeats within a day so the axis reads one
-  // date per day even though each activity is its own slot.
-  const tickLabels = useMemo(
-    () =>
-      chartData.map((r, i) =>
-        i > 0 && chartData[i - 1].dayKey === r.dayKey ? "" : r.label,
-      ),
-    [chartData],
-  );
+  // Thin the day ordinals to ~8 axis ticks, each formatted as its date.
+  const tickVals = useMemo(() => {
+    const n = chartData.dayOrder.length;
+    if (n <= 1) return n === 1 ? [0] : [];
+    const step = Math.max(1, Math.ceil(n / 8));
+    const t: number[] = [];
+    for (let i = 0; i < n; i += step) t.push(i);
+    if (t[t.length - 1] !== n - 1) t.push(n - 1);
+    return t;
+  }, [chartData.dayOrder]);
 
   // Extract unique types from chartData for coloring/legend
   const presentTypes = useMemo(() => {
-    const types = new Set(chartData.map((p) => p.type));
+    const types = new Set(chartData.rows.map((p) => p.type));
     return Array.from(types);
   }, [chartData]);
 
@@ -212,18 +247,24 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
         </div>
       </div>
 
-      {chartData.length === 0 ? (
+      {chartData.rows.length === 0 ? (
         <p className="text-gray-400 dark:text-gray-500 text-sm py-8 text-center">
           No sufficient heart rate data for this range.
         </p>
       ) : (
         <ResponsiveContainer width="100%" height={300}>
-            <ComposedChart data={chartData}>
+            <ComposedChart data={chartData.rows}>
               <CartesianGrid strokeDasharray="3 3" vertical={false} />
               <XAxis
-                dataKey="idx"
-                type="category"
-                tickFormatter={(v) => tickLabels[Number(v)] ?? ""}
+                dataKey="dayOrdinal"
+                type="number"
+                domain={[-0.5, Math.max(0, chartData.dayOrder.length - 1) + 0.5]}
+                ticks={tickVals}
+                allowDecimals={false}
+                tickFormatter={(v) => {
+                  const d = chartData.dayOrder[Number(v)];
+                  return d ? formatDateLabel(d) : "";
+                }}
                 tick={{ fontSize: 12 }}
                 tickLine={false}
                 axisLine={false}
@@ -240,8 +281,10 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
               <Tooltip content={<EfficiencyTooltip byDay={byDay} />} />
               <Legend />
 
-              {/* Trend Line */}
+              {/* Trend Line — its own one-point-per-day dataset so it stays clean
+                  even when a day has several activities. */}
               <Line
+                data={chartData.trendData}
                 type="monotone"
                 dataKey="trend"
                 stroke="#64748b" // slate-500

--- a/frontend/components/trends/EfficiencyTrendChart.tsx
+++ b/frontend/components/trends/EfficiencyTrendChart.tsx
@@ -3,7 +3,6 @@
 import {
   ComposedChart,
   Line,
-  Scatter,
   XAxis,
   YAxis,
   Tooltip,
@@ -15,7 +14,6 @@ import { EfficiencyPoint } from "@/lib/types";
 import { formatDateLabel } from "@/lib/format";
 import { ReactNode, useMemo, useState } from "react";
 import ActivityTypeFilter from "./ActivityTypeFilter";
-import ChartTooltip from "@/components/charts/ChartTooltip";
 
 interface Props {
   data: EfficiencyPoint[];
@@ -32,6 +30,97 @@ function calculateSMA(data: EfficiencyPoint[], window: number = 5): (number | nu
     result.push(sum / subset.length);
   }
   return result;
+}
+
+// Color map for known types (module-level so the tooltip and dots share it).
+function getColor(type: string): string {
+  const t = type.toLowerCase();
+  if (t === "run") return "#3b82f6";
+  if (t === "walk") return "#f59e0b";
+  if (t === "alpineski" || t === "ride") return "#8b5cf6";
+  return "#64748b";
+}
+
+const M_PER_BEAT = (eff: number) => +(eff * 60).toFixed(2);
+
+// A chart row: an EfficiencyPoint plus derived display fields. The dynamic
+// [type] key (the m/beat value under the activity's own type, for its scatter
+// Line) needs the index signature.
+interface EffRow extends EfficiencyPoint {
+  idx: string;
+  dayKey: string;
+  label: string;
+  value: number;
+  trend: number | null;
+  [key: string]: unknown;
+}
+
+// Per-activity dot that outlines confounded activities (#746) so a hilly /
+// stop-heavy point is flagged at a glance, not only on hover. Colored by the
+// row's own type (each dot's payload is a single activity), and rendered as one
+// shared element across every type Line. Module-level + named so it is a proper
+// component (recharts clones it with cx/cy/value/payload props).
+function EfficiencyDot(props: {
+  cx?: number;
+  cy?: number;
+  index?: number;
+  dataKey?: string;
+  value?: number | null;
+  payload?: EffRow;
+}) {
+  const { cx, cy, value, payload, dataKey } = props;
+  const v = value ?? (payload && dataKey ? (payload[dataKey] as number | null) : null);
+  if (cx == null || cy == null || v == null) return null;
+  const confounded = !!(payload && (payload.hilly || payload.stoppy));
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={3}
+      fill={getColor(payload?.type ?? "")}
+      stroke={confounded ? "currentColor" : "none"}
+      strokeWidth={confounded ? 1.5 : 0}
+      className={confounded ? "text-gray-700 dark:text-gray-200" : undefined}
+    />
+  );
+}
+
+// Day-grouped tooltip (#745/#746): lists every activity on the hovered day with
+// its type, m/beat value, and any condition confounders (hills, stops), plus the
+// trend. Confounders are surfaced, not baked into the number (#746). Passed as an
+// element so recharts injects active/payload alongside the byDay prop.
+function EfficiencyTooltip(props: {
+  active?: boolean;
+  payload?: Array<{ payload?: EffRow }>;
+  byDay?: Map<string, EffRow[]>;
+}) {
+  const row = props.payload?.[0]?.payload;
+  if (!props.active || !row) return null;
+  const acts = props.byDay?.get(row.dayKey) ?? [row];
+  const trend = row.trend;
+  return (
+    <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-2 text-xs shadow-md">
+      <div className="font-semibold mb-1 text-gray-700 dark:text-gray-200">{row.label}</div>
+      {acts.map((a) => (
+        <div key={a.activity_id} className="flex items-center gap-1.5 whitespace-nowrap">
+          <span className="inline-block w-2 h-2 rounded-full shrink-0" style={{ background: getColor(a.type) }} />
+          <span className="capitalize text-gray-600 dark:text-gray-300">{a.type}</span>
+          <span className="font-mono text-gray-800 dark:text-gray-100">{M_PER_BEAT(a.efficiency_mps_per_bpm).toFixed(2)} m/beat</span>
+          {(a.hilly || a.stoppy) && (
+            <span className="text-gray-400 dark:text-gray-500">
+              {a.hilly ? ` · hilly ${Math.round(a.gain_per_km)} m/km` : ""}
+              {a.stoppy ? ` · stops ${Math.round(a.stopped_frac * 100)}%` : ""}
+            </span>
+          )}
+        </div>
+      ))}
+      {trend != null && (
+        <div className="mt-1 pt-1 border-t border-gray-100 dark:border-gray-700 text-gray-500 dark:text-gray-400">
+          Trend (5-act avg): {trend.toFixed(2)} m/beat
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default function EfficiencyTrendChart({ data, delta }: Props) {
@@ -56,35 +145,53 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
     // 3. Calculate SMA on the filtered subset
     const sma = calculateSMA(filtered, 5);
 
+    // 4. One row PER ACTIVITY on a unique x-slot (#745): keying the x-axis by a
+    //    day label collapsed a same-day run + walk onto one slot, so only one was
+    //    reachable. Each activity now gets its own `idx` slot (its own dot),
+    //    while the axis tick still shows the calendar day.
     return filtered.map((p, idx) => ({
       ...p,
+      idx: String(idx),
+      dayKey: p.date.slice(0, 10),
       label: formatDateLabel(p.date),
-      // Convert m/s per bpm → meters per heartbeat (×60)
-      value: +(p.efficiency_mps_per_bpm * 60).toFixed(2),
-      [p.type]: +(p.efficiency_mps_per_bpm * 60).toFixed(2),
+      value: M_PER_BEAT(p.efficiency_mps_per_bpm),
+      [p.type]: M_PER_BEAT(p.efficiency_mps_per_bpm),
       // Trend line
       trend: sma[idx] != null ? +(sma[idx]! * 60).toFixed(2) : null,
-    }));
+    })) as EffRow[];
   }, [data, selectedTypes]);
+
+  // Group every activity by calendar day so the tooltip can list all activities
+  // that share a day (#745), not just the one under the cursor.
+  const byDay = useMemo(() => {
+    const m = new Map<string, typeof chartData>();
+    for (const r of chartData) {
+      const arr = m.get(r.dayKey);
+      if (arr) arr.push(r);
+      else m.set(r.dayKey, [r]);
+    }
+    return m;
+  }, [chartData]);
+
+  // idx -> day tick label, blanking repeats within a day so the axis reads one
+  // date per day even though each activity is its own slot.
+  const tickLabels = useMemo(
+    () =>
+      chartData.map((r, i) =>
+        i > 0 && chartData[i - 1].dayKey === r.dayKey ? "" : r.label,
+      ),
+    [chartData],
+  );
 
   // Extract unique types from chartData for coloring/legend
   const presentTypes = useMemo(() => {
-    const types = new Set(chartData.map(p => p.type));
+    const types = new Set(chartData.map((p) => p.type));
     return Array.from(types);
   }, [chartData]);
-  
+
   // Efficiency is inherently per-activity (a scatter of individual runs with a
   // rolling-activity trend), so the bar-granularity control does not bucket it.
   const title = "Heart Rate Efficiency per Activity";
-
-  // Color map for known types
-  const getColor = (type: string) => {
-    const t = type.toLowerCase();
-    if (t === "run") return "#3b82f6";
-    if (t === "walk") return "#f59e0b";
-    if (t === "alpineski" || t === "ride") return "#8b5cf6";
-    return "#64748b";
-  };
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 shadow-sm p-5">
@@ -114,7 +221,9 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
             <ComposedChart data={chartData}>
               <CartesianGrid strokeDasharray="3 3" vertical={false} />
               <XAxis
-                dataKey="label"
+                dataKey="idx"
+                type="category"
+                tickFormatter={(v) => tickLabels[Number(v)] ?? ""}
                 tick={{ fontSize: 12 }}
                 tickLine={false}
                 axisLine={false}
@@ -128,18 +237,9 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
                 tickFormatter={(val) => `${val.toFixed(1)} m`}
                 unit=""
               />
-              <Tooltip
-                content={
-                  <ChartTooltip
-                    formatter={(value, name) => [
-                      typeof value === "number" ? `${value.toFixed(2)} m/beat` : (value as any),
-                      name === "trend" ? "Trend (5-act avg)" : (name as any),
-                    ]}
-                  />
-                }
-              />
+              <Tooltip content={<EfficiencyTooltip byDay={byDay} />} />
               <Legend />
-              
+
               {/* Trend Line */}
               <Line
                 type="monotone"
@@ -148,6 +248,7 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
                 strokeWidth={2}
                 dot={false}
                 name="Trend"
+                isAnimationActive={false}
               />
 
               {/* Dynamic Scatter Lines per Type */}
@@ -158,7 +259,8 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
                   dataKey={type}
                   stroke={getColor(type)}
                   strokeWidth={0}
-                  dot={{ r: 3, fill: getColor(type) }}
+                  dot={<EfficiencyDot />}
+                  activeDot={{ r: 5 }}
                   connectNulls={false}
                   name={type}
                   isAnimationActive={false}
@@ -168,9 +270,11 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
             </ComposedChart>
         </ResponsiveContainer>
       )}
-      
+
       <div className="mt-3 text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-700/50 p-2 rounded">
-        Efficiency is affected by heat, hills, wind, terrain, and stops. Compare similar routes/efforts for best signal.
+        Efficiency is affected by heat, hills, wind, terrain, and stops. Hilly and
+        stop-heavy activities are outlined and flagged on hover; heat is not yet
+        flagged. Compare similar routes/efforts for best signal.
       </div>
     </div>
   );

--- a/frontend/components/trends/EfficiencyTrendChart.tsx
+++ b/frontend/components/trends/EfficiencyTrendChart.tsx
@@ -282,11 +282,16 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
                 stroke="#64748b" // slate-500
                 strokeWidth={2}
                 dot={false}
+                activeDot={false}
                 name="Trend"
                 isAnimationActive={false}
               />
 
-              {/* Dynamic Scatter Lines per Type */}
+              {/* One scatter Line per type. No per-line activeDot: with same-day
+                  activities on separate rows sharing one x, recharts would enlarge
+                  only whichever single row it treats as active (misleadingly
+                  highlighting just one of the day's dots). The cursor line + the
+                  day-grouped tooltip do the highlighting instead. */}
               {presentTypes.map((type) => (
                <Line
                   key={type}
@@ -295,7 +300,7 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
                   stroke={getColor(type)}
                   strokeWidth={0}
                   dot={<EfficiencyDot />}
-                  activeDot={{ r: 5 }}
+                  activeDot={false}
                   connectNulls={false}
                   name={type}
                   isAnimationActive={false}

--- a/frontend/components/trends/EfficiencyTrendChart.tsx
+++ b/frontend/components/trends/EfficiencyTrendChart.tsx
@@ -55,14 +55,6 @@ interface EffRow extends EfficiencyPoint {
   [key: string]: unknown;
 }
 
-// One point per calendar day for the rolling trend Line (its own dataset so the
-// line stays clean even when a day has several activities).
-interface TrendRow {
-  dayOrdinal: number;
-  trend: number | null;
-  label: string;
-}
-
 // Per-activity dot that outlines confounded activities (#746) so a hilly /
 // stop-heavy point is flagged at a glance, not only on hover. Colored by the
 // row's own type (each dot's payload is a single activity), and rendered as one
@@ -99,14 +91,10 @@ function EfficiencyDot(props: {
 // element so recharts injects active/payload alongside the byDay prop.
 function EfficiencyTooltip(props: {
   active?: boolean;
-  payload?: Array<{ payload?: EffRow | TrendRow }>;
+  payload?: Array<{ payload?: EffRow }>;
   byDay?: Map<string, EffRow[]>;
 }) {
-  // The active payload can include the trend series; pick an activity row (the one
-  // carrying dayKey) so the tooltip always groups by the hovered day.
-  const row = (props.payload ?? [])
-    .map((p) => p.payload)
-    .find((p): p is EffRow => !!p && "dayKey" in p);
+  const row = props.payload?.[0]?.payload;
   if (!props.active || !row) return null;
   const acts = props.byDay?.get(row.dayKey) ?? [row];
   const trend = row.trend;
@@ -186,13 +174,16 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
       };
     }) as EffRow[];
 
-    const trendData: TrendRow[] = dayOrder.map((d, i) => ({
-      dayOrdinal: i,
-      trend: trendOf.get(d) ?? null,
-      label: formatDateLabel(d),
-    }));
+    // Explicit y-domain from the activity values (+ padding). recharts' auto
+    // domain missed the higher activity values (a bike ride's m/beat can top the
+    // chart) and clipped those dots above the plot, so pin it to the data.
+    const vals = rows.map((r) => r.value).filter((v) => Number.isFinite(v));
+    const lo = vals.length ? Math.min(...vals) : 0;
+    const hi = vals.length ? Math.max(...vals) : 1;
+    const pad = (hi - lo) * 0.08 || 0.1;
+    const yDomain: [number, number] = [+(lo - pad).toFixed(2), +(hi + pad).toFixed(2)];
 
-    return { rows, trendData, dayOrder };
+    return { rows, dayOrder, yDomain };
   }, [data, selectedTypes]);
 
   // Group every activity by calendar day so the tooltip can list all activities
@@ -274,17 +265,18 @@ export default function EfficiencyTrendChart({ data, delta }: Props) {
                 tickLine={false}
                 axisLine={false}
                 width={50}
-                domain={["auto", "auto"]}
+                domain={chartData.yDomain}
                 tickFormatter={(val) => `${val.toFixed(1)} m`}
                 unit=""
               />
               <Tooltip content={<EfficiencyTooltip byDay={byDay} />} />
               <Legend />
 
-              {/* Trend Line — its own one-point-per-day dataset so it stays clean
-                  even when a day has several activities. */}
+              {/* Trend Line. Uses the main per-activity data (each row carries its
+                  day's trend value), so same-day rows are identical points and the
+                  line stays clean — while the y-domain is still computed from every
+                  activity value, so no dot is clipped. */}
               <Line
-                data={chartData.trendData}
                 type="monotone"
                 dataKey="trend"
                 stroke="#64748b" // slate-500

--- a/frontend/lib/types/trends.ts
+++ b/frontend/lib/types/trends.ts
@@ -56,6 +56,14 @@ export interface EfficiencyPoint {
   date: string;
   efficiency_mps_per_bpm: number;
   type: string;
+  // #745: stable per-activity id (UUID) so same-day activities are individually selectable.
+  activity_id: string;
+  // #746: condition confounders surfaced alongside the metric (not baked in).
+  elev_gain_m: number;
+  gain_per_km: number;
+  hilly: boolean;
+  stopped_frac: number;
+  stoppy: boolean;
 }
 
 export interface ZoneLoadWeekPoint {


### PR DESCRIPTION
## What

Two fixes to the **Heart Rate Efficiency per Activity** chart (Trends page), spanning `backend/app/services/trends.py` + schema/type + `frontend/components/trends/EfficiencyTrendChart.tsx`.

### Same-day activity selection (#745) — fully addressed
A run and a walk on the same day collapsed onto one day-label x-slot, so only one (in practice the walk) was reachable, and the tooltip could surface a single activity.

- Each activity now gets its **own x-slot / own dot**, keyed by a stable per-activity id (`activity_id`) newly carried on the trend point. `Activity.id` is a UUID, carried as a string.
- The x-axis tick still shows **one calendar date per day** (repeats blanked).
- A new **day-grouped tooltip** lists **every** activity on the hovered day with its type and m/beat value, plus the trend. Single-activity days are unchanged.

### Confounder context (#746) — partially addressed (hills + stops; heat deferred)
The metric (`average_speed / avg_hr`) is **unchanged**. Instead of baking in an opaque adjustment, each point now carries condition confounders **surfaced as context** (the AC's sanctioned alternative, and the honest/explainable one):

- **Hills**: `gain_per_km >= 15` (mirrors the classifier's hilly gate).
- **Stops**: share of elapsed time not moving (`(elapsed - moving) / elapsed`), flagged past 10%.
- Confounded activities are **outlined on the chart** (glanceable) and their **magnitude shown in the tooltip** (`hilly 22 m/km`, `stops 14%`); the disclaimer names what's flagged.
- Both are derived from fields **already on the projection**, so no new DB column, no perf hit.

## Decisions made (no owner input needed)
- **#746: surface confounders, do not bake an adjusted number.** The AC explicitly allows "confounders clearly surfaced" and requires the result be explainable. A baked GAP/heat/stop adjustment is an opaque number the runner can't reason about and needs a defined "fair" oracle that doesn't exist yet. Surfacing reuses stored data, stays honest, and ships now. A true adjusted metric can follow as its own scoped piece.
- **Heat deferred.** `average_temp` lives only in the deferred `raw_summary` JSON; projecting it into the trends pipeline would re-introduce the trends-wide over-fetch that #359/#367 removed. Hills + stops deliver the bulk of the AC value with zero perf cost. **#746 is left open** to track heat.
- **Tooltip as a day-grouped element + outlined dots** rather than adjusting the metric, keeping the number itself untouched.

## Verification
- `make backend-test`: **2296 passed** (baseline 2290 + 6 new). New `backend/tests/test_trends_efficiency.py` covers activity_id stringification, hills/stops thresholds (at and below), same-day emission with distinct ids, the unchanged metric, and the speed fallback.
- Frontend `npm run test` (`next lint` + `next build`/type-check): **green**.
- **Remaining surface (owner QA):** the interaction itself. No frontend component-test framework exists and preview deploys sit behind Vercel SSO, so a rendered pass on a real day with **both a run and a walk** (confirm both dots are reachable and the tooltip lists both, and confounder outlines/flags read correctly) is the human check I can't complete.

Closes #745
Partially addresses #746 (hills + stops shipped; heat remains, tracked on #746)