### PR TITLE
fix(profile): field hints are read out with the field they explain (#873)

### DIFF
--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -173,9 +173,10 @@ export default function ProfilePage() {
                     value={formData.max_hr || ''}
                     onChange={handleChange}
                     placeholder="e.g. 190"
+                    aria-describedby="max_hr-hint"
                     className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
                 />
-                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                 <p id="max_hr-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     Used to calculate zones. If unknown, estimate with 220 minus age.
                 </p>
             </div>
@@ -189,9 +190,10 @@ export default function ProfilePage() {
                     value={formData.resting_hr || ''}
                     onChange={handleChange}
                     placeholder="e.g. 50"
+                    aria-describedby="resting_hr-hint"
                     className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
                 />
-                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                 <p id="resting_hr-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     Your typical morning resting HR. Helps the coach read fatigue trends.
                 </p>
             </div>
@@ -218,9 +220,10 @@ export default function ProfilePage() {
                     value={formData.height_cm ?? ''}
                     onChange={handleChange}
                     placeholder="e.g. 178"
+                    aria-describedby="height_cm-hint"
                     className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
                 />
-                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                 <p id="height_cm-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     Optional. Your coach uses your build to judge how fast to ramp volume
                     and how much strength work to prescribe &mdash; not to set a target
                     weight. Leave blank and it simply won&apos;t be considered.
@@ -244,6 +247,7 @@ export default function ProfilePage() {
                 <select
                     id="week_starts_on"
                     name="week_starts_on"
+                    aria-describedby="week_starts_on-hint"
                     value={formData.week_starts_on}
                     onChange={handleChange}
                     className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
@@ -251,7 +255,7 @@ export default function ProfilePage() {
                     <option value={0}>Monday</option>
                     <option value={6}>Sunday</option>
                 </select>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                <p id="week_starts_on-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     Sets which day your training week begins, for &ldquo;this week&rdquo; on the coach and Trends.
                 </p>
             </div>


### PR DESCRIPTION
#849 associated every visible caption on the profile form with its control.
Four fields also carry a hint paragraph underneath, and those were still
unassociated adjacent text: a screen reader announced "Max Heart Rate (bpm)"
and omitted "Used to calculate zones. If unknown, estimate with 220 minus
age." For the height field the omitted sentence is the one that says the
coach uses your build to judge ramp rate and strength work rather than to set
a target weight, which is the reason the field exists at all.

Each hint gets an id and its control an `aria-describedby` pointing at it,
matching #849's htmlFor/id-on-the-field-name idiom. Four fields: max_hr,
resting_hr, height_cm, week_starts_on. Weight is the one build field with no
hint paragraph and is unchanged.

No visual, layout, or copy change: only two attributes per field.

Verified: `make frontend-test` (next lint + next build) green, and every
`aria-describedby` in the file resolves to an id declared in the same file,
with every hint paragraph referenced by exactly one control. There is no
frontend unit or component test runner in this repository (a documented gap
in project-context.md), and the profile form is client-rendered after its
fetch, so the existing smoke harness only ever sees "Loading profile..." and
cannot assert on the form markup. The association is therefore checked
statically rather than through a rendered DOM.
