### PR TITLE
docs(coach): record why the read-time-signal seam stays (#699 part b)

### DIFF
--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -1493,8 +1493,10 @@ def _novelty_axis_history(db: Session, activity: Activity) -> list[AxisSnapshot]
 # prompt; the PROMPT-GATED signals are dropped from serialization when the active
 # prompt does not carry the feature, keeping the pack byte-stable elsewhere.
 #
-# #203 slots a stored-artifact adapter in by swapping a signal's compute for a
-# read-stored one of the SAME (db, activity, as_of) shape — no call-site change.
+# A stored-artifact adapter is just a signal whose compute reads a stored row instead
+# of scanning history, at the SAME (db, activity, as_of) shape and gate: `_MEMORY_SIGNAL`
+# already is one, and #203 slots adherence/calibration in the same way, with no
+# call-site change. See read_time_signals.py for why the seam stays (#699 part b).
 _CALIBRATION_SIGNAL = ReadTimeSignal("calibration", _build_calibration_context)
 _ADHERENCE_SIGNAL = ReadTimeSignal("adherence", _build_adherence_context)
 _TRAINING_LOAD_SIGNAL = ReadTimeSignal(

--- a/backend/app/services/coach/read_time_signals.py
+++ b/backend/app/services/coach/read_time_signals.py
@@ -1,12 +1,15 @@
 """One interface for the read-time, history-scan coach-pack signals (#492).
 
-Five coach-pack sections are each a *deterministic signal computed at read time
-from a bounded scan of the runner's recent history, abstaining when history is
-thin*: M9 HR-drift calibration, M7 adherence outcomes, #400 training-volume vs
-norm, P3 training-load readiness, and #444 recent-training. Before this module
-each was wired into the pack by a bespoke ``context._build_*_context`` helper with
-its own scan limit, its own abstention rule, and its own gating clause copy-pasted
-inline — shallow per-signal wiring nearly as complex as the work behind it.
+A family of coach-pack sections are each a *deterministic signal computed at read
+time from a bounded scan of the runner's recent history, abstaining when history is
+thin*. #492 shipped with five (M9 HR-drift calibration, M7 adherence outcomes, #400
+training-volume vs norm, P3 training-load readiness, #444 recent-training); the
+registered set is now eleven, adding readiness, recent_weeks, training_history,
+training_history_2wk, memory, and intensity (see the ``_*_SIGNAL`` block in
+``context.py``). Before this module each was wired into the pack by a bespoke
+``context._build_*_context`` helper with its own scan limit, its own abstention rule,
+and its own gating clause copy-pasted inline — shallow per-signal wiring nearly as
+complex as the work behind it.
 
 This module is the single seam they share. A signal is a ``ReadTimeSignal``: a
 ``compute(db, activity, as_of) -> section | None`` adapter plus an optional
@@ -22,17 +25,48 @@ This module is the single seam they share. A signal is a ``ReadTimeSignal``: a
     each adapter's ``compute`` (delegating to the unchanged pure cores and scan
     helpers), so a caller never re-implements either.
 
-``context.py`` consumes ``gather``, not five private helpers, so a signal's private
-conventions stop leaking into the assembler. The seam is also what #203 needs:
-materialising adherence/calibration as STORED artifacts (read-stored instead of
-compute-now) is a second adapter with the SAME
-``(db, user_id, activity, as_of) -> section | None`` shape registered for the same
-``name`` — swappable with no ``context.py`` change.
+``context.py`` consumes ``gather``, not eleven private helpers, so a signal's private
+conventions stop leaking into the assembler.
 
 The adapter ``compute`` functions themselves live in ``context.py`` (they gather ORM
 rows, which is ``context``'s job); this module owns only the interface and the
 dispatch. Keeping the gathering there avoids an import cycle and keeps the row-reads
 next to the other pack assembly.
+
+Why the seam stays (#699 part b, settled 2026-08-03)
+----------------------------------------------------
+#699 asked whether this seam was premature: one adapter shape and a two-line
+``gather`` was arguably a hypothetical seam whose only justification was a FUTURE
+stored-artifact adapter (#203), so its fate was deferred to that issue. Two facts
+settled it independently of #203:
+
+  - **It has eleven consumers, not one.** Collapsing to inline gating means writing
+    the ``has_feature(...) else None`` clause at eleven call sites, restoring exactly
+    the copy-paste this module removed.
+  - **A read-stored adapter already lives behind it.** ``_MEMORY_SIGNAL`` (ADR 0025)
+    reads the stored ``runner_memory`` row rather than scanning history, through the
+    same ``(db, activity, as_of) -> section | None`` shape and the same gate. The
+    "second adapter kind" #203 was going to supply is already demonstrated, so #203
+    materialising adherence/calibration as stored artifacts is now a swap of an
+    existing signal's ``compute`` with no ``context.py`` change, not a decision about
+    whether the seam earns its keep.
+
+Two live call-site patterns deliberately sit OUTSIDE the seam. Both are transitional,
+held open only because the pre-ADR-0026 prompts must stay byte-stable, and both
+resolve when those older pack keys retire (the same blocker #704 names):
+
+  - **Exclusive alternatives.** ``training_history`` is fed by either
+    ``_TRAINING_HISTORY_SIGNAL`` or ``_TRAINING_HISTORY_2WK_SIGNAL``, never both
+    (mutually exclusive by prompt feature), so the assembler joins them with ``or``
+    into the one pack key. The seam models one signal to one section, with no
+    either/or.
+  - **A fan-out reusing a signal's compute under a different gate.** Under an
+    intensity-read prompt (ADR 0026 Slice 3) ``build_context_pack`` calls
+    ``_build_intensity_context`` directly, because that one scan fans out into THREE
+    pack sections (``intensity_read``, ``intensity_mix``, ``referral``) while nulling
+    two others. ``_INTENSITY_SIGNAL`` abstains under that prompt, so nothing is
+    computed twice. A one-signal-one-section seam cannot absorb a fan-out without
+    distorting into something broader than the concern it owns.
 """
 
 from __future__ import annotations
@@ -51,8 +85,8 @@ class SignalCompute(Protocol):
     scan as of ``as_of``, or return ``None`` to abstain.
 
     ``as_of`` is the read anchor (the subject activity's reference instant), part of
-    the seam so a future stored-artifact adapter (#203) keys off the same point in
-    time. Each adapter derives the exact anchor flavour it needs from ``activity``
+    the seam so a stored-artifact adapter (``_MEMORY_SIGNAL`` today, adherence and
+    calibration under #203) keys off the same point in time. Each adapter derives the exact anchor flavour it needs from ``activity``
     (some read ``start_date``, some the local calendar day); ``as_of`` is passed for
     the signals that key on it and ignored by the rest, keeping one uniform
     signature across all adapters.
@@ -66,8 +100,9 @@ class SignalCompute(Protocol):
 class ReadTimeSignal:
     """One read-time history-scan signal behind the shared seam.
 
-    ``name`` identifies the signal (and is the key a stored-artifact adapter would
-    re-register under, #203). ``gate_feature`` is the ``PromptFeature`` that must be
+    ``name`` identifies the signal (and is the key a stored-artifact adapter
+    re-registers under, as ``_MEMORY_SIGNAL`` already does and #203 would for
+    adherence/calibration). ``gate_feature`` is the ``PromptFeature`` that must be
     present for the section to be emitted, or ``None`` for an always-emitted signal.
     ``compute`` does the bounded scan + abstention.
     """


### PR DESCRIPTION
Closes #699.

## What

Part (a) of #699 shipped in PR #725. This closes part (b), the seam's fate, with a written justification rather than a refactor. Docstrings and comments only, no executable line changed.

## Why the seam stays

#699 argued the `ReadTimeSignal` seam was premature: one adapter shape and a two-line `gather`, whose only justification was a future stored-artifact adapter, so part (b) was deferred to #203. That premise is stale in two ways:

- **Eleven consumers, not one.** `context.py:1498-1531` registers eleven signals, all routing through one `gather`. Collapsing to inline gating means writing `has_feature(...) else None` at eleven call sites, restoring exactly the copy-paste #492 removed.
- **A read-stored adapter already lives behind it.** `_MEMORY_SIGNAL` (ADR 0025) reads the stored `runner_memory` row rather than scanning history, at the same `(db, activity, as_of) -> section | None` shape and the same gate. The second adapter kind #203 was going to supply is already demonstrated, so #203 becomes a swap of an existing signal's compute with no `context.py` change, not the decision on whether the seam earns its keep.

## Also recorded: two patterns deliberately outside the seam

Found while checking the premise, and written down so the next reader does not mistake them for drift:

- **Exclusive alternatives.** `training_history` is fed by either `_TRAINING_HISTORY_SIGNAL` or `_TRAINING_HISTORY_2WK_SIGNAL`, never both, so the assembler joins them with `or`. The seam models one signal to one section.
- **A fan-out reusing a compute under a different gate.** Under an intensity-read prompt, `build_context_pack` calls `_build_intensity_context` directly (`context.py:243-259`), because that one scan fans out into three sections while nulling two others. `_INTENSITY_SIGNAL` abstains under that prompt, so nothing is computed twice (verified: `coach_message_lean_grouped_v7` has `INTENSITY=False`, `INTENSITY_READ=True`).

Both are transitional, held open only so the pre-ADR-0026 prompts stay byte-stable, and resolve when those older pack keys retire, the same blocker #704's remaining item names. Forcing the fan-out into a one-signal-one-section seam would distort the seam rather than tidy it, so neither is changed here.

## Verification

`make backend-test`: 2313 passed, 12 deselected, matching the CI baseline. The factual claims in the docstring were each checked against the code rather than assumed, including executing `has_feature` against the live prompt id to confirm the mutual exclusivity. No behaviour changed: the diff contains no executable line, so pack byte-stability is unaffected by construction.