### PR TITLE
chore(diagrams): the chat guard notices a screen that starts resolving a view (#871)

### DIFF
--- a/backend/tests/test_diagram_drift.py
+++ b/backend/tests/test_diagram_drift.py
@@ -35,6 +35,8 @@ from check_diagram_drift import (  # noqa: E402
     _chat_nodes,
     _chat_surface_problems,
     _declared_baseline_sections,
+    _declared_screen_builders,
+    _screen_builder_extractor_problems,
     _declared_chat_content,
     _declared_chat_surface,
     _recorded_chat_content,
@@ -257,7 +259,10 @@ def test_every_conversational_input_the_coach_receives_has_a_node():
     """The half a blob comparison cannot see: the blob is generated and the topology is
     hand-authored, so regenerating one without the other leaves a real input undrawn."""
     problems = _chat_node_problems(
-        _declared_chat_surface(), _declared_baseline_sections(), _real_chat_nodes()
+        _declared_chat_surface(),
+        _declared_baseline_sections(),
+        _declared_screen_builders(),
+        _real_chat_nodes(),
     )
 
     assert not problems, "\n".join(f"  - {p}" for p in problems)
@@ -269,7 +274,7 @@ def test_the_node_check_fails_when_a_new_tool_has_no_node():
     declared["tools"] = sorted(declared["tools"] + ["get_race_predictions"])
 
     problems = _chat_node_problems(
-        declared, _declared_baseline_sections(), _real_chat_nodes()
+        declared, _declared_baseline_sections(), _declared_screen_builders(), _real_chat_nodes()
     )
 
     assert problems and "get_race_predictions" in problems[0]
@@ -284,7 +289,9 @@ def test_the_node_check_fails_when_a_baseline_section_has_no_builder_node():
     # the diagram as it was before this guard existed: the node simply not there
     nodes = [n for n in _real_chat_nodes() if n["id"] != "d_schedule"]
 
-    problems = _chat_node_problems(_declared_chat_surface(), sections, nodes)
+    problems = _chat_node_problems(
+        _declared_chat_surface(), sections, _declared_screen_builders(), nodes
+    )
 
     assert problems, "the node check did not notice an undrawn baseline section"
     assert "['schedule']" in problems[0]
@@ -297,7 +304,7 @@ def test_the_node_check_fails_when_a_prompt_slot_has_no_node():
     declared["prompt_slots"] = declared["prompt_slots"] + ["races_block"]
 
     problems = _chat_node_problems(
-        declared, _declared_baseline_sections(), _real_chat_nodes()
+        declared, _declared_baseline_sections(), _declared_screen_builders(), _real_chat_nodes()
     )
 
     assert problems and "{races_block}" in problems[0]
@@ -306,7 +313,9 @@ def test_the_node_check_fails_when_a_prompt_slot_has_no_node():
 def test_the_node_check_fails_loudly_when_the_node_parser_returns_almost_nothing():
     """A parser that quietly stopped matching would turn node coverage into a check that
     cannot fail. Same fail-loud posture as the report guard's parsers."""
-    problems = _chat_node_problems(_declared_chat_surface(), ["memory"], [])
+    problems = _chat_node_problems(
+        _declared_chat_surface(), ["memory"], _declared_screen_builders(), []
+    )
 
     assert problems and "PARSER BROKE" in problems[0]
 
@@ -409,10 +418,171 @@ def test_the_node_check_fails_when_a_node_draws_a_section_the_coach_lost():
     through the node's explicit `section:` binding, because `d_*` is the id prefix for every
     baseline builder and only some of those correspond to a section."""
     problems = _chat_node_problems(
-        _declared_chat_surface(), ["memory", "readiness"], _real_chat_nodes()
+        _declared_chat_surface(),
+        ["memory", "readiness"],
+        _declared_screen_builders(),
+        _real_chat_nodes(),
     )
 
     assert problems and "schedule" in problems[0]
+
+
+# --- screens that resolve a view (#871) --------------------------------------------
+
+
+def test_every_screen_that_resolves_a_view_has_a_resolver_node():
+    """The gap #871 names. `screens` is pinned as NAMES, so a screen key moving from
+    identity-only to view-resolving changes what the coach is served on that screen while
+    the key set, the tools, the skills, the actions and the slots all still match."""
+    problems = _chat_node_problems(
+        _declared_chat_surface(),
+        _declared_baseline_sections(),
+        _declared_screen_builders(),
+        _real_chat_nodes(),
+    )
+
+    assert not problems, "\n".join(f"  - {p}" for p in problems)
+
+
+def test_the_screens_that_resolve_a_view_are_read_off_the_resolver_itself():
+    """There is no registry to import — the fact lives in `resolve_screen_view`'s
+    branches. Pinned against the split as it stands so a reader that quietly stopped
+    matching shows up as a changed set rather than as an empty one."""
+    assert _declared_screen_builders() == ["activity", "trends"]
+
+
+def test_the_node_check_fails_when_a_screen_starts_resolving_a_view_undrawn():
+    """SENSITIVITY, on the exact shape the issue describes: a builder added for a key that
+    already exists. Every other pinned set is untouched by this change."""
+    builders = sorted(_declared_screen_builders() + ["load"])
+
+    problems = _chat_node_problems(
+        _declared_chat_surface(),
+        _declared_baseline_sections(),
+        builders,
+        _real_chat_nodes(),
+    )
+
+    assert problems, "a newly view-resolving screen went unnoticed"
+    assert any("['load']" in p for p in problems), problems
+
+
+def test_the_node_check_fails_when_a_screen_stops_resolving_a_view():
+    """Drift the other way: the diagram still draws that screen's contents reaching the
+    coach after the builder was removed."""
+    problems = _chat_node_problems(
+        _declared_chat_surface(),
+        _declared_baseline_sections(),
+        ["activity"],
+        _real_chat_nodes(),
+    )
+
+    assert problems and any("trends" in p for p in problems), problems
+
+
+def test_the_node_check_fails_loudly_when_no_screen_builder_is_read():
+    """An empty declared set is a broken extractor, not a coach that resolves nothing."""
+    problems = _chat_node_problems(
+        _declared_chat_surface(), _declared_baseline_sections(), [], _real_chat_nodes()
+    )
+
+    assert any("EXTRACTOR BROKE" in p for p in problems), problems
+
+
+def test_the_screen_builder_reader_refuses_a_dispatch_form_it_cannot_read(
+    tmp_path, monkeypatch
+):
+    """SENSITIVITY against PARTIAL blindness, the same posture the baseline reader takes.
+
+    A resolver rewritten as a `match` or as a builder-dict lookup would read as ZERO
+    builders through the equality-comparison reader, and the empty-set check would report
+    a broken extractor rather than let it pass — but a resolver that keeps one `==` branch
+    and adds a `match` for the rest would report a set that is real and incomplete, which
+    is the failure the empty-set check cannot see."""
+    probe = tmp_path / "screen_context.py"
+    probe.write_text(
+        "def resolve_screen_view(db, owner_user_id, pointer):\n"
+        "    if pointer.screen == 'activity':\n"
+        "        return detail()\n"
+        "    match pointer.screen:\n"
+        "        case 'trends':\n"
+        "            return report()\n"
+        "    return None\n"
+    )
+    monkeypatch.setattr(check_diagram_drift, "_SCREEN_CONTEXT", probe)
+
+    problems = _screen_builder_extractor_problems()
+
+    assert problems and "EXTRACTOR BROKE" in problems[0]
+    assert "match" in problems[0]
+    # and it is genuinely partial: the reader still sees the one branch it understands
+    assert _declared_screen_builders() == ["activity"]
+
+
+def test_the_screen_builder_reader_refuses_a_comparison_against_a_name(
+    tmp_path, monkeypatch
+):
+    """The other unreadable form: a branch whose key is not a literal."""
+    probe = tmp_path / "screen_context.py"
+    probe.write_text(
+        "def resolve_screen_view(db, owner_user_id, pointer):\n"
+        "    if pointer.screen == VIEW_RESOLVING_SCREEN:\n"
+        "        return detail()\n"
+        "    return None\n"
+    )
+    monkeypatch.setattr(check_diagram_drift, "_SCREEN_CONTEXT", probe)
+
+    assert any("EXTRACTOR BROKE" in p for p in _screen_builder_extractor_problems())
+
+
+def test_the_screen_builder_reader_reads_a_membership_branch(tmp_path, monkeypatch):
+    """The second form it does understand, so grouping two screens onto one builder is
+    not mistaken for removing them."""
+    probe = tmp_path / "screen_context.py"
+    probe.write_text(
+        "def resolve_screen_view(db, owner_user_id, pointer):\n"
+        "    if pointer.screen in ('trends', 'load'):\n"
+        "        return report()\n"
+        "    return None\n"
+    )
+    monkeypatch.setattr(check_diagram_drift, "_SCREEN_CONTEXT", probe)
+
+    assert _declared_screen_builders() == ["load", "trends"]
+    assert _screen_builder_extractor_problems() == []
+
+
+def test_the_screen_builder_reader_reports_a_resolver_that_was_renamed_away(
+    tmp_path, monkeypatch
+):
+    probe = tmp_path / "screen_context.py"
+    probe.write_text("def resolve(db, owner_user_id, pointer):\n    return None\n")
+    monkeypatch.setattr(check_diagram_drift, "_SCREEN_CONTEXT", probe)
+
+    assert any("no longer exists" in p for p in _screen_builder_extractor_problems())
+
+
+def test_check_drift_actually_runs_the_screen_builder_checks(monkeypatch):
+    """A check that is written but not called is no check. Make the LIVE declaration
+    disagree with the diagram and assert the top-level guard reports it."""
+    monkeypatch.setattr(
+        check_diagram_drift,
+        "_declared_screen_builders",
+        lambda: sorted(_declared_screen_builders() + ["profile"]),
+    )
+
+    problems = check_drift()
+
+    assert any("['profile']" in p for p in problems), problems
+
+
+def test_check_drift_actually_runs_the_screen_builder_extractor_check(monkeypatch):
+    monkeypatch.setattr(
+        check_diagram_drift,
+        "_screen_builder_extractor_problems",
+        lambda: ["EXTRACTOR BROKE: screen probe"],
+    )
+
+    assert "EXTRACTOR BROKE: screen probe" in check_drift()
 
 
 def test_the_baseline_section_reader_refuses_a_write_form_it_cannot_read(tmp_path, monkeypatch):

--- a/docs/diagrams/check_diagram_drift.py
+++ b/docs/diagrams/check_diagram_drift.py
@@ -106,6 +106,7 @@ _CHAT_GENERATOR = _HERE / "generate_chat_flow_data.py"
 _PACK_SHAPE = _HERE / "pack-shape.json"
 _ENV_EXAMPLE = _BACKEND / ".env.example"
 _THREAD_TURN = _BACKEND / "app" / "services" / "coach" / "thread_turn.py"
+_SCREEN_CONTEXT = _BACKEND / "app" / "services" / "coach" / "screen_context.py"
 
 # The generators whose calls into backend/app must still bind (check 5). Both build their
 # capture by importing the real pipeline, so both rot the same way; generate_example_chats.py
@@ -625,6 +626,110 @@ def _baseline_extractor_problems() -> list[str]:
     return problems
 
 
+def _screen_resolver_body() -> ast.FunctionDef | None:
+    """The AST of screen_context.resolve_screen_view, or None if it was renamed away."""
+    tree = ast.parse(_SCREEN_CONTEXT.read_text(), filename=_SCREEN_CONTEXT.name)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "resolve_screen_view":
+            return node
+    return None
+
+
+def _screen_key_comparisons(body: ast.FunctionDef) -> list[ast.Compare]:
+    """Every comparison in the resolver that tests which screen the pointer names."""
+    found = []
+    for sub in ast.walk(body):
+        if not isinstance(sub, ast.Compare):
+            continue
+        left = sub.left
+        if isinstance(left, ast.Attribute) and left.attr == "screen":
+            found.append(sub)
+    return found
+
+
+def _declared_screen_builders() -> list[str]:
+    """The screen keys that resolve a real VIEW, read off the resolver's own branches.
+
+    #871. The `screens` set pinned above is the KEYS a ScreenPointer can name, so adding
+    a key trips the guard. It says nothing about which of those keys resolve a view: the
+    keys are split between identity-only screens (the baseline already carries their
+    content, so the coach learns only WHERE the runner is) and screens that run a builder
+    and put a real view in the prompt's LOOKING AT section. Moving a screen from the first
+    group to the second changes what the coach is served and is precisely what the diagram
+    exists to depict, and every other pinned set matched through it.
+
+    There is no registry to read: the fact lives only in `resolve_screen_view`'s
+    if-branches. So this reads them statically, the same door `_declared_baseline_sections`
+    goes through for a dict built at runtime — a declaration in the code that has no
+    constant to import is still a declaration. Static, so it needs no DB and no runtime
+    state.
+
+    A branch on the screen key that does something OTHER than resolve a view would be read
+    as a builder here. That is deliberate: any special-casing of one screen is a fact about
+    what that screen gets, and the guard failing is the prompt to draw it or to say why not.
+
+    Paired with _screen_builder_extractor_problems, which refuses any branch form this
+    reader cannot get the key out of."""
+    body = _screen_resolver_body()
+    if body is None:
+        return []
+    keys: list[str] = []
+    for compare in _screen_key_comparisons(body):
+        for op, comparator in zip(compare.ops, compare.comparators):
+            if isinstance(op, ast.Eq) and isinstance(comparator, ast.Constant):
+                if isinstance(comparator.value, str):
+                    keys.append(comparator.value)
+            elif isinstance(op, ast.In) and isinstance(comparator, (ast.Tuple, ast.List, ast.Set)):
+                for element in comparator.elts:
+                    if isinstance(element, ast.Constant) and isinstance(element.value, str):
+                        keys.append(element.value)
+    return sorted(set(keys))
+
+
+def _screen_builder_extractor_problems() -> list[str]:
+    """Refuse any way of dispatching on the screen key this reader cannot follow.
+
+    _declared_screen_builders understands two forms, `pointer.screen == "x"` and
+    `pointer.screen in ("x", "y")`. A `match pointer.screen:` statement, a lookup into a
+    builder dict, or a comparison against a name rather than a literal would be invisible
+    to it — and PARTIAL blindness is worse than total, because the empty-set check below
+    would not fire. So an unrecognised dispatch is a loud failure telling the next person
+    to teach the reader that form, not a silent pass.
+
+    This is _baseline_extractor_problems' rule applied to the other statically-read
+    declaration, for the same reason: a guard that reads less than it claims to is the
+    vacuous-guard failure this whole file exists against."""
+    body = _screen_resolver_body()
+    if body is None:
+        return [
+            "EXTRACTOR BROKE: screen_context.resolve_screen_view no longer exists, so which "
+            "screens resolve a view cannot be read. Point the guard at its replacement."]
+    problems: list[str] = []
+    for sub in ast.walk(body):
+        if isinstance(sub, ast.Match):
+            problems.append(
+                f"EXTRACTOR BROKE: resolve_screen_view dispatches with `match` at line "
+                f"{sub.lineno}, a form this guard cannot read the screen keys of. Teach "
+                "_declared_screen_builders that form.")
+    for compare in _screen_key_comparisons(body):
+        for op, comparator in zip(compare.ops, compare.comparators):
+            readable = (
+                (isinstance(op, ast.Eq) and isinstance(comparator, ast.Constant)
+                 and isinstance(comparator.value, str))
+                or (isinstance(op, ast.In)
+                    and isinstance(comparator, (ast.Tuple, ast.List, ast.Set))
+                    and all(isinstance(e, ast.Constant) and isinstance(e.value, str)
+                            for e in comparator.elts))
+            )
+            if not readable:
+                problems.append(
+                    f"EXTRACTOR BROKE: resolve_screen_view tests the screen key at line "
+                    f"{compare.lineno} in a form this guard cannot read the key out of "
+                    f"({type(op).__name__} against {type(comparator).__name__}). Teach "
+                    "_declared_screen_builders that form.")
+    return problems
+
+
 def _declared_tools() -> list[dict]:
     """The tool list a thread turn is really handed.
 
@@ -870,17 +975,26 @@ def _chat_nodes(chat_src: str) -> list[dict[str, str]]:
         # binding the check could only run one way, and a section REMOVED from the builder
         # would leave its node drawing an input the coach no longer gets.
         section_m = re.search(r"\bsection:'([^']*)'", chunk)
+        # The same explicit binding, for the screen key whose view a resolver node draws
+        # (`screen:'trends'`). Explicit for the same reason: `screen_*` prefixes the
+        # resolver entry point itself as well as the per-screen builders, so an id
+        # convention could only run the check one way (#871).
+        screen_m = re.search(r"\bscreen:'([^']*)'", chunk)
         nodes.append({
             "id": id_m.group(1),
             "title": title_m.group(1) if title_m else "",
             "tag": tag_m.group(1) if tag_m else "",
             "section": section_m.group(1) if section_m else "",
+            "screen": screen_m.group(1) if screen_m else "",
         })
     return nodes
 
 
 def _chat_node_problems(
-    declared: dict[str, list[str]], baseline_sections: list[str], nodes: list[dict[str, str]]
+    declared: dict[str, list[str]],
+    baseline_sections: list[str],
+    screen_builders: list[str],
+    nodes: list[dict[str, str]],
 ) -> list[str]:
     """Every declared conversational input must be DRAWN, and every drawn one must be real.
 
@@ -937,6 +1051,27 @@ def _chat_node_problems(
             f"Builder nodes in {_CHAT_NODES.name} bound to baseline sections the thread turn "
             f"no longer assembles: {spurious}. The diagram draws an input the coach no "
             "longer receives. Remove the node.")
+
+    # Screens that resolve a view: one resolver node each, bound by `screen:'<key>'` (#871).
+    # The `screens` set is compared as names only, so a screen key moving from identity-only
+    # to view-resolving changes what the coach is served while every name-level set still
+    # matches. This is the one place that shows.
+    if not screen_builders:
+        problems.append(
+            "EXTRACTOR BROKE: no view-resolving screens were read out of "
+            "screen_context.resolve_screen_view. The chat drift guard cannot be trusted.")
+    drawn_screens = {n["screen"] for n in nodes if n["screen"]}
+    if missing := sorted(set(screen_builders) - drawn_screens):
+        problems.append(
+            "Screens that resolve a view into the prompt's LOOKING AT section but that no "
+            f"node in {_CHAT_NODES.name} binds: {missing}. Add a resolver node declaring "
+            f"screen:'{missing[0]}'. The coach is served that screen's contents and the "
+            "diagram shows it learning only where the runner is.")
+    if spurious := sorted(drawn_screens - set(screen_builders)):
+        problems.append(
+            f"Resolver nodes in {_CHAT_NODES.name} bound to screens that no longer resolve "
+            f"a view: {spurious}. That screen is identity-only now and the diagram still "
+            "draws its contents reaching the coach. Remove the node.")
     return problems
 
 
@@ -1138,8 +1273,14 @@ def check_drift() -> list[str]:
         )
     )
     problems.extend(_baseline_extractor_problems())
+    problems.extend(_screen_builder_extractor_problems())
     problems.extend(
-        _chat_node_problems(declared_chat, _declared_baseline_sections(), _chat_nodes(chat_src))
+        _chat_node_problems(
+            declared_chat,
+            _declared_baseline_sections(),
+            _declared_screen_builders(),
+            _chat_nodes(chat_src),
+        )
     )
     problems.extend(_chat_capture_problems(chat_blob))
 
@@ -1161,8 +1302,9 @@ def main() -> int:
         return 1
     print("ai-flow-graph diagram is in sync with the code (pack sections + nested pack keys "
           "+ DerivedMetric columns + kill-switch parity), the coach-chat diagram is in sync "
-          "(tools + skills + actions + screens + prompt slots + baseline sections + the "
-          "prompt/tool/skill text itself + capture parity), and the generators still bind.")
+          "(tools + skills + actions + screens + which of them resolve a view + prompt "
+          "slots + baseline sections + the prompt/tool/skill text itself + capture "
+          "parity), and the generators still bind.")
     return 0
 
 

--- a/docs/diagrams/coach-chat-nodes.js
+++ b/docs/diagrams/coach-chat-nodes.js
@@ -467,7 +467,7 @@ const NODES = [
     return head('label') + facts([['label', String(v.label)]])
     + head('view') + show(v.view, 'identity-only screen — no view.'); } },
 
-{ id:'screen_activity', layer:'resolve', kind:'code', tag:'resolver',
+{ id:'screen_activity', layer:'resolve', kind:'code', tag:'resolver', screen:'activity',
   title:'activity screen → get_session_detail', path:'query_tools.get_session_detail',
   from:['screen_resolve','t_activity'],
   body:()=> { const c=conv(), v=_B().screen_view;
@@ -475,7 +475,7 @@ const NODES = [
       return none('This conversation started from '+((c&&c.started_from)||'—')+' — this resolver did not run.');
     return head('resolved view') + show(v?v.view:null, 'nothing resolved.'); } },
 
-{ id:'screen_trends', layer:'resolve', kind:'code', tag:'resolver',
+{ id:'screen_trends', layer:'resolve', kind:'code', tag:'resolver', screen:'trends',
   title:'trends screen → get_volume_report', path:'services/trends.get_volume_report',
   from:['screen_resolve'],
   body:()=> { const c=conv(), v=_B().screen_view;


### PR DESCRIPTION
#855's chat guard pins the `ScreenPointer` screen keys as NAMES, so adding a
key trips it. It says nothing about which of those keys resolve a view. The
keys are split between identity-only screens, where the coach learns only
WHERE the runner is because the baseline already carries that screen's
content, and screens that run a builder and put a real view in the prompt's
LOOKING AT section. Moving a screen from the first group to the second changes
what the coach is served, and it was the one shape every pinned set stayed
green through: the key set, the tools, the skills, the actions, the slots and
the baseline sections are all untouched by adding an `if pointer.screen ==
"load":` branch.

The fact lives only in `resolve_screen_view`'s if-branches, so it is read
statically off them, the same door `_declared_baseline_sections` goes through
for a dict built at runtime: a declaration with no constant to import is still
a declaration, and reading it beats adding a second list in the app that could
drift from the function it describes. `_screen_builder_extractor_problems` is
its fail-loud twin, refusing a `match` statement, a comparison against a name,
or any other dispatch form the reader cannot get a key out of, because partial
blindness is worse than total: the empty-set check cannot see a reader that
still understands one branch and silently skips three.

The two resolver nodes gain an explicit `screen:'<key>'` binding, the same
device the baseline builders use for `section:'<key>'` and for the same
reason: `screen_*` prefixes the resolver entry point as well as the
per-screen builders, so an id convention could only run the check one way and
a builder REMOVED would leave its node drawing contents the coach no longer
gets.

Deliberately not done: recording the set in the generated `const CHAT` blob as
a sixth pinned surface set. It would need the generator to run, and the
generator discards its capture without a seeded database (#870), so the only
way to add the key today is to hand-edit a generated artifact. Node coverage
already fails on exactly the shape the acceptance criterion names, and a
hand-edited blob would cost more trust than the redundancy buys.

The guard was proved rather than watched passing. Adding a real `load` view
builder to `screen_context.py` and running `make diagram-check`:

  - Screens that resolve a view into the prompt's LOOKING AT section but that
    no node in coach-chat-nodes.js binds: ['load']. Add a resolver node
    declaring screen:'load'.

and the drift the other way, removing `screen:'trends'` from the diagram while
the builder stands:

  - Screens that resolve a view into the prompt's LOOKING AT section but that
    no node in coach-chat-nodes.js binds: ['trends'].

Both reverted. Eleven tests cover it, including two `check_drift()` wiring
tests, since a check that is written but not called is no check, and a
partial-blindness probe asserting the reader reports the `match` it cannot
read while still returning the one branch it can.

Backend 3244 passed, `make diagram-check` in sync.
