### PR TITLE
fix(schedule): an interval session's distance reaches the week (#876)

### DIFF
--- a/backend/app/schemas/schedule.py
+++ b/backend/app/schemas/schedule.py
@@ -181,9 +181,17 @@ class PlannedWeekShape(BaseModel):
 class SessionStructure(BaseModel):
     """The interval shape `workout_matching.match_planned_to_detected` expects.
 
-    Its exact keys, unchanged: that function has compared a plan to detected reps
-    since the beginning and has never once been handed one, because
-    `_extract_planned_workout` is a placeholder that returns None.
+    Its rep keys are unchanged: that function has compared a plan to detected
+    reps since the beginning and has never once been handed one, because
+    `_extract_planned_workout` is a placeholder that returns None. It reads every
+    key through `.get`, so the warm-up and cool-down below are invisible to it
+    rather than breaking it.
+
+    The warm-up and cool-down are DISTANCES, in the same unit as everything else
+    the runner reads (#876). They used to live in the detail prose as minutes,
+    which meant the session's real length could only be recovered by multiplying
+    by an assumed pace — so a 4.5 km interval session counted as its 2.4 km of
+    reps. Stated as a distance, the total is addition instead of inference.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -191,6 +199,8 @@ class SessionStructure(BaseModel):
     reps_planned: int = Field(ge=1, le=60)
     rep_distance_m: Optional[float] = Field(default=None, gt=0)
     rest_s: Optional[float] = Field(default=None, ge=0)
+    warmup_distance_m: Optional[float] = Field(default=None, gt=0)
+    cooldown_distance_m: Optional[float] = Field(default=None, gt=0)
 
 
 class PlannedSessionRead(BaseModel):

--- a/backend/app/services/schedule/draft.py
+++ b/backend/app/services/schedule/draft.py
@@ -147,6 +147,11 @@ mean an easy walk or a gentle spin, that is an easy session of that discipline \
 (intent `easy`, discipline `walk` or `bike`), not a rest day with a target on it.
 - Every other session needs enough to size it: a distance, a duration, or rep \
 structure. A session with none of the three is rejected.
+- Write a warm-up and a cool-down as a DISTANCE, never as minutes. \
+`warmup_distance_m` and `cooldown_distance_m` are part of the session and are \
+added to its reps to give what the runner sees; the same thing said in prose as \
+"10 min easy" is not a distance and counts as nothing. Say it in the detail too \
+if you like, but say it in the fields regardless.
 - Do not plan sessions in the past.
 - Do not invent a race, a goal or an injury the runner has not told you about.
 - Do not give medical advice, diagnose, or prescribe treatment. If something in \

--- a/backend/app/services/schedule/draft_contract.py
+++ b/backend/app/services/schedule/draft_contract.py
@@ -74,6 +74,11 @@ class DraftedSession(BaseModel):
     reps_planned: Optional[int] = Field(default=None, ge=1, le=60)
     rep_distance_m: Optional[float] = Field(default=None, gt=0, le=50_000)
     rest_s: Optional[float] = Field(default=None, ge=0, le=3_600)
+    # Distances, not durations (#876). A warm-up written as "10 min easy" is only
+    # a distance once multiplied by a pace nobody stated, so the session it
+    # belongs to could not be added up; asked for in metres it simply adds.
+    warmup_distance_m: Optional[float] = Field(default=None, gt=0, le=50_000)
+    cooldown_distance_m: Optional[float] = Field(default=None, gt=0, le=50_000)
 
     @model_validator(mode="after")
     def _validate_shape(self) -> "DraftedSession":
@@ -86,10 +91,20 @@ class DraftedSession(BaseModel):
         # coach wrote and nothing stored is worse than a rejected plan.
         has_reps = self.reps_planned is not None
         has_rep_args = self.rep_distance_m is not None or self.rest_s is not None
-        if (has_reps or has_rep_args) and self.intent != "quality":
+        # The warm-up and cool-down ride with the reps under the same guard: they
+        # describe the session BUILT around an interval block, so on an easy run
+        # they are noise, and stored without a count they would state a distance
+        # for a session whose work is unknown.
+        has_edges = (
+            self.warmup_distance_m is not None or self.cooldown_distance_m is not None
+        )
+        if (has_reps or has_rep_args or has_edges) and self.intent != "quality":
             raise ValueError("rep structure belongs to a quality session")
-        if has_rep_args and not has_reps:
-            raise ValueError("rep_distance_m and rest_s need reps_planned")
+        if (has_rep_args or has_edges) and not has_reps:
+            raise ValueError(
+                "rep_distance_m, rest_s, warmup_distance_m and cooldown_distance_m "
+                "need reps_planned"
+            )
         return self
 
     def structure(self) -> Optional[Dict[str, float]]:
@@ -102,6 +117,10 @@ class DraftedSession(BaseModel):
             shape["rep_distance_m"] = self.rep_distance_m
         if self.rest_s is not None:
             shape["rest_s"] = self.rest_s
+        if self.warmup_distance_m is not None:
+            shape["warmup_distance_m"] = self.warmup_distance_m
+        if self.cooldown_distance_m is not None:
+            shape["cooldown_distance_m"] = self.cooldown_distance_m
         return shape
 
 
@@ -313,11 +332,37 @@ RECORD_TRAINING_PLAN_TOOL = {
                                     },
                                     "title": {"type": "string"},
                                     "detail": {"type": "string"},
-                                    "target_distance_m": {"type": "number"},
+                                    "target_distance_m": {
+                                        "type": "number",
+                                        "description": (
+                                            "The WHOLE session in metres, "
+                                            "door to door. On an interval "
+                                            "session give the warm-up and "
+                                            "cool-down below instead and leave "
+                                            "this out — the app adds them up."
+                                        ),
+                                    },
                                     "target_duration_s": {"type": "integer"},
                                     "reps_planned": {"type": "integer"},
                                     "rep_distance_m": {"type": "number"},
                                     "rest_s": {"type": "number"},
+                                    "warmup_distance_m": {
+                                        "type": "number",
+                                        "description": (
+                                            "The warm-up in METRES, not "
+                                            "minutes. It is part of the "
+                                            "session's distance and the runner "
+                                            "reads it in the same unit as "
+                                            "everything else."
+                                        ),
+                                    },
+                                    "cooldown_distance_m": {
+                                        "type": "number",
+                                        "description": (
+                                            "The cool-down in METRES, not "
+                                            "minutes, for the same reason."
+                                        ),
+                                    },
                                 },
                             },
                         },

--- a/backend/app/services/schedule/horizon.py
+++ b/backend/app/services/schedule/horizon.py
@@ -22,6 +22,7 @@ from app.models.user import User
 from app.schemas.schedule import GoalRaceRead, HorizonWeek, ScheduleHorizonRead
 from app.services.schedule import store
 from app.services.schedule.placement import WEEK_LENGTH_DAYS
+from app.services.schedule.planned_distance import planned_distance_m
 from app.services.weeks import resolve_week_start, week_start
 
 DEFAULT_HORIZON_WEEKS = 12
@@ -60,7 +61,10 @@ def _week_from_sessions(sessions: List[Any]) -> Dict[str, Any]:
         )
         by_intent[session.intent] = by_intent.get(session.intent, 0.0) + effort
         if session.discipline == "run":
-            running_distance += session.target_distance_m or 0.0
+            # Rep-structured runs count their work here too (#876), so the
+            # three-month view does not repeat the week headline's gap across
+            # every week of the block.
+            running_distance += planned_distance_m(session)
     return {
         "running_distance_m": running_distance,
         "effort_score": load,

--- a/backend/app/services/schedule/plan_validator.py
+++ b/backend/app/services/schedule/plan_validator.py
@@ -32,6 +32,7 @@ from datetime import date, timedelta
 from typing import List, Optional, Sequence
 
 from app.services.schedule.placement import validate_session_window
+from app.services.schedule.planned_distance import planned_distance_m
 from app.services.schedule.rules import check_rules
 from app.services.weeks import MONDAY, week_start
 
@@ -261,8 +262,12 @@ def _validate_volume(
     """
     if not norm_weekly_running_m:
         return
