### PR TITLE
refactor(coach): fold the readiness twins onto one shared read (#704)

### DIFF
--- a/backend/app/services/coach/context.py
+++ b/backend/app/services/coach/context.py
@@ -17,7 +17,7 @@ default pack.
 import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from typing import Optional
+from typing import Optional, TypeVar
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, joinedload, undefer
@@ -427,28 +427,31 @@ def _build_stance_context(
     )
 
 
-def _build_training_load_context(
-    db: Session, activity: Activity, as_of: datetime
-) -> Optional[TrainingLoadContext]:
-    """The P3 training-load readiness pack section (ADR 0016), or None.
+_ReadinessSectionT = TypeVar("_ReadinessSectionT", TrainingLoadContext, ReadinessContext)
 
-    A read-time history-scan signal behind the shared `ReadTimeSignal` seam (#492):
-    the `TRAINING_LOAD` gating is applied once in `gather`, so this `compute` is
-    reached ONLY under a training-load-aware prompt — the section is dropped from
-    serialization when None, exactly like `corpus`/`stance`/`block`. Computed at read
-    time (mirroring M9 calibration) as of this activity's LOCAL day (#507, the
-    `local_start` convention the volume signal uses), so this run is in the acute load,
-    the daily series agrees with the volume signal on the day boundary, and a regen of
-    an old activity reproduces the condition as of then. A tier-3 deterministic FACT the coach may cite, but it never
-    overrides the run's re-derived DerivedMetric or the safety floor (prompt rule 27).
-    Degrades to None when no history is available (build_readiness guards)."""
+
+def _build_readiness_section(
+    db: Session, activity: Activity, section_cls: type[_ReadinessSectionT]
+) -> Optional[_ReadinessSectionT]:
+    """The runner's current-condition readiness read, projected into `section_cls`.
+
+    ONE read behind the two keyed twins: `training_load` (P3/ADR 0016) and its ADR 0026
+    Slice 2 rename `right_now.readiness` carry byte-for-byte the same content under
+    different pack keys, so the read and the projection live here once and the two
+    builders below differ only in which model they fill (#704).
+
+    Computed at read time (mirroring M9 calibration) as of this activity's LOCAL day
+    (#507, the `local_start` convention the volume signal uses), so this run is in the
+    acute load, the daily series agrees with the volume signal on the day boundary, and
+    a regen of an old activity reproduces the condition as of then. Degrades to None when
+    no history is available (build_readiness guards)."""
     # #507: anchor on the runner's LOCAL day so the daily-load series buckets by local
     # calendar day, agreeing with the volume signal on the day boundary (a late-evening
     # run that rolled to the next UTC day stays on its local day across both signals).
     model = build_readiness(db, activity.user_id, activity.local_start)
     if model is None:
         return None
-    return TrainingLoadContext(
+    return section_cls(
         fitness=model.fitness,
         fatigue=model.fatigue,
         form=model.form,
@@ -459,6 +462,21 @@ def _build_training_load_context(
         warming_up=model.warming_up,
         sample_count=model.sample_count,
     )
+
+
+def _build_training_load_context(
+    db: Session, activity: Activity, as_of: datetime
+) -> Optional[TrainingLoadContext]:
+    """The P3 training-load readiness pack section (ADR 0016), or None.
+
+    A read-time history-scan signal behind the shared `ReadTimeSignal` seam (#492):
+    the `TRAINING_LOAD` gating is applied once in `gather`, so this `compute` is
+    reached ONLY under a training-load-aware prompt — the section is dropped from
+    serialization when None, exactly like `corpus`/`stance`/`block`. A tier-3
+    deterministic FACT the coach may cite, but it never overrides the run's re-derived
+    DerivedMetric or the safety floor (prompt rule 27). The read itself is
+    `_build_readiness_section`, shared with the `readiness` twin."""
+    return _build_readiness_section(db, activity, TrainingLoadContext)
 
 
 def _build_training_volume_context(
@@ -521,25 +539,12 @@ def _build_readiness_context(
     The renamed successor to `training_load` (identical content, coaching-question key),
     behind the shared `ReadTimeSignal` seam gated on `READINESS` — reached ONLY under a
     readiness-aware prompt (the new grouped prompt), so it is dropped from serialization
-    (byte-stable) under every prior prompt that still reads `training_load`. Same read as
-    `_build_training_load_context`: the runner's condition as of this run's LOCAL day, so
-    the run is in the acute load. A deterministic FACT the coach may cite; never overrides
-    the run's re-derived DerivedMetric or the safety floor. Degrades to None when no
-    history is available (build_readiness guards)."""
-    model = build_readiness(db, activity.user_id, activity.local_start)
-    if model is None:
-        return None
-    return ReadinessContext(
-        fitness=model.fitness,
-        fatigue=model.fatigue,
-        form=model.form,
-        ramp_rate=model.ramp_rate,
-        condition=model.condition,
-        trend=model.trend,
-        ramp_aggressive=model.ramp_aggressive,
-        warming_up=model.warming_up,
-        sample_count=model.sample_count,
-    )
+    (byte-stable) under every prior prompt that still reads `training_load`. Literally the
+    same read as `_build_training_load_context` — both delegate to
+    `_build_readiness_section` and differ only in the model they fill (#704) — so the two
+    keys can never drift apart while both are live. A deterministic FACT the coach may
+    cite; never overrides the run's re-derived DerivedMetric or the safety floor."""
+    return _build_readiness_section(db, activity, ReadinessContext)
 
 
 def _query_recent_checkins(db: Session, activity_ids: list) -> dict:

--- a/backend/tests/test_recent_weeks_in_pack.py
+++ b/backend/tests/test_recent_weeks_in_pack.py
@@ -140,3 +140,24 @@ def test_grouped_v2_pack_strict_reparses(db):
         reloaded = CoachContextPack.load(shape)
         assert reloaded.recent_weeks is not None
         assert reloaded.readiness is not None
+
+
+def test_readiness_and_training_load_twins_carry_identical_content(db):
+    """#704: `readiness` is a keyed RENAME of `training_load` — same read, same fields,
+    different pack key. Both builders delegate to one `_build_readiness_section`, so this
+    pins the property that makes the fold safe: for the same activity, whichever key the
+    active prompt emits, the content is identical. If the two ever drift, one of the two
+    live prompt families is being fed a different condition read than the other."""
+    activity = _seed(db)
+
+    old = build_context_pack(db, activity, prompt_id="coach_message_lean_v1")
+    new = build_context_pack(db, activity, prompt_id="coach_message_lean_grouped_v2")
+
+    assert old.training_load is not None
+    assert new.readiness is not None
+    assert old.training_load.model_dump() == new.readiness.model_dump()
+    # And the serialized sections agree too, not just the models.
+    assert (
+        old.to_serializable_dict()["training_load"]
+        == new.to_serializable_dict()["readiness"]
+    )


### PR DESCRIPTION
Closes #704 — the last open item on the cleanup tail. (The dead symbols and the voice/stance resolver fold shipped in #725.)

## What

`_build_training_load_context` and `_build_readiness_context` in `services/coach/context.py` were the ADR 0026 keyed-rename twins: the same `build_readiness(db, user_id, local_start)` call followed by the same nine-field copy, into two field-for-field identical models (`TrainingLoadContext` vs `ReadinessContext`).

Both now delegate to one `_build_readiness_section(db, activity, section_cls)`, parameterised only by the model to fill.

## Why the stated blocker didn't hold

The issue comment deferred this as "gated on the old `training_load` pack key being retired". Retiring the key removes one *caller*; the duplication lives in the *body* the two callers share. So the fold stands on its own and lands now, with both keys still live and both prompt families still served.

Both pack keys, both `PackSection` gates, and both `ReadTimeSignal` registrations are untouched — the fold is inside the builders, not at the seam.

## Verification

Refactor modality, so the oracle is the captured behaviour of the current code, not the new code's own tests:

- **Byte-comparison before/after.** Serialized both sections for the same seeded activity under `coach_message_lean_v1` (emits `training_load`) and `coach_message_lean_grouped_v2` (emits `readiness`), captured with the change stashed and unstashed. Output identical, including the full pack key sets.
- **Full backend suite:** 2316 passed, 12 deselected (baseline was 2315; +1 is the new test).
- **New test** `test_readiness_and_training_load_twins_carry_identical_content` pins that the two keys carry identical content for the same activity. Note this is tautological *while* they share a body — its value is that a future re-split fails loudly rather than drifting silently.

## Not verified

No runtime execution against the deployed coach pipeline. The change is a pure mechanical extraction with byte-identical serialization proven offline, and prod runs `coach_message_lean_grouped_v7` (the `readiness` key), whose section is proven unchanged.