### PR TITLE
fix(profile): associate every form caption with its control

### DIFF
--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -121,10 +121,11 @@ export default function ProfilePage() {
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-                <label className="block text-sm font-medium mb-1">Goal Type</label>
-                <select 
-                    name="goal_type" 
-                    value={formData.goal_type} 
+                <label htmlFor="goal_type" className="block text-sm font-medium mb-1">Goal Type</label>
+                <select
+                    id="goal_type"
+                    name="goal_type"
+                    value={formData.goal_type}
                     onChange={handleChange}
                     className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
                 >
@@ -137,10 +138,11 @@ export default function ProfilePage() {
             </div>
 
             <div>
-                <label className="block text-sm font-medium mb-1">Experience Level</label>
-                <select 
-                    name="experience_level" 
-                    value={formData.experience_level} 
+                <label htmlFor="experience_level" className="block text-sm font-medium mb-1">Experience Level</label>
+                <select
+                    id="experience_level"
+                    name="experience_level"
+                    value={formData.experience_level}
                     onChange={handleChange}
                     className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
                 >
@@ -151,9 +153,10 @@ export default function ProfilePage() {
             </div>
 
             <div>
-                <label className="block text-sm font-medium mb-1">Weekly Days Available</label>
-                <input 
+                <label htmlFor="weekly_days_available" className="block text-sm font-medium mb-1">Weekly Days Available</label>
+                <input
                     type="number" min="1" max="7"
+                    id="weekly_days_available"
                     name="weekly_days_available"
                     value={formData.weekly_days_available}
                     onChange={handleChange}
@@ -162,9 +165,10 @@ export default function ProfilePage() {
             </div>
 
             <div>
-                <label className="block text-sm font-medium mb-1">Max Heart Rate (bpm)</label>
-                <input 
+                <label htmlFor="max_hr" className="block text-sm font-medium mb-1">Max Heart Rate (bpm)</label>
+                <input
                     type="number" min="100" max="250"
+                    id="max_hr"
                     name="max_hr"
                     value={formData.max_hr || ''}
                     onChange={handleChange}
@@ -177,9 +181,10 @@ export default function ProfilePage() {
             </div>
 
             <div>
-                <label className="block text-sm font-medium mb-1">Resting Heart Rate (bpm)</label>
+                <label htmlFor="resting_hr" className="block text-sm font-medium mb-1">Resting Heart Rate (bpm)</label>
                 <input
                     type="number" min="30" max="120"
+                    id="resting_hr"
                     name="resting_hr"
                     value={formData.resting_hr || ''}
                     onChange={handleChange}
@@ -192,9 +197,10 @@ export default function ProfilePage() {
             </div>
 
             <div>
-                <label className="block text-sm font-medium mb-1">Weight (kg)</label>
+                <label htmlFor="weight_kg" className="block text-sm font-medium mb-1">Weight (kg)</label>
                 <input
                     type="number" min="20" max="300" step="0.1"
+                    id="weight_kg"
                     name="weight_kg"
                     value={formData.weight_kg ?? ''}
                     onChange={handleChange}
@@ -204,9 +210,10 @@ export default function ProfilePage() {
             </div>
 
             <div>
-                <label className="block text-sm font-medium mb-1">Height (cm)</label>
+                <label htmlFor="height_cm" className="block text-sm font-medium mb-1">Height (cm)</label>
                 <input
                     type="number" min="100" max="250" step="0.5"
+                    id="height_cm"
                     name="height_cm"
                     value={formData.height_cm ?? ''}
                     onChange={handleChange}
@@ -221,9 +228,10 @@ export default function ProfilePage() {
             </div>
 
             <div>
-                <label className="block text-sm font-medium mb-1">Current Weekly Volume (km)</label>
+                <label htmlFor="current_weekly_km" className="block text-sm font-medium mb-1">Current Weekly Volume (km)</label>
                 <input
                     type="number" min="0"
+                    id="current_weekly_km"
                     name="current_weekly_km"
                     value={formData.current_weekly_km}
                     onChange={handleChange}
@@ -232,8 +240,9 @@ export default function ProfilePage() {
             </div>
 
             <div>
-                <label className="block text-sm font-medium mb-1">Week Starts On</label>
+                <label htmlFor="week_starts_on" className="block text-sm font-medium mb-1">Week Starts On</label>
                 <select
+                    id="week_starts_on"
                     name="week_starts_on"
                     value={formData.week_starts_on}
                     onChange={handleChange}
@@ -249,8 +258,9 @@ export default function ProfilePage() {
         </div>
 
         <div>
-            <label className="block text-sm font-medium mb-1">Injury / Health Notes</label>
-            <textarea 
+            <label htmlFor="injury_notes" className="block text-sm font-medium mb-1">Injury / Health Notes</label>
+            <textarea
+                id="injury_notes"
                 name="injury_notes"
                 value={formData.injury_notes}
                 onChange={handleChange}


### PR DESCRIPTION
## What changed

Every named field on the profile form (`frontend/app/profile/page.tsx`) had a visible caption rendered as adjacent `<label>` text with no `htmlFor`/`id` link to its control, so assistive technology got the placeholder text (where one existed) or nothing at all. This adds an explicit `htmlFor`/`id` pair to every field. No visual, layout, spacing, or copy change: only markup semantics.

All ten controls are plain selects, number inputs, or a textarea (no radio-like or segmented-button groups on this form), so explicit `htmlFor`/`id` association was sufficient everywhere; no `fieldset`/`legend`/`role="group"` was needed.

## Per-field association table

| Field (issue name) | Control id | `name` | Control type | Label now points via |
|---|---|---|---|---|
| Goal type | `goal_type` | `goal_type` | `select` | `htmlFor="goal_type"` |
| Experience level | `experience_level` | `experience_level` | `select` | `htmlFor="experience_level"` |
| Days available | `weekly_days_available` | `weekly_days_available` | `input[number]` | `htmlFor="weekly_days_available"` |
| Max HR | `max_hr` | `max_hr` | `input[number]` | `htmlFor="max_hr"` |
| Resting HR | `resting_hr` | `resting_hr` | `input[number]` | `htmlFor="resting_hr"` |
| Weight | `weight_kg` | `weight_kg` | `input[number]` | `htmlFor="weight_kg"` |
| Height | `height_cm` | `height_cm` | `input[number]` | `htmlFor="height_cm"` |
| Current weekly km | `current_weekly_km` | `current_weekly_km` | `input[number]` | `htmlFor="current_weekly_km"` |
| Week start | `week_starts_on` | `week_starts_on` | `select` | `htmlFor="week_starts_on"` |
| Injury notes | `injury_notes` | `injury_notes` | `textarea` | `htmlFor="injury_notes"` |

Every field already carried real visible label text (not placeholder-only), so acceptance criterion 2 ("a placeholder is not doing a label's job") was already true before this change on every field; a few inputs (`max_hr`, `resting_hr`, `weight_kg`, `height_cm`) additionally carry a `placeholder="e.g. ..."` example value, which stays as a hint alongside the real, now-associated label, not in place of one.

## Scope

`VoiceDialsPanel`, `StanceDialsPanel`, `UserMaterialsPanel`, and `LinkTelegramButton` (also rendered on the profile page) were checked: none of the ten fields the issue names live in those components, so they are untouched, matching the issue's own scope (`frontend/app/profile/page.tsx`).

## Decisions and rationale

- Used the field's existing `name` string as its `id` (they were already unique per field and match backend field names one-to-one), rather than inventing a new id scheme. Lowest-risk choice: no risk of colliding with an id used elsewhere, confirmed by grep across `frontend/components/` and `frontend/app/` (no other element on this page or its child components declares any of these ten ids).
- Chose explicit `htmlFor`/`id` over wrapping the input inside `<label>`, matching the task's stated preference and requiring the smallest diff against the existing JSX structure.
- Did not touch the descriptive helper `<p>` text under `max_hr`, `resting_hr`, `height_cm`, `week_starts_on` (e.g. "Used to calculate zones...") with `aria-describedby`. The issue's acceptance criteria are about the visible *caption* being associated, not about hint text; adding `aria-describedby` would be an accessibility improvement beyond what was asked and outside this fix's scope.

## Verification

- `npm run test` (`next lint && next build`) passes clean, no new warnings.
- `./.ai-policy/scripts/run-validation.sh` passes (3058 backend tests unaffected, frontend build/lint deferred to CI as documented, which was run manually above).
- `git diff` inspection confirms the only changes are added `id`/`htmlFor` attributes; every `name`, `value`, `onChange`, `className`, and visible text string is byte-identical to before.
- Grepped `frontend/components/` and `frontend/app/` for each of the ten new ids: no collision with any other rendered element.

## Not verified

- Actual assistive-technology output (VoiceOver/NVDA reading the associated label aloud) was not exercised: no screen reader is available in this environment, and standing up the full local app (Clerk `LOCAL_NO_AUTH`, docker compose Postgres/Redis, backend) for a live accessibility-tree read was judged disproportionate to a ten-attribute markup diff already confirmed to touch nothing else. The `htmlFor`/`id` mechanism is standard HTML/ARIA behaviour, not something specific to this app.
- No pixel-level visual regression screenshot was taken; the diff shows zero `className` or text changes, so visual risk is effectively nil but unobserved directly.

Closes #849
