### PR TITLE
fix(notifications): never substitute a recipient at the builder layer (#795)

### DIFF
--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -147,24 +147,46 @@ def warn_if_coach_prompt_inert() -> None:
     )
 
 
-def warn_notification_config() -> None:
+# Which Telegram vars each process actually needs, keyed by process (#795).
+#
+# Env vars are PER-SERVICE on Railway, so "is the deployment configured?" is not a
+# question any single process can answer — it can only answer "am I configured?".
+# #609 wired this warning into the web process only, which is why `OWNER_EMAIL`
+# missing on the WORKER went unannounced through the #795 leak: the alarm was
+# installed on the service that did not need it.
+#   web    -> mints the /start deep link (TELEGRAM_BOT_USERNAME) and authenticates
+#             inbound taps against the owner identity (OWNER_EMAIL).
+#   worker -> sends every outbound notification, so it needs OWNER_EMAIL to route
+#             the owner's own unbound fallback. It never mints a link.
+_NOTIFICATION_VARS_BY_PROCESS = {
+    "web": ("TELEGRAM_BOT_USERNAME", "OWNER_EMAIL"),
+    "worker": ("OWNER_EMAIL",),
+}
+
+
+def warn_notification_config(process: str = "web") -> None:
     """Log a loud WARNING when Telegram is the active channel in production but a
-    var that SILENTLY degrades multi-user delivery or linking is unset (#600/#609).
+    var THIS process needs, which degrades delivery SILENTLY, is unset (#600/#609/#795).
 
     NON-FATAL by design. The #549 lesson: a boot crash took prod fully down on
     Railway (removed deploys), so this is left as a warning rather than a
     ``ProductionConfigError``. Unlike the Clerk/basic-auth gates, a missing value
     here does NOT 503 every route — it fails quietly:
-      - ``TELEGRAM_BOT_USERNAME`` unset -> the ``/start`` deep link cannot be minted,
-        so the "Link Telegram" button produces nothing and no new user can bind (#609).
+      - ``TELEGRAM_BOT_USERNAME`` unset on web -> the ``/start`` deep link cannot be
+        minted, so "Link Telegram" produces nothing and no new user can bind (#609).
       - ``OWNER_EMAIL`` unset on a multi-user deploy -> the owner's own unbound
         global-chat fallback is suppressed (fail closed, #600), so even the owner
         stops receiving notifications until they bind a chat.
 
+    ``process`` selects what to check, because Railway env vars are per-service and
+    a process can only vouch for its own (#795). Both processes are expected to call
+    this: the worker is the one that SENDS, so an unwarned worker is precisely the
+    hole that let #795 run in production.
+
     Only warns when Telegram is actually the active channel (both bot token + chat
     id set) and ``APP_ENV=production``; a no-Telegram or non-production process is a
-    silent no-op. Called once per process group right after ``init_logging``. Never
-    raises, so it can never crash the boot.
+    silent no-op. Called once per process right after ``init_logging``. Never raises,
+    so it can never crash the boot.
     """
     if settings.APP_ENV != "production":
         return
@@ -172,17 +194,21 @@ def warn_notification_config() -> None:
         return  # Telegram is not the active channel; these vars are irrelevant.
     missing = [
         name
-        for name in ("TELEGRAM_BOT_USERNAME", "OWNER_EMAIL")
+        for name in _NOTIFICATION_VARS_BY_PROCESS.get(process, ())
         if not str(getattr(settings, name, "") or "").strip()
     ]
     if not missing:
         return
     logging.getLogger(__name__).warning(
         "notification_config_incomplete: Telegram is the active channel but %s "
-        "unset -- new-user linking and/or the owner's unbound fallback will fail "
-        "silently. Set these on the web service. See docs/deployment/topology.md.",
+        "unset on the %s service -- new-user linking and/or the owner's unbound "
+        "fallback will fail silently. Set these on THIS service (env vars are "
+        "per-service). See docs/deployment/topology.md.",
         ", ".join(missing),
-        extra={"missing": missing},
+        process,
+        # NB "service", not "process": LogRecord reserves `process` for the PID and
+        # raises if `extra` tries to overwrite it.
+        extra={"missing": missing, "service": process},
     )
 
 

--- a/backend/app/jobs/cadence/receipt.py
+++ b/backend/app/jobs/cadence/receipt.py
@@ -127,8 +127,12 @@ class ReceiptCadence(PostActivityCadence):
             lifecycle.open_exchange(db, exchange)
 
         if notification is None:
+            # Either no channel, or no recipient resolved for this runner (#795 —
+            # suppression is the SAFE outcome). `_resolve_to` logs the recipient
+            # case with its reason just before this; don't assert a cause here.
             logger.info(
-                "No receipt notification for activity %s: no channel configured",
+                "No receipt notification for activity %s: nothing to deliver "
+                "(no channel configured, or no recipient for this runner)",
                 activity.strava_activity_id,
             )
             return None

--- a/backend/app/jobs/exchange_ops.py
+++ b/backend/app/jobs/exchange_ops.py
@@ -106,8 +106,13 @@ def notify_stage(
         recipient=resolve_recipient(activity.user, db=db),
     )
     if notification is None:
+        # Two reasons land here: no channel configured, or no recipient resolved
+        # for this runner (#795 — suppression is the SAFE outcome, not an error).
+        # `_resolve_to` logs the recipient case with its own reason immediately
+        # before this line, so don't assert a cause we haven't checked.
         logger.info(
-            "Skipping %s notification for activity %s: no channel configured",
+            "Skipping %s notification for activity %s: nothing to deliver "
+            "(no channel configured, or no recipient for this runner)",
             stage, activity.strava_activity_id,
         )
         return None

--- a/backend/app/services/notifications/__init__.py
+++ b/backend/app/services/notifications/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 from app.schemas.coach import CoachReportRead
@@ -8,6 +9,8 @@ from app.services.notifications.port import (
     NotificationRenderer,
     NotifierPort,
 )
+
+logger = logging.getLogger(__name__)
 
 _active: NotifierPort | None = None
 
