### PR TITLE
feat(activities): the activity list carries the coach's opening line (#797)

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -17,6 +17,7 @@ from app.services.checkins import write_checkin
 from app.services.intents import write_activity_intent
 from app.services.analysis.classifier import Classification, compose_headline
 from app.services.analysis.splits import calculate_splits
+from app.services.coach import service as coach_service
 from app.services.laps import project_laps
 from app.services.readiness import build_readiness
 from app.services.strava_ingestion import get_strava_port, ingest_recent_activities
@@ -227,6 +228,8 @@ def read_activities(
         db, skip=skip, limit=limit, user_id=user.id,
         types=types, start_date=start_date, end_date=end_date,
     )
+    # #797: one batched lookup for the whole page, not one per row.
+    coach_leads = coach_service.get_displayable_report_leads(db, activities)
     responses = []
     for activity in activities:
         response = ActivityRead.model_validate(activity)
@@ -234,6 +237,7 @@ def read_activities(
             response.headline = compose_headline(
                 activity, Classification.from_metrics(activity.metrics)
             )
+        response.coach_lead = coach_leads.get(activity.id)
         responses.append(response)
     # #684: the models above are already validated once (model_validate). Returning
     # them directly would let FastAPI re-validate against `response_model`, re-running

--- a/backend/app/schemas/activity.py
+++ b/backend/app/schemas/activity.py
@@ -40,6 +40,11 @@ class ActivityRead(ActivityBase):
     # Classification headline composed at read time from DerivedMetric axes;
     # null until the activity has been analysed (#136).
     headline: Optional[str] = None
+    # The coach report's opening claim, projected at read time (#797). Null when
+    # the run has no displayable non-fallback report yet. Telegram is the only
+    # channel that announces a report, so this is how a runner who has not linked
+    # one discovers their runs were coached at all.
+    coach_lead: Optional[str] = None
     created_at: datetime
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/coach/service.py
+++ b/backend/app/services/coach/service.py
@@ -312,6 +312,89 @@ def get_displayable_report_row(db: Session, activity_id) -> Optional[CoachReport
     )
 
 
+def _lead_sentence(row: CoachReport, activity: Activity) -> Optional[str]:
+    """This report's opening claim, as one line.
+
+    Prefers the STORED digest (written for every non-fallback report since A2a)
+    and re-projects through the shared `build_report_digest` only for older rows,
+    mirroring `retrieval._resolve_digest` — so the line shown in a list is the same
+    text the longitudinal read treats as this report's lead, never a second
+    projection that could drift from it.
+    """
+    stored = row.digest if isinstance(row.digest, dict) else None
+    if stored:
+        lead = stored.get("lead_argument")
+        if isinstance(lead, str) and lead.strip():
+            return lead.strip()
+    report = row.report if isinstance(row.report, dict) else None
+    if not report:
+        return None
+    try:
+        return (build_report_digest(report, activity.start_date).lead_argument or "").strip() or None
+    except Exception:  # a malformed stored row must never break the activity list
+        logger.exception("Could not project a lead sentence for report %s", row.id)
+        return None
+
+
+def get_displayable_report_leads(db: Session, activities) -> dict:
+    """`{activity_id: lead sentence}` for a page of activities (#797).
+
+    Telegram is the only channel that ever ANNOUNCES a report, so a runner who
+    declines to link one had no way to discover their runs were coached at all —
+    the reports were written, stored and visible, and nothing said so. This is the
+    activity list's way of saying so, without inventing read/unread state.
+
+    Batched deliberately: one query for the whole page. The obvious
+    `get_displayable_report_row` per row would be N+1 on the home page's default
+    20 activities, on a path a runner hits on every app open.
+
+    Selection mirrors `get_displayable_report_row` — the active
+    (prompt_id, schema_version) row when one exists, else the most recent current
+    row of any version — so the list and the detail page cannot show leads from
+    two different reports. Fallback reports are excluded: `is_fallback` marks a
+    generation that FAILED, and its apology text is not coaching to advertise.
+
+    Scoped to each activity's OWN report, deliberately NOT the #482 block-primary
+    fallback: a session's report is generated once per block, so borrowing it for
+    every member would print the same sentence against a walk and the run beside
+    it. In a multi-activity block only the primary carries the line.
+    """
+    by_id = {a.id: a for a in activities}
+    if not by_id:
+        return {}
+
+    prompt_id = settings.COACH_PROMPT_ID
+    active_schema = active_schema_version(prompt_id)
+
+    def _is_active(row: CoachReport) -> bool:
+        return row.prompt_id == prompt_id and row.schema_version == active_schema
+
+    rows = (
+        db.query(CoachReport)
+        .filter(
+            CoachReport.activity_id.in_(list(by_id)),
+            # #646: current rows only, never a superseded audit copy.
+            CoachReport.superseded_at.is_(None),
+            CoachReport.is_fallback.is_(False),
+        )
+        .order_by(CoachReport.created_at.desc())
+        .all()
+    )
+
+    chosen: dict = {}
+    for row in rows:  # newest first, so the first of any class is the newest of it
+        held = chosen.get(row.activity_id)
+        if held is None or (_is_active(row) and not _is_active(held)):
+            chosen[row.activity_id] = row
+
+    leads = {}
+    for activity_id, row in chosen.items():
+        lead = _lead_sentence(row, by_id[activity_id])
+        if lead:
+            leads[activity_id] = lead
+    return leads
+
+
 def get_block_primary_report_row(db: Session, activity_id) -> Optional[CoachReport]:
     """Block-aware DISPLAY fallback (#482): the displayable report of this
     activity's block PRIMARY, when the activity itself owns none.

--- a/backend/tests/test_activity_list_coach_lead.py
+++ b/backend/tests/test_activity_list_coach_lead.py
@@ -1,0 +1,213 @@
+"""The activity list carries the coach's opening line (#797).
+
+Telegram is the only channel that ever ANNOUNCES a report. A runner who declines
+to link one still has every report generated, stored and visible — and, before
+this, nothing anywhere in the app said so. Declining was a silent dead end rather
+than a supported choice.
+
+These cover the selection rules that decide WHICH report speaks for a row, since
+getting that wrong shows a runner the wrong run's coaching, and the batching that
+keeps the home page from issuing one query per activity.
+"""
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.core.config import settings
+from app.models import Activity, User
+from app.models.coach_report import CoachReport
+from app.services.coach.service import (
+    active_schema_version,
+    get_displayable_report_leads,
+)
+
+_LEAD = "You held drift under 3% the whole way, which is new for you."
+
+
+@pytest.fixture
+def user(db):
+    u = User(id=uuid4(), email=f"{uuid4()}@x.dev")
+    db.add(u)
+    db.commit()
+    return u
+
+
+def _activity(db, user, *, offset_days=0, name="Evening Run"):
+    a = Activity(
+        id=uuid4(), user_id=user.id, strava_activity_id=int(uuid4().int % 10**12),
+        name=name, type="Run",
+        start_date=datetime(2026, 8, 1, tzinfo=timezone.utc) - timedelta(days=offset_days),
+        distance_m=10000, moving_time_s=3000, elapsed_time_s=3000, elev_gain_m=10.0,
+    )
+    db.add(a)
+    db.commit()
+    return a
+
+
+def _report(db, activity, *, message=_LEAD, digest=None, is_fallback=False,
+            prompt_id=None, schema_version=None, superseded_at=None, created_offset=0):
+    prompt_id = prompt_id or settings.COACH_PROMPT_ID
+    schema_version = schema_version or active_schema_version(prompt_id)
+    row = CoachReport(
+        id=uuid4(), activity_id=activity.id,
+        prompt_id=prompt_id,
+        schema_version=schema_version,
+        report={"message": message, "headline": "Solid run"},
+        meta={
+            "confidence": "medium", "model_id": "claude-sonnet-4-6",
+            "prompt_id": prompt_id, "schema_version": schema_version,
+            "input_hash": "h", "generated_at": "2026-08-01T00:00:00Z",
+        },
+        context_pack={},
+        digest=digest,
+        is_fallback=is_fallback,
+        superseded_at=superseded_at,
+        created_at=datetime(2026, 8, 1, tzinfo=timezone.utc) + timedelta(hours=created_offset),
+    )
+    db.add(row)
+    db.commit()
+    return row
+
+
+def test_lead_is_the_reports_first_sentence(db, user):
+    a = _activity(db, user)
+    _report(db, a, message=f"{_LEAD} The second sentence should not appear.")
+    assert get_displayable_report_leads(db, [a])[a.id] == _LEAD
+
+
+def test_stored_digest_is_preferred_over_reprojection(db, user):
+    # The stored digest is what the longitudinal read treats as this report's
+    # lead. The list must show the SAME text, not a second projection that could
+    # drift from it.
+    a = _activity(db, user)
+    _report(db, a, message="Re-projected text.", digest={"lead_argument": "Stored lead."})
+    assert get_displayable_report_leads(db, [a])[a.id] == "Stored lead."
+
+
+def test_activity_without_a_report_has_no_lead(db, user):
+    a = _activity(db, user)
+    assert get_displayable_report_leads(db, [a]) == {}
+
+
+def test_fallback_report_is_never_shown(db, user):
+    # is_fallback marks a generation that FAILED. Its apology text is not
+    # coaching, and advertising it on the list would be worse than silence.
+    a = _activity(db, user)
+    _report(db, a, message="I could not analyse this run.", is_fallback=True)
+    assert get_displayable_report_leads(db, [a]) == {}
+
+
+def test_superseded_audit_copy_is_never_shown(db, user):
+    # #646: a force-regeneration keeps the prior row as an immutable audit copy.
+    a = _activity(db, user)
+    _report(db, a, message="The old, replaced take.",
+            superseded_at=datetime(2026, 8, 1, tzinfo=timezone.utc))
+    assert get_displayable_report_leads(db, [a]) == {}
+
+
+def test_active_version_wins_over_a_newer_stale_version(db, user):
+    """Selection must match `get_displayable_report_row`, or the list and the
+    detail page quote two different reports for one run."""
+    a = _activity(db, user)
+    _report(db, a, message="Active version lead.", created_offset=0)
+    _report(db, a, message="Older prompt, written later.",
+            prompt_id="coach_message_v1", schema_version="2.0", created_offset=5)
+    assert get_displayable_report_leads(db, [a])[a.id] == "Active version lead."
+
+
+def test_falls_back_to_most_recent_when_no_active_version_exists(db, user):
+    # #261 display-safety: after a COACH_PROMPT_ID flip, prior-version reports
+    # must still render rather than vanishing from the list.
+    a = _activity(db, user)
+    _report(db, a, message="Older of the two.",
+            prompt_id="coach_message_v1", schema_version="2.0", created_offset=0)
+    _report(db, a, message="Newer of the two.",
+            prompt_id="coach_message_v2", schema_version="2.0", created_offset=5)
+    assert get_displayable_report_leads(db, [a])[a.id] == "Newer of the two."
+
+
+def test_opener_only_row_yields_no_lead(db, user):
+    # A two-stage opener row has an empty `message`; the run is not yet coached.
+    a = _activity(db, user)
+    _report(db, a, message="")
+    assert get_displayable_report_leads(db, [a]) == {}
+
+
+def test_malformed_report_does_not_break_the_list(db, user):
+    a = _activity(db, user)
+    row = _report(db, a)
+    row.report = "not a dict"
+    db.commit()
+    assert get_displayable_report_leads(db, [a]) == {}  # no exception
+
+
+def test_leads_are_matched_to_their_own_activity(db, user):
+    a1 = _activity(db, user, offset_days=0, name="Run A")
+    a2 = _activity(db, user, offset_days=1, name="Run B")
+    a3 = _activity(db, user, offset_days=2, name="Run C")
+    _report(db, a1, message="Lead for A.")
+    _report(db, a2, message="Lead for B.")
+    leads = get_displayable_report_leads(db, [a1, a2, a3])
+    assert leads == {a1.id: "Lead for A.", a2.id: "Lead for B."}
+
+
+def test_one_query_regardless_of_page_size(db, user):
+    """Batched on purpose: this runs on every app open, for 20 activities by
+    default. A per-row `get_displayable_report_row` would be N+1 here."""
+    activities = [_activity(db, user, offset_days=i) for i in range(12)]
+    for a in activities:
+        _report(db, a)
+
+    statements = []
+    from sqlalchemy import event
+
+    def record(conn, cursor, stmt, *args):
+        if "coach_reports" in stmt:
+            statements.append(stmt)
+
+    event.listen(db.bind, "before_cursor_execute", record)
+    try:
+        leads = get_displayable_report_leads(db, activities)
+    finally:
+        event.remove(db.bind, "before_cursor_execute", record)
+
+    assert len(leads) == 12
+    assert len(statements) == 1, f"expected 1 coach_reports query, got {len(statements)}"
+
+
+def test_empty_page_does_not_query_at_all(db, user):
+    assert get_displayable_report_leads(db, []) == {}
+
+
+# --- endpoint wiring ----------------------------------------------------------
+#
+# The tests above exercise the projection. These prove the WIRING: the schema
+# field exists, the router populates it, and it survives serialisation. #684
+# serialises the list by hand (jsonable_encoder over pre-validated models) rather
+# than via response_model, so a new field reaching the client is not automatic.
+
+
+def test_endpoint_exposes_the_coach_lead(client, db):
+    u = User(id=uuid4(), email=f"{uuid4()}@x.dev")
+    db.add(u)
+    db.commit()
+    a = _activity(db, u, name="Coached Run")
+    _report(db, a, message=f"{_LEAD} Trailing sentence.")
+
+    resp = client.get("/api/activities")
+    assert resp.status_code == 200, resp.text
+    item = next(i for i in resp.json() if i["name"] == "Coached Run")
+    assert item["coach_lead"] == _LEAD
+
+
+def test_endpoint_returns_null_lead_for_an_uncoached_run(client, db):
+    u = User(id=uuid4(), email=f"{uuid4()}@x.dev")
+    db.add(u)
+    db.commit()
+    _activity(db, u, name="Uncoached Run")
+
+    resp = client.get("/api/activities")
+    item = next(i for i in resp.json() if i["name"] == "Uncoached Run")
+    assert item["coach_lead"] is None

--- a/frontend/components/ActivityList.tsx
+++ b/frontend/components/ActivityList.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { format } from 'date-fns';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, MessageSquareQuote } from 'lucide-react';
 
 import { activityStartDate, hasMeaningfulDistance } from '@/lib/format';
 
@@ -13,6 +13,10 @@ interface Activity {
   distance_m: number;
   moving_time_s: number;
   headline?: string | null;
+  // #797: the coach report's opening line. Telegram is the only channel that
+  // announces a report, so for a runner who has not linked one this is how they
+  // find out the run was coached at all. Absent until a report exists.
+  coach_lead?: string | null;
 }
 
 export default function ActivityList({ activities }: { activities: Activity[] }) {
@@ -49,6 +53,19 @@ export default function ActivityList({ activities }: { activities: Activity[] })
                 <span aria-hidden="true">•</span>
                 <span>{Math.floor(activity.moving_time_s / 60)} min</span>
               </div>
+              {/* font-serif matches how coach prose reads in CoachSheet and
+                  CoachReportPanel, so the coach's voice looks the same wherever
+                  it appears rather than like list metadata. */}
+              {activity.coach_lead && (
+                <p className="mt-2 flex items-start gap-2 font-serif text-sm leading-snug text-gray-700 dark:text-gray-300">
+                  <MessageSquareQuote
+                    size={15}
+                    aria-hidden="true"
+                    className="mt-0.5 shrink-0 text-gray-400 dark:text-gray-500"
+                  />
+                  <span className="line-clamp-2">{activity.coach_lead}</span>
+                </p>
+              )}
             </div>
             <ChevronRight className="text-gray-400 dark:text-gray-500 shrink-0" />
           </div>


### PR DESCRIPTION
Closes #797.

## Why

Telegram is the only channel that ever **announces** a report. A runner who declines to link one still has every report generated, stored and visible on the activity page — and nothing anywhere in the app said so.

That is not a degraded experience, it is a silent one: the product keeps working perfectly and never mentions it. Declining Telegram was a dead end rather than a supported choice. It is also why #795 ran for a week unreported — the runner best placed to notice their notifications were misrouted had never received one, so silence looked normal.

## What this does

The activity list carries each run's **coach lead** — the report's own opening sentence — so opening the app is enough to discover the run was coached.

```
Evening Run   [Hilly moderate run]
Aug 5, 2026 · 5.08 km · 29 min
💬 The headline tonight is actually the drift: -1.8% across 91m of
   climbing, against your own typical of about +2.2% on comparable hilly runs.

Evening Walk  [Walk]
Aug 5, 2026 · 3.20 km · 30 min
```

Coached runs carry a line; walks carry none (reports are runs-only, #643).

## What this deliberately does not do

- **No read/unread state.** A per-device `localStorage` marker lies on a second browser, and server-side read tracking is a migration plus a write path for a cosmetic signal. Someone who declines push has accepted they check in themselves — what they need is the coaching visible when they do, not a notification substitute.
- **No new pressure to link.** No extra prompt, no escalation, no onboarding gate. `TelegramLinkPrompt`'s permanent dismissal is the runner's choice being honoured correctly and is untouched.

## Correcting the issue

#797 as originally filed was wrong on two counts, [corrected in a comment](https://github.com/philippe-ths/ai-running-coach/issues/797#issuecomment-5197292257) before work started:

- *"The prompt is not reaching new signups"* — false. `TelegramLinkPrompt` shipped 2026-07-01, four weeks before the affected runner signed up, renders on both the home and activity pages, and `TELEGRAM_BOT_USERNAME` is set on `web`, so it would have rendered for them.
- *"Receives nothing"* — overstated. Reports were generated, stored and visible in-app. What was lost is delivery.

## Design notes

- **Selection mirrors `get_displayable_report_row`** (active version, else most recent current row), so the list and the detail page can never quote two different reports for one run.
- **Fallback rows excluded.** `is_fallback` marks a generation that FAILED; its apology text is not coaching to advertise.
- **Each activity's own report**, not the #482 block-primary fallback — otherwise one session's report prints against both a walk and the run beside it.
- **One query per page**, not per row. This path runs on every app open for 20 activities by default. Pinned by test.
- **Reuses the stored digest**, re-projecting through the shared `build_report_digest` only for pre-A2a rows (mirroring `retrieval._resolve_digest`), so the sentence shown is the same text the longitudinal read treats as that report's lead rather than a second projection that could drift.
- `font-serif` matches how coach prose renders in `CoachSheet` and `CoachReportPanel`, so the coach's voice looks the same wherever it appears rather than like list metadata.

## Verification

- **Browser, real data:** production-seeded local DB (`make seed-local`), checked in **both light and dark** — coached runs carry a genuine lead, walks carry none.
- **API end-to-end:** `GET /api/activities` returns `coach_lead` populated from real reports.
- **Suite:** 2443 passed against a 2429 baseline; the delta is the 14 new tests.
- **Wiring covered explicitly:** #684 serialises this list by hand (`jsonable_encoder` over pre-validated models) rather than via `response_model`, so a new field reaching the client is not automatic — there are endpoint tests for it, not only service tests.

Edge cases pinned: no report, fallback report, superseded audit copy (#646), opener-only row with an empty message, stale-version fallback after a `COACH_PROMPT_ID` flip (#261), a malformed stored row, and lead-to-activity matching across a page.

## Not verified

- No component test runner exists in this repo, so the frontend evidence is the browser check plus `next lint`/`next build`.
- Visual quality is a human judgement — the screenshots are above.
