### PR TITLE
fix(schedule): a tempo session may have a warm-up (#878)

### DIFF
--- a/backend/app/schemas/schedule.py
+++ b/backend/app/schemas/schedule.py
@@ -179,24 +179,28 @@ class PlannedWeekShape(BaseModel):
 
 
 class SessionStructure(BaseModel):
-    """The interval shape `workout_matching.match_planned_to_detected` expects.
+    """How a planned session is BUILT: its reps, its warm-up, its cool-down.
 
-    Its rep keys are unchanged: that function has compared a plan to detected
-    reps since the beginning and has never once been handed one, because
-    `_extract_planned_workout` is a placeholder that returns None. It reads every
-    key through `.get`, so the warm-up and cool-down below are invisible to it
-    rather than breaking it.
+    The rep keys are the shape `workout_matching.match_planned_to_detected`
+    expects, which it has compared against detected reps since the beginning of
+    the project. It reads every key through `.get`, so the warm-up and cool-down
+    are invisible to it rather than breaking it.
 
     The warm-up and cool-down are DISTANCES, in the same unit as everything else
     the runner reads (#876). They used to live in the detail prose as minutes,
     which meant the session's real length could only be recovered by multiplying
     by an assumed pace — so a 4.5 km interval session counted as its 2.4 km of
     reps. Stated as a distance, the total is addition instead of inference.
+
+    Every field is optional, `reps_planned` included (#878). A tempo run is built
+    out of a warm-up and a cool-down and no reps at all, and requiring the count
+    here said the opposite: that a session has parts only when those parts are
+    reps.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    reps_planned: int = Field(ge=1, le=60)
+    reps_planned: Optional[int] = Field(default=None, ge=1, le=60)
     rep_distance_m: Optional[float] = Field(default=None, gt=0)
     rest_s: Optional[float] = Field(default=None, ge=0)
     warmup_distance_m: Optional[float] = Field(default=None, gt=0)

--- a/backend/app/services/analysis/_orchestrator.py
+++ b/backend/app/services/analysis/_orchestrator.py
@@ -78,12 +78,24 @@ def _extract_planned_workout(planned_session) -> dict | None:
     unnoticed. That day is this one.
 
     The session is resolved in the load phase (`schedule.completion`), so this
-    stays a pure projection: a planned session carries `structure` only when the
-    coach gave it reps, and everything else still matches with no plan.
+    stays a pure projection.
+
+    A REP COUNT is what makes a plan scoreable, and since #878 a session's
+    `structure` may exist without one: a tempo run carries a warm-up and a
+    cool-down and no reps. `match_planned_to_detected` scores whatever it is
+    handed, and against an edges-only plan it finds nothing to compare, scores
+    0.0, and `compute_confidence` then appends the CRITICAL
+    `interval_structure_mismatch` — so a tempo run with a warm-up would be
+    reported as a botched interval session. A plan with no reps in it is not a
+    rep plan, and saying so here is cheaper than teaching every reader of
+    `structure` to ask.
     """
     if planned_session is None:
         return None
-    return getattr(planned_session, "structure", None) or None
+    structure = getattr(planned_session, "structure", None) or None
+    if structure and not structure.get("reps_planned"):
+        return None
+    return structure
 
 async def analyze_with_streams(db: Session, activity_id: str) -> Optional[DerivedMetric]:
     """

--- a/backend/app/services/schedule/draft.py
+++ b/backend/app/services/schedule/draft.py
@@ -148,10 +148,13 @@ mean an easy walk or a gentle spin, that is an easy session of that discipline \
 - Every other session needs enough to size it: a distance, a duration, or rep \
 structure. A session with none of the three is rejected.
 - Write a warm-up and a cool-down as a DISTANCE, never as minutes. \
-`warmup_distance_m` and `cooldown_distance_m` are part of the session and are \
-added to its reps to give what the runner sees; the same thing said in prose as \
-"10 min easy" is not a distance and counts as nothing. Say it in the detail too \
-if you like, but say it in the fields regardless.
+`warmup_distance_m` and `cooldown_distance_m` are part of the session; the same \
+thing said in prose as "10 min easy" is not a distance and counts as nothing.
+- A session's distance has to ADD UP. Reps plus their warm-up and cool-down do, \
+so leave `target_distance_m` out of a rep session. Nothing else does: give a tempo \
+its whole distance in `target_distance_m`, door to door, with the warm-up and \
+cool-down as the parts inside it. Anything you do not say in metres counts as \
+nothing towards the runner's week.
 - Do not plan sessions in the past.
 - Do not invent a race, a goal or an injury the runner has not told you about.
 - Do not give medical advice, diagnose, or prescribe treatment. If something in \

--- a/backend/app/services/schedule/draft_contract.py
+++ b/backend/app/services/schedule/draft_contract.py
@@ -91,28 +91,41 @@ class DraftedSession(BaseModel):
         # coach wrote and nothing stored is worse than a rejected plan.
         has_reps = self.reps_planned is not None
         has_rep_args = self.rep_distance_m is not None or self.rest_s is not None
-        # The warm-up and cool-down ride with the reps under the same guard: they
-        # describe the session BUILT around an interval block, so on an easy run
-        # they are noise, and stored without a count they would state a distance
-        # for a session whose work is unknown.
+        # The warm-up and cool-down do NOT ride with the reps (#878). They tied to
+        # the rep count when they arrived, which made a tempo run — a quality
+        # session with a warm-up and no reps, and the commonest one in coaching —
+        # impossible to write down. A live draft was refused on exactly that and,
+        # with only two attempts, the whole plan died for one session.
+        #
+        # The rep ARGUMENTS keep the count requirement, because they describe
+        # reps: "400s off 60" with no count is an instruction `structure()` would
+        # drop silently, and an instruction the coach wrote and nothing stored is
+        # worse than a rejected plan. The edges describe the SESSION, which exists
+        # whether or not it is built around an interval block.
         has_edges = (
             self.warmup_distance_m is not None or self.cooldown_distance_m is not None
         )
         if (has_reps or has_rep_args or has_edges) and self.intent != "quality":
             raise ValueError("rep structure belongs to a quality session")
-        if (has_rep_args or has_edges) and not has_reps:
-            raise ValueError(
-                "rep_distance_m, rest_s, warmup_distance_m and cooldown_distance_m "
-                "need reps_planned"
-            )
+        if has_rep_args and not has_reps:
+            raise ValueError("rep_distance_m and rest_s need reps_planned")
         return self
 
     def structure(self) -> Optional[Dict[str, float]]:
-        """The `{reps_planned, rep_distance_m, rest_s}` shape `workout_matching`
-        expects, or None when the session has no rep structure."""
-        if self.reps_planned is None:
-            return None
-        shape: Dict[str, float] = {"reps_planned": self.reps_planned}
+        """How this session is built, or None when it is not built out of parts.
+
+        It carries the `{reps_planned, rep_distance_m, rest_s}` shape
+        `workout_matching` expects, and since #878 it may also carry only the
+        edges: a tempo run has a warm-up and no reps, and keying this off the rep
+        count dropped that warm-up on the floor. Whoever reads this reads through
+        `.get`, so a shape with no count is invisible to a reader that wants one
+        rather than misread by it — with one place that has to say so out loud,
+        `_extract_planned_workout`, because the interval matcher scores whatever
+        it is handed and would grade a tempo as a botched rep session.
+        """
+        shape: Dict[str, float] = {}
+        if self.reps_planned is not None:
+            shape["reps_planned"] = self.reps_planned
         if self.rep_distance_m is not None:
             shape["rep_distance_m"] = self.rep_distance_m
         if self.rest_s is not None:
@@ -121,7 +134,7 @@ class DraftedSession(BaseModel):
             shape["warmup_distance_m"] = self.warmup_distance_m
         if self.cooldown_distance_m is not None:
             shape["cooldown_distance_m"] = self.cooldown_distance_m
-        return shape
+        return shape or None
 
 
 class DraftedWeek(BaseModel):
@@ -335,11 +348,11 @@ RECORD_TRAINING_PLAN_TOOL = {
                                     "target_distance_m": {
                                         "type": "number",
                                         "description": (
-                                            "The WHOLE session in metres, "
-                                            "door to door. On an interval "
-                                            "session give the warm-up and "
-                                            "cool-down below instead and leave "
-                                            "this out — the app adds them up."
+                                            "The WHOLE session in metres, door "
+                                            "to door, warm-up and cool-down "
+                                            "included. Leave it out only when "
+                                            "the reps below already add up to "
+                                            "the session."
                                         ),
                                     },
                                     "target_duration_s": {"type": "integer"},
@@ -350,10 +363,9 @@ RECORD_TRAINING_PLAN_TOOL = {
                                         "type": "number",
                                         "description": (
                                             "The warm-up in METRES, not "
-                                            "minutes. It is part of the "
-                                            "session's distance and the runner "
-                                            "reads it in the same unit as "
-                                            "everything else."
+                                            "minutes, so the session adds up "
+                                            "instead of being inferred from a "
+                                            "pace nobody stated."
                                         ),
                                     },
                                     "cooldown_distance_m": {

--- a/backend/app/services/schedule/planned_distance.py
+++ b/backend/app/services/schedule/planned_distance.py
@@ -103,6 +103,14 @@ def planned_distance_m(session: Any) -> float:
     has stated the whole session, warm-up and cool-down included, so adding the
     structured parts on top would count the work twice — and the total is the
     more complete of the two statements, not merely the first one checked.
+
+    That precedence is load-bearing rather than incidental (#878). A tempo run
+    has a warm-up and no reps, so its work has no field of its own: with a total
+    stated this reads it, and without one the session contributes the warm-up and
+    the cool-down and nothing for the tempo block between them. Both answers are
+    the module's own rule — what the coach actually wrote — and the second is the
+    same abstention a duration-sized session has always made, improved on rather
+    than made worse by the edges being stated.
     """
     total = getattr(session, "target_distance_m", None)
     if total:

--- a/backend/tests/test_analysis_stages.py
+++ b/backend/tests/test_analysis_stages.py
@@ -375,6 +375,50 @@ def test_a_planned_session_now_feeds_the_interval_matcher(db):
     ) == {"reps_planned": 8, "rep_distance_m": 400}
 
 
+def test_a_tempo_sessions_warmup_is_not_handed_over_as_a_rep_plan(db):
+    """#878: `structure` can exist without reps, and only reps make a plan.
+
+    A tempo run states a warm-up and a cool-down and no reps. Passed to
+    `match_planned_to_detected` that structure finds nothing to score, lands
+    `match_score` at 0.0, and `compute_confidence` then appends the CRITICAL
+    `interval_structure_mismatch` — the run reported as a botched interval
+    session it was never prescribed as. So this projection asks for a rep count,
+    not merely for a structure.
+    """
+    from app.models.planned_session import PlannedSession
+
+    assert (
+        _orchestrator._extract_planned_workout(
+            PlannedSession(
+                structure={"warmup_distance_m": 1000, "cooldown_distance_m": 1000}
+            )
+        )
+        is None
+    )
+
+
+def test_an_edges_only_plan_would_have_graded_a_run_as_a_failed_rep_session(db):
+    """The consequence the guard above exists to prevent, stated once.
+
+    Not a test of the guard: a test of what `match_planned_to_detected` does with
+    an edges-only plan, so the reason the guard is there survives someone reading
+    it later and finding it arbitrary.
+    """
+    from app.services.analysis.workout_matching import match_planned_to_detected
+
+    detected = {
+        "summary": {"rep_count": 6, "consistency_score": "high"},
+        "work_segments": [{"distance_m": 400, "duration_s": 100} for _ in range(6)],
+    }
+
+    graded = match_planned_to_detected(
+        detected, {"warmup_distance_m": 1000, "cooldown_distance_m": 1000}
+    )
+
+    assert graded["match_score"] == 0.0
+    assert graded["detection_confidence"] == "low"
+
+
 def test_interval_structure_mismatch_can_now_fire_through_analyze(db, monkeypatch):
     """The branch that no composition could reach, reached.
 

--- a/backend/tests/test_schedule_draft.py
+++ b/backend/tests/test_schedule_draft.py
@@ -284,6 +284,55 @@ async def test_the_interval_structure_lands_on_the_row_in_the_matchers_own_shape
     }
 
 
+async def test_878_a_plan_carrying_a_tempo_with_a_warmup_is_accepted_and_stored(
+    db, monkeypatch
+):
+    """The shape a live draft died on, driven through the whole chain.
+
+    Production, 2026-08-13: a runner asked for a plan in conversation and the
+    coach wrote a Week 2 tempo with a warm-up and a cool-down and no reps. The
+    contract refused it, and since a draft gets two attempts and the first had
+    already gone, the whole seven-week block was lost. The runner was told
+    nothing and went on believing the plan was in.
+
+    Coercion, the coherence gate and persistence, not just the schema: the
+    session that killed the plan has to survive all three and land on a row.
+    """
+    user = _seed_user(db)
+    _seed_history(db, user)
+    plan = store.create_drafting_plan(db, user.id)
+
+    payload = _good_plan()
+    payload["weeks"][0]["sessions"].append(
+        {
+            "window_start": SUN.isoformat(),
+            "window_end": SUN.isoformat(),
+            "intent": "quality",
+            "discipline": "run",
+            "title": "Tempo: 5 km @ 4:50/km",
+            "detail": "1 km easy, 5 km at 4:50/km, 1 km easy.",
+            "target_distance_m": 7000,
+            "warmup_distance_m": 1000,
+            "cooldown_distance_m": 1000,
+        }
+    )
+    _inject(monkeypatch, _FakeClient([payload]))
+
+    outcome = await draft_plan(db, user, plan, today=TODAY)
+
+    assert outcome.ok, outcome.failures
+    tempo = (
+        db.query(PlannedSession)
+        .filter(PlannedSession.title == "Tempo: 5 km @ 4:50/km")
+        .one()
+    )
+    assert tempo.target_distance_m == 7000
+    assert tempo.structure == {
+        "warmup_distance_m": 1000,
+        "cooldown_distance_m": 1000,
+    }
+
+
 async def test_an_accepted_plan_becomes_active_and_supersedes_its_predecessor(
     db, monkeypatch
 ):

--- a/backend/tests/test_schedule_draft_contract.py
+++ b/backend/tests/test_schedule_draft_contract.py
@@ -162,15 +162,69 @@ def test_the_warmup_and_cooldown_ride_into_the_structure_as_distances():
     }
 
 
-def test_the_warmup_and_cooldown_are_guarded_like_every_other_rep_argument():
-    """Same containment rule: they describe the session built around an interval
-    block, so on an easy run they are noise, and with no count they would state a
-    distance for a session whose work is unknown."""
+def test_a_tempo_session_may_state_a_warmup_without_any_reps():
+    """#878: the shape a live draft was refused on, and the plan died for it.
+
+    A tempo run has a warm-up. So does almost every quality session. #876 tied
+    the warm-up and cool-down to a rep COUNT along with the rep arguments proper,
+    which made the commonest quality session in coaching unrepresentable — and
+    since a draft gets two attempts, one such session ended the whole plan.
+
+    The rep ARGUMENTS still need a count, because they describe reps. The edges
+    describe the session, and a session can have edges without having reps.
+    """
+    session = DraftedSession(
+        **_session(
+            intent="quality",
+            title="Tempo: 5 km @ 4:50/km",
+            target_distance_m=7000,
+            warmup_distance_m=1000,
+            cooldown_distance_m=1000,
+        )
+    )
+
+    assert session.structure() == {
+        "warmup_distance_m": 1000,
+        "cooldown_distance_m": 1000,
+    }
+
+
+def test_a_tempo_measured_in_minutes_may_still_state_its_warmup():
+    """Nothing here demands a session be sized in the same unit as its edges.
+
+    Coaches write tempos in minutes — "warm up 10 min easy, 4 x 5 min at
+    comfortably hard" is an ordinary prescription — and a contract that refused
+    the metres alongside those minutes would be #878 one shape further on, for
+    the same reason and at the same cost: a draft gets two attempts, so one
+    refused session loses the whole plan.
+
+    Such a session simply contributes the distances that were stated. That is
+    already how a duration-sized session behaves: it contributes nothing to the
+    week's kilometres and nothing rejects it, so stating a warm-up can only
+    improve on that.
+    """
+    session = DraftedSession(
+        **_session(
+            intent="quality",
+            title="Tempo: 4 x 5 min",
+            target_distance_m=None,
+            target_duration_s=2400,
+            warmup_distance_m=1000,
+            cooldown_distance_m=1000,
+        )
+    )
+
+    assert session.structure() == {
+        "warmup_distance_m": 1000,
+        "cooldown_distance_m": 1000,
+    }
+
+
+def test_the_warmup_and_cooldown_are_still_guarded_on_the_intent_and_the_value():
+    """What #876's containment rule keeps: on an easy run the edges are noise,
+    and a non-positive distance is not a distance."""
     with pytest.raises(ValidationError, match="quality session"):
         DraftedSession(**_session(warmup_distance_m=1000))
-
-    with pytest.raises(ValidationError, match="need reps_planned"):
-        DraftedSession(**_session(intent="quality", cooldown_distance_m=1000))
 
     with pytest.raises(ValidationError):
         DraftedSession(
@@ -178,9 +232,9 @@ def test_the_warmup_and_cooldown_are_guarded_like_every_other_rep_argument():
         )
 
 
-def test_a_session_with_no_reps_carries_no_structure_at_all():
-    """None rather than an empty dict: a session with no rep structure must not
-    reach the matcher as a plan it can score."""
+def test_a_session_with_neither_reps_nor_edges_carries_no_structure_at_all():
+    """None rather than an empty dict: a session with no structure at all must
+    not reach the matcher as a plan it can score."""
     assert DraftedSession(**_session()).structure() is None
     assert DraftedSession(**_session(intent="quality")).structure() is None
 

--- a/backend/tests/test_schedule_week.py
+++ b/backend/tests/test_schedule_week.py
@@ -66,6 +66,7 @@ def _seed_session(
     commitment: str = "committed",
     title: str = "Session",
     target_distance_m: float = None,
+    target_duration_s: int = None,
     target_effort_score: float = None,
     structure: dict = None,
     completed_at: datetime = None,
@@ -81,6 +82,7 @@ def _seed_session(
         commitment=commitment,
         title=title,
         target_distance_m=target_distance_m,
+        target_duration_s=target_duration_s,
         structure=structure,
         target_effort_score=target_effort_score,
         completed_at=completed_at,
@@ -377,6 +379,58 @@ def test_a_rep_structured_run_that_also_states_a_total_is_not_double_counted(db)
     week = build_week(db, user, today=MON)
 
     assert week.headline.planned_running_distance_m == 9000
+
+
+def test_a_tempo_with_a_warmup_reaches_the_week_as_the_whole_session(db):
+    """#878: a session whose parts do NOT add up to it reads its stated total.
+
+    A tempo run has a warm-up and a cool-down and no reps, so its work has no
+    field of its own. Summing what is stated would return 2 km of edges and drop
+    the 5 km tempo between them, which is #876's defect one session type further
+    on. The contract makes such a session state its whole distance, and the week
+    reads that.
+    """
+    user = _seed_user(db)
+    plan = _seed_plan(db, user)
+    _seed_session(
+        db,
+        plan,
+        start=WED,
+        discipline="run",
+        intent="quality",
+        target_distance_m=7000,
+        structure={"warmup_distance_m": 1000.0, "cooldown_distance_m": 1000.0},
+    )
+
+    week = build_week(db, user, today=MON)
+
+    assert week.headline.planned_running_distance_m == 7000
+
+
+def test_a_tempo_measured_in_minutes_contributes_only_what_it_stated_in_metres(db):
+    """The abstention, unchanged, and improved on rather than made worse.
+
+    A session sized in minutes has always contributed nothing to the week's
+    kilometres, because a duration is not a distance until multiplied by a pace
+    nobody stated. Once its warm-up and cool-down are stated in metres those two
+    parts count, and the block between them still does not. Guessing the rest
+    would be the app inventing distance.
+    """
+    user = _seed_user(db)
+    plan = _seed_plan(db, user)
+    _seed_session(
+        db,
+        plan,
+        start=WED,
+        discipline="run",
+        intent="quality",
+        target_duration_s=2400,
+        structure={"warmup_distance_m": 1000.0, "cooldown_distance_m": 1000.0},
+    )
+
+    week = build_week(db, user, today=MON)
+
+    assert week.headline.planned_running_distance_m == 2000
 
 
 def test_reps_with_no_measurement_at_all_add_nothing_to_the_headline(db):


### PR DESCRIPTION
A live draft died on a Week 2 tempo run. The coach wrote it with a warm-up
and a cool-down and no reps, the contract refused the shape, and since a
draft gets two attempts and the first had already gone to an unrelated
rejection, the whole seven-week block was lost. Nothing told the runner, so
they and the coach spent four more turns believing the plan was in.

The edges were tied to a rep COUNT when they arrived in #876, which made the
commonest quality session in coaching unrepresentable. They describe the
SESSION, not the reps, so they no longer need one. The rep arguments keep the
requirement, because they do describe reps: "400s off 60" with no count is an
instruction `structure()` would drop silently.

Three consequences the schema change alone would have missed:

`structure()` keyed off the rep count too, so relaxing the validator would
have stored nothing. It now emits whatever parts the session has.

`_extract_planned_workout` hands any truthy structure to the interval matcher,
which finds no reps to score, lands `match_score` at 0.0, and reaches the
CRITICAL `interval_structure_mismatch` branch: a tempo run reported as a
botched interval session. A plan with no reps in it is not a rep plan, and
saying so at the projection is cheaper than teaching every reader to ask.

The tool description and the prompt bullet both named a session TYPE ("on an
interval session", "added to its reps") where the rule is about a PROPERTY:
whether the session's parts add up to it. Naming the type is why an ordinary
tempo fell outside every instruction, so both are rewritten at that altitude
rather than given a tempo clause.

A first attempt also required edges-without-reps to state a total.
Clean-context end-to-end verification showed that refused a tempo written in
minutes, which is how the real coach writes them, so it reproduced #878 one
shape further on at the same cost. Dropped: such a session contributes the
metres that were stated, which is the module's existing rule and strictly
better than the zero a duration-sized session has always contributed.

Verified end-to-end by an agent that did not write the change: the real
`GET /api/schedule/week` returns 29900.0 across all three session shapes with
`/horizon` agreeing independently, and `analyze` on a matched edges-only
session is byte-identical to the no-plan baseline while a positive control
confirms the mismatch branch still fires. Six sensitivity breaks, each caught
by its own test. 3140 -> 3147 passing.

---

Closes #878.

**How this was verified.** A failing test reproducing the exact production payload shape, then passing. Six sensitivity breaks, each caught by its own test. End-to-end by a clean-context agent that did not write the change: the real `GET /api/schedule/week` returns 29900.0 across all three session shapes with `/horizon` agreeing independently, and `analyze` on a matched edges-only session is byte-identical to the no-plan baseline while a positive control confirms the interval-mismatch branch still fires.

**Production data already corrected.** `backfill_session_edges.py --set <id>:1050/1050 --apply` was run against production with the owner's authorisation, so the live 6x400m now reads 4.50 km and that week reads 28.0 km. The week-3 5x800m deliberately still abstains: no warm-up distance was ever agreed for it, and the script declines to invent one.

**Merge order.** Independent of the rest of the stack; can go first.
