### PR TITLE
fix(checks): the stale-branch check survives a squash merge

### DIFF
--- a/project-checks.md
+++ b/project-checks.md
@@ -22,12 +22,24 @@ Railway CLI is not logged in; commands below read a project token from
   live work.
 - Matters: separates what the human left mid-task from what arrived without them.
 
-### Merged branches left behind
-- Check: `git branch --merged main | grep -v '^\* main'`
-- Normal: empty. GitHub auto-deletes the remote branch on merge, so a local
-  survivor is cleanup debt rather than work in progress.
-- Matters: `worktree-agent-*` branches accumulate from sub-agent isolation runs and
-  are indistinguishable at a glance from a real branch someone is still using.
+### Branches left behind after a merge
+- Check: intersect the merged PRs' head branches with the branches that still
+  exist, locally and on the remote:
+  ```sh
+  gh pr list --state merged --limit 100 --json headRefName --jq '.[].headRefName' | sort -u > /tmp/merged
+  git branch --format='%(refname:short)' | sort -u | comm -12 /tmp/merged -
+  git ls-remote --heads origin | sed 's|.*refs/heads/||' | sort -u | comm -12 /tmp/merged -
+  ```
+- Normal: both empty.
+- Matters: **do not use `git branch --merged`.** This repository squash-merges, so
+  a branch tip never becomes an ancestor of `main` and the ancestry test reports a
+  false clean for every ordinary merged branch. It appears to work only for a
+  branch built on a real merge commit, which is why the `worktree-agent-*` stack
+  from #799 showed up under it while seven genuinely stale remote branches did not.
+  Deleting the remote copy is not automatic either: it is a per-merge choice on
+  GitHub, so some merged branches are removed and others survive.
+- Note: deleting a remote branch is a human call, so report these rather than
+  clearing them.
 
 ### Registered worktrees
 - Check: `git worktree list`


### PR DESCRIPTION
Corrects a check added in #819 that was wrong on the day it was written.

## The defect

`project-checks.md` used `git branch --merged main` to find branches left behind after a merge. That tests **ancestry**, and this repository squash-merges, so a merged branch's tip never becomes an ancestor of `main`. The check reported a false clean for every ordinary merged branch.

## Why it looked right

The branches in front of it when it was authored were the `worktree-agent-*` stack from #799, which was built on a real merge commit and so genuinely were ancestors. They were found, deleted, and the check looked confirmed. At that same moment seven stale remote branches from squash-merged PRs were sitting there invisible to it, including the head branch of #819 itself once that merged.

A check whose declared normal is wrong is worse than an absent one, because it reports green and the surface reads as covered.

## The fix

Intersect the merged PRs' head branches with the branches that still exist, locally and on the remote. That is indifferent to how the merge was performed.

Two further corrections to the same entry:

- Removing the remote branch on merge is a **per-merge choice** on GitHub, not automatic. #820's head branch was removed, #819's was not. The old entry asserted it always happens.
- Deleting a remote branch reaches beyond the local working tree, so the entry now says to report these rather than clear them.

## Verified

Running the corrected check names seven stale remote branches the old one could not see:

```
chore/814-wire-project-tests-into-validation-gate
docs/coach-thread-spec
feat/647-pack-per-run-distance-duration
feat/765-thread-storage
feat/766-thread-surface
feat/767-screen-context
fix/653-coach-week-frame-default
```