@@ -27,33 +30,36 @@ def _renderer_for_channel(channel: Optional[str]) -> Optional[NotificationRender
     return None
 
 
-def _recipient_for_channel(channel: str) -> str:
-    """The channel-specific recipient address (transport config, not shape)."""
-    from app.core.config import settings
-
-    return str(settings.TELEGRAM_CHAT_ID)
-
-
 def _resolve_to(channel: Optional[str], recipient: Optional[str]) -> Optional[str]:
-    """The address to deliver to, or None to SUPPRESS the notification (#542).
+    """The address to deliver to, or None to SUPPRESS the notification (#542, #795).
 
-    A per-user `recipient` (from `resolve_recipient`) always wins. With no
-    recipient and the Telegram channel: in MULTI-USER mode (`OWNER_EMAIL` set) this
-    is a non-owner unbound runner that `resolve_recipient` deliberately suppressed,
-    so we return None and never fall back to the global owner chat — defense in
-    depth, so the builder refuses to leak to the owner's chat even if a caller
-    bypassed `resolve_recipient`. In SINGLE-USER mode (`OWNER_EMAIL` unset) there is
-    no owner concept, so the original global fallback is preserved. Telegram is the
-    only channel (#595).
+    No recipient means NO notification. This layer never substitutes an address of
+    its own, so no configuration an individual process happens to hold can turn a
+    suppressed runner into a delivery.
+
+    #795: it used to. With no recipient it re-derived single-vs-multi-user from
+    `OWNER_EMAIL` alone and, reading "unset" as single-user, substituted the global
+    chat. That is the one question this layer cannot answer — it has no `db`. On the
+    deployed stack `OWNER_EMAIL` was set on `web` but not on `worker`, and `worker`
+    is the process that sends: `resolve_recipient` correctly suppressed an unbound
+    non-owner (it asked the db and saw more than one user) and this function handed
+    their run to the owner's chat anyway. Two copies of one decision, and only the
+    copy with the evidence got hardened by #600.
+
+    The single-user global fallback still exists, in `resolve_recipient`, where a
+    `db` can prove the deployment has earned it. Telegram is the only channel
+    (#595); `channel` is retained because suppression is only meaningful once a
+    channel is configured at all.
     """
     if recipient:
         return recipient
-    if channel == "telegram":
-        from app.core.config import settings
-
-        if (settings.OWNER_EMAIL or "").strip():
-            return None  # multi-user: suppress, never the global owner chat
-        return _recipient_for_channel(channel)  # single-user back-compat
+    if channel is not None:
+        logger.info(
+            "Suppressing %s notification: no recipient resolved for this runner. "
+            "An unbound runner is only delivered to the global chat when they are "
+            "the identified owner or the deployment is provably single-user (#795).",
+            channel,
+        )
     return None
 
 
@@ -127,11 +133,34 @@ def resolve_recipient(user, db=None) -> Optional[str]:
         user_email = (getattr(user, "email", "") or "").strip().lower()
         if user_email and user_email == owner_email:
             return str(settings.TELEGRAM_CHAT_ID)
-        return None  # non-owner, unbound -> suppress (no leak to the owner chat)
+        return _suppress(user)  # non-owner, unbound -> no leak to the owner chat
     # OWNER_EMAIL unset: keep the single-user global fallback ONLY when we can prove
     # the deployment has at most one user; otherwise fail closed (#600).
     if db is not None and _user_count(db) <= 1:
         return str(settings.TELEGRAM_CHAT_ID)
+    return _suppress(user)
+
+
+def _suppress(user) -> None:
+    """Suppress delivery for an unbound runner, loudly (#795).
+
+    Suppression is the SAFE outcome, but it is not a neutral one: this runner
+    receives nothing at all, indefinitely, and until now that was invisible from
+    both ends. The #795 leak ran for a week partly because the affected runner had
+    never received a single notification and so had nothing to report — silence
+    reads as "no runs yet", not "misrouted".
+
+    WARNING rather than INFO on purpose: a runner getting nothing is a broken
+    product experience, and it is fixed by them binding a chat, which they will
+    only do if someone notices. Never raises and never blocks delivery decisions.
+    """
+    logger.warning(
+        "notification_suppressed_unbound_runner: user_id=%s has no linked Telegram "
+        "chat and is not the identified owner, so this notification is not "
+        "delivered to anyone. They receive nothing until they link a chat (#795).",
+        getattr(user, "id", None),
+        extra={"user_id": str(getattr(user, "id", None))},
+    )
     return None
 
 

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -17,6 +17,7 @@ from app.core.observability import (
     init_sentry,
     log_budget_cap_status,
     warn_if_coach_prompt_inert,
+    warn_notification_config,
 )
 from app.core.queue import redis_conn
 
@@ -74,6 +75,12 @@ def main() -> None:
     # not a boot crash -- the #543 guard took prod down on Railway (#549). This
     # only logs the resulting posture.
     log_budget_cap_status()
+    # #795: the worker is the ONLY process that sends notifications, so it is the
+    # one that must vouch for its own notification config. Railway env vars are
+    # per-service; #609 wired this warning into `web` alone, so `OWNER_EMAIL`
+    # missing HERE — the config that produced the #795 cross-user leak — booted
+    # silently. Worker-scoped: TELEGRAM_BOT_USERNAME is a web-only concern.
+    warn_notification_config("worker")
     logger.info(
         "Worker booting; listening on %s (WORKER_POOL_SIZE=%d)",
         ",".join(LISTEN),

--- a/backend/tests/test_notification_characterization.py
+++ b/backend/tests/test_notification_characterization.py
@@ -182,6 +182,11 @@ def _coach(report: CoachReportRead, stage: str = "fuller", distance_m: int = 820
         distance_m=distance_m,
         app_base_url=_BASE,
         stage=stage,
+        # The recipient is stated explicitly because these snapshots pin RENDERING,
+        # not routing: the builder no longer invents an address of its own (#795).
+        # "42" is the same address the old global fallback produced, so every
+        # pinned byte below is unchanged.
+        recipient="42",
     )
 
 
@@ -330,6 +335,7 @@ class TestReceipt:
             activity_id=_RID,
             distance_m=5000,
             app_base_url=_BASE,
+            recipient="42",  # stated, not invented (#795) — see `_coach`
         )
         assert n is not None
         assert n.to == "42"
@@ -349,6 +355,7 @@ class TestReceipt:
             activity_id=_RID,
             distance_m=5000,
             app_base_url=_BASE,
+            recipient="42",  # stated, not invented (#795) — see `_coach`
         )
         body = _telegram_wire(n)
         assert body["text"] == (

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -319,6 +319,49 @@ class TestWarnNotificationConfig:
         self._telegram_active(monkeypatch, username="", owner="")
         observability.warn_notification_config()  # no exception
 
+    # --- per-process scoping (#795) --------------------------------------------
+
+    def test_worker_warns_when_owner_email_unset(self, monkeypatch, caplog):
+        """#795: the worker SENDS, so an OWNER_EMAIL it lacks is its own problem.
+
+        This is the exact production configuration that leaked — set on `web`,
+        absent on `worker` — and it booted without a word, because #609 wired the
+        warning into the web process only.
+        """
+        self._telegram_active(monkeypatch, username="bot", owner="")
+        with caplog.at_level(logging.WARNING, logger="app.core.observability"):
+            observability.warn_notification_config("worker")
+        assert any("OWNER_EMAIL" in r.getMessage() + str(getattr(r, "missing", ""))
+                   for r in caplog.records)
+
+    def test_worker_ignores_bot_username(self, monkeypatch, caplog):
+        # TELEGRAM_BOT_USERNAME mints the /start deep link, which only web does.
+        # Warning the worker about it would train the operator to ignore this line.
+        self._telegram_active(monkeypatch, username="", owner="o@x.dev")
+        with caplog.at_level(logging.WARNING, logger="app.core.observability"):
+            observability.warn_notification_config("worker")
+        assert not caplog.records
+
+    def test_worker_boot_checks_its_own_notification_config(self, monkeypatch):
+        """The wiring, not just the function: `python -m app.worker` must call it.
+
+        Pinned because the #795 defect was never in this function — it was in which
+        processes bothered to call it.
+        """
+        from app import worker as worker_module
+
+        called: list[str] = []
+        monkeypatch.setattr(worker_module, "warn_notification_config",
+                            lambda process="web": called.append(process))
+        for name in ("init_logging", "init_sentry", "warn_if_coach_prompt_inert",
+                     "log_budget_cap_status"):
+            monkeypatch.setattr(worker_module, name, lambda *a, **k: None)
+        monkeypatch.setattr(worker_module, "build_worker_runtime", lambda *a, **k: object())
+        monkeypatch.setattr(worker_module, "run_worker_runtime", lambda *a, **k: None)
+
+        worker_module.main()
+        assert called == ["worker"]
+
 
 @pytest.fixture(autouse=True)
 def _restore_logging_after_each_test():

--- a/backend/tests/test_per_user_notifications.py
+++ b/backend/tests/test_per_user_notifications.py
@@ -6,19 +6,48 @@ Telegram adapter honoring `to`. The linking flow + inbound multi-user callback
 auth are the deferred follow-up (need P2.0's authenticated user).
 """
 
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from app.core.config import settings
 from app.models import User
+from app.schemas.coach import (
+    CoachMessageReport,
+    CoachReportDebug,
+    CoachReportMeta,
+    CoachReportRead,
+)
 from app.services.notifications import (
+    build_coach_notification,
     build_receipt_notification,
     resolve_owner_user,
     resolve_recipient,
 )
 from app.services.notifications.port import Notification
 from app.services.notifications.telegram_adapter import TelegramNotifier
+
+
+def _coach_report_read() -> CoachReportRead:
+    """A minimal prose report, enough to render either Exchange stage."""
+    return CoachReportRead(
+        id=uuid4(),
+        activity_id=uuid4(),
+        report=CoachMessageReport(
+            message="Solid effort on the hills today.",
+            opener_message="Nice work getting that one in!",
+            headline="Hilly moderate run",
+        ),
+        meta=CoachReportMeta(
+            confidence="medium", model_id="claude-sonnet-4-6",
+            prompt_id="coach_message_v2", schema_version="2.0",
+            input_hash="hash123",
+            generated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+        debug=CoachReportDebug(context_pack={}, system_prompt="", raw_llm_response=None),
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
 
 
 def _telegram_active(monkeypatch, *, chat_id="GLOBAL", owner_email=""):
@@ -100,6 +129,38 @@ def test_resolve_recipient_unbound_non_owner_is_suppressed(monkeypatch):
     assert resolve_recipient(None) is None
 
 
+def test_suppressed_unbound_runner_is_logged_loudly(monkeypatch, caplog):
+    """#795: suppression is safe, but a runner receiving nothing must be visible.
+
+    The leak ran a week partly because the affected runner had never received a
+    single notification, so had nothing to report. Silence from a new signup is
+    indistinguishable from "hasn't run yet" unless the server says otherwise.
+    """
+    import logging
+
+    _telegram_active(monkeypatch, chat_id="GLOBAL", owner_email="owner@x.dev")
+    non_owner = SimpleNamespace(
+        telegram_chat_id=None, email="runner@x.dev", id="user-123",
+    )
+    with caplog.at_level(logging.WARNING, logger="app.services.notifications"):
+        assert resolve_recipient(non_owner) is None
+    assert any("user-123" in r.getMessage() for r in caplog.records), (
+        "a runner who receives nothing must be identifiable in the logs"
+    )
+
+
+def test_owner_and_bound_runners_are_not_logged_as_suppressed(monkeypatch, caplog):
+    # The warning must stay rare enough to be worth reading: successful routing
+    # never emits it, or an operator learns to scroll past it.
+    import logging
+
+    _telegram_active(monkeypatch, chat_id="GLOBAL", owner_email="owner@x.dev")
+    with caplog.at_level(logging.WARNING, logger="app.services.notifications"):
+        resolve_recipient(SimpleNamespace(telegram_chat_id=None, email="owner@x.dev"))
+        resolve_recipient(SimpleNamespace(telegram_chat_id="BOUND", email="r@x.dev"))
+    assert not caplog.records
+
+
 # --- resolve_owner_user (the identified deployment owner, #600/#608) -----------
 
 def test_resolve_owner_user_by_email_case_insensitive(monkeypatch, db):
@@ -154,13 +215,19 @@ def test_receipt_routes_to_per_user_recipient(monkeypatch):
     assert n.to == "USER_CHAT_1"  # the owner's chat, not the global
 
 
-def test_receipt_telegram_single_user_falls_back_to_global(monkeypatch):
-    # OWNER_EMAIL unset => single-user mode: a recipientless Telegram build keeps
-    # the original global fallback (back-compat), so single-owner is unchanged.
+def test_receipt_telegram_single_user_falls_back_to_global(monkeypatch, db):
+    # #795: the single-user global fallback survives, but it is now earned at the
+    # RESOLVER, which has a db to prove the deployment really is single-user. The
+    # builder no longer re-derives it. Previously this test built with no recipient
+    # at all and asserted the builder invented "GLOBAL" — which pinned the leak.
     _telegram_active(monkeypatch, chat_id="GLOBAL", owner_email="")
+    only = User(id=uuid4(), email="a@x.dev", telegram_chat_id=None)
+    db.add(only)
+    db.commit()
     n = build_receipt_notification(
         receipt_text="Nice run", headline="Easy 5k", activity_id="act-1",
-        distance_m=5000, app_base_url="http://app",  # no recipient
+        distance_m=5000, app_base_url="http://app",
+        recipient=resolve_recipient(only, db=db),
     )
     assert n is not None and n.to == "GLOBAL"
 
@@ -175,6 +242,58 @@ def test_receipt_telegram_multiuser_suppressed_when_recipient_none(monkeypatch):
         distance_m=5000, app_base_url="http://app",  # no recipient
     )
     assert n is None  # suppressed, not routed to OWNER_CHAT
+
+
+def test_builder_suppresses_recipientless_build_when_owner_email_is_absent(monkeypatch):
+    """#795: the leak. A recipientless build must NOT invent the global chat just
+    because THIS process has no OWNER_EMAIL.
+
+    This is the exact deployed configuration that leaked: `OWNER_EMAIL` was set on
+    Railway's `web` service but not on `worker`, and `worker` is the process that
+    sends. `resolve_recipient` correctly suppressed the non-owner runner (it asked
+    the db and found more than one user), and the builder then turned that None
+    back into the owner's global chat, because it re-derived "single-user" from
+    `OWNER_EMAIL` alone — the one question it has no db to answer.
+
+    The builder layer now has NO configuration-dependent recipient behaviour: no
+    recipient means no notification, whatever config an individual process holds.
+    """
+    _telegram_active(monkeypatch, chat_id="OWNER_CHAT", owner_email="")
+    assert build_receipt_notification(
+        receipt_text="Someone else's run", headline="Easy run — 10.0km",
+        activity_id="act-1", distance_m=10000, app_base_url="http://app",
+    ) is None
+
+
+def test_multi_user_leak_end_to_end_with_owner_email_absent(monkeypatch, db):
+    """#795 end-to-end, at the layer that builds the notification.
+
+    Multi-user deployment, `OWNER_EMAIL` absent from this process. The runner is
+    not the owner and has no bound chat. Nothing may be built for them — the
+    global owner chat is not a fallback, it is another tenant's inbox.
+
+    The pre-#795 resolver-only tests could not catch this: they stopped at
+    `resolve_recipient` returning None and never asked what the builder did with
+    it.
+    """
+    _telegram_active(monkeypatch, chat_id="OWNER_CHAT", owner_email="")
+    owner = User(id=uuid4(), email="owner@x.dev", telegram_chat_id=None)
+    other = User(id=uuid4(), email="runner@x.dev", telegram_chat_id=None)
+    db.add_all([owner, other])
+    db.commit()
+
+    for report_stage in ("opener", "fuller"):
+        assert build_coach_notification(
+            report=_coach_report_read(), headline="Hilly moderate run",
+            distance_m=5100, app_base_url="http://app", stage=report_stage,
+            recipient=resolve_recipient(other, db=db),
+        ) is None, f"{report_stage} stage leaked another runner's report"
+
+    assert build_receipt_notification(
+        receipt_text="Got your run", headline="Easy run", activity_id="act-1",
+        distance_m=10000, app_base_url="http://app",
+        recipient=resolve_recipient(other, db=db),
+    ) is None
 
 
 def test_non_owner_unbound_receipt_is_not_built_end_to_end(monkeypatch):

--- a/backend/tests/test_receipt_delivery.py
+++ b/backend/tests/test_receipt_delivery.py
@@ -76,6 +76,8 @@ def test_receipt_notification_telegram_carries_taps(telegram):
         activity_id=_aid(),
         distance_m=5000,
         app_base_url="https://app.example.com",
+        # Routing is stated, not inferred (#795): this test pins the tap keyboard.
+        recipient="42",
     )
     assert n is not None
     assert n.text == "Got your run — how did it feel?"

--- a/backend/tests/test_telegram_callback.py
+++ b/backend/tests/test_telegram_callback.py
@@ -122,6 +122,7 @@ class TestOpenerKeyboardComposition:
         notification = build_coach_notification(
             report=read, headline="Easy Run", distance_m=5000,
             app_base_url="https://app.example.com", stage="opener",
+            recipient="42",  # stated, not invented (#795); these pin the keyboard
         )
         assert [a.label for a in notification.actions] == ["Easy (6)", "Hard (8)", "No pain"]
         # Each token decodes back to the right activity + kind + value.
@@ -140,6 +141,7 @@ class TestOpenerKeyboardComposition:
         notification = build_coach_notification(
             report=read, headline="Easy Run", distance_m=5000,
             app_base_url="https://app.example.com", stage="opener",
+            recipient="42",  # stated, not invented (#795); these pin the keyboard
         )
         assert [a.label for a in notification.actions] == ["RPE 7"]
 
@@ -150,6 +152,7 @@ class TestOpenerKeyboardComposition:
         notification = build_coach_notification(
             report=read, headline="Easy Run", distance_m=5000,
             app_base_url="https://app.example.com", stage="opener",
+            recipient="42",  # stated, not invented (#795); these pin the keyboard
         )
         assert notification.actions == ()
 
@@ -161,6 +164,7 @@ class TestOpenerKeyboardComposition:
         notification = build_coach_notification(
             report=read, headline="Easy Run", distance_m=5000,
             app_base_url="https://app.example.com", stage="fuller",
+            recipient="42",  # stated, not invented (#795); these pin the keyboard
         )
         assert notification.actions == ()
 

--- a/docs/deployment/topology.md
+++ b/docs/deployment/topology.md
@@ -111,10 +111,23 @@ Clerk production instance, and verification) is **[custom-domain.md](custom-doma
 | `STRAVA_CLIENT_ID/SECRET`, `STRAVA_REDIRECT_URI`, `STRAVA_WEBHOOK_*` | — | ✓ (all) | ✓ (client id/secret + webhook verify token only) |
 | `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` | — | ✓ (inbound callback auth + button-mark edits) | ✓ (outbound sends) |
 | `TELEGRAM_WEBHOOK_SECRET` | — | ✓ (web hosts the inbound callback) | — |
+| `TELEGRAM_BOT_USERNAME` | — | ✓ (mints the `/start` deep link) | — |
+| `OWNER_EMAIL` | — | ✓ (inbound tap auth) | ✓ (**outbound routing — #795**) |
 | `CORS_ALLOWED_ORIGINS` | — | ✓ | — |
 
 The Vercel-side names are `BACKEND_*`; the Railway-side gate names are `BASIC_AUTH_*`. They are different
 variables that must agree in value for the proxy to authenticate against the backend.
+
+**Env vars are per-service, so "the deployment is configured" is not a fact any one process can check.**
+This is not a formality — it caused a live cross-user leak (#795). `OWNER_EMAIL` was set on `web` and
+absent on `worker`; `worker` is the process that sends notifications, so another runner's coach receipts
+were delivered to the owner's Telegram chat. Three separate safeguards missed it for the same reason: the
+multi-user audit verified the var "in prod" without asking *which service*, the #600 hardening fixed only
+the copy of the decision it was pointed at, and the #609 boot warning was wired into `web` alone — the
+service that did not need it. Since #795 the recipient decision is made in exactly one place that has a
+database to prove single-user, the builder layer never substitutes an address of its own, and **both**
+processes warn at boot about their own missing vars. When adding a row above, state the value per service
+and assume nothing carries across.
 
 ### Spend controls
 


### PR DESCRIPTION
Closes #795.

## What happened

Another runner's coach notifications reached the owner's Telegram chat for seven days. Confirmed against the production database:

| | |
|---|---|
| **Delivered to the wrong person** | 13 receipts + 11 full coach reports |
| **Affected runner** | one account, unbound (no `telegram_chat_id`) |
| **Window** | 2026-07-30 11:59 UTC → 2026-08-05 19:14 UTC |
| **Stopped** | 2026-08-05 ~19:59 UTC, by setting `OWNER_EMAIL` on `worker` |
| **Direction** | one-way *into* the owner's chat; no runner received another's data |

The affected runner received **nothing at all** for the whole week, which is why it went unreported from their side — silence from a new signup reads as "hasn't run yet".

## Why

The recipient decision lived in two places.

`resolve_recipient` asks the database whether the deployment is genuinely single-user before keeping the global-chat fallback. It worked: it saw more than one user and suppressed the unbound non-owner.

The builders then applied a **second** fallback, deciding single-vs-multi-user from `OWNER_EMAIL` alone — the one question that layer cannot answer, because it has no `db` — and turned the suppressed recipient back into the owner's chat.

`OWNER_EMAIL` was set on Railway's `web` service and absent on `worker`. `worker` is the process that sends.

Three safeguards missed it for one shared reason — each reasoned about "the deployment's config" when there are two processes holding two configs:

1. The multi-user audit **found this exact defect** (N5) and graded it *"config fragility, not a live leak"* on the evidence *"set in prod today"* — without asking which service.
2. #600 hardened `resolve_recipient`, precisely the line the audit's evidence pointed at. `_resolve_to`, twenty lines above, held the second copy.
3. #609 built the boot guard the audit asked for and wired it into `web` only — the service that did not need it.

## The fix

The builder layer now has **no configuration-dependent recipient behaviour**. No recipient means no notification, whatever config an individual process holds. The single-user fallback survives only in `resolve_recipient`, where a database can prove it is earned.

Alongside, because env vars are per-service and no process can vouch for the deployment:

- `warn_notification_config` is process-aware, and **the worker now calls it**.
- `resolve_recipient` warns when it suppresses — safe is not the same as neutral, and a runner receiving nothing needs to be visible.
- `topology.md` documents `OWNER_EMAIL`/`TELEGRAM_BOT_USERNAME` per service and records why per-service config defeated three safeguards.
- Removed `_recipient_for_channel`, now dead — a helper handing back the global chat id is a trap in a module whose rule is "never invent an address".

## Verification

- **Fix modality:** the new test fails before the change with `Notification(to='OWNER_CHAT', ...)` carrying another runner's run, and passes after.
- **Rendering unchanged:** all characterisation snapshots pass with pinned bytes untouched — routing moved, rendering did not.
- **Suite:** 2429 passed against a 2422 baseline; the delta is exactly the 7 new tests.
- **Runtime:** exercised under the real deployed worker configuration (Telegram live, `OWNER_EMAIL` absent) — boot guard fires, builder suppresses, web guard still fires independently.
- **Sweep:** no second instance of the two-copies-of-one-decision shape. The other `OWNER_EMAIL` readers are `web`-only, and the inbound one already routes through the db-aware `resolve_owner_user`.

**The coverage gap that let this ship:** every existing test stopped at `resolve_recipient` returning `None` and never asked what the builder did with it — and the one test that did exercise the builder asserted the leak was correct. The suite did not merely miss the bug, it pinned it. That test is retargeted here to prove the fallback through the resolver with a `db`.

## Not verified

- No real Telegram send; the adapter is unchanged but the last hop is unexercised.
- The new boot guard is not yet exercised in production — the deployed code does not call it until this lands.
- Self-verified: the agent that wrote the change also checked it.