### PR TITLE
fix(diagrams): the chat generator will not replace a real capture with none (#870)

### DIFF
--- a/backend/tests/test_chat_generator_capture_870.py
+++ b/backend/tests/test_chat_generator_capture_870.py
@@ -1,0 +1,114 @@
+"""#870: the chat diagram generator refuses to replace a real capture with none.
+
+`generate_chat_flow_data.py` needs a seeded database to capture one real turn
+end to end. Run without one it still completed and wrote a template-only blob,
+discarding the capture rather than refusing — so an agent or a developer
+satisfying the standing "regenerate the diagram in the same PR" rule could
+mechanically leave the committed artifact showing LESS than it did before.
+
+#855's capture-parity check catches the aftermath at the guard. This moves the
+failure one step earlier, to the thing that produces the bad artifact, and
+makes it say what is missing rather than read as a guard complaint.
+
+The decision is a pure function so it can be tested with no database at all,
+which is the condition the whole check is about.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_DIAGRAMS = Path(__file__).resolve().parents[2] / "docs" / "diagrams"
+if str(_DIAGRAMS) not in sys.path:
+    sys.path.insert(0, str(_DIAGRAMS))
+
+import generate_chat_flow_data as gen  # noqa: E402
+
+_TARGET = _DIAGRAMS / "coach-chat-nodes.js"
+
+
+def _blob_line(blob: dict) -> str:
+    return f"const CHAT = {json.dumps(blob, separators=(',', ':'))};\n"
+
+
+_REAL = {
+    "meta": {"coach_prompt_id": "coach_message_lean_grouped_v9"},
+    "assembled": {"ok": True, "chars": 12590, "present": {"baseline_block": True}},
+    "template": "unchanged declaration",
+}
+
+
+# --- a run that captured a real turn changes nothing --------------------------
+
+
+def test_a_real_capture_is_left_exactly_as_the_run_produced_it():
+    assert gen.plan_capture({"ok": True}, _blob_line(_REAL)) == {}
+
+
+# --- a run with no database keeps what is committed ---------------------------
+
+
+def test_a_template_only_run_keeps_the_committed_capture(capsys):
+    """The #870 defect. Before the fix this run wrote its empty capture over a
+    real one and the guard reported it a step later."""
+    kept = gen.plan_capture({"ok": False, "reason": "CHAT_NO_DB set"}, _blob_line(_REAL))
+
+    assert kept["assembled"] == _REAL["assembled"]
+    # The config the capture was taken under travels WITH it. A fresh `meta`
+    # over a preserved `assembled` would describe the capture with a config it
+    # was not taken under, which is a subtler version of the same dishonesty.
+    assert kept["meta"] == _REAL["meta"]
+    # Declarations are NOT preserved: refreshing those is what a no-DB run is for.
+    assert "template" not in kept
+
+    note = capsys.readouterr().out
+    assert "CHAT_NO_DB set" in note
+    assert "make seed-local" in note
+
+
+def test_the_preserved_keys_are_only_the_capture_and_its_config():
+    """A widened preserve set would start freezing declarations, which is
+    exactly the drift #855's blob comparison exists to catch."""
+    assert gen._CAPTURE_KEYS == ("assembled", "meta")
+
+
+# --- a run with nothing to fall back on refuses -------------------------------
+
+
+@pytest.mark.parametrize(
+    "committed, why",
+    [
+        (_blob_line({"assembled": {"ok": False, "reason": "no DB"}}), "already template-only"),
+        (_blob_line({}), "no assembled key at all"),
+        ("const CHAT = not json;\n", "unparseable blob"),
+        ("// no blob line here\n", "no blob line"),
+    ],
+)
+def test_a_template_only_run_with_nothing_to_keep_refuses(committed, why):
+    with pytest.raises(gen.CaptureRefused) as refused:
+        gen.plan_capture({"ok": False, "reason": "no DB"}, committed)
+
+    message = str(refused.value)
+    assert "refusing to write a template-only capture" in message, why
+    # It must say what is missing and how to get it, per the issue's second AC.
+    assert "no DB" in message
+    assert "make seed-local" in message
+
+
+# --- the reader describes the file that is actually committed -----------------
+
+
+def test_the_committed_diagram_holds_a_real_capture_this_reader_can_find():
+    """Anti-rot, and the reason the tests above are not self-referential: if the
+    blob line's form changed, `_committed_capture` would return None for the
+    real file and every no-DB run would refuse instead of preserving — a guard
+    that fails closed, but for the wrong reason and with a misleading message."""
+    kept = gen._committed_capture(_TARGET.read_text(encoding="utf-8"))
+
+    assert kept is not None, (
+        "the committed coach-chat-nodes.js carries no capture this reader can find"
+    )
+    assert kept["assembled"]["ok"] is True
+    assert kept["meta"]["coach_prompt_id"]

--- a/docs/diagrams/generate_chat_flow_data.py
+++ b/docs/diagrams/generate_chat_flow_data.py
@@ -803,8 +803,97 @@ def build() -> dict:
     }
 
 