+    # Rep structure counts toward the ceiling (#876). Reading `target_distance_m`
+    # alone scored an interval week's hardest running at zero, which failed
+    # PERMISSIVE: the check that exists to catch an absurd week was blind to the
+    # sessions most able to make one.
     planned = sum(
-        session.target_distance_m or 0.0
+        planned_distance_m(session)
         for session in week.sessions
         if session.discipline == "run" and session.commitment == "committed"
     )

--- a/backend/app/services/schedule/planned_distance.py
+++ b/backend/app/services/schedule/planned_distance.py
@@ -9,45 +9,61 @@ plan (see `plan_validator._validate_sessions`).
 
 Every sum of planned running nonetheless read `target_distance_m` alone, so a
 session sized the second legal way summed as ZERO. A real week showed 23.5 km
-with a 6 x 400m sitting in it and its 2.4 km of work nowhere — present as a card,
-counted in "2 of 4 sessions", counted in the mix bar, absent from the only number
-the runner reads as their week.
+with a 6 x 400m sitting in it and its work nowhere — present as a card, counted
+in "2 of 4 sessions", counted in the mix bar, absent from the only number the
+runner reads as their week.
 
 This module is the single answer, in the spirit of `disciplines.py`'s ONE
 definition of a run: the headline, the three-month horizon and the volume
 ceiling all ask here, so they cannot drift into three different opinions about
 the same week.
 
