### PR TITLE
feat(schedule): the three-month horizon (#830)

### DIFF
--- a/backend/app/services/schedule/draft_contract.py
+++ b/backend/app/services/schedule/draft_contract.py
@@ -328,7 +328,18 @@ RECORD_TRAINING_PLAN_TOOL = {
                     "required": ["week_start"],
                     "properties": {
                         "week_start": {"type": "string"},
-                        "phase": {"type": "string"},
+                        "phase": {
+                            "type": "string",
+                            "description": (
+                                "The BLOCK this week belongs to — Base, Build, "
+                                "Peak, Taper, Recovery. Weeks in the same block "
+                                "share the SAME name, so the horizon can group "
+                                "them under one heading. Do not number them "
+                                "individually ('Base — Week 3'): a name unique to "
+                                "one week groups nothing and turns the horizon "
+                                "into a label per row."
+                            ),
+                        },
                         "target_running_distance_m": {"type": "number"},
                         "sessions_by_discipline": {
                             "type": "object",

--- a/frontend/app/schedule/page.tsx
+++ b/frontend/app/schedule/page.tsx
@@ -10,6 +10,7 @@
 // the done count AND the discipline mix, which no client can correctly patch.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { fetchFromAPI } from "@/lib/api";
 import { formatDateLabel } from "@/lib/format";
@@ -21,7 +22,10 @@ import SessionCard from "@/components/schedule/SessionCard";
 import RulesPanel from "@/components/schedule/RulesPanel";
 import LoggedList from "@/components/schedule/LoggedList";
 import EmptyWeek from "@/components/schedule/EmptyWeek";
+import HorizonView from "@/components/schedule/HorizonView";
 import { addDaysIso, todayIso } from "@/components/schedule/dates";
+
+type View = "week" | "horizon";
 
 const PLACEMENT_RANK: Record<string, number> = { pinned: 0, window: 1, week: 2 };
 
@@ -35,6 +39,9 @@ function sortSessions(sessions: PlannedSession[]): PlannedSession[] {
 }
 
 export default function SchedulePage() {
+  // The week stays the default view: it is what the runner is doing next, and
+  // the horizon is the step back from it.
+  const [view, setView] = useState<View>("week");
   // null = "the current week", which is what the API defaults to. Navigation
   // sets an explicit day and the API resolves it to the runner's own week
   // boundary, so the client never has to know where their week starts.
@@ -158,31 +165,43 @@ export default function SchedulePage() {
             The week ahead, and how it is going.
           </p>
         </div>
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            aria-label="Previous week"
-            onClick={() => week && setWeekParam(addDaysIso(week.week_start, -7))}
-            disabled={!week}
-            className="rounded-md p-2 text-gray-500 hover:bg-gray-100 disabled:opacity-30 dark:text-gray-400 dark:hover:bg-gray-700/50"
-          >
-            <ChevronLeft size={18} aria-hidden="true" />
-          </button>
-          <span className="min-w-[8rem] text-center text-sm font-medium text-gray-600 dark:text-gray-400">
-            {label}
-          </span>
-          <button
-            type="button"
-            aria-label="Next week"
-            onClick={() => week && setWeekParam(addDaysIso(week.week_start, 7))}
-            disabled={!week}
-            className="rounded-md p-2 text-gray-500 hover:bg-gray-100 disabled:opacity-30 dark:text-gray-400 dark:hover:bg-gray-700/50"
-          >
-            <ChevronRight size={18} aria-hidden="true" />
-          </button>
-        </div>
+        {view === "week" && (
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              aria-label="Previous week"
+              onClick={() => week && setWeekParam(addDaysIso(week.week_start, -7))}
+              disabled={!week}
+              className="rounded-md p-2 text-gray-500 hover:bg-gray-100 disabled:opacity-30 dark:text-gray-400 dark:hover:bg-gray-700/50"
+            >
+              <ChevronLeft size={18} aria-hidden="true" />
+            </button>
+            <span className="min-w-[8rem] text-center text-sm font-medium text-gray-600 dark:text-gray-400">
+              {label}
+            </span>
+            <button
+              type="button"
+              aria-label="Next week"
+              onClick={() => week && setWeekParam(addDaysIso(week.week_start, 7))}
+              disabled={!week}
+              className="rounded-md p-2 text-gray-500 hover:bg-gray-100 disabled:opacity-30 dark:text-gray-400 dark:hover:bg-gray-700/50"
+            >
+              <ChevronRight size={18} aria-hidden="true" />
+            </button>
+          </div>
+        )}
       </header>
 
+      <ViewTabs view={view} onChange={setView} />
+
+      {view === "horizon" && (
+        <div id="panel-horizon" role="tabpanel" aria-labelledby="tab-horizon">
+          <HorizonView />
+        </div>
+      )}
+
+      {view === "week" && (
+        <div id="panel-week" role="tabpanel" aria-labelledby="tab-week" className="space-y-6">
       {error && (
         <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-300">
           {error}
@@ -275,6 +294,76 @@ export default function SchedulePage() {
           <LoggedList logged={week.logged} />
         </>
       )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const VIEWS: { value: View; label: string }[] = [
+  { value: "week", label: "This week" },
+  { value: "horizon", label: "Next 3 months" },
+];
+
+/**
+ * The two views of one schedule.
+ *
+ * A real tablist rather than two links: both views are the same page and the
+ * week must stay the default. Roving tabindex plus arrow keys is the WAI
+ * pattern — one Tab stop for the group, arrows to move within it — so the
+ * control is reachable and operable without a pointer.
+ */
+function ViewTabs({
+  view,
+  onChange,
+}: {
+  view: View;
+  onChange: (view: View) => void;
+}) {
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const index = VIEWS.findIndex((v) => v.value === view);
+    let next = index;
+    if (event.key === "ArrowRight") next = (index + 1) % VIEWS.length;
+    else if (event.key === "ArrowLeft") next = (index - 1 + VIEWS.length) % VIEWS.length;
+    else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = VIEWS.length - 1;
+    else return;
+    event.preventDefault();
+    onChange(VIEWS[next].value);
+    // The newly selected tab is the group's only tab stop, so focus has to
+    // follow the selection or the next Tab press would leave the group.
+    document.getElementById(`tab-${VIEWS[next].value}`)?.focus();
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Schedule view"
+      onKeyDown={onKeyDown}
+      className="flex gap-1 border-b border-gray-200 dark:border-gray-700"
+    >
+      {VIEWS.map((v) => {
+        const selected = v.value === view;
+        return (
+          <button
+            key={v.value}
+            id={`tab-${v.value}`}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            aria-controls={`panel-${v.value}`}
+            tabIndex={selected ? 0 : -1}
+            onClick={() => onChange(v.value)}
+            className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+              selected
+                ? "border-blue-600 text-blue-700 dark:border-blue-400 dark:text-blue-300"
+                : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-200"
+            }`}
+          >
+            {v.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/components/schedule/HorizonChart.tsx
+++ b/frontend/components/schedule/HorizonChart.tsx
@@ -1,0 +1,499 @@
+// #830: the horizon — three months of training as load per week.
+//
+// VERTICAL by design. Twelve weeks as horizontal bars running DOWN the page,
+// chosen over a twelve-column chart because at phone width twelve columns get
+// ~28px each and force 8px labels. As rows every week gets the full width, the
+// ramp reads down the right-hand edge, and a wide screen simply lengthens the
+// bars — one layout, no breakpoint where the reading changes.
+//
+// Bar LENGTH is the week's load as a true proportion of the peak week. True
+// proportions are the whole point: segment widths that overflow their track make
+// every bar look maxed out and the ramp disappears. So the bar's length carries
+// the peak proportion and the segments inside it only ever divide THAT length —
+// they are laid out with flex-grow against a zero basis, which cannot overflow
+// however the shares round.
+//
+// TWO BANDS, ONE LENGTH, because they are the same week's load seen two ways: a
+// thick band split by discipline over a thin band split by intent. Nothing is
+// normalised away, so the ramp reads identically down either edge.
+//
+// `planned` vs sketched is a TICK, not a fade. Fading sketched rows washes out
+// ten of twelve rows and costs the reader the ramp to say something a 8px mark
+// says better.
+//
+// The chart itself is aria-hidden and its text alternative is the table twin
+// below it, which carries every number the bars encode plus the phases and the
+// races. Screen readers always reach it; sighted readers toggle it open.
+
+import type { ReactNode } from "react";
+import type { GoalRace, ScheduleHorizon } from "@/lib/types/schedule";
+import { formatDateLabel } from "@/lib/format";
+import { addDaysIso } from "./dates";
+import {
+  DISCIPLINE_FILL,
+  DISCIPLINE_LABEL,
+  DISCIPLINE_ORDER,
+  INTENT_FILL,
+  INTENT_LABEL,
+  INTENT_ORDER,
+  safeDiscipline,
+  safeIntent,
+} from "./palette";
+
+export type Segmentation = "both" | "intent" | "discipline";
+
+interface Segment {
+  key: string;
+  label: string;
+  fill: string;
+  share: number;
+}
+
+// Draw order is FIXED by the palette's declared order, never sorted by share.
+// A stack re-sorted per week makes its segments jump sideways row to row, which
+// destroys the one thing a vertical horizon is for: tracking a band down the
+// page.
+function buildSegments(
+  mix: Record<string, number>,
+  order: readonly string[],
+  label: (key: string) => string,
+  fill: (key: string) => string,
+): Segment[] {
+  const seen = new Set<string>();
+  const out: Segment[] = [];
+  for (const key of order) {
+    const share = mix[key];
+    if (typeof share === "number" && share > 0) {
+      seen.add(key);
+      out.push({ key, label: label(key), fill: fill(key), share });
+    }
+  }
+  // A key the plan invented that is not in the vocabulary still has to draw, or
+  // the bands would silently under-report the week they are a mix of. It keeps
+  // its OWN key so React never collides two unknowns onto one degraded slot.
+  for (const [key, share] of Object.entries(mix)) {
+    if (!seen.has(key) && share > 0) {
+      out.push({ key, label: label(key), fill: fill(key), share });
+    }
+  }
+  return out;
+}
+
+function disciplineSegments(mix: Record<string, number>): Segment[] {
+  return buildSegments(
+    mix,
+    DISCIPLINE_ORDER,
+    (k) => DISCIPLINE_LABEL[safeDiscipline(k)],
+    (k) => DISCIPLINE_FILL[safeDiscipline(k)],
+  );
+}
+
+function intentSegments(mix: Record<string, number>): Segment[] {
+  return buildSegments(
+    mix,
+    INTENT_ORDER,
+    (k) => INTENT_LABEL[safeIntent(k)],
+    (k) => INTENT_FILL[safeIntent(k)],
+  );
+}
+
+function pct(share: number): number {
+  return Math.round(share * 100);
+}
+
+/** Running km, exact. A week with no running distance reads as an absence. */
+function km(metres: number | null): string {
+  if (metres == null || metres <= 0) return "—";
+  return (metres / 1000).toFixed(1);
+}
+
+function describeMix(segments: Segment[]): string {
+  if (segments.length === 0) return "no mix";
+  return segments.map((s) => `${s.label} ${pct(s.share)}%`).join(", ");
+}
+
+/** One band of the bar: the segments, separated by 2px of the row's surface. */
+function Band({
+  segments,
+  height,
+  surface,
+}: {
+  segments: Segment[];
+  height: string;
+  surface: string;
+}) {
+  return (
+    <div className={`flex ${height} gap-[2px] overflow-hidden rounded-r-[3px] ${surface}`}>
+      {segments.map((s) => (
+        <div
+          key={s.key}
+          className={s.fill}
+          // flex-grow against a zero basis: the shares divide the bar's own
+          // length and cannot overflow it, however they round.
+          style={{ flexGrow: s.share, flexBasis: 0, minWidth: 0 }}
+        />
+      ))}
+    </div>
+  );
+}
+
+const GRID_STOPS = [25, 50, 75];
+
+const ROW_GRID =
+  "grid grid-cols-[3.25rem_0.75rem_minmax(0,1fr)_3rem] items-center gap-x-2";
+
+export default function HorizonChart({
+  horizon,
+  segmentation,
+  showTable,
+}: {
+  horizon: ScheduleHorizon;
+  segmentation: Segmentation;
+  showTable: boolean;
+}) {
+  const peak = horizon.peak_effort_score ?? 0;
+  const showDiscipline = segmentation !== "intent";
+  const showIntent = segmentation !== "discipline";
+  const both = segmentation === "both";
+
+  // A race lands in the week whose seven days contain it. Weeks are contiguous
+  // and the API only returns races inside the span, so a race that matches no
+  // week is a mismatch worth not silently dropping — it falls to the tail.
+  const racesByWeek = new Map<string, GoalRace[]>();
+  const placed = new Set<string>();
+  for (const race of horizon.races) {
+    const week = horizon.weeks.find(
+      (w) => race.race_date >= w.week_start && race.race_date <= addDaysIso(w.week_start, 6),
+    );
+    if (!week) continue;
+    placed.add(race.id);
+    const list = racesByWeek.get(week.week_start) ?? [];
+    list.push(race);
+    racesByWeek.set(week.week_start, list);
+  }
+  const unplacedRaces = horizon.races.filter((r) => !placed.has(r.id));
+
+  const rows: ReactNode[] = [];
+  let lastPhase: string | null = null;
+
+  for (const week of horizon.weeks) {
+    const disc = disciplineSegments(week.discipline_mix);
+    const intent = intentSegments(week.intent_mix);
+    const load = week.effort_score ?? 0;
+    const length = peak > 0 && load > 0 ? Math.min(100, (load / peak) * 100) : 0;
+
+    if (week.phase && week.phase !== lastPhase) {
+      rows.push(
+        <div
+          key={`phase-${week.week_start}`}
+          className="mt-3 flex items-center gap-2 pb-1 pt-2 first:mt-0 first:pt-0"
+        >
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {week.phase}
+          </span>
+          <span className="h-px flex-1 bg-gray-200 dark:bg-gray-700" aria-hidden="true" />
+        </div>,
+      );
+      lastPhase = week.phase;
+    }
+
+    // The row's own surface, which is also what shows through the 2px gaps
+    // between segments. The current week is tinted, so the gaps have to be
+    // tinted with it or every gap would read as a white seam.
+    const surface = week.is_current
+      ? "bg-blue-50 dark:bg-blue-950/50"
+      : "bg-white dark:bg-gray-800";
+
+    const summary = [
+      `Week of ${formatDateLabel(week.week_start)}`,
+      load > 0 ? `${Math.round(load)} load` : "nothing planned",
+      week.running_distance_m ? `${km(week.running_distance_m)} km running` : null,
+      disc.length ? `discipline: ${describeMix(disc)}` : null,
+      intent.length ? `intent: ${describeMix(intent)}` : null,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+
+    rows.push(
+      <div
+        key={week.week_start}
+        className={`${ROW_GRID} rounded-sm py-1 ${
+          week.is_current ? "bg-blue-50 dark:bg-blue-950/50" : ""
+        }`}
+      >
+        <span
+          className={`font-mono text-[11px] tabular-nums ${
+            week.is_current
+              ? "font-semibold text-blue-800 dark:text-blue-300"
+              : "text-gray-500 dark:text-gray-400"
+          }`}
+        >
+          {formatDateLabel(week.week_start)}
+        </span>
+
+        {/* Solid = real sessions, hollow = shape only. A tick rather than a
+            fade: fading the sketched weeks washes out most of the chart. */}
+        <span className="flex justify-center">
+          {week.planned ? (
+            <span className="h-2 w-2 rounded-full bg-gray-600 dark:bg-gray-300" />
+          ) : (
+            <span className="h-2 w-2 rounded-full border border-dashed border-gray-400 dark:border-gray-500" />
+          )}
+        </span>
+
+        <div className={`relative ${both ? "h-5" : "h-3.5"} ${surface}`} title={summary}>
+          {GRID_STOPS.map((stop) => (
+            <span
+              key={stop}
+              className="absolute inset-y-0 w-px bg-gray-200 dark:bg-gray-700"
+              style={{ left: `${stop}%` }}
+            />
+          ))}
+          {length > 0 && (
+            <div
+              className={`absolute inset-y-0 left-0 flex flex-col justify-center gap-[2px] ${surface}`}
+              style={{ width: `${length}%` }}
+            >
+              {showDiscipline && (
+                <Band
+                  segments={disc}
+                  height={both ? "h-3" : "h-3.5"}
+                  surface={surface}
+                />
+              )}
+              {showIntent && (
+                <Band
+                  segments={intent}
+                  height={both ? "h-1.5" : "h-3.5"}
+                  surface={surface}
+                />
+              )}
+            </div>
+          )}
+        </div>
+
+        <span
+          className={`text-right font-mono text-[11px] tabular-nums ${
+            week.is_current
+              ? "font-semibold text-blue-800 dark:text-blue-300"
+              : "text-gray-600 dark:text-gray-300"
+          }`}
+        >
+          {km(week.running_distance_m)}
+        </span>
+      </div>,
+    );
+
+    for (const race of racesByWeek.get(week.week_start) ?? []) {
+      rows.push(
+        <div key={race.id} className={`${ROW_GRID} py-0.5`}>
+          <span className="font-mono text-[11px] tabular-nums text-rose-700 dark:text-rose-400">
+            {formatDateLabel(race.race_date)}
+          </span>
+          <span className="flex justify-center">
+            <span className="h-2 w-0.5 bg-rose-700 dark:bg-rose-400" />
+          </span>
+          <span className="flex items-center gap-2 truncate text-[11px] font-medium text-rose-700 dark:text-rose-400">
+            <span className="h-px w-3 shrink-0 bg-rose-700 dark:bg-rose-400" />
+            <span className="truncate">{race.name}</span>
+          </span>
+          <span className="text-right font-mono text-[11px] tabular-nums text-rose-700 dark:text-rose-400">
+            {(race.distance_m / 1000).toFixed(0)}k
+          </span>
+        </div>,
+      );
+    }
+  }
+
+  // The legend covers exactly the series actually on the chart. Identity never
+  // rests on colour alone: every swatch is named here and again in the table.
+  const legendDisciplines = new Map<string, Segment>();
+  const legendIntents = new Map<string, Segment>();
+  for (const week of horizon.weeks) {
+    for (const s of disciplineSegments(week.discipline_mix)) legendDisciplines.set(s.key, s);
+    for (const s of intentSegments(week.intent_mix)) legendIntents.set(s.key, s);
+  }
+
+  const hasAnyLoad = peak > 0;
+
+  return (
+    <div>
+      <div aria-hidden="true">
+        <div className="space-y-0.5">{rows}</div>
+
+        {/* The scale. Bars are true proportions of the peak week, so the reader
+            is owed the number the proportion is of. */}
+        <div className={`${ROW_GRID} mt-2 border-t border-gray-100 pt-1.5 dark:border-gray-700`}>
+          <span />
+          <span />
+          <span className="flex justify-between text-[10px] text-gray-400 dark:text-gray-500">
+            <span className="font-mono tabular-nums">0</span>
+            <span>
+              {hasAnyLoad ? (
+                <>
+                  <span className="font-mono tabular-nums">{Math.round(peak)}</span> load
+                </>
+              ) : (
+                "no load"
+              )}
+            </span>
+          </span>
+          <span />
+        </div>
+
+        <div className="mt-3 space-y-1.5">
+          {showDiscipline && legendDisciplines.size > 0 && (
+            <LegendRow
+              title={both ? "Discipline" : "Discipline · thick band"}
+              items={Array.from(legendDisciplines.values())}
+            />
+          )}
+          {showIntent && legendIntents.size > 0 && (
+            <LegendRow
+              title={both ? "Intent" : "Intent · thick band"}
+              items={Array.from(legendIntents.values())}
+            />
+          )}
+          <p className="pt-1 text-[11px] text-gray-400 dark:text-gray-500">
+            Bar length is the week&rsquo;s load against your biggest week. Solid tick =
+            real sessions, hollow tick = shape only. The number on the right is
+            running km, so a long bar beside a small number is a week you cross-train.
+          </p>
+        </div>
+      </div>
+
+      <HorizonTable
+        horizon={horizon}
+        peak={peak}
+        unplacedRaces={unplacedRaces}
+        className={showTable ? "mt-6" : "sr-only"}
+      />
+    </div>
+  );
+}
+
+function LegendRow({ title, items }: { title: string; items: Segment[] }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+      <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+        {title}
+      </span>
+      {items.map((s) => (
+        <span
+          key={s.key}
+          className="flex items-center gap-1.5 text-[11px] text-gray-500 dark:text-gray-400"
+        >
+          <span className={`h-2 w-2 shrink-0 rounded-sm ${s.fill}`} />
+          {s.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The chart's text alternative, and the only place every value is written out.
+ *
+ * Always in the DOM: hidden it is `sr-only`, so a screen-reader user reaches the
+ * whole ramp, the mixes, the phases and the races without seeing the bars; shown
+ * it is the same table for everyone else. The bars are aria-hidden precisely so
+ * this is read once rather than twice.
+ */
+function HorizonTable({
+  horizon,
+  peak,
+  unplacedRaces,
+  className,
+}: {
+  horizon: ScheduleHorizon;
+  peak: number;
+  unplacedRaces: GoalRace[];
+  className: string;
+}) {
+  const cell = "px-2 py-1.5 align-top";
+  const head =
+    "px-2 py-1.5 text-left font-semibold text-gray-600 dark:text-gray-300";
+
+  return (
+    <div className={className}>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[34rem] border-collapse text-[11px] text-gray-600 dark:text-gray-300">
+          <caption className="pb-2 text-left text-[11px] text-gray-500 dark:text-gray-400">
+            Every week in the horizon, in words. Load is shown as a share of the
+            biggest week ({peak > 0 ? `${Math.round(peak)} load` : "no load planned"}),
+            which is what the bar lengths encode.
+          </caption>
+          <thead>
+            <tr className="border-b border-gray-200 dark:border-gray-700">
+              <th scope="col" className={head}>
+                Week of
+              </th>
+              <th scope="col" className={head}>
+                Phase
+              </th>
+              <th scope="col" className={head}>
+                Plan
+              </th>
+              <th scope="col" className={head}>
+                Load
+              </th>
+              <th scope="col" className={head}>
+                Running
+              </th>
+              <th scope="col" className={head}>
+                Discipline
+              </th>
+              <th scope="col" className={head}>
+                Intent
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {horizon.weeks.map((week) => {
+              const load = week.effort_score ?? 0;
+              const share = peak > 0 && load > 0 ? Math.round((load / peak) * 100) : 0;
+              return (
+                <tr
+                  key={week.week_start}
+                  className="border-b border-gray-100 last:border-0 dark:border-gray-700/60"
+                >
+                  <th
+                    scope="row"
+                    className={`${cell} whitespace-nowrap text-left font-medium text-gray-700 dark:text-gray-200`}
+                  >
+                    {formatDateLabel(week.week_start)}
+                    {week.is_current && " (this week)"}
+                  </th>
+                  <td className={cell}>{week.phase ?? "—"}</td>
+                  <td className={cell}>{week.planned ? "Sessions" : "Shape only"}</td>
+                  <td className={`${cell} whitespace-nowrap font-mono tabular-nums`}>
+                    {load > 0 ? `${share}% of peak` : "—"}
+                  </td>
+                  <td className={`${cell} whitespace-nowrap font-mono tabular-nums`}>
+                    {week.running_distance_m ? `${km(week.running_distance_m)} km` : "—"}
+                  </td>
+                  <td className={cell}>{describeMix(disciplineSegments(week.discipline_mix))}</td>
+                  <td className={cell}>{describeMix(intentSegments(week.intent_mix))}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {horizon.races.length > 0 && (
+        <p className="mt-2 text-[11px] text-gray-500 dark:text-gray-400">
+          Races in this window:{" "}
+          {horizon.races
+            .map(
+              (r) =>
+                `${r.name} on ${formatDateLabel(r.race_date)} (${(r.distance_m / 1000).toFixed(0)} km)`,
+            )
+            .join("; ")}
+          .
+          {unplacedRaces.length > 0 && " Some fall outside the weeks shown."}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/schedule/HorizonView.tsx
+++ b/frontend/components/schedule/HorizonView.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+// #830: the horizon's shell — the two filters, the fetch, and the states the
+// chart itself should never have to know about.
+//
+// Both filters sit in ONE row ABOVE the chart card rather than inside it: a
+// control that scopes what is drawn belongs outside the drawing. Range changes
+// refetch (the window is a server parameter); segmentation does not (it is a
+// view over data already in hand), so switching Intent/Discipline/Both never
+// costs a request.
+//
+// A refetch holds the previous chart at reduced opacity instead of dropping to
+// a skeleton, so changing range does not make the page jump.
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchFromAPI } from "@/lib/api";
+import type { ScheduleHorizon } from "@/lib/types/schedule";
+import HorizonChart, { type Segmentation } from "./HorizonChart";
+
+const RANGES = [
+  { label: "1M", weeks: 4, name: "One month" },
+  { label: "2M", weeks: 8, name: "Two months" },
+  { label: "3M", weeks: 12, name: "Three months" },
+] as const;
+
+const SEGMENTATIONS: { value: Segmentation; label: string }[] = [
+  { value: "intent", label: "Intent" },
+  { value: "discipline", label: "Discipline" },
+  { value: "both", label: "Both" },
+];
+
+function SegmentedControl<T extends string | number>({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: { value: T; label: string; name?: string }[];
+  value: T;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className="inline-flex rounded-md border border-gray-200 bg-white p-0.5 dark:border-gray-700 dark:bg-gray-800"
+    >
+      {options.map((option) => {
+        const selected = option.value === value;
+        return (
+          <button
+            key={String(option.value)}
+            type="button"
+            aria-pressed={selected}
+            onClick={() => onChange(option.value)}
+            className={`rounded px-2.5 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+              selected
+                ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
+                : "text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+            }`}
+          >
+            <span aria-hidden={option.name ? "true" : undefined}>{option.label}</span>
+            {option.name && <span className="sr-only">{option.name}</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function HorizonView() {
+  const [weeks, setWeeks] = useState<number>(12);
+  const [segmentation, setSegmentation] = useState<Segmentation>("both");
+  const [showTable, setShowTable] = useState(false);
+  const [horizon, setHorizon] = useState<ScheduleHorizon | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (count: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data: ScheduleHorizon | null = await fetchFromAPI(
+        `/api/schedule/horizon?weeks=${count}`,
+      );
+      if (data) setHorizon(data);
+      else setError("Your horizon is not available right now.");
+    } catch {
+      setError("Could not load your horizon.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(weeks);
+  }, [weeks, load]);
+
+  // Empty is "no week carries any load", not "no plan": a plan whose weeks are
+  // all shape-less would otherwise draw twelve blank rows and a scale of zero.
+  const isEmpty =
+    !!horizon && !horizon.weeks.some((w) => (w.effort_score ?? 0) > 0);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <SegmentedControl
+          label="Horizon range"
+          options={RANGES.map((r) => ({ value: r.weeks, label: r.label, name: r.name }))}
+          value={weeks}
+          onChange={setWeeks}
+        />
+        <SegmentedControl
+          label="Split the bars by"
+          options={SEGMENTATIONS}
+          value={segmentation}
+          onChange={setSegmentation}
+        />
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {loading && !horizon && (
+        <div className="py-16 text-center text-gray-400 dark:text-gray-500">
+          Loading your horizon…
+        </div>
+      )}
+
+      {horizon && (
+        <section
+          className={`rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition-opacity dark:border-gray-700 dark:bg-gray-800 sm:p-5 ${
+            loading ? "opacity-60" : ""
+          }`}
+        >
+          <h2 className="mb-1 text-sm font-semibold text-gray-700 dark:text-gray-300">
+            Load per week
+          </h2>
+          <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
+            {horizon.has_plan
+              ? "The shape of the block: concrete for the next few weeks, sketched beyond."
+              : "You have no plan yet, so this is the shape of the weeks ahead as it stands."}
+          </p>
+
+          {isEmpty ? (
+            <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">
+              Nothing is planned across these weeks yet.
+            </p>
+          ) : (
+            <>
+              <HorizonChart
+                horizon={horizon}
+                segmentation={segmentation}
+                showTable={showTable}
+              />
+              <div className="mt-4 border-t border-gray-100 pt-3 dark:border-gray-700">
+                <button
+                  type="button"
+                  onClick={() => setShowTable((v) => !v)}
+                  className="-ml-2 rounded-md px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-blue-400 dark:hover:bg-blue-900/30"
+                >
+                  {showTable ? "Hide the numbers" : "Show the numbers"}
+                  {/* Deliberately no aria-expanded: the table is in the
+                      accessibility tree either way (hidden it is sr-only), so
+                      claiming it is collapsed would be false. This button
+                      controls whether it is drawn on screen. */}
+                  <span className="sr-only"> on screen</span>
+                </button>
+              </div>
+            </>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/schedule/palette.ts
+++ b/frontend/components/schedule/palette.ts
@@ -59,15 +59,48 @@ export const DISCIPLINE_LABEL: Record<Discipline, string> = {
   other: "Other",
 };
 
-// One hue, stepped. Run is the darkest step because it is the priority sport.
+// One hue, stepped by priority — run is the most prominent step because it is
+// the priority sport. Five real disciplines take the ramp; `other` is the
+// residual bucket and sits OUTSIDE it in neutral grey, because a residual has
+// no rank to encode and six steps of one hue cannot hold a visible gap between
+// each pair.
+//
+// The steps are not eyeballed. Six blue steps failed the ordinal checks twice
+// over (blue-700↔blue-600 ΔL 0.058, under the 0.06 floor; blue-200's light end
+// at 1.42:1 against white, under the 2:1 floor) and two disciplines collapsed
+// onto the same dark twin. Five steps clear every check in both modes
+// (light end 2.54:1 light, 2.84:1 dark). The horizon draws these as stacked
+// segments at width, which is where a collapsed pair actually costs a reading.
+//
+// The dark twins REVERSE the anchor: on a dark surface prominence is lightness,
+// so run takes the lightest step there and the ordering survives the flip.
 export const DISCIPLINE_FILL: Record<Discipline, string> = {
-  run: "bg-blue-700 dark:bg-blue-500",
-  bike: "bg-blue-600 dark:bg-blue-400",
-  strength: "bg-blue-500 dark:bg-blue-300",
-  row: "bg-blue-400 dark:bg-blue-200",
-  walk: "bg-blue-300 dark:bg-blue-200",
-  other: "bg-blue-200 dark:bg-blue-100",
+  run: "bg-blue-950 dark:bg-blue-200",
+  bike: "bg-blue-800 dark:bg-blue-300",
+  strength: "bg-blue-600 dark:bg-blue-400",
+  row: "bg-blue-500 dark:bg-blue-500",
+  walk: "bg-blue-400 dark:bg-blue-600",
+  other: "bg-gray-500 dark:bg-gray-400",
 };
+
+/** Stable draw order for a stacked mix: the ramp, darkest first, residual last. */
+export const DISCIPLINE_ORDER: Discipline[] = [
+  "run",
+  "bike",
+  "strength",
+  "row",
+  "walk",
+  "other",
+];
+
+/** Stable draw order for an intent mix. Rest last: it is an absence. */
+export const INTENT_ORDER: SessionIntent[] = [
+  "easy",
+  "long",
+  "quality",
+  "strength",
+  "rest",
+];
 
 // The letter carried inside a pip, so discipline never needs a second colour.
 // Run has none: it is the default sport, and "R" is owed to Row.

--- a/frontend/lib/types/schedule.ts
+++ b/frontend/lib/types/schedule.ts
@@ -139,3 +139,38 @@ export interface GoalRace {
   distance_m: number;
   priority: string;
 }
+
+// --- the horizon ------------------------------------------------------------
+//
+// The block's SHAPE rather than its sessions: concrete for about three weeks,
+// sketched beyond. `planned` is derived server-side from what is actually
+// there, so it can never claim a week holds sessions it does not.
+//
+// A week the plan says nothing about still arrives, with a null load and empty
+// mixes, so the horizon stays a continuous run of weeks and a gap reads as a
+// gap rather than as a shorter block.
+
+export interface HorizonWeek {
+  week_start: string;
+  phase: string | null;
+  // True when the week holds committed sessions; false when it is shape only.
+  planned: boolean;
+  is_current: boolean;
+  running_distance_m: number | null;
+  effort_score: number | null;
+  // discipline/intent -> share of the week's load, 0..1. Shares, not absolutes,
+  // so a mix can never contradict the total it is a mix of. An all-zero week
+  // yields an empty map rather than a fake even split.
+  discipline_mix: Record<string, number>;
+  intent_mix: Record<string, number>;
+}
+
+export interface ScheduleHorizon {
+  weeks: HorizonWeek[];
+  races: GoalRace[];
+  has_plan: boolean;
+  // The largest weekly load in the window. Bar lengths are true proportions of
+  // it — null (or zero) means there is nothing to scale against and every week
+  // draws empty.
+  peak_effort_score: number | null;
+}

--- a/frontend/scripts/smoke.mjs
+++ b/frontend/scripts/smoke.mjs
@@ -306,6 +306,148 @@ const mockScheduleWeek = {
   ],
 };
 
+// #830: the horizon. Twelve weeks carrying every shape the chart has to survive
+// — planned weeks with real mixes, sketched weeks, a phase change, an EMPTY week
+// the plan says nothing about (null load, empty mixes — the divide-by-zero
+// case), a race, and a peak that is not the first or last week.
+const mockScheduleHorizon = {
+  weeks: [
+    {
+      week_start: "2026-03-23",
+      phase: "Base",
+      planned: true,
+      is_current: true,
+      running_distance_m: 42000,
+      effort_score: 210,
+      discipline_mix: { run: 0.72, strength: 0.18, bike: 0.1 },
+      intent_mix: { easy: 0.55, long: 0.3, quality: 0.15 },
+    },
+    {
+      week_start: "2026-03-30",
+      phase: "Base",
+      planned: true,
+      is_current: false,
+      running_distance_m: 46000,
+      effort_score: 232,
+      discipline_mix: { run: 0.7, strength: 0.2, bike: 0.1 },
+      intent_mix: { easy: 0.5, long: 0.32, quality: 0.18 },
+    },
+    {
+      week_start: "2026-04-06",
+      phase: "Base",
+      planned: true,
+      is_current: false,
+      running_distance_m: 34000,
+      effort_score: 168,
+      discipline_mix: { run: 0.64, strength: 0.24, walk: 0.12 },
+      intent_mix: { easy: 0.7, long: 0.3 },
+    },
+    {
+      week_start: "2026-04-13",
+      phase: "Build",
+      planned: false,
+      is_current: false,
+      running_distance_m: 52000,
+      effort_score: 268,
+      discipline_mix: { run: 0.75, strength: 0.15, bike: 0.1 },
+      intent_mix: { easy: 0.45, long: 0.3, quality: 0.25 },
+    },
+    {
+      week_start: "2026-04-20",
+      phase: "Build",
+      planned: false,
+      is_current: false,
+      running_distance_m: 56000,
+      effort_score: 290,
+      discipline_mix: { run: 0.78, strength: 0.14, row: 0.08 },
+      intent_mix: { easy: 0.42, long: 0.3, quality: 0.28 },
+    },
+    // The plan says nothing about this week: it still arrives, so the run of
+    // weeks stays continuous and a gap reads as a gap.
+    {
+      week_start: "2026-04-27",
+      phase: null,
+      planned: false,
+      is_current: false,
+      running_distance_m: null,
+      effort_score: null,
+      discipline_mix: {},
+      intent_mix: {},
+    },
+    {
+      week_start: "2026-05-04",
+      phase: "Build",
+      planned: false,
+      is_current: false,
+      running_distance_m: 60000,
+      effort_score: 312,
+      discipline_mix: { run: 0.8, strength: 0.12, bike: 0.08 },
+      intent_mix: { easy: 0.4, long: 0.3, quality: 0.3 },
+    },
+    {
+      week_start: "2026-05-11",
+      phase: "Build",
+      planned: false,
+      is_current: false,
+      running_distance_m: 44000,
+      effort_score: 226,
+      discipline_mix: { run: 0.7, strength: 0.2, walk: 0.1 },
+      intent_mix: { easy: 0.62, long: 0.28, quality: 0.1 },
+    },
+    {
+      week_start: "2026-05-18",
+      phase: "Peak",
+      planned: false,
+      is_current: false,
+      running_distance_m: 66000,
+      effort_score: 340,
+      discipline_mix: { run: 0.84, strength: 0.1, other: 0.06 },
+      intent_mix: { easy: 0.38, long: 0.3, quality: 0.32 },
+    },
+    {
+      week_start: "2026-05-25",
+      phase: "Peak",
+      planned: false,
+      is_current: false,
+      running_distance_m: 62000,
+      effort_score: 318,
+      discipline_mix: { run: 0.82, strength: 0.12, bike: 0.06 },
+      intent_mix: { easy: 0.4, long: 0.3, quality: 0.3 },
+    },
+    {
+      week_start: "2026-06-01",
+      phase: "Taper",
+      planned: false,
+      is_current: false,
+      running_distance_m: 38000,
+      effort_score: 180,
+      discipline_mix: { run: 0.88, strength: 0.12 },
+      intent_mix: { easy: 0.55, quality: 0.25, rest: 0.2 },
+    },
+    {
+      week_start: "2026-06-08",
+      phase: "Taper",
+      planned: false,
+      is_current: false,
+      running_distance_m: 26000,
+      effort_score: 120,
+      discipline_mix: { run: 0.92, walk: 0.08 },
+      intent_mix: { easy: 0.6, quality: 0.15, rest: 0.25 },
+    },
+  ],
+  races: [
+    {
+      id: "22222222-2222-2222-2222-222222222222",
+      name: "Amsterdam Half",
+      race_date: "2026-06-13",
+      distance_m: 21097,
+      priority: "A",
+    },
+  ],
+  has_plan: true,
+  peak_effort_score: 340,
+};
+
 const mockScheduleDraft = {
   status: "active",
   plan_id: "11111111-1111-1111-1111-111111111111",
@@ -320,6 +462,10 @@ const routesToCheck = [
   { path: "/profile", expectedText: "Loading profile..." },
   { path: "/activity/42", expectedText: "Morning Tempo" },
   { path: "/schedule", expectedText: "The week ahead" },
+  // #830: the horizon is the page's second view. The week stays the default, so
+  // what the server renders is the TAB — checking for it is what catches the
+  // view being dropped from the page.
+  { path: "/schedule", expectedText: "Next 3 months" },
 ];
 
 function createMockApiServer() {
@@ -362,6 +508,29 @@ function createMockApiServer() {
 
     if (pathname === "/api/schedule/week") {
       return sendJson(res, 200, mockScheduleWeek);
+    }
+
+    // #830: the horizon. `weeks` is honoured so the 1M/2M/3M range control is
+    // exercised against a server that actually narrows the window.
+    if (pathname === "/api/schedule/horizon") {
+      const count = Number(searchParams.get("weeks") ?? "12");
+      const weeks = mockScheduleHorizon.weeks.slice(0, count);
+      // The peak and the race list are scoped to the WINDOW, as the real
+      // builder scopes them — a narrower range must not keep scaling its bars
+      // against a peak week it no longer shows.
+      const loads = weeks.map((w) => w.effort_score).filter(Boolean);
+      const lastWeek = weeks[weeks.length - 1];
+      const spanEnd = lastWeek
+        ? new Date(new Date(`${lastWeek.week_start}T00:00:00Z`).getTime() + 6 * 86400000)
+            .toISOString()
+            .slice(0, 10)
+        : "";
+      return sendJson(res, 200, {
+        ...mockScheduleHorizon,
+        weeks,
+        races: mockScheduleHorizon.races.filter((r) => r.race_date <= spanEnd),
+        peak_effort_score: loads.length ? Math.max(...loads) : null,
+      });
     }
 
     // The empty-state CTA polls this on mount to pick up an in-flight draft, so
@@ -520,6 +689,24 @@ async function main() {
         `Route ${route.path} did not include expected text: ${route.expectedText}`,
       );
     }
+  }
+
+  // #830: the horizon fetches client-side, so no server-rendered route touches
+  // it. Drive the endpoint through the app's own proxy instead, which exercises
+  // the same path the browser takes and proves the range control's `weeks`
+  // parameter reaches the backend rather than being ignored.
+  const horizonResponse = await fetch(`${FRONTEND_BASE_URL}/api/schedule/horizon?weeks=4`);
+  if (!horizonResponse.ok) {
+    throw new Error(`Expected 200 for /api/schedule/horizon, received ${horizonResponse.status}`);
+  }
+  const horizon = await horizonResponse.json();
+  if (!Array.isArray(horizon.weeks) || horizon.weeks.length !== 4) {
+    throw new Error(
+      `/api/schedule/horizon?weeks=4 returned ${horizon.weeks?.length} weeks, expected 4`,
+    );
+  }
+  if (typeof horizon.peak_effort_score !== "number" || horizon.peak_effort_score <= 0) {
+    throw new Error("/api/schedule/horizon returned no peak to scale the bars against");
   }
 
   console.log("Frontend smoke checks passed.");


### PR DESCRIPTION
Partially addresses #830. Fifth slice, and the last of the schedule surface. **Base is `feat/830-schedule-ui` (PR #834)** — merge #831 → #832 → #833 → #834 first.

Twelve weeks as horizontal bars running **down** the page. Vertical was chosen over a twelve-column chart because at phone width each column was ~28px, which forced 8px labels and segments too thin to tell apart. As rows, every week gets full width, the ramp reads down the right-hand edge, and a wide screen simply gets longer bars — one layout, no breakpoint where the reading changes.

Bar **length** is the week's load as a true proportion of the peak week. The two bands share that one length because they are the same week's load — thick split by discipline, thin by intent — so nothing is normalised away and the ramp reads identically down either edge. Planned vs sketched is a **tick**, not a fade (fading ten of twelve rows is what made an earlier attempt unreadable). The number on the right is running km, exact rather than estimated off a bar; the gap between a long bar and a small number is the week the runner cross-trained.

## Building the consumer found two defects in what it consumes

**1. Nothing grouped.** The coach was naming every sketched week individually — *"Base — Week 3"*, *"Base — Week 4 (cutback)"* — so the horizon's phase headings became a label per row instead of sections. The tool now asks for the **block** name, and the same runner's plan comes back `Base ×4, Build ×4, Peak`, which is what a phase heading is for.

**2. `walk` and `row` shared the same dark-mode colour** — two disciplines indistinguishable in dark mode, in the mix bar that ships in PR #834. Six steps of one hue cannot hold a visible gap between every pair, so the ramp is now five steps and `other` moves to neutral grey (a residual bucket has no rank to encode). **This fixes a bug introduced in #834**, which is why the palette file changes here.

Both were found by *checking* rather than looking: the second came from running the palette validator, not from eyeballing the bar.

## Verification

- `npm run test` (lint + build) clean; `npm run smoke` passes with a new `/api/schedule/horizon` mock. The agent proved both new smoke assertions can fail before restoring them — a smoke check that cannot fail is decoration.
- **2974 backend tests pass**; policy validation green.
- **Driven in a browser against the seeded production snapshot with a real coach-drafted plan.** The ramp reads 15 → 18 → 18 → 20 → 22 → 24 → 19 → 26 → 28 → 30 → 24 → 32 with BASE / BUILD / PEAK section headings, solid ticks on the three concrete weeks and hollow beyond, the scale row, both legends, and a "Show the numbers" table twin.

## Accessibility, from the `dataviz` skill

The agent ran the skill's palette validator rather than eyeballing: solid hairline gridlines, a 2px surface gap between segments (no borders on marks), marks ≤24px, a legend listing only series actually present, stable segment order (never re-sorted per week), and a full table twin with the bars `aria-hidden` so a screen reader gets the values once rather than twice.

**One flagged FAIL I did not act on.** In dark mode `emerald-500`, `orange-500` and `violet-400` sit just above the skill's 0.67 lightness ceiling (0.696–0.709). Fixing it means re-picking the intent colours you settled over four rounds of wireframe review. Contrast, CVD separation (ΔE 25.2) and the normal-vision floor (26.5) all pass comfortably, so the overshoot is cosmetic. **Your call, flagged rather than taken.**

## Notes for review

- The horizon is a second tab on `/schedule` ("This week" stays default), with a real `role="tablist"`, roving tabindex and Arrow/Home/End keys.
- Hover is a native `title` on each week's track plus the table twin, rather than a custom tooltip layer. No value is ever gated behind hover.
- `draft_contract.py` changes here (the phase-name instruction) even though drafting is #832's slice — the defect was only visible once something consumed the output.