### PR TITLE
fix(schedule): guarantee the horizon's plan-end boundary is contiguous

### DIFF
--- a/backend/app/services/schedule/horizon.py
+++ b/backend/app/services/schedule/horizon.py
@@ -79,23 +79,30 @@ def _last_covered_week(
     `beyond_plan` reads against.
 
     `horizon_end` (the last DAY of the last week the plan mentions, written by
-    `draft.py`) is authoritative when the plan states one. Nullable for older or
-    edge-case rows, which fall back to the latest week among the plan's own week
-    shapes and its COMMITTED sessions (a suggestion nobody agreed to does not
-    extend the plan's reach, the same reading `planned` above already applies).
-    `rows` is `sessions_in_range`'s result, bounded to the requested window, so
-    this fallback can undercount a plan whose committed sessions run past the
-    window asked for; that is an accepted limitation of the safety net, not of
-    `horizon_end` itself.
+    `draft.py`) is a FLOOR on the plan's reach, never a ceiling: it is always
+    taken together with the latest week among the plan's own week shapes and its
+    COMMITTED sessions (a suggestion nobody agreed to does not extend the plan's
+    reach, the same reading `planned` above already applies), and the later of
+    the two wins (#848). A `TrainingPlan.horizon_end` that understates what was
+    actually written — the writer disagreeing with itself, a correction, a
+    directly-constructed row — must never let a week holding real content read
+    as `beyond_plan`: the view downstream draws a single "Plan ends here"
+    divider on the assumption that once a week is `beyond_plan` every later
+    week is too, so this function is the one place that assumption is made
+    true rather than merely hoped true. `rows` is `sessions_in_range`'s result,
+    bounded to the requested window, so this can still undercount a plan whose
+    committed sessions run past the window asked for; that is an accepted
+    limitation of the safety net, not of `horizon_end` itself.
 
     None (no plan, or a plan stating nothing at all) means there is nothing to
     be beyond — every week then reads `empty`, never `beyond_plan`.
     """
     if plan is None:
         return None
+    candidates: List[date] = []
     if plan.horizon_end is not None:
-        return week_start(plan.horizon_end, starts_on)
-    candidates = list(shapes.keys())
+        candidates.append(week_start(plan.horizon_end, starts_on))
+    candidates.extend(shapes.keys())
     candidates.extend(
         week_start(row.window_start, starts_on)
         for row in rows

--- a/backend/tests/test_schedule_horizon.py
+++ b/backend/tests/test_schedule_horizon.py
@@ -389,6 +389,73 @@ def test_coverage_planned_always_agrees_with_the_planned_flag(db):
         assert week.planned == (week.coverage == "planned")
 
 
+def test_a_committed_session_past_the_recorded_reach_is_never_beyond_plan(db):
+    """#848: `horizon_end` is written once, at draft time, and is not a DB
+    constraint on what a `PlannedSession` can later say — a correction, a
+    disagreeing writer, or (as here) a directly-constructed row can leave a
+    committed session in a week later than the plan's own recorded reach. The
+    view draws a single "Plan ends here" divider on the assumption that once a
+    week reads `beyond_plan` every later week does too; a `planned` week
+    surfacing after that divider would be the exact violation #848 named — a
+    week with real sessions rendered as past the end of a plan that plainly
+    still covers it. `_last_covered_week` must extend to cover it, not just the
+    committed week itself but every INTERIOR week between the recorded reach
+    and it, so none of them reads `beyond_plan` either.
+
+    This state is not reachable through drafting (`draft.py` derives
+    `horizon_end` from the weeks it writes), so it is constructed directly,
+    exactly as the adversarial review that filed the issue did.
+    """
+    user = _seed_user(db)
+    # The plan claims to reach only WEEK_1, but a committed session two weeks
+    # later says otherwise.
+    plan = _seed_plan(db, user, horizon_end=WEEK_1 + timedelta(days=6))
+    _seed_session(db, plan, start=WEEK_3, target_effort_score=60.0)
+
+    horizon = build_horizon(db, user, weeks=5, today=TODAY)
+
+    assert _week(horizon, WEEK_0).coverage == "empty"
+    # WEEK_1 and WEEK_2 are interior gaps now, not `beyond_plan`: the plan's
+    # true reach (derived from what it actually holds) extends to WEEK_3.
+    assert _week(horizon, WEEK_1).coverage == "empty"
+    assert _week(horizon, WEEK_2).coverage == "empty"
+    assert _week(horizon, WEEK_3).coverage == "planned"
+    # Only the week genuinely past the plan's true reach reads beyond_plan.
+    assert _week(horizon, WEEK_4).coverage == "beyond_plan"
+
+    # The invariant the divider depends on, checked directly: no `planned` or
+    # `sketched` week ever follows a `beyond_plan` one.
+    seen_beyond_plan = False
+    for week in horizon.weeks:
+        if week.coverage == "beyond_plan":
+            seen_beyond_plan = True
+        elif seen_beyond_plan:
+            assert week.coverage not in ("planned", "sketched"), (
+                f"{week.week_start} is {week.coverage} after a beyond_plan week"
+            )
+
+
+def test_a_sketched_week_past_the_recorded_reach_is_never_beyond_plan(db):
+    """Same #848 guarantee, for a week shape rather than a committed session."""
+    user = _seed_user(db)
+    plan = _seed_plan(
+        db,
+        user,
+        horizon_end=WEEK_0 + timedelta(days=6),
+        week_shapes=[
+            {"week_start": WEEK_2.isoformat(), "phase": "build", "target_effort_score": 300}
+        ],
+    )
+    _seed_session(db, plan, start=WEEK_0, target_effort_score=60.0)
+
+    horizon = build_horizon(db, user, weeks=4, today=TODAY)
+
+    assert _week(horizon, WEEK_0).coverage == "planned"
+    assert _week(horizon, WEEK_1).coverage == "empty"
+    assert _week(horizon, WEEK_2).coverage == "sketched"
+    assert _week(horizon, WEEK_3).coverage == "beyond_plan"
+
+
 # --- mixes are shares ------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Closes #848.

The schedule horizon (`HorizonChart.tsx`) draws a single "Plan ends here" divider before the first week whose `coverage` is `beyond_plan`, on the assumption that every later week is `beyond_plan` too. Nothing enforced that assumption. `horizon.py`'s `_last_covered_week` treated `plan.horizon_end` as authoritative even when a committed session or week shape actually written to the plan fell later than it — so a directly-constructed (or otherwise divergent) plan could produce a `planned` week after a `beyond_plan` one, which the frontend would then render below the "Plan ends here" line: a factual claim to the runner that is simply false.

This is latent, not live: the drafting path (`draft.py`) derives `horizon_end` from the weeks it writes, so it cannot currently produce the violating state. Filed by an adversarial review during #847 (#842) that constructed the state directly.

## Which branch of the acceptance criteria

**Guaranteed and tested the ordering**, rather than making the view stop depending on it. Rationale: the per-week `coverage` value already carries the correct semantics (a week with a committed session is always `planned`, regardless of any reach figure — that logic was never the bug). What broke the divider's assumption was a single derivation, `_last_covered_week`, silently disagreeing with the plan's own written content in one case. The fix is one function: `_last_covered_week` now takes `horizon_end` as a FLOOR on the plan's reach rather than a ceiling — always the max of `horizon_end`, every week shape's `week_start`, and every committed session's week — so the contiguity invariant (`beyond_plan` only ever follows other `beyond_plan` or nothing) holds by construction from the same data the view renders, not from a separately-trusted stored field. This is the narrower, better-tested fix; re-deriving the divider position in the React component would duplicate this same logic one layer up for no added safety.

## How the violating state is tested

`backend/tests/test_schedule_horizon.py` gets two new tests that construct the state directly (bypassing `draft.py`, exactly as the adversarial review that filed the issue did):

- `test_a_committed_session_past_the_recorded_reach_is_never_beyond_plan`: a plan with `horizon_end` reaching only WEEK_1, and a *committed session* seeded directly at WEEK_3. Asserts WEEK_1/WEEK_2 read `empty` (not `beyond_plan`), WEEK_3 reads `planned`, and only WEEK_4 (genuinely past the true reach) reads `beyond_plan`. It also walks the whole horizon asserting the general invariant the divider depends on: no `planned`/`sketched` week ever follows a `beyond_plan` one.
- `test_a_sketched_week_past_the_recorded_reach_is_never_beyond_plan`: same guarantee for a week *shape* (rather than a session) written later than `horizon_end`.

## Proof the normal case is unchanged

All 21 pre-existing tests in `test_schedule_horizon.py` pass unmodified, including the ones that specifically pin the current `beyond_plan` behaviour for a plan whose `horizon_end` already covers everything it wrote (`test_a_plan_shorter_than_the_window_reads_its_tail_as_beyond_plan`, `test_coverage_is_empty_for_an_interior_gap_inside_the_plans_own_span`, `test_horizon_end_null_falls_back_to_the_latest_shape_or_committed_session`, etc.) — the fix only changes the result when `horizon_end` understates what the plan actually holds, which none of those fixtures do. Full backend suite: `python -m pytest -q -m "not integration"` — 3060 passed, 0 failed. `HorizonChart.tsx` itself is untouched.

## Decisions

- Fixed at the backend derivation rather than the frontend divider logic (see branch rationale above).
- `horizon_end` is now read as a floor, never a ceiling, on the plan's recorded reach — matches the existing docstring's own framing of `horizon_end` as "the last DAY of the last week the plan mentions," which a week it demonstrably also mentions (via a session or shape) should never contradict.
- Did not touch the pre-existing, documented limitation that this can still undercount a plan whose committed sessions run past the fetched window (`rows` is bounded to the requested horizon window) — out of scope for #848, which is about ordering within the visible window.

## Not verified

- No frontend file changed, so `npm run test` was not run for this PR; `HorizonChart.tsx`'s divider logic was already correct given a contiguous `coverage` sequence, which this fix now guarantees at the source.
- No live/browser verification against a real or seeded schedule — the defect and its fix are both in the backend derivation, which is covered by direct unit tests including the two new ones constructing the violating state.