### PR TITLE
fix(tests): the schedule-correction tests stop rotting at midnight (#881)

### DIFF
--- a/backend/tests/test_schedule_adjust_881.py
+++ b/backend/tests/test_schedule_adjust_881.py
@@ -41,8 +41,16 @@ from app.services.schedule.adjust import (
     describe_adjustment,
 )
 
-TODAY = date(2026, 8, 12)
+# RELATIVE to the real today, not a fixed calendar date. A correction is refused
+# on a session whose window has passed, and the offer path resolves "passed"
+# against `date.today()` rather than any date a test can inject — so a session
+# pinned to a fixed tomorrow is a future session until that date arrives and a
+# past one every day after. These tests were written on 2026-08-12, were green
+# that day and the next, and failed on the third: the suite rots at midnight
+# rather than on a change, which is the worst way for it to fail.
+TODAY = date.today()
 TOMORROW = TODAY + timedelta(days=1)
+_NOON = datetime.combine(TODAY, datetime.min.time(), tzinfo=timezone.utc).replace(hour=9)
 
 
 class _FakeRedis:
@@ -78,8 +86,7 @@ def _history(db, user: User) -> None:
         activity = Activity(
             user_id=user.id,
             strava_activity_id=abs(hash(str(uuid.uuid4()))) % 10**9,
-            start_date=datetime(2026, 8, 12, 9, 0, tzinfo=timezone.utc)
-            - timedelta(days=offset),
+            start_date=_NOON - timedelta(days=offset),
             type="Run", name="Run", distance_m=10000, moving_time_s=3000,
             elapsed_time_s=3000, elev_gain_m=0.0, raw_summary={},
         )
@@ -325,24 +332,39 @@ def test_the_coach_can_actually_name_a_session_to_act_on(db):
     `complete_session` (#830) shipped with the same gap, so this unblocks both.
     """
     from app.services.schedule.coach_view import build_schedule_context
+    from app.services.weeks import week_start
 
     user = _user(db)
     plan = _plan(db, user)
-    session = _session(db, plan)
-    activity = Activity(
-        user_id=user.id,
-        strava_activity_id=abs(hash(str(uuid.uuid4()))) % 10**9,
-        start_date=datetime(2026, 8, 12, 9, 0, tzinfo=timezone.utc),
-        type="Run", name="Run", distance_m=9000, moving_time_s=2700,
-        elapsed_time_s=2700, elev_gain_m=0.0, raw_summary={},
-    )
-    db.add(activity)
-    db.commit()
+    # The window runs from today to the end of today's week: the only shape that
+    # is BOTH still upcoming and inside the week this section reads, whatever day
+    # the suite is run on. A session pinned to "tomorrow" is neither on the last
+    # day of a week, when tomorrow belongs to the next one.
+    week_end = week_start(TODAY, 0) + timedelta(days=6)
+    session = _session(db, plan, window_start=TODAY, window_end=week_end)
 
-    section = build_schedule_context(db, activity)
+    def _activity(kind: str) -> Activity:
+        row = Activity(
+            user_id=user.id,
+            strava_activity_id=abs(hash(str(uuid.uuid4()))) % 10**9,
+            start_date=_NOON,
+            type=kind, name=kind, distance_m=9000, moving_time_s=2700,
+            elapsed_time_s=2700, elev_gain_m=0.0, raw_summary={},
+        )
+        db.add(row)
+        db.commit()
+        return row
 
-    ids = [item.session_id for item in section.still_to_come_this_week]
-    assert str(session.id) in ids
+    # A ride cannot be the run session, so the session stays in the upcoming list.
+    upcoming = build_schedule_context(db, _activity("Ride"))
+    assert str(session.id) in [i.session_id for i in upcoming.still_to_come_this_week]
+
+    # A run on the same day IS matched to it, which moves the session out of the
+    # upcoming list and into `planned_for_this_activity`. The id has to be
+    # reachable there too, or the coach can act on every session except the one
+    # the report it is writing is about.
+    matched = build_schedule_context(db, _activity("Run"))
+    assert matched.planned_for_this_activity.session_id == str(session.id)
 
 
 def test_the_schedule_kill_switch_closes_this_write_path_too(db, monkeypatch):


### PR DESCRIPTION
`main` is currently RED. CI passed on `47a7050` and failed on `cbf77e7` with no relevant change between them — the tests crossed a date boundary overnight.

The #881 tests pinned `TODAY = date(2026, 8, 12)` and built their sessions on a fixed "tomorrow". A correction is refused on a session whose window has passed, and the OFFER path resolves that against the real `date.today()` rather than any date a test can inject. So those sessions were in the future for two days and in the past on the third. A suite that fails on the calendar rather than on a change is the worst way for it to fail: nothing in the diff explains it, and the natural first suspicion is the code.

Every date in the file now derives from `date.today()`.

## A second assumption in the same test

Fixing the dates exposed one. The test asserts the coach can name an upcoming session, using one pinned to "tomorrow" — which on the LAST day of a week belongs to the next week, and so is not in the week the section reads. The window now runs from today to the end of today's week, the only shape that is both still upcoming and in-week whatever day it runs on.

The session then turned out to be MATCHED to the test's own activity, which moves it out of the upcoming list entirely. So the test now covers both places the id can reach the coach: the upcoming list, and `planned_for_this_activity` for the session the report is about. Without the second, the coach could act on every session except the one it is writing about.

## Proven, not argued

The file passes under a frozen clock at **seventeen dates** — every weekday, five month ends, a leap day and two year boundaries.

A whole-suite sweep under the same instrument is **not** evidence and was not treated as such: freezing the client clock against a real Postgres `now()` fails ~302 tests by itself at today's own date. The delta above that control was six tests, each inspected, each an artefact of that mismatch or of a BST/GMT boundary shift, none reachable on the real calendar.

## Scope

Test-only. Nothing about the correction feature changed.

One thing deliberately not fixed: `tests/test_chat_tool_loop.py::test_multi_window_fetch_shows_one_record_per_call` is sensitive to a BST/GMT boundary at the edge of its 90-day window. Pre-existing, has never failed on the real calendar, untouched here — flagged rather than widening a hotfix.
