### PR TITLE
fix(coach): the card says how recent the plan it would replace is (#883)

### DIFF
--- a/backend/app/services/coach/proposed_actions.py
+++ b/backend/app/services/coach/proposed_actions.py
@@ -352,6 +352,16 @@ def _require_owned_planned_session(db: Session, owner_user_id: UUID, session_id)
     return session
 
 
+def _replace_description(existing, describe_age) -> str:
+    """What this card will write over, said plainly enough to stop a mistake."""
+    if existing is None:
+        return "Write this plan into your schedule"
+    age = describe_age(existing)
+    if age is None:
+        return "Write this plan into your schedule, replacing your current one"
+    return f"Write this plan into your schedule, replacing the one written {age}"
+
+
 def _describe_complete_session(session) -> str:
     when = (
         session.window_start.strftime("%a %-d %b")
@@ -375,6 +385,8 @@ def _build_offer(
             # The surface's kill switch reaches the offer too. Putting a card up
             # for a screen that answers 503 would be a promise the app cannot keep.
             raise ValueError("the schedule is unavailable")
+        from app.services.schedule.coach_view import describe_written_ago
+
         existing = schedule_store.get_active_plan(db, owner_user_id)
         frame = ProposedActionFrame(
             action_type="draft_plan",
@@ -384,11 +396,14 @@ def _build_offer(
             # that is the part of this action they most need to see before it
             # happens — the runner-confirms-before-anything-is-written property
             # is only worth having if the card says what will be written over.
-            description=(
-                "Write this plan into your schedule, replacing your current one"
-                if existing is not None
-                else "Write this plan into your schedule"
-            ),
+            #
+            # And named with its AGE (#883). A runner asked "Is it added?", was
+            # offered a second card, and confirmed it — replacing the plan they
+            # had accepted ninety seconds earlier. Drafting is not deterministic,
+            # so the replacement was a different plan. "Your current one" was
+            # true and said nothing about the part that would have stopped them:
+            # that the plan in question was the one they had just agreed.
+            description=_replace_description(existing, describe_written_ago),
             confirm_label="Put it in my schedule",
         )
         stored = StoredProposedAction(

--- a/backend/app/services/schedule/coach_view.py
+++ b/backend/app/services/schedule/coach_view.py
@@ -28,7 +28,7 @@ what gets read out.
 """
 
 import logging
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, List, Optional
 
 from sqlalchemy.orm import Session
@@ -88,6 +88,40 @@ def _km(metres: float, unmeasured_runs: int = 0) -> Optional[str]:
         return total
     runs = "run" if unmeasured_runs == 1 else "runs"
     return f"{total}, plus {unmeasured_runs} {runs} whose distance was not stated"
+
+
+def describe_written_ago(plan: Any, now: Optional[datetime] = None) -> Optional[str]:
+    """How long ago this plan was written, in the terms a person would use.
+
+    Shared by the runner's confirm card and the coach's own read of the schedule
+    (#883), because both need the same fact and a plan cannot be two ages. A
+    runner asked "Is it added?", was offered a second card, and confirmed it —
+    replacing the plan they had accepted ninety seconds earlier with a differently
+    generated one. Drafting is not deterministic, so that is a different plan, and
+    the card said only "your current one": true, and silent about the part that
+    would have stopped them.
+    """
+    written = getattr(plan, "generated_at", None) or getattr(plan, "created_at", None)
+    if written is None:
+        return None
+    now = now or datetime.now(timezone.utc)
+    # SQLite hands back naive datetimes where Postgres does not, and subtracting
+    # across the two raises rather than being wrong quietly.
+    if written.tzinfo is None:
+        written = written.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    minutes = int((now - written).total_seconds() // 60)
+    if minutes < 1:
+        return "just now"
+    if minutes < 60:
+        return f"{minutes} minute{'s' if minutes != 1 else ''} ago"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours} hour{'s' if hours != 1 else ''} ago"
+    days = hours // 24
+    return f"{days} day{'s' if days != 1 else ''} ago"
 
 
 def _target(session: Any) -> Optional[str]:
@@ -329,6 +363,10 @@ def build_thread_schedule(
     return {
         "has_plan": True,
         **({"draft": draft} if draft else {}),
+        # So "Is it added?" can be answered from the record (#883). Without it the
+        # coach could see a plan but not that it was the one written ninety
+        # seconds ago, so it offered to write another and the runner confirmed.
+        "written": describe_written_ago(plan),
         "runs_through": plan.horizon_end.isoformat() if plan.horizon_end else None,
         # The headline number on the runner's own screen (#880). Without it, a
         # runner asking why their week read 25 was asking the coach about a

--- a/backend/tests/test_schedule_from_conversation_856.py
+++ b/backend/tests/test_schedule_from_conversation_856.py
@@ -149,10 +149,17 @@ def test_a_second_confirm_joins_the_draft_already_running(db):
     assert len(enqueues) == 1
 
 
-def test_the_card_names_the_plan_it_would_replace(db):
+def test_the_card_names_the_plan_it_would_replace_and_how_recent_it_is(db):
     """Writing a plan supersedes the one the runner is training to, and that is
     the part of this action they most need to see BEFORE it happens. A confirm
-    step is only worth having if the card says what will be written over."""
+    step is only worth having if the card says what will be written over.
+
+    With its AGE (#883). A runner asked "Is it added?", was offered a second
+    card, and confirmed it — replacing the plan they had accepted ninety seconds
+    earlier with a differently generated one, because drafting is not
+    deterministic. "Your current one" was true and silent about the only part
+    that would have stopped them: that it was the plan they had just agreed.
+    """
     user = _user(db)
     with patch.object(proposed_actions, "redis_conn", _FakeRedis()):
         _r, without = proposed_actions.mint_proposed_action(
@@ -164,7 +171,100 @@ def test_the_card_names_the_plan_it_would_replace(db):
         )
 
     assert "replacing" not in without["description"]
-    assert "replacing your current one" in with_plan["description"]
+    assert with_plan["description"] == (
+        "Write this plan into your schedule, replacing the one written just now"
+    )
+
+
+def test_the_card_names_an_older_plans_age_in_its_own_terms(db):
+    """The same fact, when the plan is genuinely old. A runner who has been
+    training to a plan for a fortnight is not making the mistake this exists to
+    catch, and telling them "just now" would be a lie in the other direction."""
+    user = _user(db)
+    plan = _active_plan(db, user)
+    plan.generated_at = datetime.now(timezone.utc) - timedelta(days=14)
+    db.commit()
+
+    with patch.object(proposed_actions, "redis_conn", _FakeRedis()):
+        _r, frame = proposed_actions.mint_proposed_action(
+            db, user.id, {"action_type": "draft_plan"}
+        )
+
+    assert frame["description"].endswith("replacing the one written 14 days ago")
+
+
+@pytest.mark.parametrize(
+    "minutes_ago, expected",
+    [
+        (0, "just now"),
+        (1, "1 minute ago"),
+        (5, "5 minutes ago"),
+        (60, "1 hour ago"),
+        (200, "3 hours ago"),
+        (60 * 24, "1 day ago"),
+        (60 * 24 * 14, "14 days ago"),
+    ],
+)
+def test_a_plans_age_is_said_the_way_a_person_would_say_it(minutes_ago, expected):
+    """One phrasing, two audiences: the runner's card and the coach's own read.
+    A plan cannot be two ages, so neither may invent its own wording."""
+    from app.services.schedule.coach_view import describe_written_ago
+
+    now = datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)
+
+    class _Plan:
+        generated_at = None
+        created_at = now - timedelta(minutes=minutes_ago)
+
+    assert describe_written_ago(_Plan(), now=now) == expected
+
+
+def test_a_plan_with_no_timestamp_yields_no_age_rather_than_raising():
+    """The card must still describe what it replaces when the age is unknown.
+    Unreachable through the app today — every stored plan carries `created_at` —
+    so it is exercised here rather than left as an untested claim in the code."""
+    from app.services.coach.proposed_actions import _replace_description
+    from app.services.schedule.coach_view import describe_written_ago
+
+    class _Timeless:
+        generated_at = None
+        created_at = None
+
+    assert describe_written_ago(_Timeless()) is None
+    assert _replace_description(_Timeless(), describe_written_ago) == (
+        "Write this plan into your schedule, replacing your current one"
+    )
+
+
+def test_a_naive_timestamp_is_read_as_utc_rather_than_raising():
+    """SQLite hands back naive datetimes where Postgres does not, and subtracting
+    across the two raises instead of being quietly wrong."""
+    from app.services.schedule.coach_view import describe_written_ago
+
+    class _Plan:
+        generated_at = None
+        created_at = datetime(2026, 8, 13, 11, 55)  # naive
+
+    assert describe_written_ago(
+        _Plan(), now=datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)
+    ) == "5 minutes ago"
+
+
+def test_the_coach_can_see_when_the_current_plan_was_written(db):
+    """So "Is it added?" is answered from the record rather than re-offered.
+
+    The offer that caused this was a reasonable reply to a question the coach
+    could not check: it could see a plan but not that the plan WAS the one it had
+    written ninety seconds before.
+    """
+    from app.services.coach import thread_turn
+
+    user = _user(db)
+    _active_plan(db, user)
+
+    schedule = thread_turn._build_baseline_sections(db, user)["schedule"]
+
+    assert schedule["written"] == "just now"
 
 
 def test_the_offer_is_refused_while_the_schedule_is_switched_off(db, monkeypatch):


### PR DESCRIPTION
A runner confirmed a plan, then asked "Is it added?" — a question about
something that had already happened. They were offered a second card and
confirmed that too, and 103 seconds after accepting one plan they had a
different one. Drafting is not deterministic, so the replacement was not a
re-run of the same block. Thirteen sessions were stranded on the plan they
had agreed to.

Nothing here was broken. The existing guard covers a draft still RUNNING,
which is the case it was written for, and the card did say it would replace
"your current one". That was true and silent about the only part that would
have stopped them: that "your current one" was the plan they had accepted a
minute and a half earlier.

So the card names the plan's AGE, and the coach can see it too. The offer
itself was a reasonable answer to a question the coach had no way to check:
it could see a plan but not that the plan WAS the one it had just written.
One phrasing serves both, because a plan cannot be two ages.

Deliberately no hard block on a second confirm. A runner who reads
"replacing the one written just now" and taps anyway may well mean it — a
plan they dislike on sight is exactly when a redo is right — and refusing
them would trade a silent replacement for a silent refusal.

Six sensitivity breaks, each caught. Two of them cover paths the app cannot
currently reach — a plan with no timestamp, and the naive datetimes SQLite
returns where Postgres does not — because a degradation branch nothing
exercises is a claim about the system rather than a property of it.
3140 -> 3151.

---

Closes #883.

**How this was verified.** Six sensitivity breaks, each caught. Two of them cover paths the app cannot currently reach — a plan with no timestamp, and the naive datetimes SQLite returns where Postgres does not — because a degradation branch nothing exercises is a claim about the system rather than a property of it.

**One deliberate non-change.** There is no hard block on a second confirm. A runner who reads "replacing the one written just now" and taps anyway may well mean it, and refusing them would trade a silent replacement for a silent refusal.

**Merge order.** Rebase onto #879 and #880: all three add keys to the same `build_thread_schedule` dict. Resolution is additive.
