### PR TITLE
fix(diagrams): the history node applies the bound it advertises (#793)

### DIFF
--- a/docs/diagrams/coach-chat-nodes.js
+++ b/docs/diagrams/coach-chat-nodes.js
@@ -191,11 +191,23 @@ function askedTurn(){
   for(let i=a.i-1; i>=0; i--) if(c.turns[i].role==='user') return c.turns[i];
   return null;
 }
-/* The rows that existed when this turn generated: everything before the reply
-   (the runner's message is written before generation, so it is included). */
+/* The rows the model actually saw for this turn: everything before the reply
+   (the runner's message is written before generation, so it is included), then
+   the SAME tail bound the turn itself applies -- `thread_messages(...)[-40:]` in
+   thread_turn.py, carried here as CHAT.bounds.max_llm_history_turns rather than
+   a second copy of 40, so the node cannot drift from the constant it draws. */
+function historyBound(){ return (CHAT.bounds||{}).max_llm_history_turns || null; }
 function historyForTurn(){
   const c = conv(), a = selectedTurn(); if(!c || !a) return [];
-  return c.turns.slice(0, a.i);
+  const all = c.turns.slice(0, a.i), b = historyBound();
+  return b ? all.slice(-b) : all;
+}
+/* How many of the oldest rows the bound dropped for this turn. 0 = the whole
+   thread fitted, which is every conversation in the current capture. */
+function historyDroppedForTurn(){
+  const a = selectedTurn(), b = historyBound();
+  if(!a || !b) return 0;
+  return Math.max(0, a.i - b);
 }
 function turnLabel(){
   const a = selectedTurn(); if(!a) return '—';
@@ -635,10 +647,17 @@ const NODES = [
 
 /* ===== 5 · THE TURN ===== */
 { id:'history', layer:'loop', kind:'store', tag:'bounded read',
-  title:'Thread history', path:'threads.thread_messages(...)[-40:]',
+  title:'Thread history', path:'threads.thread_messages(...)[-'+(historyBound()||'')+':]',
   from:['t_chat','t_thread','user_msg'],
-  body:()=> { const h=historyForTurn(), c=conv(); if(!c) return none('no capture');
-    return head('sent to the model for '+turnLabel()+' — '+h.length+' of '+c.turn_count+' rows')
+  body:()=> { const h=historyForTurn(), c=conv(), d=historyDroppedForTurn(); if(!c) return none('no capture');
+    /* Say whether the bound BIT, not just that it exists: a node drawn to show a
+       limit should distinguish "the whole thread fitted" from "the oldest rows
+       were dropped", and every captured conversation is currently the former. */
+    const bound = historyBound();
+    const note = d
+      ? ' · the '+bound+'-row bound dropped the '+d+' oldest'
+      : (bound ? ' · under the '+bound+'-row bound' : '');
+    return head('sent to the model for '+turnLabel()+' — '+h.length+' of '+c.turn_count+' rows'+note)
     + jsonHTML(h.map(t=>({role:t.role, content:t.content})), true); } },
 
 { id:'llm', layer:'loop', kind:'llm', tag:'LLM call', span:true,


### PR DESCRIPTION
The chat diagram's `history` node is drawn to show a **bounded** read. Its path label said `threads.thread_messages(...)[-40:]`, and `_MAX_LLM_HISTORY_TURNS` was already captured in the blob as `CHAT.bounds.max_llm_history_turns`, but the helper behind the node never read it:

```js
function historyForTurn(){
  const c = conv(), a = selectedTurn(); if(!c || !a) return [];
  return c.turns.slice(0, a.i);
}
```

So the one node whose whole job is to illustrate a limit was the node that did not apply it, and the `llm` node's "messages" count inherited the same unbounded number.

## The change

Three edits, all in the hand-authored half. **No regeneration, no database, the blob is untouched.**

- `historyForTurn` slices the tail to `CHAT.bounds.max_llm_history_turns` — the value already captured from the constant, rather than a second copy of `40` that could drift away from it.
- The path label is built from that same value, so changing the constant and regenerating moves the label with it instead of leaving it stale.
- `historyDroppedForTurn` lets the node say whether the bound actually **bit**. A node drawn to show a limit should distinguish "the whole thread fitted" from "the oldest rows were dropped"; every captured conversation today is the former, and the node now says so rather than staying silent.

## The fix is currently unobservable, which is worth stating rather than papering over

The longest captured conversation is 22 rows and the generator caps a thread at `_MAX_TURNS_PER_THREAD = 24`, so 40 is unreachable from real data. **Raising that cap would not help either** — the longest real thread in the source is 22 rows. The diagram therefore renders identically with and without this change. I considered raising the cap and decided against it for exactly that reason.

It is still worth doing: the node exists to illustrate the bound, it would drift silently if the constant changed, and it should say when the bound bit.

## Proof

Proved by driving the module directly, with a synthetic 60-row conversation injected into `CHAT.assembled.conversations` and the helper read through a `vm` context. Verbatim, against HEAD and against this commit:

```
=== BEFORE THE FIX (HEAD) ===
bound in blob                : 40
history node path label      : threads.thread_messages(...)[-40:]
turn 59 (60-row thread) sent : 59 | dropped: n/a | oldest kept: m0
turn 11 (short prefix)  sent : 11 | dropped: n/a | oldest kept: m0
FAIL

=== AFTER THE FIX ===
bound in blob                : 40
history node path label      : threads.thread_messages(...)[-40:]
turn 59 (60-row thread) sent : 40 | dropped: 19 | oldest kept: m19
turn 11 (short prefix)  sent : 11 | dropped: 0 | oldest kept: m0
PASS: the bound is applied and reported.
```

The probe script was **not committed**: `docs/diagrams/` has no JS test runner, and a one-off file nothing owns and no CI runs is surface without a keeper. It is reproducible from the transcript above — inject a long conversation into `CHAT.assembled.conversations`, set `SEL_CONV`/`SEL_TURN`, read `historyForTurn()`.

`make diagram-check` passes; backend suite 3233 passed, 12 deselected.

## Merge note

Trial-merged against `fix/chat-capture-lane-792-793-871` (the other half of #793 plus #792): **clean auto-merge, both fixes verifiably still live, `make diagram-check` green.** Either order works.

Partially addresses #793 — the second half, the overstated `prod-pinned` capture label, needs a regeneration and rides the chat-capture branch.