### PR TITLE
fix(db): the migration guard sees every model, not the seven it names (#869)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,13 +8,24 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 from alembic import context
 
 # --- CUSTOM: Import our settings and model Base ---
+import importlib
+import pkgutil
+
 from app.core.config import settings
 from app.db.base import Base
-# Import models to ensure they are attached to Base.metadata
-from app.models import (  # noqa
-    User, StravaAccount, Activity, ActivityStream,
-    DerivedMetric, UserProfile, CheckIn,
-)
+import app.models as _models_package
+
+# Import every model module so `Base.metadata` carries every table (#869).
+# This used to name seven models and receive the other fourteen only because
+# importing `app.models` runs the barrel `__init__.py`. That made completeness
+# rest on a convention nobody checked: a model in a file missing from the
+# barrel would be absent from the metadata, so `--autogenerate` would not see
+# its table and the `alembic check` drift guard (#839) would report no drift
+# while blind to it. Walking the package removes the barrel from the path
+# entirely, so the guard's reach no longer depends on an import list staying
+# in sync by hand.
+for _module in pkgutil.iter_modules(_models_package.__path__):
+    importlib.import_module(f"{_models_package.__name__}.{_module.name}")
 
 config = context.config
 

--- a/backend/tests/test_model_registry_coverage.py
+++ b/backend/tests/test_model_registry_coverage.py
@@ -1,0 +1,98 @@
+"""#869: `Base.metadata` must carry every model, or the drift guard goes blind.
+
+`alembic check` (the CI job #839 added) answers "do the models and the
+migrations agree" by diffing the live database against `Base.metadata`. That
+answer is only worth what the metadata's completeness is worth: a model whose
+module never gets imported has no table in the metadata, so `--autogenerate`
+emits nothing for it and `check` reports no drift. The guard passes while
+looking at less than the whole schema.
+
+`alembic/env.py` used to name seven models and receive the other fourteen only
+as a side effect of the barrel `__init__.py` running. These tests pin the two
+properties that replaced that convention.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import pkgutil
+from pathlib import Path
+
+import app.models as models_package
+from app.db.base import Base
+
+MODELS_DIR = Path(models_package.__file__).parent
+
+
+def _module_names_on_disk() -> set[str]:
+    """Every model module as the filesystem has it, the barrel not consulted."""
+    return {
+        path.stem
+        for path in MODELS_DIR.glob("*.py")
+        if path.stem != "__init__"
+    }
+
+
+def test_package_walk_sees_every_model_module_on_disk():
+    """The mechanism `env.py` relies on must find every module.
+
+    `env.py` imports models by walking the package with `pkgutil`. If that walk
+    ever saw less than the directory holds, the metadata would be incomplete
+    again and nothing else here would notice.
+    """
+    walked = {module.name for module in pkgutil.iter_modules(models_package.__path__)}
+
+    assert walked == _module_names_on_disk()
+
+
+def test_every_model_class_has_its_table_in_the_metadata():
+    """Import every module the way `env.py` does; every mapped class registers.
+
+    This is the property `alembic check` actually depends on. A model that
+    imports but fails to register (a missing `__tablename__`, a class that never
+    reached the declarative base) would be invisible to autogenerate.
+    """
+    unregistered: list[str] = []
+
+    for module_info in pkgutil.iter_modules(models_package.__path__):
+        module = importlib.import_module(
+            f"{models_package.__name__}.{module_info.name}"
+        )
+        for attribute_name in dir(module):
+            attribute = getattr(module, attribute_name)
+            if not isinstance(attribute, type) or not issubclass(attribute, Base):
+                continue
+            if attribute is Base:
+                continue
+            table_name = getattr(attribute, "__tablename__", None)
+            # A class declared in one module and imported into another (a
+            # relationship's target, say) shows up under both; the table is what
+            # matters, so the same name simply passes twice.
+            if table_name is None or table_name not in Base.metadata.tables:
+                unregistered.append(f"{module_info.name}.{attribute_name}")
+
+    assert unregistered == []
+
+
+def test_the_barrel_still_exports_every_model_module():
+    """The barrel is the documented index, so it should stay honest.
+
+    `env.py` no longer depends on this (it walks the package), which is exactly
+    why the barrel could now drift unnoticed: nothing else would break. The
+    barrel is what application code imports from, so a module missing here is
+    still a real defect, just a quieter one than it used to be.
+    """
+    barrel_source = (MODELS_DIR / "__init__.py").read_text(encoding="utf-8")
+
+    imported: set[str] = set()
+    for node in ast.walk(ast.parse(barrel_source)):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            prefix = f"{models_package.__name__}."
+            if node.module.startswith(prefix):
+                imported.add(node.module[len(prefix) :])
+
+    missing = _module_names_on_disk() - imported
+    assert missing == set(), (
+        f"model modules not re-exported by app/models/__init__.py: {sorted(missing)}"
+    )


### PR DESCRIPTION
## What was wrong

`backend/alembic/env.py` imported seven model classes by name and received the other fourteen only because importing `app.models` runs the barrel `__init__.py`. Completeness of `Base.metadata` therefore rested on a convention nothing checked.

That matters because `alembic check` (the CI job #839 added last week) answers "do the models and the migrations agree" by diffing the live database against `Base.metadata`. A model in a file missing from the barrel has no table in that metadata, so `--autogenerate` emits nothing for it and `check` reports no drift. The guard passes while inspecting less than the whole schema.

Latent, not live: all 21 files under `app/models/` are currently in the barrel, checked file by file.

## Measured

A probe model in `app/models/_probe_869.py`, deliberately left out of the barrel, against a local Postgres at head:

| `env.py` | `alembic check` |
|---|---|
| before (seven named imports) | `No new upgrade operations detected.` |
| after (package walk) | `FAILED: New upgrade operations detected: [('add_table', Table('probe_869', ...))]` |

The old code was blind to an entire absent table. The probe was removed before commit; `alembic check` is clean on the final tree.

## The change

`env.py` walks the package with `pkgutil` and imports every module, so the guard's reach no longer depends on an import list staying in sync by hand.

Three tests in `backend/tests/test_model_registry_coverage.py` pin the properties that replaced the convention:

1. the walk sees every module on disk (the mechanism `env.py` depends on);
2. every mapped class registers a table in `Base.metadata` (the property `alembic check` depends on);
3. the barrel still re-exports every module.

Test 3 needs its own justification, since `env.py` no longer depends on the barrel: that independence is exactly why the barrel could now drift with nothing else breaking. It is what application code imports from, so a gap there is still a defect, only a quieter one than before.

## Sensitivity

Both guards were proven to fail, not assumed to:

- with the probe present, test 3 fails naming `_probe_869` as unexported;
- the `alembic check` comparison above is the sensitivity proof for the `env.py` change itself.

## Decisions

- **Walk the package rather than extend the named import list.** A longer list has the same failure mode one model later.
- **Kept the barrel and tested it, rather than deleting it.** It is public import surface used across the app; removing it is a deletion this issue does not call for.
- **No migration.** Nothing about the schema changes; this only affects what autogenerate can see.

## Verification

- `make backend-test`: 3125 passed, 12 deselected.
- `alembic upgrade head` then `alembic check` against local Postgres 16: clean.
- The before/after probe above.

## Not verified

- Not exercised against the production schema; the change affects only which models are imported, and the probe result is dialect-independent.
- Test 2 cannot distinguish a class that never reached the declarative base from one that was never imported at all, since importing is what registers it. Test 1 covers the import half.

Closes #869