### PR TITLE
fix(auth): the local degrade resolves the owner, not an arbitrary runner (#817)

### DIFF
--- a/backend/app/core/clerk_auth.py
+++ b/backend/app/core/clerk_auth.py
@@ -334,9 +334,23 @@ def _lookup_user_by_email(db: Session, normalized: str) -> Optional[User]:
 def _degraded_single_user(db: Session) -> Optional[User]:
     """The one local user when Clerk is unconfigured outside production.
 
-    Prefer the Strava-linked user (matches the legacy profile resolution), else
-    any user. Does not create a row -- callers that need a default own that.
+    Prefer the owner (``OWNER_EMAIL``), then the Strava-linked user (the legacy
+    profile resolution), else any user. Does not create a row -- callers that
+    need a default own that.
+
+    The owner check is what makes "the single local user" single. A local DB
+    seeded from the production snapshot can hold several Strava-linked users, and
+    the Strava fallback below is an unordered scan: it returns whichever row sits
+    first in the heap, and that changes when a token refresh rewrites a row. So
+    the ungated stack silently switched between real people's data from one
+    request to the next, and anything reading it (the local UI, the Auto-real
+    video build) rendered whoever it happened to get.
     """
+    owner = settings.OWNER_EMAIL.strip().lower()
+    if owner:
+        user = _lookup_user_by_email(db, owner)
+        if user is not None:
+            return user
     strava = db.execute(select(StravaAccount)).scalars().first()
     if strava is not None:
         return strava.user

--- a/backend/tests/test_clerk_auth.py
+++ b/backend/tests/test_clerk_auth.py
@@ -563,6 +563,68 @@ class TestLocalNoAuth:
         monkeypatch.setattr(settings, "CLERK_JWKS_URL", "")
         assert settings.clerk_enabled is False
 
+    def test_degrade_resolves_the_owner_when_several_strava_users_exist(
+        self, db, monkeypatch
+    ):
+        # The real local shape: a DB seeded from the production snapshot holds
+        # more than one Strava-linked user. The Strava fallback is an unordered
+        # scan, so before the owner check it returned whichever row sat first in
+        # the heap -- and a token refresh reorders that, silently switching the
+        # ungated stack between real people's data mid-session.
+        monkeypatch.setattr(settings, "OWNER_EMAIL", "owner@gmail.com")
+        other = User(email="someone-else@gmail.com")
+        owner = User(email="owner@gmail.com")
+        db.add_all([other, owner])  # non-owner first, so insertion order != owner
+        db.flush()
+        db.add_all(
+            [
+                StravaAccount(
+                    user_id=other.id,
+                    strava_athlete_id=101,
+                    access_token="t",
+                    refresh_token="r",
+                    expires_at=0,
+                    scope="read",
+                ),
+                StravaAccount(
+                    user_id=owner.id,
+                    strava_athlete_id=102,
+                    access_token="t",
+                    refresh_token="r",
+                    expires_at=0,
+                    scope="read",
+                ),
+            ]
+        )
+        db.commit()
+        owner_id = owner.id
+
+        assert clerk_auth._degraded_single_user(db).id == owner_id
+
+    def test_degrade_falls_back_to_strava_user_without_owner_email(
+        self, db, monkeypatch
+    ):
+        # No owner configured: the legacy Strava-linked resolution is unchanged,
+        # so a DB with one linked user keeps working exactly as before.
+        monkeypatch.setattr(settings, "OWNER_EMAIL", "")
+        linked = User(email="linked@gmail.com")
+        db.add(linked)
+        db.flush()
+        db.add(
+            StravaAccount(
+                user_id=linked.id,
+                strava_athlete_id=103,
+                access_token="t",
+                refresh_token="r",
+                expires_at=0,
+                scope="read",
+            )
+        )
+        db.commit()
+        linked_id = linked.id
+
+        assert clerk_auth._degraded_single_user(db).id == linked_id
+
 
 # --- real ASGI transport (httpx), not just TestClient ----------------------
 


### PR DESCRIPTION
Closes #817.

## Goal

The dev-only ungated mode should resolve one identifiable runner. Today it resolves whichever Strava-linked row an unordered scan returns first.

## Provenance (please read)

This change was authored in the working tree during epic #799, while verifying routes against a locally seeded production snapshot, and was found uncommitted during session close-out. It is unrelated to any phase of that epic and was never part of a reviewed branch, so it is on its own PR rather than folded into someone else's. Treat it as unreviewed work that happens to come with tests.

## What changed

`_degraded_single_user` prefers `OWNER_EMAIL` before falling back to the existing Strava-linked resolution. Two tests: one pinning owner resolution when several Strava users exist and the non-owner is inserted first, one pinning the unchanged fallback when no owner is configured.

## Decisions

- **Owner first, then the legacy path**, rather than replacing it. The no-owner and single-user cases stay byte-identical, so nothing about existing local setups changes.
- **No ordering added to the fallback scan.** Making the scan deterministic would mask the real problem rather than fix it, and the fallback is correct where it applies (one user).
- **Not treated as a security fix.** The degrade cannot engage in production: `LOCAL_NO_AUTH` is ignored when `APP_ENV=production`, and unconfigured Clerk fails closed with a 503 there. The impact is that local verification against real data could silently be reading a different runner than intended.

## Verification

- Full backend suite green: 2674 passed, 12 deselected (2672 on `main` plus the two added here).
- `tests/test_clerk_auth.py` 39 passed.
- Not exercised end to end through the ungated stack in a browser; the tests cover the resolution function directly.

## Unverified surface

The symptom that prompted this (the local UI rendering a different runner between requests) is not reproduced by an automated test, only the resolution rule underneath it.