### PR TITLE
docs(checks): record abandoned branches as their own check

### DIFF
--- a/project-checks.md
+++ b/project-checks.md
@@ -41,6 +41,19 @@ Railway CLI is not logged in; commands below read a project token from
 - Note: deleting a remote branch is a human call, so report these rather than
   clearing them.
 
+### Branches left behind without a merge
+- Check: `git ls-remote --heads origin | sed 's|.*refs/heads/||'`, then date each
+  tip with `git log -1 --format='%ci %s' <sha>`.
+- Normal: exactly `main` plus these three known long-lived branches, none of which
+  came from a merged PR and so are invisible to the check above:
+  `claude/table-header-clipping-wrkz14` (2026-06-16),
+  `experiment/726-stream-representation-image-vs-json` (2026-07-21, the #726
+  experiment, also checked out locally), and `feat/118-magic-link-auth-infra`
+  (2026-06-02, superseded by Clerk under ADR 0022). Report any fourth.
+- Matters: the merged-branch check answers "was this cleaned up after merging" and
+  says nothing about a branch that was abandoned instead. Left alone, an abandoned
+  branch is indistinguishable from work in flight.
+
 ### Registered worktrees
 - Check: `git worktree list`
 - Normal: exactly one line, the main checkout. `.claude/worktrees/` empty.
@@ -57,7 +70,7 @@ Railway CLI is not logged in; commands below read a project token from
 
 ### Open issues
 - Check: `gh issue list --state open --limit 200 --json number --jq 'length'`
-- Normal: 31 as of 2026-08-07. Report the count and any issue opened since the last
+- Normal: 33 as of 2026-08-08. Report the count and any issue opened since the last
   session; do not list all of them.
 - Matters: an issue filed by the audit sweeps often already covers the work about to
   be started.


### PR DESCRIPTION
Doc-only. `project-checks.md` is the per-repository record of what a session preflight checks and what normal looks like for each (owned by `aiw-init`).

## Why

The existing check asks whether a branch was cleaned up **after merging**, and says nothing about one that was **abandoned** instead. Those look identical to a preflight: three stale remote branches read as three things possibly in flight.

This adds them as their own check, with each branch dated and its reason recorded, so the preflight becomes "report any fourth" rather than a list to re-derive and re-judge every session.

Verified still accurate at time of PR — `git ls-remote --heads origin` returns exactly `main` plus the three named:

- `claude/table-header-clipping-wrkz14` (2026-06-16)
- `experiment/726-stream-representation-image-vs-json` (2026-07-21, the #726 experiment, also checked out locally)
- `feat/118-magic-link-auth-infra` (2026-06-02, superseded by Clerk under ADR 0022)

## Also

Refreshes the open-issue baseline from 28 to **33** (2026-08-08). It had drifted during the #822 voice work, which opened five issues. A "normal" figure that is already wrong on the day it merges trains the reader to skip the line, which defeats the check.

## Provenance

The abandoned-branches section was written in the 2026-08-07 preflight session and left uncommitted. I kept it out of #823 because it was not mine and unrelated to that change; this carries it in on its own, with both of its factual claims re-verified rather than taken on trust.

No code, no tests affected. Repo validation gate passed before commit.
