### PR TITLE
fix(profile): panel hints are read out with the control they explain (#873)

### DIFF
--- a/frontend/components/UserMaterialsPanel.tsx
+++ b/frontend/components/UserMaterialsPanel.tsx
@@ -199,6 +199,7 @@ export default function UserMaterialsPanel() {
             <select
               value={kind}
               onChange={(e) => setKind(e.target.value as MaterialKind)}
+              aria-describedby={kind === 'philosophy' ? 'materials-kind-hint' : undefined}
               className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
             >
               {KIND_OPTIONS.map((o) => (
@@ -208,7 +209,7 @@ export default function UserMaterialsPanel() {
               ))}
             </select>
             {kind === 'philosophy' && (
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              <p id="materials-kind-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                 Your own coaching philosophy, in your own words — what you believe makes
                 training work for you.
               </p>
@@ -234,9 +235,10 @@ export default function UserMaterialsPanel() {
             type="file"
             accept=".md,.markdown,text/markdown,text/plain"
             onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            aria-describedby="materials-file-hint"
             className="block w-full text-sm text-gray-600 dark:text-gray-300 file:mr-3 file:py-2 file:px-4 file:rounded file:border-0 file:bg-blue-50 dark:file:bg-blue-950 file:text-blue-700 dark:file:text-blue-300 hover:file:bg-blue-100 dark:hover:file:bg-blue-900"
           />
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          <p id="materials-file-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1">
             UTF-8 text/markdown, up to 256 KB.
           </p>
         </div>

--- a/frontend/components/VoiceDialsPanel.tsx
+++ b/frontend/components/VoiceDialsPanel.tsx
@@ -334,9 +334,10 @@ export default function VoiceDialsPanel() {
           rows={2}
           maxLength={1000}
           placeholder="e.g. talk to me like a calm, dry mentor; no hype."
+          aria-describedby="voice-freetext-hint"
           className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
         />
-        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+        <p id="voice-freetext-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1">
           Your coach reads this only to shape its tone. It can never change your data or
           skip a safety message.
         </p>


### PR DESCRIPTION
Partially addresses #873. Finishes what #898 started, across the whole profile screen rather than one file.

## What was left

#849 associated the profile form's visible captions with their controls. #898 associated the four hint paragraphs on `frontend/app/profile/page.tsx`. A re-review of that batch found the profile **screen** still had unassociated hint paragraphs living in the panel components — at least one (the voice free-text hint) with the identical shape #898 had just fixed.

A screen reader announced the control and omitted the sentence explaining it. For the voice free-text field, the omitted sentence is the one that says the coach reads it only to shape tone and can never change your data or skip a safety message — which is exactly the reassurance a runner needs before typing into that box.

## What changed

Same idiom as #898 (`id` on the hint, `aria-describedby` on the control), so the codebase keeps one technique rather than growing a second.

- `VoiceDialsPanel.tsx` — the "In your own words" textarea now points at its hint.
- `UserMaterialsPanel.tsx` — the file input points at its "UTF-8 text/markdown, up to 256 KB" hint; the Kind select points at the philosophy hint **only while that hint renders**, since `aria-describedby` pointing at an absent id is worse than absent.

## Scope: 14 candidates, 3 changed

The panel list was taken from `profile/page.tsx`'s **real imports**, not from the issue's guess. Surveying `ConnectStravaButton`, `LinkTelegramButton`, `ImportStravaHistory`, `ThemeToggle`, `VoiceDialsPanel`, `StanceDialsPanel`, `UserMaterialsPanel`, `FeatureDisabledGate` found 14 paragraph-style text blocks beyond the four `page.tsx` already covers. Three are genuine field hints in the #898 shape. Eleven were deliberately left alone:

- **Section intros** describing a whole panel rather than one control (Voice, Stance, Materials headers; the Strava import intro). There is no single control to attach them to without misrepresenting what they describe.
- **Decorative chart captions** for the radar and quadrant mirrors, both already `aria-hidden`.
- **Conditional status text** tied to a multi-button picker rather than one form control (Voice's Default/Custom state, Stance's "No philosophy chosen", Materials' "Distillation failed", empty states).
- **`FeatureDisabledGate`'s note**, which describes a gated section.

Blanket-applying `aria-describedby` to all 14 would have made the screen noisier to navigate, not more accessible.

## Verification

- `npm run test` (`next lint` + `next build`): green. One pre-existing warning in `CoachSheet.tsx`, an untouched file.
- Backend suite via the repo's commit gate: 3323 passed, 0 failed.
- **Runtime browser verification**, not just a build: local Postgres/Redis up, backend with `LOCAL_NO_AUTH=true`, frontend with `NEXT_PUBLIC_LOCAL_NO_AUTH=true`, real seeded DB, navigated to `/profile` and programmatically resolved each fixed control's `aria-describedby` to its target element to confirm it reaches the right text. Also confirmed the Kind hint's association appears and disappears in lockstep with the conditional paragraph as the select value changes, and re-checked that #898's `max_hr` association still resolves. Servers stopped afterwards.

Static reasoning alone is not evidence for an accessibility fix, which is why this was driven in a real browser.

## Follow-ups found, not acted on (they need their own issues)

1. **Missing accessible names.** `VoiceDialsPanel`'s free-text field and `UserMaterialsPanel`'s Kind/Title/file fields have `<label>` elements with no `htmlFor`/`id` pairing at all. That is arguably more severe than the hint gap this PR closes (no accessible *name*, versus no accessible *description*), but it is a different defect and outside #873's scope. `aria-describedby` works regardless.
2. **Range-slider pole labels.** The Voice and Stance dials render their poles ("Hostile"/"Devoted") as plain sibling spans. The inputs carry only a generic `aria-label` like "warmth dial", so a screen reader announces the dial and its number but never what low and high mean.