### PR TITLE
refactor(analysis): thread IntervalSession through compute_confidence (#739), with real-data proof for #701

### DIFF
--- a/backend/app/services/analysis/_orchestrator.py
+++ b/backend/app/services/analysis/_orchestrator.py
@@ -52,11 +52,23 @@ def _coerce_uuid(value) -> uuid.UUID:
     return uuid.UUID(str(value))
 
 
-def compute_confidence(activity, streams_dict, check_in, interval_structure=None, workout_match=None):
+def compute_confidence(
+    activity,
+    streams_dict,
+    check_in,
+    interval_session: IntervalSession,
+    workout_match=None,
+):
     """
     Determine confidence level and reasons based on available data.
     Includes interval-specific sanity checks when applicable.
     Returns (level, reasons) tuple.
+
+    `interval_session` is the typed output of the ONE gate (#701/#739). Taking
+    the `IntervalSession` itself rather than a raw structure dict means this
+    function cannot re-derive "is this an interval session" independently, and
+    is required so a caller must have consulted the gate to call at all. Pass
+    `IntervalSession(structure=None)` for a non-interval activity.
     """
     reasons = []
 
@@ -72,12 +84,10 @@ def compute_confidence(activity, streams_dict, check_in, interval_structure=None
     # Interval-specific sanity checks. These reasons (no_intervals_detected,
     # rep variability, match mismatch) only describe an interval session, so
     # they must not lower the overall confidence of a non-interval activity
-    # (#169). `interval_structure` here is already the gated value from the
-    # single owner (IntervalSession, #701): it is non-None only for an interval
-    # session, so this function makes no independent session decision — its
-    # presence is the gate, and without it workout_match's reasons stay confined
-    # to workout_match.
-    if interval_structure and workout_match:
+    # (#169). The single owner's verdict (`IntervalSession.is_session`, #701) IS
+    # the gate: this function makes no independent session decision, and for a
+    # non-session workout_match's reasons stay confined to workout_match.
+    if interval_session.is_session and workout_match:
         match_reasons = workout_match.get("confidence_reasons", [])
         for r in match_reasons:
             if r not in reasons:
@@ -92,15 +102,16 @@ def compute_confidence(activity, streams_dict, check_in, interval_structure=None
     # runner's own ground-truth segmentation (#170), so "implausibly high" work
     # time is just a long session the runner marked, and a missing warmup means
     # they genuinely started at rep 1 — neither is a confidence deficiency.
-    if interval_structure and interval_structure.get("source") != "recorded_laps":
-        summary = interval_structure.get("summary", {})
+    structure = interval_session.structure
+    if interval_session.is_session and structure.get("source") != "recorded_laps":
+        summary = structure.get("summary", {})
         # Check for implausible total work time (> 45 min of hard running)
         total_work = summary.get("total_work_time_s", 0)
         if total_work > 2700:
             reasons.append("work_time_implausibly_high")
 
         # Check warmup/cooldown detection
-        if not interval_structure.get("warmup_duration_s"):
+        if not structure.get("warmup_duration_s"):
             reasons.append("no_warmup_detected")
 
     # Determine level — more reasons = lower confidence
@@ -328,12 +339,12 @@ def analyze(db: Session, activity_id: str, skip_baseline: bool = False) -> Optio
     state.risk_score = risk_result["risk_score"]
     state.risk_reasons = risk_result["risk_reasons"]
 
-    # 9. Confidence (with interval sanity checks). Consumes the gated structure
-    # from the single owner (interval_session), so the interval-only reasons
-    # stay confined to an interval session (#169/#701).
+    # 9. Confidence (with interval sanity checks). Consumes the single owner's
+    # verdict itself (#701/#739), so the interval-only reasons stay confined to
+    # an interval session (#169) and the type flows the whole way through.
     confidence, confidence_reasons = compute_confidence(
         activity, streams_dict, check_in,
-        interval_structure=interval_session.structure,
+        interval_session=interval_session,
         workout_match=workout_match,
     )
     state.confidence = confidence

--- a/backend/tests/test_analysis_composition.py
+++ b/backend/tests/test_analysis_composition.py
@@ -25,6 +25,7 @@ from app.models.activity_stream import ActivityStream
 from app.services.analysis import analyze
 from app.services.analysis import _orchestrator
 from app.services.analysis import baseline as baseline_mod
+from app.services.analysis.composition import IntervalSession
 
 
 BASE_DATE = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
@@ -188,6 +189,76 @@ def test_interval_session_keeps_structure_and_kpis(db, monkeypatch):
     assert dm.structure == "intervals"
     assert dm.interval_structure == _LAP_STRUCTURE
     assert dm.interval_kpis is not None
+
+
+def _spy_on_confidence(monkeypatch):
+    """Capture the arguments `analyze` hands to compute_confidence, call through."""
+    captured = {}
+    real = _orchestrator.compute_confidence
+
+    def spy(*args, **kwargs):
+        captured.update(kwargs)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(_orchestrator, "compute_confidence", spy)
+    return captured
+
+
+def test_confidence_consumes_the_gates_own_session(db, monkeypatch):
+    """#739: compute_confidence receives the single gate's `IntervalSession`
+    itself, not a separately-derived structure, so the two cannot drift into
+    deciding "is this an interval session" independently."""
+    activity = _seed_run(db)
+
+    monkeypatch.setattr(_orchestrator, "detect_intervals_from_laps", lambda *a, **k: _LAP_STRUCTURE)
+    monkeypatch.setattr(_orchestrator, "detect_intervals", lambda *a, **k: None)
+
+    real_classify = _orchestrator.classify_activity
+
+    def force_intervals(*args, **kwargs):
+        c = real_classify(*args, **kwargs)
+        c.structure = "intervals"
+        return c
+
+    monkeypatch.setattr(_orchestrator, "classify_activity", force_intervals)
+    captured = _spy_on_confidence(monkeypatch)
+
+    dm = analyze(db, activity.id)
+
+    session = captured["interval_session"]
+    assert isinstance(session, IntervalSession)
+    assert session.is_session is True
+    # The very object the probe produced reaches the confidence stage (identity,
+    # not just equality), so there is one structure in play and not two. The
+    # persisted column compares by value: a JSON column re-serialises on commit.
+    assert session.structure is _LAP_STRUCTURE
+    assert dm.interval_structure == _LAP_STRUCTURE
+
+
+def test_confidence_sees_a_closed_gate_as_a_structureless_session(db, monkeypatch):
+    """The gated-out case reaches compute_confidence as an IntervalSession with
+    no structure, rather than as a bare None the function could interpret."""
+    activity = _seed_run(db)
+
+    monkeypatch.setattr(_orchestrator, "detect_intervals_from_laps", lambda *a, **k: _LAP_STRUCTURE)
+    monkeypatch.setattr(_orchestrator, "detect_intervals", lambda *a, **k: None)
+
+    real_classify = _orchestrator.classify_activity
+
+    def force_continuous(*args, **kwargs):
+        c = real_classify(*args, **kwargs)
+        c.structure = "continuous"
+        return c
+
+    monkeypatch.setattr(_orchestrator, "classify_activity", force_continuous)
+    captured = _spy_on_confidence(monkeypatch)
+
+    analyze(db, activity.id)
+
+    session = captured["interval_session"]
+    assert isinstance(session, IntervalSession)
+    assert session.is_session is False
+    assert session.structure is None
 
 
 # --- Invariant 3: commit-before-baseline ---

--- a/backend/tests/test_compute_confidence.py
+++ b/backend/tests/test_compute_confidence.py
@@ -10,6 +10,7 @@ detection_confidence the same structure carries.
 from types import SimpleNamespace
 
 from app.services.analysis._orchestrator import compute_confidence
+from app.services.analysis.composition import IntervalSession
 
 
 def _activity(avg_hr=160.0):
@@ -36,7 +37,7 @@ def test_recorded_laps_structure_is_not_penalised():
 
     level, reasons = compute_confidence(
         _activity(), _full_streams(), check_in=SimpleNamespace(),
-        interval_structure=interval_structure, workout_match=workout_match,
+        interval_session=IntervalSession(structure=interval_structure), workout_match=workout_match,
     )
 
     assert "work_time_implausibly_high" not in reasons
@@ -55,7 +56,7 @@ def test_stream_sourced_structure_still_penalised():
 
     level, reasons = compute_confidence(
         _activity(), _full_streams(), check_in=SimpleNamespace(),
-        interval_structure=interval_structure, workout_match=workout_match,
+        interval_session=IntervalSession(structure=interval_structure), workout_match=workout_match,
     )
 
     assert "work_time_implausibly_high" in reasons
@@ -65,9 +66,9 @@ def test_stream_sourced_structure_still_penalised():
 
 # --- #169: interval-detection signals must not leak into the overall
 # confidence of a non-interval activity. When the structure axis did not
-# resolve to intervals, the orchestrator nulls interval_structure before this
-# call, so workout_match still reports "no_intervals_detected" but it must not
-# merge into the activity-level reasons.
+# resolve to intervals, the single gate (`IntervalSession`, #701) yields a
+# structure-less session, so workout_match still reports "no_intervals_detected"
+# but it must not merge into the activity-level reasons.
 
 def test_non_interval_activity_does_not_carry_no_intervals_detected():
     # A steady run: no interval structure, but match_planned_to_detected still
@@ -79,7 +80,7 @@ def test_non_interval_activity_does_not_carry_no_intervals_detected():
 
     level, reasons = compute_confidence(
         _activity(), _full_streams(), check_in=SimpleNamespace(),
-        interval_structure=None, workout_match=workout_match,
+        interval_session=IntervalSession(structure=None), workout_match=workout_match,
     )
 
     assert "no_intervals_detected" not in reasons
@@ -95,7 +96,7 @@ def test_non_interval_activity_with_complete_data_stays_high():
 
     level, reasons = compute_confidence(
         _activity(), _full_streams(), check_in=SimpleNamespace(),
-        interval_structure=None, workout_match=workout_match,
+        interval_session=IntervalSession(structure=None), workout_match=workout_match,
     )
 
     assert reasons == []
@@ -113,7 +114,7 @@ def test_interval_session_still_merges_its_reasons():
 
     level, reasons = compute_confidence(
         _activity(), _full_streams(), check_in=SimpleNamespace(),
-        interval_structure=interval_structure, workout_match=workout_match,
+        interval_session=IntervalSession(structure=interval_structure), workout_match=workout_match,
     )
 
     assert "high_rep_distance_variability" in reasons


### PR DESCRIPTION
Closes #739. Closes #701.

## What

`compute_confidence` was the last boundary in the analysis composition still taking a raw `interval_structure=` dict rather than the typed `IntervalSession` that PR #732 made the single owner of the "is this an interval session" gate. It now takes the `IntervalSession` itself, **required** rather than defaulted, so a caller must have consulted the gate to call at all, and gates on `is_session` rather than dict truthiness.

That completes #701's typed-composition intent end to end: the gate's verdict is now a type that flows from `IntervalSession.gate` to every consumer, instead of being re-expressed as a dict one stage before the end.

## Real-data behaviour proof (and why this also closes #701)

PR #732 shipped #701's four acceptance criteria but named its own gap under "Verification not done": no reprocessing against a production seed, with the behaviour-preservation claim resting on one golden snapshot. This PR closes that gap for both changes.

Method: seed 300 production activities locally (`make seed-local`, read-only on prod), replay `analyze` over every one of them at three revisions, and diff canonical JSON of the resulting `DerivedMetric` rows. Isolation is one connection plus outer transaction per activity, rolled back, because `analyze` commits internally and savepoints would break.

| Comparison | What it proves | Result |
|---|---|---|
| `main` run twice | the harness itself is deterministic, so a zero diff is signal | **identical** |
| `3fb902c` (pre-#732) vs `main` | PR #732 was behaviour-preserving | **identical, 0 diff lines** |
| `main` vs this branch | #739 is behaviour-preserving | **identical** |
| pre-#732 vs this branch | the whole typed-composition change | **identical** |

300/300 activities analysed with zero errors at every revision.

**Branch coverage within that data**, so the zero diff is not just 300 activities that never reached the changed code: 10 interval sessions (5 `recorded_laps`, 5 stream-sourced), so both sides of the `source != "recorded_laps"` check ran; `no_warmup_detected` fired on 2 and `high_rep_distance_variability` on 3, exercising the gated sanity checks and the workout-match reason merge; and 290 non-interval activities carried a non-null `workout_match`, which is the #169 leak-guard path this function exists to hold.

## Tests

Full suite **2315 passed, 12 deselected** (baseline on `main` was 2313; +2 new).

Two new composition tests pin what #739 actually buys: that the gate's own `IntervalSession` object reaches `compute_confidence` (identity, not equality) when the gate is open, and reaches it as a structure-less session rather than a bare `None` when closed.

## Residual risk

`is_session` (`structure is not None`) replaces dict truthiness, which differ for an empty dict. `detect_intervals` and `detect_intervals_from_laps` return either `None` or a multi-key dict (`intervals.py:225,251,617`), and no such case occurs in 300 real activities, so the two are equivalent today. A future detector returning `{}` would now be treated as a session where it previously was not. Named rather than hidden; the typed gate is the place that would need to state the rule.