-What is NOT counted
--------------------
-The warm-up and cool-down. They live in the session's prose ("Warm up 10 min
-easy... Cool down 10 min easy") and nothing structured states them, so counting
-them would mean inventing distance the plan never specified — the same abstention
-`effort.py` makes when a runner's history is too thin to size a session. The
-consequence is honest and known: an interval session's planned figure is its
-WORK, and reads under what the runner will actually cover door to door.
+A session is warm-up + work + cool-down
+---------------------------------------
+The reps are the WORK, not the session. The first fix counted only the reps, so
+a 6 x 400m the runner had agreed as 4.5 km door to door still landed in the week
+as 2.4 km — closer, and still wrong. The warm-up and cool-down were unreachable
+then because the coach wrote them as TIME, in prose ("Warm up 10 min easy"), and
+turning that into a distance means multiplying by an assumed pace: the app
+inventing distance, which is what `effort.py` abstains from doing rather than
+guess.
+
+So the prescription changed instead of the arithmetic (#876). The coach now
+states a warm-up and cool-down as a DISTANCE, in the same unit as everything
+else on the card, and the total is addition rather than inference. Nothing here
+estimates: a session's planned distance is the sum of the distances the coach
+actually wrote, and a part they did not write contributes nothing.
 """
 
 from typing import Any, Dict, Optional
+
+# The keys of the rep shape, nested under `structure` once stored and carried
+# flat on the drafted session on its way there.
+_REP_KEYS = ("reps_planned", "rep_distance_m", "warmup_distance_m", "cooldown_distance_m")
 
 
 def _structure(session: Any) -> Dict[str, Any]:
     """The rep shape, from whichever of the two shapes this reader was handed.
 
     `PlannedSessionRead` and the ORM row nest it under `structure`; the drafted
-    session carries `reps_planned`/`rep_distance_m` flat, because the coach's
-    tool arguments are flat and `DraftedSession.structure()` only nests them on
-    the way to storage. The volume ceiling runs BEFORE that, on the flat shape,
-    so a helper that read only `structure` would abstain on every plan it is
-    supposed to be guarding.
+    session carries the same keys flat, because the coach's tool arguments are
+    flat and `DraftedSession.structure()` only nests them on the way to storage.
+    The volume ceiling runs BEFORE that, on the flat shape, so a helper that read
+    only `structure` would abstain on every plan it is supposed to be guarding.
     """
     nested = getattr(session, "structure", None)
     if isinstance(nested, dict):
         return nested
-    return {
-        "reps_planned": getattr(session, "reps_planned", None),
-        "rep_distance_m": getattr(session, "rep_distance_m", None),
-    }
+    return {key: getattr(session, key, None) for key in _REP_KEYS}
+
+
+def _positive(value: Any) -> float:
+    """A stated distance, or nothing. Never a negative and never a guess."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return number if number > 0 else 0.0
 
 
 def rep_work_m(session: Any) -> Optional[float]:
@@ -65,15 +81,30 @@ def rep_work_m(session: Any) -> Optional[float]:
     return float(reps) * float(distance)
 
 
+def structured_distance_m(session: Any) -> float:
+    """Warm-up + work + cool-down, from what the coach actually wrote.
+
+    Each part is independent: a session may state a warm-up and no cool-down, or
+    reps with no distance on them but a warm-up either side. Whatever is stated
+    counts, and whatever is not contributes nothing rather than an estimate.
+    """
+    structure = _structure(session)
+    return (
+        _positive(structure.get("warmup_distance_m"))
+        + (rep_work_m(session) or 0.0)
+        + _positive(structure.get("cooldown_distance_m"))
+    )
+
+
 def planned_distance_m(session: Any) -> float:
     """What this session prescribes, in metres. Zero when it prescribes none.
 
     `target_distance_m` WINS when both are present. A coach who writes a total
     has stated the whole session, warm-up and cool-down included, so adding the
-    reps on top would count the work twice — and the total is the more complete
-    of the two statements, not merely the first one checked.
+    structured parts on top would count the work twice — and the total is the
+    more complete of the two statements, not merely the first one checked.
     """
     total = getattr(session, "target_distance_m", None)
     if total:
         return float(total)
-    return rep_work_m(session) or 0.0
+    return structured_distance_m(session)

--- a/backend/app/services/schedule/planned_distance.py
+++ b/backend/app/services/schedule/planned_distance.py
@@ -1,0 +1,79 @@
+"""How far a PLANNED session goes — one definition, three readers (#876).
+
+A run can be sized two ways, and both are legal by deliberate decision. Most
+sessions carry a `target_distance_m`. An interval session usually does not:
+"6 x 400m off 90s" already is the prescription, so `plan_validator` accepts rep
+structure in place of a distance — demanding a total there rejected three real
+interval sessions in a live draft, and the requirement was judged wrong, not the
+plan (see `plan_validator._validate_sessions`).
+
+Every sum of planned running nonetheless read `target_distance_m` alone, so a
+session sized the second legal way summed as ZERO. A real week showed 23.5 km
+with a 6 x 400m sitting in it and its 2.4 km of work nowhere — present as a card,
+counted in "2 of 4 sessions", counted in the mix bar, absent from the only number
+the runner reads as their week.
+
+This module is the single answer, in the spirit of `disciplines.py`'s ONE
+definition of a run: the headline, the three-month horizon and the volume
+ceiling all ask here, so they cannot drift into three different opinions about
+the same week.
+
+What is NOT counted
+-------------------
+The warm-up and cool-down. They live in the session's prose ("Warm up 10 min
+easy... Cool down 10 min easy") and nothing structured states them, so counting
+them would mean inventing distance the plan never specified — the same abstention
+`effort.py` makes when a runner's history is too thin to size a session. The
+consequence is honest and known: an interval session's planned figure is its
+WORK, and reads under what the runner will actually cover door to door.
+"""
+
+from typing import Any, Dict, Optional
+
+
+def _structure(session: Any) -> Dict[str, Any]:
+    """The rep shape, from whichever of the two shapes this reader was handed.
+
+    `PlannedSessionRead` and the ORM row nest it under `structure`; the drafted
+    session carries `reps_planned`/`rep_distance_m` flat, because the coach's
+    tool arguments are flat and `DraftedSession.structure()` only nests them on
+    the way to storage. The volume ceiling runs BEFORE that, on the flat shape,
+    so a helper that read only `structure` would abstain on every plan it is
+    supposed to be guarding.
+    """
+    nested = getattr(session, "structure", None)
+    if isinstance(nested, dict):
+        return nested
+    return {
+        "reps_planned": getattr(session, "reps_planned", None),
+        "rep_distance_m": getattr(session, "rep_distance_m", None),
+    }
+
+
+def rep_work_m(session: Any) -> Optional[float]:
+    """`reps x rep_distance`, or None when the reps carry no distance.
+
+    "6 reps" with no distance on them is a real and legal prescription — the
+    runner's card says exactly that — but it is not a distance, and guessing one
+    would put a number the coach never wrote into the week's total.
+    """
+    structure = _structure(session)
+    reps = structure.get("reps_planned")
+    distance = structure.get("rep_distance_m")
+    if not reps or not distance:
+        return None
+    return float(reps) * float(distance)
+
+
+def planned_distance_m(session: Any) -> float:
+    """What this session prescribes, in metres. Zero when it prescribes none.
+
+    `target_distance_m` WINS when both are present. A coach who writes a total
+    has stated the whole session, warm-up and cool-down included, so adding the
+    reps on top would count the work twice — and the total is the more complete
+    of the two statements, not merely the first one checked.
+    """
+    total = getattr(session, "target_distance_m", None)
+    if total:
+        return float(total)
+    return rep_work_m(session) or 0.0

--- a/backend/app/services/schedule/week.py
+++ b/backend/app/services/schedule/week.py
@@ -54,6 +54,7 @@ from app.services.schedule.placement import (
     session_status,
 )
 from app.services.schedule.norms import running_vs_norm
+from app.services.schedule.planned_distance import planned_distance_m
 from app.services.schedule.rule_text import describe_rule
 from app.services.schedule.rules import check_rules
 from app.services.weeks import days_into_week, resolve_week_start, week_start
@@ -216,8 +217,10 @@ def build_week(
     committed = [s for s in sessions if s.commitment == "committed"]
     headline = WeekHeadline(
         planned_running_distance_m=(
+            # Via `planned_distance_m`, so a run sized by rep structure rather
+            # than by a total counts its work instead of summing as zero (#876).
             sum(
-                s.target_distance_m or 0.0
+                planned_distance_m(s)
                 for s in committed
                 if s.discipline == "run"
             )

--- a/backend/scripts/backfill_session_edges.py
+++ b/backend/scripts/backfill_session_edges.py
@@ -1,0 +1,217 @@
+"""Backfill the warm-up and cool-down distance on interval sessions (#876).
+
+Sessions written before #876 carry rep structure and no `warmup_distance_m` or
+`cooldown_distance_m`, so they count only their reps: the runner's own 4.5 km
+6 x 400m reads as 2.4 km until its plan is redrafted. This fills those two keys
+in on the sessions already stored.
+
+It never converts a time into a distance
+----------------------------------------
+Most of these sessions state their edges in the detail as MINUTES ("Warm up 10
+min easy"). Turning that into a distance means multiplying by a pace nobody
+wrote down, which is the invention #876 exists to remove -- so this script reads
+a distance only where the coach actually wrote one, and ABSTAINS loudly on
+everything else rather than estimating. An abstention is not a failure here: it
+is the script declining to make up the runner's training, and the value can be
+supplied with `--set` once a human decides what it should be.
+
+Scope is deliberately narrow: committed, rep-structured RUN sessions of the
+ACTIVE plan whose window has not already passed. A past session is history and
+nothing reads its planned distance any more; a superseded plan's sessions are
+history too.
+
+    python -m scripts.backfill_session_edges                    # report only
+    python -m scripts.backfill_session_edges --set <id>:1100/1000
+    python -m scripts.backfill_session_edges --apply            # write proposals
+
+Idempotent: a session that already carries both keys is skipped, so re-running
+after an interruption is safe. Dry by default -- `--apply` is the only path that
+writes, and it writes exactly what the report showed.
+"""
+
+import argparse
+import re
+import uuid
+from datetime import date
+from typing import Dict, Optional, Tuple
+
+from app.db.session import SessionLocal
+from app.models.planned_session import PlannedSession
+from app.models.training_plan import TrainingPlan
+
+# "1.1 km", "1,1km", "1100 m", "1100m". Deliberately NOT minutes: a duration is
+# not a distance until a pace is assumed, and assuming one is the bug.
+_KM = re.compile(r"(\d+(?:[.,]\d+)?)\s*k(?:m|ilometres?|ilometers?)\b", re.I)
+_M = re.compile(r"(\d+(?:[.,]\d+)?)\s*m(?:etres?|eters?)?\b", re.I)
+
+
+def _metres(fragment: str) -> Optional[float]:
+    """A distance stated in a fragment of prose, or None if it states none."""
+    km = _KM.search(fragment)
+    if km:
+        return float(km.group(1).replace(",", ".")) * 1000
+    metres = _M.search(fragment)
+    if metres:
+        return float(metres.group(1).replace(",", "."))
+    return None
+
+
+def _sentence_with(detail: str, *words: str) -> Optional[str]:
+    """The first sentence naming one of `words` -- the edge's own clause.
+
+    Sentence-scoped so a warm-up cannot pick up the rep distance from "6 reps of
+    400m" sitting in the next sentence.
+    """
+    for sentence in re.split(r"(?<=[.!?])\s+|\n+", detail or ""):
+        lowered = sentence.lower()
+        if any(word in lowered for word in words):
+            return sentence
+    return None
+
+
+def propose(session: PlannedSession) -> Tuple[Optional[float], Optional[float]]:
+    """(warm-up, cool-down) in metres, each None where the coach wrote no distance."""
+    detail = session.detail or ""
+    warm = _sentence_with(detail, "warm up", "warm-up", "warmup")
+    cool = _sentence_with(detail, "cool down", "cool-down", "cooldown")
+    return (_metres(warm) if warm else None, _metres(cool) if cool else None)
+
+
+def candidates(db, *, today: date):
+    """Committed rep-structured runs of active plans, still ahead of the runner."""
+    rows = (
+        db.query(PlannedSession)
+        .join(TrainingPlan, PlannedSession.plan_id == TrainingPlan.id)
+        .filter(
+            TrainingPlan.status == "active",
+            PlannedSession.discipline == "run",
+            PlannedSession.commitment == "committed",
+            PlannedSession.window_end >= today,
+            PlannedSession.structure.isnot(None),
+        )
+        .order_by(PlannedSession.window_start.asc())
+        .all()
+    )
+    out = []
+    for row in rows:
+        structure = row.structure or {}
+        if not structure.get("reps_planned"):
+            continue
+        # Idempotence: a session already carrying both edges is done.
+        if structure.get("warmup_distance_m") and structure.get("cooldown_distance_m"):
+            continue
+        # A session stating its whole self needs nothing -- the total already wins.
+        if row.target_distance_m:
+            continue
+        out.append(row)
+    return out
+
+
+def _parse_set(values) -> Dict[uuid.UUID, Tuple[Optional[float], Optional[float]]]:
+    """`<session_id>:<warmup_m>/<cooldown_m>`; either side may be `-` to skip."""
+    out = {}
+    for raw in values or []:
+        try:
+            ident, pair = raw.split(":", 1)
+            warm_s, cool_s = pair.split("/", 1)
+            out[uuid.UUID(ident.strip())] = (
+                None if warm_s.strip() == "-" else float(warm_s),
+                None if cool_s.strip() == "-" else float(cool_s),
+            )
+        except (ValueError, AttributeError) as exc:
+            raise SystemExit(f"could not read --set {raw!r}: {exc}")
+    return out
+
+
+def run(db, *, today: date, apply: bool, overrides) -> int:
+    rows = candidates(db, today=today)
+    if not rows:
+        print("nothing to backfill: no rep-structured session is missing its edges.")
+        return 0
+
+    written = 0
+    abstained = []
+    for row in rows:
+        structure = dict(row.structure or {})
+        warm, cool = overrides.get(row.id, (None, None))
+        source = "--set"
+        if warm is None and cool is None:
+            warm, cool = propose(row)
+            source = "detail"
+
+        # Never overwrite an edge the session already carries.
+        warm = None if structure.get("warmup_distance_m") else warm
+        cool = None if structure.get("cooldown_distance_m") else cool
+
+        reps = structure.get("reps_planned")
+        rep_d = structure.get("rep_distance_m") or 0
+        work = (reps or 0) * rep_d
+
+        if warm is None and cool is None:
+            abstained.append(row)
+            print(f"  ABSTAIN  {row.id}  {row.title!r}")
+            print(f"           detail states no distance: {(row.detail or '')[:90]!r}")
+            continue
+
+        if warm:
+            structure["warmup_distance_m"] = float(warm)
+        if cool:
+            structure["cooldown_distance_m"] = float(cool)
+        total = (
+            structure.get("warmup_distance_m", 0)
+            + work
+            + structure.get("cooldown_distance_m", 0)
+        )
+        print(
+            f"  {'WRITE  ' if apply else 'PROPOSE'}  {row.id}  {row.title!r}  [{source}]"
+        )
+        print(
+            f"           warm-up {structure.get('warmup_distance_m', 0):.0f} m + "
+            f"work {work:.0f} m + cool-down "
+            f"{structure.get('cooldown_distance_m', 0):.0f} m = {total / 1000:.2f} km"
+        )
+        if apply:
+            row.structure = structure
+            db.add(row)
+            written += 1
+
+    if apply:
+        db.commit()
+        print(f"\nwrote {written} session(s).")
+    else:
+        print("\nDRY RUN -- nothing written. Re-run with --apply to write the above.")
+    if abstained:
+        print(
+            f"{len(abstained)} session(s) abstained: their detail gives a time, not a "
+            "distance. Supply values with --set <id>:<warmup_m>/<cooldown_m>."
+        )
+    return written
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true", help="write the proposals (default: dry run)"
+    )
+    parser.add_argument(
+        "--set",
+        action="append",
+        metavar="ID:WARM/COOL",
+        help="explicit metres for one session; '-' leaves a side alone",
+    )
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        run(
+            db,
+            today=date.today(),
+            apply=args.apply,
+            overrides=_parse_set(args.set),
+        )
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_backfill_session_edges.py
+++ b/backend/tests/test_backfill_session_edges.py
@@ -1,0 +1,191 @@
+"""#876: the backfill that fills in an interval session's edges, and abstains.
+
+The point of this script is what it REFUSES to do. Sessions written before #876
+state their warm-up in the detail as minutes, and the whole reason the warm-up
+was missing in the first place is that a duration is not a distance until a pace
+is assumed. So the abstention is the load-bearing behaviour here, not the happy
+path -- a backfill that quietly estimated would put invented distance into the
+runner's own plan, which is worse than the undercount it was fixing.
+
+All row data is synthetic test setup (exercises code paths; represents no real
+runner).
+"""
+
+from datetime import date, timedelta
+from uuid import uuid4
+
+from app.models import User
+from app.models.planned_session import PlannedSession
+from app.models.training_plan import TrainingPlan
+from scripts.backfill_session_edges import candidates, propose, run
+
+MON = date(2026, 8, 10)
+INTERVALS = {"reps_planned": 6, "rep_distance_m": 400.0, "rest_s": 90.0}
+
+
+def _user(db) -> User:
+    user = User(email=f"bf-{uuid4()}@example.com")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _plan(db, user, *, status="active") -> TrainingPlan:
+    plan = TrainingPlan(user_id=user.id, status=status, rules=[], week_shapes=[])
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+    return plan
+
+
+def _session(db, plan, **kw) -> PlannedSession:
+    payload = {
+        "window_start": MON + timedelta(days=2),
+        "window_end": MON + timedelta(days=2),
+        "intent": "quality",
+        "discipline": "run",
+        "commitment": "committed",
+        "title": "Intervals: 6x400m",
+        "structure": dict(INTERVALS),
+    }
+    payload.update(kw)
+    session = PlannedSession(plan_id=plan.id, user_id=plan.user_id, **payload)
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    return session
+
+
+# --- what it refuses to do -------------------------------------------------
+
+
+def test_a_warmup_written_as_minutes_is_abstained_on_never_estimated(db):
+    """The whole reason #876 happened, and the one thing this must not do."""
+    plan = _plan(db, _user(db))
+    row = _session(
+        db,
+        plan,
+        detail=(
+            "Warm up 10 min easy. 6 reps of 400m at 4:30/km with 90 sec standing "
+            "recovery between reps. Cool down 10 min easy."
+        ),
+    )
+
+    assert propose(row) == (None, None)
+
+    written = run(db, today=MON, apply=True, overrides={})
+    db.refresh(row)
+
+    assert written == 0
+    assert "warmup_distance_m" not in row.structure
+
+
+def test_a_rep_distance_in_a_neighbouring_sentence_is_not_read_as_the_warmup(db):
+    """Sentence-scoped: "6 reps of 400m" must not become a 400 m warm-up."""
+    plan = _plan(db, _user(db))
+    row = _session(
+        db, plan, detail="Warm up easy. 6 reps of 400m at 4:30/km. Cool down easy."
+    )
+
+    assert propose(row) == (None, None)
+
+
+# --- what it does do -------------------------------------------------------
+
+
+def test_a_warmup_written_as_a_distance_is_read_and_written(db):
+    plan = _plan(db, _user(db))
+    row = _session(
+        db,
+        plan,
+        detail="Warm up 1.1 km easy. 6 reps of 400m at 4:30/km. Cool down 1000 m easy.",
+    )
+
+    assert propose(row) == (1100.0, 1000.0)
+
+    run(db, today=MON, apply=True, overrides={})
+    db.refresh(row)
+
+    assert row.structure["warmup_distance_m"] == 1100.0
+    assert row.structure["cooldown_distance_m"] == 1000.0
+    # The session the runner agreed: 1.1 + 2.4 + 1.0.
+    total = (
+        row.structure["warmup_distance_m"]
+        + row.structure["reps_planned"] * row.structure["rep_distance_m"]
+        + row.structure["cooldown_distance_m"]
+    )
+    assert total == 4500.0
+
+
+def test_an_explicit_set_supplies_what_the_detail_cannot(db):
+    """The abstain path's way out: a human decides, the script writes it."""
+    plan = _plan(db, _user(db))
+    row = _session(db, plan, detail="Warm up 10 min easy. Cool down 10 min easy.")
+
+    run(db, today=MON, apply=True, overrides={row.id: (1100.0, 1000.0)})
+    db.refresh(row)
+
+    assert row.structure["warmup_distance_m"] == 1100.0
+    assert row.structure["cooldown_distance_m"] == 1000.0
+
+
+def test_a_dry_run_writes_nothing(db):
+    plan = _plan(db, _user(db))
+    row = _session(db, plan, detail="Warm up 1.1 km easy. Cool down 1 km easy.")
+
+    written = run(db, today=MON, apply=False, overrides={})
+    db.refresh(row)
+
+    assert written == 0
+    assert "warmup_distance_m" not in row.structure
+
+
+# --- scope and idempotence -------------------------------------------------
+
+
+def test_it_leaves_alone_what_is_not_its_business(db):
+    """History, superseded plans, easy runs, and sessions stating a total.
+
+    Each is excluded for its own reason: a past session's planned distance is no
+    longer read, a superseded plan is history, an easy run has no edges to fill,
+    and a session carrying `target_distance_m` already states the whole of itself
+    -- writing edges under it would put two answers on one session.
+    """
+    user = _user(db)
+    plan = _plan(db, user)
+    detail = "Warm up 1.1 km easy. Cool down 1 km easy."
+
+    past = _session(
+        db, plan, detail=detail,
+        window_start=MON - timedelta(days=7), window_end=MON - timedelta(days=7),
+    )
+    superseded = _session(db, _plan(db, user, status="superseded"), detail=detail)
+    easy = _session(db, plan, detail=detail, intent="easy", structure=None)
+    stated = _session(db, plan, detail=detail, target_distance_m=4500)
+
+    picked = {row.id for row in candidates(db, today=MON)}
+
+    assert picked == set()
+    for row in (past, superseded, easy, stated):
+        assert row.id not in picked
+
+
+def test_it_is_idempotent_and_never_overwrites_an_existing_edge(db):
+    plan = _plan(db, _user(db))
+    row = _session(
+        db,
+        plan,
+        detail="Warm up 1.1 km easy. Cool down 1 km easy.",
+        structure={**INTERVALS, "warmup_distance_m": 900.0},
+    )
+
+    run(db, today=MON, apply=True, overrides={})
+    db.refresh(row)
+
+    # The stored warm-up stands; only the missing cool-down is filled.
+    assert row.structure["warmup_distance_m"] == 900.0
+    assert row.structure["cooldown_distance_m"] == 1000.0
+
+    # Second run has nothing left to do.
+    assert run(db, today=MON, apply=True, overrides={}) == 0

--- a/backend/tests/test_schedule_draft_contract.py
+++ b/backend/tests/test_schedule_draft_contract.py
@@ -135,6 +135,49 @@ def test_structure_is_exactly_the_shape_the_interval_matcher_expects():
     assert set(session.structure()) == {"reps_planned", "rep_distance_m", "rest_s"}
 
 
+def test_the_warmup_and_cooldown_ride_into_the_structure_as_distances():
+    """#876: they are part of the session, and they are METRES.
+
+    Written as "10 min easy" in the detail they were unrecoverable — a distance
+    only after multiplying by a pace nobody stated — so an interval session the
+    runner had agreed as 4.5 km counted as its 2.4 km of reps.
+    """
+    session = DraftedSession(
+        **_session(
+            intent="quality",
+            reps_planned=6,
+            rep_distance_m=400,
+            rest_s=90,
+            warmup_distance_m=1100,
+            cooldown_distance_m=1000,
+        )
+    )
+
+    assert session.structure() == {
+        "reps_planned": 6,
+        "rep_distance_m": 400,
+        "rest_s": 90,
+        "warmup_distance_m": 1100,
+        "cooldown_distance_m": 1000,
+    }
+
+
+def test_the_warmup_and_cooldown_are_guarded_like_every_other_rep_argument():
+    """Same containment rule: they describe the session built around an interval
+    block, so on an easy run they are noise, and with no count they would state a
+    distance for a session whose work is unknown."""
+    with pytest.raises(ValidationError, match="quality session"):
+        DraftedSession(**_session(warmup_distance_m=1000))
+
+    with pytest.raises(ValidationError, match="need reps_planned"):
+        DraftedSession(**_session(intent="quality", cooldown_distance_m=1000))
+
+    with pytest.raises(ValidationError):
+        DraftedSession(
+            **_session(intent="quality", reps_planned=6, warmup_distance_m=0)
+        )
+
+
 def test_a_session_with_no_reps_carries_no_structure_at_all():
     """None rather than an empty dict: a session with no rep structure must not
     reach the matcher as a plan it can score."""

--- a/backend/tests/test_schedule_horizon.py
+++ b/backend/tests/test_schedule_horizon.py
@@ -73,6 +73,7 @@ def _seed_session(
     title: str = "Session",
     target_distance_m: float = None,
     target_effort_score: float = None,
+    structure: dict = None,
 ) -> PlannedSession:
     session = PlannedSession(
         plan_id=plan.id,
@@ -84,6 +85,7 @@ def _seed_session(
         commitment=commitment,
         title=title,
         target_distance_m=target_distance_m,
+        structure=structure,
         target_effort_score=target_effort_score,
     )
     db.add(session)
@@ -154,6 +156,34 @@ def test_a_week_with_sessions_is_planned_and_its_numbers_come_from_them(db):
     assert week.effort_score == 100.0
     # The phase is still the shape's: it is the only place a phase is named.
     assert week.phase == "base"
+
+
+def test_a_rep_structured_run_carries_its_distance_into_the_block(db):
+    """#876: the horizon read `target_distance_m` alone, like the week headline.
+
+    Left unfixed here, the week's gap would repeat across every week of a
+    three-month view — and the running number rides ALONGSIDE the load bar
+    precisely so the runner can read it as exact rather than estimate it off a
+    bar, which it is not while a quality session counts as zero.
+    """
+    user = _seed_user(db)
+    plan = _seed_plan(db, user)
+    _seed_session(
+        db, plan, start=WEEK_0, target_distance_m=8000, target_effort_score=60.0
+    )
+    _seed_session(
+        db,
+        plan,
+        start=WEEK_0 + timedelta(days=2),
+        intent="quality",
+        title="Intervals: 6x400m",
+        target_effort_score=40.0,
+        structure={"reps_planned": 6, "rep_distance_m": 400.0, "rest_s": 90.0},
+    )
+
+    week = _week(build_horizon(db, user, weeks=2, today=TODAY), WEEK_0)
+
+    assert (week.running_distance_m, week.effort_score) == (10400, 100.0)
 
 
 def test_a_suggestion_carries_no_weight_in_the_blocks_shape(db):

--- a/backend/tests/test_schedule_plan_validator.py
+++ b/backend/tests/test_schedule_plan_validator.py
@@ -489,6 +489,41 @@ def test_the_volume_ceiling_fires_above_twice_the_runners_own_norm():
     assert "km of running against a typical" in _failures(check)
 
 
+def test_the_volume_ceiling_counts_rep_structured_running():
+    """#876: the ceiling used to read `target_distance_m` alone, so an interval
+    week's hardest running scored zero against it.
+
+    That failed PERMISSIVE — the one check meant to catch an absurd week was
+    blind to exactly the sessions most able to make one. The reps here clear the
+    ceiling on their own, and nothing in the week states a total distance.
+    """
+    norm = 20000.0
+    reps = 50
+    plan = _plan(
+        weeks=[
+            _week(
+                MON,
+                [
+                    _session(
+                        window_start=TUE,
+                        window_end=TUE,
+                        title="Absurd intervals",
+                        intent="quality",
+                        target_distance_m=None,
+                        reps_planned=reps,
+                        rep_distance_m=(norm * MAX_WEEKLY_MULTIPLE + 1000) / reps,
+                    )
+                ],
+            )
+        ]
+    )
+
+    check = validate_drafted_plan(plan, today=MON, norm_weekly_running_m=norm)
+
+    assert check.ok is False
+    assert "km of running against a typical" in _failures(check)
+
+
 def test_a_bold_but_not_absurd_week_is_left_alone():
     """No 10% rule and no cap on quality sessions live here. Whether this week is
     right for this runner is the judgment the coach is FOR."""

--- a/backend/tests/test_schedule_week.py
+++ b/backend/tests/test_schedule_week.py
@@ -67,6 +67,7 @@ def _seed_session(
     title: str = "Session",
     target_distance_m: float = None,
     target_effort_score: float = None,
+    structure: dict = None,
     completed_at: datetime = None,
     dismissed_at: datetime = None,
 ) -> PlannedSession:
@@ -80,6 +81,7 @@ def _seed_session(
         commitment=commitment,
         title=title,
         target_distance_m=target_distance_m,
+        structure=structure,
         target_effort_score=target_effort_score,
         completed_at=completed_at,
         dismissed_at=dismissed_at,
@@ -271,6 +273,82 @@ def test_the_planned_running_headline_counts_committed_runs_only(db):
     assert week.has_plan is True
     assert week.plan_id == plan.id
     assert week.headline.planned_running_distance_m == 10000
+
+
+def test_a_rep_structured_run_carries_its_distance_into_the_headline(db):
+    """An interval session's work is `reps x rep_distance`, and it counts.
+
+    Rep structure is a first-class way to SIZE a run: `plan_validator` accepts it
+    in place of a distance precisely because "6 x 400m off 90s" is a fully
+    specified session a coach would never also write as a total, and demanding a
+    total rejected real interval sessions. But the headline only ever summed
+    `target_distance_m`, so every one of those sessions landed in the week as
+    zero km -- the runner's own week read 23.5 km with a 6 x 400m in it, and the
+    2.4 km of work was nowhere.
+
+    The reps are the WORK, not the session: the warm-up and cool-down live in
+    prose and are deliberately not counted, because nothing structured states
+    them and inventing a number for them would be the app making up distance.
+    """
+    user = _seed_user(db)
+    plan = _seed_plan(db, user)
+    _seed_session(db, plan, start=TUE, discipline="run", target_distance_m=5000)
+    _seed_session(
+        db,
+        plan,
+        start=WED,
+        end=FRI,
+        discipline="run",
+        intent="quality",
+        title="Intervals: 6x400m @ 4:30/km",
+        structure={"reps_planned": 6, "rep_distance_m": 400.0, "rest_s": 90.0},
+    )
+
+    week = build_week(db, user, today=MON)
+
+    assert week.headline.planned_running_distance_m == 7400
+
+
+def test_a_rep_structured_run_that_also_states_a_total_is_not_double_counted(db):
+    """`target_distance_m` wins when both are present.
+
+    A coach who writes a total has stated the whole session -- warm-up and
+    cool-down included -- so adding the reps on top would count the work twice.
+    """
+    user = _seed_user(db)
+    plan = _seed_plan(db, user)
+    _seed_session(
+        db,
+        plan,
+        start=WED,
+        discipline="run",
+        intent="quality",
+        target_distance_m=9000,
+        structure={"reps_planned": 6, "rep_distance_m": 400.0},
+    )
+
+    week = build_week(db, user, today=MON)
+
+    assert week.headline.planned_running_distance_m == 9000
+
+
+def test_reps_with_no_rep_distance_add_nothing_to_the_headline(db):
+    """"6 reps" with no distance on them is not a distance, and is not guessed."""
+    user = _seed_user(db)
+    plan = _seed_plan(db, user)
+    _seed_session(db, plan, start=TUE, discipline="run", target_distance_m=5000)
+    _seed_session(
+        db,
+        plan,
+        start=WED,
+        discipline="run",
+        intent="quality",
+        structure={"reps_planned": 6, "rest_s": 90.0},
+    )
+
+    week = build_week(db, user, today=MON)
+
+    assert week.headline.planned_running_distance_m == 5000
 
 
 # --- ONE definition of a run ----------------------------------------------

--- a/backend/tests/test_schedule_week.py
+++ b/backend/tests/test_schedule_week.py
@@ -275,20 +275,22 @@ def test_the_planned_running_headline_counts_committed_runs_only(db):
     assert week.headline.planned_running_distance_m == 10000
 
 
-def test_a_rep_structured_run_carries_its_distance_into_the_headline(db):
-    """An interval session's work is `reps x rep_distance`, and it counts.
+def test_an_interval_session_counts_warmup_reps_and_cooldown(db):
+    """The session, not just its work -- the whole of #876.
 
     Rep structure is a first-class way to SIZE a run: `plan_validator` accepts it
     in place of a distance precisely because "6 x 400m off 90s" is a fully
-    specified session a coach would never also write as a total, and demanding a
-    total rejected real interval sessions. But the headline only ever summed
-    `target_distance_m`, so every one of those sessions landed in the week as
-    zero km -- the runner's own week read 23.5 km with a 6 x 400m in it, and the
-    2.4 km of work was nowhere.
+    specified session a coach would never also write as a total. But the headline
+    only ever summed `target_distance_m`, so every one of those sessions landed
+    in the week as zero km -- a real week read 23.5 km with a 6 x 400m in it and
+    its distance nowhere.
 
-    The reps are the WORK, not the session: the warm-up and cool-down live in
-    prose and are deliberately not counted, because nothing structured states
-    them and inventing a number for them would be the app making up distance.
+    Counting only the reps was still wrong: it made that session 2.4 km when the
+    runner had agreed 4.5 km door to door. The warm-up and cool-down were the
+    missing 2.1 km, and they were unreachable while the coach wrote them as
+    MINUTES in prose -- recovering a distance from "10 min easy" means assuming a
+    pace, which is the app inventing distance. So the prescription changed: they
+    are stated as distances now, and this is addition rather than inference.
     """
     user = _seed_user(db)
     plan = _seed_plan(db, user)
@@ -301,19 +303,59 @@ def test_a_rep_structured_run_carries_its_distance_into_the_headline(db):
         discipline="run",
         intent="quality",
         title="Intervals: 6x400m @ 4:30/km",
-        structure={"reps_planned": 6, "rep_distance_m": 400.0, "rest_s": 90.0},
+        structure={
+            "reps_planned": 6,
+            "rep_distance_m": 400.0,
+            "rest_s": 90.0,
+            "warmup_distance_m": 1100.0,
+            "cooldown_distance_m": 1000.0,
+        },
     )
 
     week = build_week(db, user, today=MON)
 
-    assert week.headline.planned_running_distance_m == 7400
+    # 1.1 warm-up + 2.4 of reps + 1.0 cool-down = the 4.5 km session, + the easy 5.
+    assert week.headline.planned_running_distance_m == 9500
+
+
+def test_each_part_of_an_interval_session_stands_on_its_own(db):
+    """A part the coach did not write contributes nothing, and blocks nothing.
+
+    A warm-up with no cool-down is a real prescription, and so is a warm-up
+    either side of reps that carry no distance of their own. The missing part
+    must not zero the parts that were stated, nor be filled in with a guess.
+    """
+    user = _seed_user(db)
+    plan = _seed_plan(db, user)
+    _seed_session(
+        db,
+        plan,
+        start=TUE,
+        discipline="run",
+        intent="quality",
+        structure={"reps_planned": 6, "rep_distance_m": 400.0, "warmup_distance_m": 1100.0},
+    )
+    _seed_session(
+        db,
+        plan,
+        start=THU,
+        discipline="run",
+        intent="quality",
+        structure={"reps_planned": 8, "warmup_distance_m": 1000.0, "cooldown_distance_m": 1000.0},
+    )
+
+    week = build_week(db, user, today=MON)
+
+    # (1.1 + 2.4) + (1.0 + 1.0, the 8 unmeasured reps adding nothing)
+    assert week.headline.planned_running_distance_m == 5500
 
 
 def test_a_rep_structured_run_that_also_states_a_total_is_not_double_counted(db):
     """`target_distance_m` wins when both are present.
 
     A coach who writes a total has stated the whole session -- warm-up and
-    cool-down included -- so adding the reps on top would count the work twice.
+    cool-down included -- so adding the structured parts on top would count them
+    twice.
     """
     user = _seed_user(db)
     plan = _seed_plan(db, user)
@@ -324,7 +366,12 @@ def test_a_rep_structured_run_that_also_states_a_total_is_not_double_counted(db)
         discipline="run",
         intent="quality",
         target_distance_m=9000,
-        structure={"reps_planned": 6, "rep_distance_m": 400.0},
+        structure={
+            "reps_planned": 6,
+            "rep_distance_m": 400.0,
+            "warmup_distance_m": 1000.0,
+            "cooldown_distance_m": 1000.0,
+        },
     )
 
     week = build_week(db, user, today=MON)
@@ -332,7 +379,7 @@ def test_a_rep_structured_run_that_also_states_a_total_is_not_double_counted(db)
     assert week.headline.planned_running_distance_m == 9000
 
 
-def test_reps_with_no_rep_distance_add_nothing_to_the_headline(db):
+def test_reps_with_no_measurement_at_all_add_nothing_to_the_headline(db):
     """"6 reps" with no distance on them is not a distance, and is not guessed."""
     user = _seed_user(db)
     plan = _seed_plan(db, user)

--- a/frontend/components/schedule/SessionCard.tsx
+++ b/frontend/components/schedule/SessionCard.tsx
@@ -44,22 +44,45 @@ function placementChip(
  * intensity. Load sizes the BARS, where it is a proportion rather than an
  * instruction, and it labels nothing.
  *
- * A rep-structured session usually carries neither a distance nor a duration,
- * because "6 × 400 m off 90 s" already is the prescription. So the structure is
- * the fallback, not a number the app worked out.
+ * A rep-structured session usually carries no `target_distance_m`, because
+ * "6 × 400 m off 90 s" already is the prescription. It is still a distance the
+ * runner covers, though, so #876 gives the measure column BOTH: the session's
+ * total in km on top — the same unit every other card shows, and the number the
+ * week's headline counts — with the rep prescription under it, because that is
+ * what they actually go out and do. Warm-up and cool-down are part of the total
+ * and are now stated as distances, so this is addition, not an estimate.
  */
+function structuredDistance(session: PlannedSession): number {
+  const s = session.structure;
+  if (!s) return 0;
+  const positive = (value: number | undefined) => (value && value > 0 ? value : 0);
+  const reps = positive(s.reps_planned);
+  const repDistance = positive(s.rep_distance_m);
+  return (
+    positive(s.warmup_distance_m) + reps * repDistance + positive(s.cooldown_distance_m)
+  );
+}
+
 function targetLine(session: PlannedSession): string | null {
   const parts: string[] = [];
   if (session.target_distance_m) parts.push(formatDistanceKm(session.target_distance_m));
   if (session.target_duration_s) parts.push(formatDuration(session.target_duration_s));
   if (parts.length) return parts.join(" · ");
 
+  const total = structuredDistance(session);
+  if (total > 0) return formatDistanceKm(total);
+
   const reps = session.structure?.reps_planned;
-  if (reps) {
-    const distance = session.structure?.rep_distance_m;
-    return distance ? `${reps} × ${Math.round(distance)} m` : `${reps} reps`;
-  }
+  if (reps) return `${reps} reps`;
   return null;
+}
+
+/** The reps themselves, shown under the total so the prescription survives it. */
+function repLine(session: PlannedSession): string | null {
+  const reps = session.structure?.reps_planned;
+  const distance = session.structure?.rep_distance_m;
+  if (!reps || !distance) return null;
+  return `${reps} × ${Math.round(distance)} m`;
 }
 
 function actualLine(actual: LoggedActivity): string {
@@ -98,6 +121,7 @@ export default function SessionCard({
   const isSuggestion = session.commitment === "suggested";
   const isDone = session.status === "done";
   const target = targetLine(session);
+  const reps = repLine(session);
 
   return (
     <li
@@ -175,6 +199,11 @@ export default function SessionCard({
             <div className="font-mono text-sm tabular-nums text-gray-700 dark:text-gray-200">
               {target}
             </div>
+            {reps && (
+              <div className="font-mono text-[11px] tabular-nums text-gray-500 dark:text-gray-400">
+                {reps}
+              </div>
+            )}
             <div className="text-[10px] uppercase tracking-wider text-gray-400 dark:text-gray-500">
               target
             </div>


### PR DESCRIPTION
Closes #876.

A real week read **23.5 km** with a 6 × 400m sitting in it — the session rendered its own card, counted in "2 of 4 sessions", counted in the mix bar, and contributed **zero** to the only number the runner reads as their week. The session had been agreed with the coach as 4.5 km door to door.

That week now reads **28.0 km**, and the session reads **4.50 km**.

## Two defects, one behind the other

**1. Rep structure was never summed.** A run can be sized by a total distance *or* by rep structure — `plan_validator` accepts the latter deliberately, because demanding a total once rejected three real interval sessions in a live draft. Every sum of planned running nonetheless read `target_distance_m` alone, so a session sized the accepted second way summed as zero. Three readers did this, and they now share one definition (`schedule/planned_distance.py`, in the spirit of `disciplines.py`'s ONE definition of a run):

| Reader | Was |
| --- | --- |
| `week.py` | the headline in the report |
| `horizon.py` | the same gap repeated across every week of the 3-month view |
| `plan_validator.py` | the volume ceiling, failing **permissive** — the check for an absurd week scored an interval week's hardest running at zero |

**2. The warm-up and cool-down were never captured at all.** Counting the reps alone still gives 2.4 km against the agreed 4.5 km. The missing 2.1 km lived only as prose in the detail — "Warm up 10 min easy" — and recovering a distance from that means multiplying by a pace nobody stated, which is the app inventing distance.

The cause was upstream, in what the coach is asked for: the draft prompt said a session needs "a distance, a duration, **or** rep structure", so for intervals the coach wrote the reps and omitted the total. Reinforcing it, `target_distance_m` was the one field in the tool schema carrying **no description at all**.

So the prescription changed rather than the arithmetic. `warmup_distance_m` and `cooldown_distance_m` join the rep shape as **distances**, guarded by the same containment rule as every other rep argument (quality intent, and a rep count to belong to). `workout_matching` reads through `.get`, so the new keys are invisible to it rather than breaking it. `structure` is a JSON column — no migration.

## The card

Leads with the session total in km — the same unit every other card shows, and the number the headline counts — keeping `6 × 400 m` beneath it so the prescription survives the number.

## Backfilling what is already stored

`backend/scripts/backfill_session_edges.py` fills the edges in on sessions written before this change. **What it refuses to do is the point:** it reads a distance only where the coach actually wrote one, scoped to the edge's own sentence so "6 reps of 400m" next door cannot be mistaken for a warm-up, and abstains loudly on time-only prose rather than estimating. `--set` is how a human supplies the number instead.

Dry by default — `--apply` is the only path that writes. Idempotent, never overwrites an edge a session already carries, and scoped to committed rep-structured runs of the *active* plan whose window has not passed.

## Verification

- **End-to-end through `GET /api/schedule/week`** on the four sessions from the report: headline 28.0 km, interval card 4.50 km / 6 × 400 m.
- **Backend suite 3139 passed.** One pre-existing failure (`test_the_ingestion_pipeline_survives_a_schedule_fault`) is environmental — an outbound call blocked by the sandbox proxy — and was failing identically before any change here.
- **Frontend typecheck, lint and build pass.**
- Each new test was confirmed to fail without its fix, so none passes for the wrong reason. The load-bearing backfill tests are the refusals: `"10 min easy"` yields nothing, and a neighbouring rep distance is not read as a warm-up.
- The backfill script was exercised through its **real CLI** against a seeded database, not only through its functions.

## Deliberately not done

- `schedule/completion.py`'s `_closeness` has the same blind spot: a rep-structured session has no total, so it scores 1.0 ("nothing to be far from") when an activity is matched to it. Changing it alters completion matching. **No issue has been opened for this yet.**
- Whether "Warm up 10 min easy" in the original session was itself a coach transcription drift is unresolved — at the plan's stated easy pace that is ~1.7 km each way, not the ~1.05 km the agreed 4.5 km total implies. Worth its own issue if the prose is wrong too.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G1BQwn98VcmMMUHm8L6LPF)_