+# The two keys that ARE the capture: what one real turn was served, and the
+# configuration it was served under. Everything else in the blob is a
+# declaration read straight out of the code, which needs no database at all.
+# They travel together — a fresh `meta` over a preserved `assembled` would
+# describe the capture with a config it was not taken under, which is a subtler
+# version of the dishonesty this is fixing.
+_CAPTURE_KEYS = ("assembled", "meta")
+
+
+def _committed_capture(target_text: str) -> dict | None:
+    """The capture already in the file, if it holds a real one.
+
+    Read straight off the committed `const CHAT = ...` line rather than through
+    the drift guard, so the generator does not import the thing that checks it.
+    """
+    match = re.search(r"(?m)^const CHAT = (.*);$", target_text)
+    if not match:
+        return None
+    try:
+        blob = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return None
+    if not (blob.get("assembled") or {}).get("ok"):
+        return None
+    return {key: blob[key] for key in _CAPTURE_KEYS if key in blob}
+
+
+class CaptureRefused(Exception):
+    """Raised rather than writing a diagram that shows less than the one it replaces."""
+
+
+def plan_capture(assembled: dict | None, target_text: str) -> dict:
+    """What to do about a run whose capture came back template-only (#870).
+
+    Returns the capture keys to splice into the fresh data — empty when this
+    run captured a real turn and nothing needs keeping — and raises
+    CaptureRefused when there is neither a fresh capture nor a committed one to
+    fall back on.
+
+    Pure, so its own behaviour can be tested without a database, which is the
+    condition the whole check is about.
+    """
+    if (assembled or {}).get("ok"):
+        return {}
+    reason = (assembled or {}).get("reason")
+    preserved = _committed_capture(target_text)
+    if preserved is None:
+        raise CaptureRefused(
+            f"refusing to write a template-only capture to {TARGET.name}.\n"
+            f"  no turn could be captured: {reason}\n"
+            f"  and the committed file holds no real capture to keep.\n"
+            f"  Every node would render 'no capture' instead of what the coach was\n"
+            f"  really served, which is the diagram's whole promise.\n"
+            f"  Seed a local database first: make seed-local"
+        )
+    print(
+        f"NOTE: no turn could be captured ({reason}).\n"
+        f"  The declarations below were refreshed; the committed capture and the\n"
+        f"  config it was taken under were kept as they were, so nothing the\n"
+        f"  diagram shows has been downgraded.\n"
+        f"  Run against a seeded local DB (make seed-local) to refresh the capture\n"
+        f"  itself."
+    )
+    return preserved
+
+
 def main() -> None:
     data = build()
+
+    # #870: without a seeded database the capture comes back template-only, and
+    # writing it would silently replace every real value in the committed
+    # diagram with "no capture". The standing project rule is that a change to
+    # what the coach receives regenerates the diagram in the same PR, so an
+    # agent or a developer with no seeded DB could satisfy that rule
+    # mechanically and leave the artifact showing LESS than it did before.
+    # #855's capture-parity check catches the aftermath at the guard; this
+    # refuses to produce it in the first place, one step earlier and with a
+    # message that says what is missing rather than reading as a guard
+    # complaint.
+    #
+    # Preserving beats hard-failing, and the issue's acceptance criteria allow
+    # either: most regenerations exist to refresh the DECLARATIONS (the tools,
+    # the skills, the prompt template — the sets #855 pins), and none of those
+    # need a database. Refusing outright would make a declaration refresh
+    # impossible without a production snapshot, for no gain. What must never
+    # happen is a real capture being replaced by an empty one.
+    try:
+        data.update(plan_capture(data.get("assembled"), TARGET.read_text(encoding="utf-8")))
+    except CaptureRefused as refusal:
+        sys.exit(str(refusal))
+
     blob = json.dumps(data, default=str, separators=(",", ":"))
     line = f"const CHAT = {blob};\n"
 


### PR DESCRIPTION
`generate_chat_flow_data.py` needs a seeded database to capture one real turn
end to end. Run without one it completed anyway and wrote a template-only
blob, discarding the capture rather than refusing. The standing project rule is
that a change to what the coach receives regenerates the diagram in the same
PR, so an agent or a developer with no seeded DB could satisfy that rule
mechanically and leave the committed artifact showing less than it did before.

#855's capture-parity check catches the aftermath at the guard. This moves the
failure to the thing that produces the bad artifact, one step earlier, with a
message that says what is missing and how to get it rather than reading as a
guard complaint about a file you just wrote.

It PRESERVES rather than hard-failing, which the issue's acceptance criteria
allow as the second option and which is the more useful one: most
regenerations exist to refresh the DECLARATIONS — the tools, the skills, the
prompt template, the sets #855 pins — and none of those need a database.
Refusing outright would make a declaration refresh impossible without a
production snapshot, for no gain. What must never happen is a real capture
being replaced by an empty one. So a template-only run keeps the committed
capture, prints what it did, and writes the refreshed declarations; a
template-only run with nothing to keep exits non-zero.

The capture and the `meta` block travel together. `meta` records the prompt id,
the model and the kill-switch flags the capture was taken under, and #855's
capture-parity check reads it — a fresh `meta` over a preserved `assembled`
would describe the capture with a configuration it was not taken under, which
is a subtler version of the dishonesty being fixed here.

The decision is a pure function, `plan_capture`, so its behaviour is testable
with no database at all — which is the condition the whole check is about.

Proved on both branches rather than reasoned about. The defect first, with the
generator as it stands on main and no DB reachable:

  assembled capture skipped — CHAT_NO_DB set
  docs/diagrams/coach-chat-nodes.js | 2 +-
  - coach-chat-nodes.js carries a TEMPLATE-ONLY capture (assembled.ok is
    false: 'CHAT_NO_DB set') [...]

Then the same run with the fix in place: the artifact comes back byte-identical
to HEAD and `make diagram-check` stays green. And with the committed capture
deliberately blanked first, so there is nothing to fall back on:

  refusing to write a template-only capture to coach-chat-nodes.js.
    no turn could be captured: CHAT_NO_DB set
    and the committed file holds no real capture to keep. [...]
    Seed a local database first: make seed-local

exit 1, artifact untouched, restored after.

Eight tests cover it, including an anti-rot one asserting the reader can find a
real capture in the REAL committed file: if the blob line's form changed, every
no-DB run would refuse instead of preserving, which fails closed but for the
wrong reason and with a misleading message.

Backend 3241 passed, `make diagram-check` in sync.
