### PR TITLE
chore: restore multi-tool .gitignore entries after workflow update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,8 @@ frontend/tsconfig.tsbuildinfo
 
 # AI workflow and skills (tooling config, not product code)
 # The installer only ignores the last-installed tool's paths in its managed
-# block below; these keep every installed tool's artifacts local-only.
+# block below, and strips those paths from anywhere else in this file; after
+# every `scripts/update.sh` run, re-add the other tools' paths here.
 .agents/
 .gemini/
 .github/*
@@ -58,7 +59,9 @@ claude.md
 CLAUDE.md
 .claude/
 .codex/
+.vscode/
 AGENTS.md
+GEMINI.md
 .vercel
 .env*
 
@@ -72,8 +75,6 @@ docs/audit/coach-*
 ai-workflow.md
 .ai-policy/
 .githooks/
-.github/copilot-instructions.md
-.github/hooks/
-.vscode/
-.agents/skills/
+CLAUDE.md
+.claude/
 # <<< ai-workflow <<<


### PR DESCRIPTION
Closes #789.

## What

The vendored AI workflow was updated 3.12.0 -> 3.13.0 (one `scripts/update.sh` run per installed tool: gemini, codex, copilot, claude). Every vendored file is gitignored and local-only, so `.gitignore` is the sole tracked file the update touches — and it came back wrong.

The installer rewrites its managed block to `shared + <that tool>` paths **and strips those paths from anywhere else in the file**, including the hand-maintained "AI workflow and skills" section put there to survive it. After four sequential runs only the last tool's paths were ignored: `.gemini/`, `CLAUDE.md`, `.claude/`, `.codex/` and `AGENTS.md` showed as untracked, so a later `git add -A` would have committed vendored tooling.

This restores them, adds `.vscode/` (copilot, never listed) and `GEMINI.md` (created by the gemini install), and corrects the section comment to say the entries must be re-checked after every updater run rather than claiming they are safe from it.

## Verification

- `git check-ignore -q` passes for all fourteen vendored paths (`.claude/ .codex/ .gemini/ .vscode/ .agents/ AGENTS.md CLAUDE.md GEMINI.md ai-workflow.md .ai-policy/ .githooks/ .github/copilot-instructions.md .github/hooks/`).
- `.github/workflows/deploy.yml` stays tracked (the `!.github/workflows/` negation still wins over `.github/*`).
- `git status --porcelain` shows only `.gitignore` modified.
- `.ai-policy/scripts/project-validation.sh`: 24/24 pass, including the two new 3.13.0 assertions that `block-pr-merge.sh` blocks a PR merge on both the shell and MCP routes.

No product code changes, so the backend/frontend suites are unaffected by this diff; CI runs them anyway.

## Not verified

The updater's stripping behaviour itself is upstream in `philippe-ths/ai-coding-workflow`; nothing here prevents the next update from clobbering the section again. The procedure is the mitigation.