### PR TITLE
fix(coach): a reply withheld for medical overreach ships no proposed action

### DIFF
--- a/backend/app/services/coach/thread_turn.py
+++ b/backend/app/services/coach/thread_turn.py
@@ -384,6 +384,7 @@ async def stream_thread_turn(
     ):
         yield event
 
+    gated = False
     if out["stream_failed"]:
         assistant_text = out["stream_fail_message"]
     else:
@@ -413,6 +414,15 @@ async def stream_thread_turn(
                 [v.rule for v in violations],
             )
             assistant_text = MEDICAL_REDIRECT_MESSAGE
+            # The offer was minted by the same reasoning whose prose we just
+            # withheld, so it does not survive it (#787). Withholding the text
+            # and shipping the card would leave the runner an unexplained offer
+            # to write to their record, since the prose that would have explained
+            # it is exactly what was removed. The report path sets the precedent:
+            # a medical violation there forces is_fallback for the whole artifact
+            # rather than trimming part of it. The minted token is simply left to
+            # expire unspent; nothing can redeem it without this frame.
+            gated = True
         elif violations:
             logger.warning(
                 "thread reply has tolerated policy violations (thread %s): %s",
@@ -423,7 +433,7 @@ async def stream_thread_turn(
     for piece in _slice_for_stream(assistant_text):
         yield ChatStreamEvent(text=piece)
 
-    if out.get("proposed_action") is not None:
+    if out.get("proposed_action") is not None and not gated:
         yield ChatStreamEvent(proposed_action=out["proposed_action"])
 
     assistant_msg = CoachChatMessage(

--- a/backend/tests/test_thread_api.py
+++ b/backend/tests/test_thread_api.py
@@ -430,6 +430,69 @@ class TestThreadTurn:
         assert "Mark" in actions[0]["description"]
         assert actions[0]["token"]
 
+    def test_a_reply_gated_for_medical_overreach_ships_no_proposed_action(
+        self, client, db
+    ):
+        """#787: the turn's reasoning was judged unsafe and its prose withheld, so
+        an offer minted during that same reasoning does not survive it. The runner
+        would otherwise get the safe redirect followed by an unexplained card
+        offering to write to their record: the prose that would have explained the
+        offer is exactly what the floor removed. The report path sets the
+        precedent, forcing `is_fallback=True` for the whole artifact rather than
+        trimming part of it."""
+        user = _seed_user(db)
+        activity = _seed_activity(db, user)
+        _act_as(user)
+
+        class _FakeRedis:
+            def __init__(self):
+                self._store = {}
+
+            def set(self, key, value, ex=None):
+                self._store[key] = value
+                return True
+
+            def getdel(self, key):
+                return self._store.pop(key, None)
+
+        fake_redis = _FakeRedis()
+        rounds = [
+            [
+                {
+                    "name": "offer_proposed_action",
+                    "input": {
+                        "action_type": "intent",
+                        "activity_id": str(activity.id),
+                        "user_intent": "Tempo",
+                    },
+                }
+            ],
+            "That knee pain is patellar tendinopathy. Take 400mg of ibuprofen first.",
+        ]
+        with patch(
+            "app.services.coach.llm.AnthropicClient.stream_chat_turn",
+            new=chat_tool_loop_stub(rounds),
+        ), patch("app.services.coach.proposed_actions.redis_conn", fake_redis):
+            resp = client.post(
+                "/api/coach/threads/messages",
+                json={
+                    "message": "knee hurts, was this a tempo?",
+                    "anchor_activity_id": str(activity.id),
+                    "asked_from": "activity",
+                },
+            )
+
+        assert resp.status_code == 200
+        text, objects = _parse_sse(resp.text)
+
+        # The floor still works: unsafe prose is replaced, not merely flagged.
+        assert "patellar" not in text
+        assert "ibuprofen" not in text
+        assert MEDICAL_REDIRECT_MESSAGE in text
+
+        # And the offer minted in the same turn does not ride along behind it.
+        assert [o for o in objects if o.get("type") == "proposed_action"] == []
+
     def test_a_loaded_skill_is_recorded_on_the_turn_and_costs_no_lookup(
         self, client, db
     ):


### PR DESCRIPTION
Closes #787.

## The defect

When a thread turn's reply trips validator rule 5, the prose is replaced with `MEDICAL_REDIRECT_MESSAGE`. The proposed-action frame was then yielded anyway, because it sat after the text with no reference to whether the reply had been gated.

The runner saw a safe non-diagnostic redirect followed by an unexplained card offering to write to their record, carrying a live confirmable token. The offer was minted by the same reasoning whose conclusions were judged unsafe, and the prose that would have explained it is exactly what the floor removed.

## The fix

Suppress the frame when the reply is gated, which is the first of the two options #787 puts up. The minted token is left to expire unspent; nothing can redeem it without the frame.

The report path sets the precedent for the stricter reading: a medical-overreach violation surviving there forces `is_fallback=True` for the whole artifact rather than trimming part of it. This matches that behaviour at the yield.

The alternative, moving the mint decision after validation so an offer is never created for a reply that will be gated, is structurally cleaner and cannot drift back. It reshapes the tool loop, so it is not folded in here.

## Verification

The regression test drives the real SSE wire and asserts both halves:

- the floor still replaces the prose (`patellar` and `ibuprofen` absent, redirect present), and
- no `proposed_action` frame follows it.

Written first and confirmed red against the old code, where it failed with the card present: `Left contains one more item: {'action_type': 'intent', 'description': "Mark Thursday's 8.2 km run as Tempo", ...}`. That is the issue's reproduction, reproduced.

`test_thread_turn_streams_a_proposed_action_frame` is untouched and still passes, so the suppression is scoped to the gated case rather than disabling the feature. Full backend suite: 2675 passed.

## Scope

`thread_turn.py:437` is the only site that yields this frame; the activity chat box that would have been the second copy was retired in #770. Confirmed by grep across `backend/app/`.

Not a data-safety hole either way, as the issue records: the action set is fixed and reversible, and a card's description is server-authored from whitelisted values, so no unsafe text could ever have ridden it.