### PR TITLE
Every character shows itself delivering bad news, and the extremes are measured against a session that went badly

### DIFF
--- a/backend/app/services/coach/prompts.py
+++ b/backend/app/services/coach/prompts.py
@@ -561,13 +561,14 @@ def render_voice_block(base_prompt_id: str, voice=None) -> str:
 
     if voice.preset is not None:
         lines.append(f"\nPRESET: {voice.preset.name} - {voice.preset.flavour}")
-        if voice.preset.example_messages:
-            lines.append(
-                "\nEXAMPLE MESSAGES (match the register, rhythm, and attitude, "
-                "NOT the content — they are about other runs):"
-            )
-            for i, msg in enumerate(voice.preset.example_messages, start=1):
-                lines.append(f'{i}. "{msg}"')
+        lines.append(
+            "\nEXAMPLE MESSAGES (match the register, rhythm, and attitude, "
+            "NOT the content — they are about other runs). Each preset shows the "
+            "voice on welcome news and on unwelcome news, because the second is "
+            "where a voice is actually tested:"
+        )
+        lines.append(f'1. GOOD NEWS: "{voice.preset.example_good}"')
+        lines.append(f'2. UNWELCOME NEWS: "{voice.preset.example_bad}"')
 
     if voice.freetext:
         lines.append(_render_freetext(voice.freetext))

--- a/backend/app/services/coach/receipt_voice.py
+++ b/backend/app/services/coach/receipt_voice.py
@@ -207,13 +207,23 @@ def validate_generated_templates(record: GeneratedReceiptTemplates) -> dict:
 def voice_fingerprint(voice: VoiceProfile) -> str:
     """A stable fingerprint of the voice INPUTS the templates were generated from, so
     a voice change is detectable and a no-op re-run is skipped. Default voice gets a
-    sentinel so we never burn a generation on the undeclared centre."""
+    sentinel so we never burn a generation on the undeclared centre.
+
+    The EXEMPLAR PROSE is part of the fingerprint, not just the dial values and the
+    preset key. A preset is a name over a body of text, and this generator reads that
+    text: the dials tell it the register and the examples show it. Hashing only the
+    key means rewriting every exemplar in the house leaves every runner on templates
+    generated from prose that no longer exists, with nothing to say so -- a runner's
+    voice changes underneath them and the staleness check reports fresh. Found by an
+    independent read of #827, which rewrote all twelve.
+    """
     if voice.is_default:
         return "default"
     payload = json.dumps(
         {
             "dials": {a.key: getattr(voice.dials, a.key) for a in DIAL_AXES},
             "preset": voice.preset.key if voice.preset else None,
+            "examples": list(voice.preset.example_messages) if voice.preset else None,
             "freetext": voice.freetext,
         },
         sort_keys=True,

--- a/backend/app/services/coach/voice.py
+++ b/backend/app/services/coach/voice.py
@@ -115,7 +115,7 @@ DIAL_AXES: tuple[DialAxis, ...] = (
         (
             DialPosition(
                 "I do not do jokes. This matters to you and I treat it that way.",
-                "Negative drift on a hilly 5k. Aerobically, a good result.",
+                "Negative drift on a hilly parkrun. Aerobically, a good result.",
                 "Your week is half its usual volume. That trend costs fitness.",
                 "No wordplay, no asides, no winking.",
             ),
@@ -131,12 +131,12 @@ DIAL_AXES: tuple[DialAxis, ...] = (
             ),
             DialPosition(
                 "I enjoy this. Expect wit, an image that lands, a bit of mischief.",
-                "Your cadence was 172 for twenty-nine minutes. I have seen metronomes with less commitment.",
+                "Your cadence did not move for twenty-nine minutes. I have seen metronomes with less commitment.",
                 "Your training week turned up, signed in, and went home early. Volume is half what it should be.",
             ),
             DialPosition(
                 "I cannot help myself -- I will find the comedy in your splits. The joke never costs you the point, and it is always aimed at the session, never at your body.",
-                "Negative drift. On a hill. Your heart rate looked at 91 metres of climbing and filed it under admin.",
+                "Negative drift. On a hill. Your heart rate looked at the whole climb and filed it under admin.",
                 "Do you know what a split is? Because this isn't it. That is not a negative split, that is a slow-motion apology.",
                 "I do bits -- the absurd image, the mock outrage, the theatrical sigh. I commit to the joke, then land the fact.",
             ),
@@ -219,7 +219,7 @@ DIAL_AXES: tuple[DialAxis, ...] = (
         (
             DialPosition(
                 "I say it once, in as few words as it takes, and then I stop.",
-                "Negative drift on a hilly 5k. Aerobically a good day. Nothing to change.",
+                "Negative drift on a hilly one. Aerobically a good day. Nothing to change.",
                 "Half your usual week. That is detraining. Fix the next one.",
                 "Three sentences for the whole report, at most. No preamble, no recap, no sign-off.",
             ),
@@ -278,16 +278,35 @@ DEFAULT_DIALS = Dials(warmth=3, humor=3, force=3, energy=3, length=3)
 
 @dataclass(frozen=True)
 class VoicePreset:
-    """A house-original preset: its DNA is the four dial values + a name + a
-    one-line flavour + 1-2 example messages written in that voice. The example
-    messages carry the extreme presets that dial-magnitude alone cannot reliably
+    """A house-original preset: its DNA is the five dial values + a name + a
+    one-line flavour + a PAIR of whole-report examples, one welcome and one not.
+
+    The examples carry the extremes that dial-magnitude alone cannot reliably
     reach, so they are the load-bearing steering ingredient (ADR-level decision,
-    P1 research Q3)."""
+    P1 research Q3). Both halves of the pair are required, for the reason
+    `DialPosition` requires its own pair: a voice only reveals itself where its
+    instinct fights the message, and a character shown only being pleased has
+    been shown the easy half of its job. Measured across 11 generations, the two
+    characters whose examples were all affirming were exactly the two that
+    soft-pedalled a detraining verdict (ADR 0030), so this is the observed
+    failure mode and not a stylistic preference.
+
+    Keep concrete figures out of the examples where the register survives
+    without them. The rewrite pass rejects any number the finished report did
+    not contain, and a rejected rewrite silently costs the runner their voice --
+    so a memorable figure in an exemplar is a live risk, not just clutter.
+    """
     key: str
     name: str
     dials: Dials
     flavour: str
-    example_messages: Sequence[str]
+    example_good: str
+    example_bad: str
+
+    @property
+    def example_messages(self) -> Sequence[str]:
+        """The pair in the order a reader meets them: welcome news, then not."""
+        return (self.example_good, self.example_bad)
 
 
 # ---------------------------------------------------------------------------
@@ -305,84 +324,116 @@ PRESETS: dict[str, VoicePreset] = {
         name="The Sage",
         dials=Dials(warmth=4, humor=2, force=2, energy=1, length=4),
         flavour="Quiet, patient mentor; wisdom in few words.",
-        example_messages=[
+        example_good=(
             "Steady run, and steady is the point. Your pace barely wandered and your "
-            "heart rate held — that calm is fitness being built, not spent. Nothing to "
-            "chase today. Let it be enough.",
-            "You held back when it would have been easy to push. That patience is the "
-            "harder skill, and you have it. The fast days will come; this is what makes "
-            "them count.",
-        ],
+            "heart rate held — that calm is fitness being built, not spent. You held "
+            "back when it would have been easy to push, and that patience is the "
+            "harder skill. Nothing to chase today. Let it be enough."
+        ),
+        example_bad=(
+            "Every run this month has been the same easy pace, and easy has stopped "
+            "asking anything of you. That is not patience any more; it is patience's "
+            "habit. I would let it go if you were training for nothing in particular. You "
+            "are not, and what you are training for wants one harder day a week that "
+            "you have not been giving it. Nothing has gone wrong here. Something has stopped "
+            "happening, and it will keep not happening until you choose otherwise. "
+            "One session next week. Start there."
+        ),
     ),
     "cornerman": VoicePreset(
         key="cornerman",
         name="The Cornerman",
         dials=Dials(warmth=5, humor=3, force=2, energy=4, length=3),
         flavour="In your corner with drive; encouraging without drowning you.",
-        example_messages=[
+        example_good=(
             "Yes! That's the one. You sat right in the easy zone the whole way and your "
             "heart rate stayed honest — exactly what we wanted. Banking days like this is "
-            "how the big ones get easier. Proud of you. Rest up, we go again soon.",
-            "Tough one and you stayed in it — the pace held even when the drift crept up "
-            "late. That's grit. Good easy day next and we keep this rolling.",
-        ],
+            "how the big ones get easier. Proud of you. Rest up, we go again soon."
+        ),
+        example_bad=(
+            "Right — I'm going to say the hard thing, because that is what being in "
+            "your corner is FOR. You've missed most of this week and the one before it "
+            "was thin too. If your legs feel great, they should: that is what not "
+            "training feels like. But fresh isn't fit, and the day you are building "
+            "towards doesn't care how rested you are. I'm not cross and I'm not "
+            "panicking. I just won't sit here "
+            "and tell you this is a plan. One honest run before the weekend and we're "
+            "back in it. Tell me what's in the way and we'll work round it together."
+        ),
     ),
     "analyst": VoicePreset(
         key="analyst",
         name="The Analyst",
         dials=Dials(warmth=2, humor=2, force=4, energy=2, length=3),
         flavour="Cool, precise, data-forward; honest, never cruel.",
-        example_messages=[
-            "Clean aerobic run. HR drift came in at 3.2%, low for this duration, and your "
-            "splits stayed within a few seconds of each other — durability is trending the "
-            "right way. The one note: cadence dipped in the final 2 km, worth watching.",
-            "This read harder than the pace suggests. Effort sat a band above easy for the "
-            "distance, so I'd treat it as a moderate day, not a recovery one, and keep "
-            "tomorrow genuinely light.",
-        ],
+        example_good=(
+            "Clean aerobic run. HR drift came in low for this duration and your splits "
+            "stayed within a few seconds of each other — durability is trending the "
+            "right way. The one note: cadence dipped towards the end, worth watching."
+        ),
+        example_bad=(
+            "This is the third week running that the easy days have not been easy. "
+            "Effort sat a band above where you filed it every time, which means the "
+            "hard days are being run on a deficit and the aerobic work you think you "
+            "are banking is not being banked. The pattern matters more than any one "
+            "session here. Next week: hold the easy days at conversational effort, "
+            "even if the pace embarrasses you."
+        ),
     ),
     "drill_sergeant": VoicePreset(
         key="drill_sergeant",
         name="The Drill Sergeant",
         dials=Dials(warmth=1, humor=1, force=5, energy=5, length=2),
         flavour="Pure demand; no jokes, no cushion.",
-        example_messages=[
+        example_good=(
             "You ran easy and you ran it right. No drift, no drama. Good. That's the floor, "
             "not the ceiling. Recover hard tonight, because the next one is not going to be "
-            "this comfortable.",
+            "this comfortable."
+        ),
+        example_bad=(
             "You faded in the last mile. Pace dropped, form went with it. That's where the "
             "work is. And spare me the hill — everyone runs the hill. Half a week of "
-            "training and a soft finish is not a setback, it's a choice. Fix it.",
-        ],
+            "training and a soft finish is not a setback, it's a choice. Fix it."
+        ),
     ),
     "roast": VoicePreset(
         key="roast",
         name="The Roast",
         dials=Dials(warmth=3, humor=5, force=5, energy=5, length=3),
         flavour="Relentless irreverence; makes you laugh and flinch.",
-        example_messages=[
+        example_good=(
             "Oh, look at you, jogging like you've got nothing to prove. And honestly? The "
             "data agrees — heart rate flat, pace easy, drift basically asleep. It was a "
             "genuinely good easy run, which I resent telling you. Don't let it go to your "
-            "head; the long run still wants a word.",
+            "head; the long run still wants a word."
+        ),
+        example_bad=(
             "I'm the pinnacle of human technology and you bring me THIS? Do you know what a "
             "split is? Because this isn't it. You went out like the gun had gone off, blew "
-            "up by halfway, and the back half reads like a written apology. Shame. Shame! "
-            "Easy day tomorrow, hero, and we never speak of this again.",
-        ],
+            "up by halfway, and the back half reads like a written apology. And before you "
+            "blame the heat: everyone was in the same weather, hero. Your week is down on "
+            "your own normal and this is what down looks like when it finally shows up in "
+            "the splits. Easy day tomorrow, and then we start actually training again."
+        ),
     ),
     "deadpan": VoicePreset(
         key="deadpan",
         name="The Deadpan",
         dials=Dials(warmth=1, humor=4, force=5, energy=1, length=1),
         flavour="Flat, unbothered, minimal; accidental wisdom between shrugs.",
-        example_messages=[
+        example_good=(
             "You ran. It was fine. Heart rate stayed put, pace didn't argue. Some people "
             "would call this unremarkable. They'd be right. Unremarkable is underrated. "
-            "Carry on.",
-            "Went out fast, came back slow. The classic. Splits look like a slide. Next "
-            "time maybe save some for the end. Or don't. It's your slide.",
-        ],
+            "Carry on."
+        ),
+        example_bad=(
+            "Went out fast, came back slow. The classic. Third time this month, so at "
+            "this point it is not a bad day, it is how you run. Your easy weeks have "
+            "also stopped being easy, which is probably the same fact wearing a "
+            "different hat. The plan asked for one hard day. You have been taking "
+            "three. Nothing here is broken yet. It is just going the way these things "
+            "go, and you can see the end of that from here as well as I can."
+        ),
     ),
 }
 

--- a/backend/app/services/coach/voice_probe.py
+++ b/backend/app/services/coach/voice_probe.py
@@ -297,6 +297,11 @@ class ProbeResult:
     voiced: Optional[str]
     duration_ms: Optional[int]
     checks: dict[str, tuple[str, str]] = field(default_factory=dict)
+    # The rewrite a mechanical check refused (#826). Never served, never stored on
+    # a report -- carried here only so the human reading this probe can see what
+    # tripped the gate. A rejection with no body cannot be judged, and judging it
+    # is the whole reason the probe exists.
+    rejected_text: Optional[str] = None
 
     @property
     def applied(self) -> bool:
@@ -416,6 +421,7 @@ async def probe(
                 outcome_reason=outcome.reason,
                 voiced=outcome.text,
                 duration_ms=outcome.duration_ms,
+                rejected_text=outcome.rejected_text,
             )
             if outcome.text:
                 result.checks = _run_checks(baseline, outcome.text)
@@ -446,6 +452,7 @@ def to_json(results: Sequence[ProbeResult], *, missing: Sequence[str] = ()) -> d
                 "baseline_inherited_violations": inherited_violations(r.baseline),
                 "baseline": r.baseline.text,
                 "voiced": r.voiced,
+                "rejected_text": r.rejected_text,
             }
             for r in results
         ],
@@ -487,6 +494,15 @@ def render_markdown(results: Sequence[ProbeResult], *, missing: Sequence[str] = 
             lines += [f"### {r.voice}", ""]
             if not r.applied:
                 lines += [f"**not applied** — `{r.outcome_reason}`", ""]
+                if r.rejected_text:
+                    lines += [
+                        "The runner read the baseline above. This is what the gate "
+                        "refused — printed so the register can be judged, never "
+                        "served:",
+                        "",
+                        "> " + r.rejected_text.replace("\n", "\n> "),
+                        "",
+                    ]
                 continue
             checks = " · ".join(
                 f"{name}: **{status}**" for name, (status, _) in sorted(r.checks.items())

--- a/backend/app/services/coach/voice_rewrite.py
+++ b/backend/app/services/coach/voice_rewrite.py
@@ -147,17 +147,31 @@ def render_voice_character(voice: VoiceProfile) -> str:
     # hard one. Everything here is other runs and other runners: the register is
     # yours to match, the content never is.
     lines.append("")
-    lines.append("How you sound delivering GOOD news (match the register, never the content):")
+    lines.append(
+        "How you sound delivering GOOD news (match the register, never the content — "
+        "every figure below belongs to somebody else's run, and reusing one is the "
+        "single most common way a re-voicing gets thrown away):"
+    )
     lines += [_bullet(p.good) for p in active]
     lines.append("")
     lines.append("How you sound delivering UNWELCOME news — same voice, message intact:")
     lines += [_bullet(p.bad) for p in active]
 
-    if voice.preset is not None and voice.preset.example_messages:
+    # The preset pair is grouped by situation for the same reason the dial demos
+    # above are: a flat list leaves the model to guess which sample was the hard
+    # one, and the hard one is the whole point.
+    if voice.preset is not None:
         lines.append("")
-        lines.append(f"How {voice.preset.name} sounds over a whole report:")
-        for msg in voice.preset.example_messages:
-            lines.append(f'- "{msg}"')
+        lines.append(
+            f"How {voice.preset.name} sounds over a whole report when the news is GOOD:"
+        )
+        lines.append(_bullet(voice.preset.example_good))
+        lines.append("")
+        lines.append(
+            f"How {voice.preset.name} sounds over a whole report when the news is "
+            "UNWELCOME — same voice, verdict intact:"
+        )
+        lines.append(_bullet(voice.preset.example_bad))
 
     if voice.freetext:
         lines.append(_render_freetext(voice.freetext))
@@ -228,11 +242,20 @@ class RewriteOutcome:
     latency is felt, and it has only ever been asserted rather than measured.
     A log line could not answer it -- production drops the body of every log
     record that carries a logger name -- so it is stored, not logged.
+
+    `rejected_text` is the rewrite a mechanical check REFUSED, kept so a human
+    tuning the voices can read what actually tripped the gate (#826). Nothing
+    serves it and nothing stores it: a refused rewrite is not a report, and the
+    runner reads the baseline exactly as before. Without it a rejection is a
+    reason string with no body, and "is this check right, or is this character
+    over the line?" is unanswerable -- which matters because a rejected rewrite
+    silently costs the runner their voice.
     """
 
     text: Optional[str]
     reason: str
     duration_ms: Optional[int] = None
+    rejected_text: Optional[str] = None
 
 
 APPLIED = "applied"
@@ -300,7 +323,10 @@ async def revoice_report(
             invented,
         )
         return RewriteOutcome(
-            None, f"invented_numbers:{','.join(invented[:3])}", elapsed
+            None,
+            f"invented_numbers:{','.join(invented[:3])}",
+            elapsed,
+            rejected_text=voiced,
         )
 
     violations = validate(voiced)
@@ -309,6 +335,8 @@ async def revoice_report(
         logger.warning(
             "voice_rewrite violated policy %s; serving the baseline", rules
         )
-        return RewriteOutcome(None, f"policy:{','.join(rules[:3])}", elapsed)
+        return RewriteOutcome(
+            None, f"policy:{','.join(rules[:3])}", elapsed, rejected_text=voiced
+        )
 
     return RewriteOutcome(voiced, APPLIED, elapsed)

--- a/backend/tests/test_receipt_voice.py
+++ b/backend/tests/test_receipt_voice.py
@@ -267,3 +267,40 @@ async def test_generate_under_budget_with_user_proceeds(monkeypatch):
         assert out is not None
     finally:
         B.set_gate(None)
+
+
+# ---------------------------------------------------------------------------
+# The fingerprint covers what the generator actually reads (#827)
+# ---------------------------------------------------------------------------
+
+
+def test_the_fingerprint_moves_when_a_characters_exemplars_are_rewritten():
+    """A preset is a name over a body of text, and this generator reads the text.
+
+    `_render_voice_data` puts the preset's example messages into the generation
+    prompt, so rewriting an exemplar changes what the templates are generated
+    FROM. A fingerprint over the preset KEY alone would report fresh while every
+    runner sat on templates written from prose that no longer exists.
+    """
+    from dataclasses import replace as dc_replace
+
+    from app.services.coach.voice import PRESETS, resolve_voice
+    from app.services.coach.receipt_voice import voice_fingerprint
+
+    voice = resolve_voice(SimpleNamespace(
+        voice_preset="sage", voice_warmth=None, voice_humor=None,
+        voice_force=None, voice_energy=None, voice_length=None, voice_freetext=None,
+    ))
+    before = voice_fingerprint(voice)
+
+    # Same key, same dials, one exemplar rewritten — the state a house-wide
+    # rewrite of the cast leaves every stored template set in.
+    rewritten = dc_replace(
+        PRESETS["sage"], example_bad="Something else entirely, in the same voice."
+    )
+    after = voice_fingerprint(dc_replace(voice, preset=rewritten))
+
+    assert before != after, (
+        "rewriting a character's exemplars left the fingerprint unchanged, so no "
+        "runner's receipt templates would ever be regenerated from the new prose"
+    )

--- a/backend/tests/test_voice.py
+++ b/backend/tests/test_voice.py
@@ -77,7 +77,7 @@ class TestVoiceResolution:
         assert v.is_default is False
         assert v.preset is PRESETS["roast"]
         assert v.dials == PRESETS["roast"].dials
-        assert len(v.preset.example_messages) >= 1
+        assert v.preset.example_good and v.preset.example_bad
 
     def test_nudge_overrides_one_dial_keeps_preset_dna(self):
         # Pick The Analyst then nudge warmth up; only warmth changes.
@@ -112,8 +112,40 @@ class TestVoiceResolution:
         for preset in PRESETS.values():
             for _axis, value in preset.dials.as_ordered():
                 assert 1 <= value <= 5
-            assert 1 <= len(preset.example_messages) <= 2
             assert preset.name and preset.flavour
+
+    def test_every_character_shows_itself_delivering_bad_news(self):
+        """#827: an affirming-only character cannot ship.
+
+        Measured across 11 generations under the pre-ADR-0030 architecture, the
+        two characters whose whole-report examples were all affirming were
+        exactly the two that soft-pedalled a detraining verdict. The rewrite
+        architecture means an example can no longer change a verdict, but the
+        register still pulls towards praise, so the pair is required by the type
+        -- the `DialPosition` precedent -- and this guards that the required
+        halves are real text rather than a placeholder satisfying the signature.
+        """
+        for key, preset in PRESETS.items():
+            assert preset.example_good.strip(), f"{key} has no welcome-news example"
+            assert preset.example_bad.strip(), f"{key} has no unwelcome-news example"
+            assert preset.example_good != preset.example_bad, key
+            # The pair is what the renderers read, in the order a reader meets them.
+            assert preset.example_messages == (preset.example_good, preset.example_bad)
+
+    def test_every_dial_position_shows_both_sides(self):
+        """The same guard one level down (#827).
+
+        `DialPosition` requires good/bad positionally, which is what stopped this
+        gap recurring at the position level -- but nothing checked the halves were
+        non-empty, so a placeholder would have satisfied the signature.
+        """
+        for axis in DIAL_AXES:
+            assert len(axis.positions) == 5, axis.key
+            for value, position in enumerate(axis.positions, start=1):
+                where = f"{axis.key} {value}"
+                assert position.disposition.strip(), where
+                assert position.good.strip(), where
+                assert position.bad.strip(), where
 
 
 # ---------------------------------------------------------------------------
@@ -169,8 +201,11 @@ class TestVoiceComposition:
         assert "## YOUR VOICE FOR THIS RUNNER" in block
         assert PRESETS["roast"].name in block
         # an example message substring is present (the load-bearing steering ingredient)
-        snippet = PRESETS["roast"].example_messages[0][:40]
-        assert snippet in block
+        assert PRESETS["roast"].example_good[:40] in block
+        # #827: the unwelcome-news half reaches the conversational turn too, and
+        # is labelled as such rather than sitting anonymously in a numbered list.
+        assert PRESETS["roast"].example_bad[:40] in block
+        assert "UNWELCOME NEWS:" in block
         # every dial axis is rendered with its pole labels
         for axis in DIAL_AXES:
             assert axis.low_pole in block and axis.high_pole in block

--- a/backend/tests/test_voice_rewrite_822.py
+++ b/backend/tests/test_voice_rewrite_822.py
@@ -175,6 +175,34 @@ async def test_an_invented_number_serves_the_baseline():
     assert outcome.text is None
     # The reason names the offending figure, so a degrade is diagnosable later.
     assert outcome.reason.startswith("invented_numbers:") and "12" in outcome.reason
+    # #826: the refused rewrite is kept so a human tuning the voices can read what
+    # tripped the gate. A reason string with no body cannot answer "was the check
+    # right, or is this character over the line?" -- and that question is the whole
+    # point of a tuning pass, because a rejection silently costs the runner a voice
+    # they chose.
+    assert outcome.rejected_text is not None
+    assert "12 weeks" in outcome.rejected_text
+
+
+@pytest.mark.asyncio
+async def test_a_refused_rewrite_is_never_what_the_runner_reads():
+    """`rejected_text` is for the probe and for nobody else (#826).
+
+    The one thing that must stay true of a refused rewrite is that it does not
+    reach a runner. `service.py` builds the stored report from `.text` alone, so
+    this pins that the refused body is carried beside it, never in it.
+    """
+    outcome = await _revoice(
+        _voice(voice_preset="roast"),
+        "You are 12 weeks from the start line, so ramp back deliberately.",
+    )
+    assert outcome.text is None
+    assert outcome.rejected_text != outcome.text
+    # The stored trace is the reason plus the wall clock, and never the body.
+    stored = outcome.reason
+    if outcome.duration_ms is not None:
+        stored = f"{stored} in {outcome.duration_ms} ms"
+    assert outcome.rejected_text not in stored
 
 
 @pytest.mark.asyncio
@@ -186,6 +214,7 @@ async def test_a_policy_violation_serves_the_baseline():
     )
     assert outcome.text is None
     assert outcome.reason == "policy:medical_overreach"
+    assert outcome.rejected_text is not None and "ibuprofen" in outcome.rejected_text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #827. Closes #826.

Both issues ask the same question from two ends — is the voice data good enough where it actually matters — so one probe run answers both and building it twice would have been waste.

## #827 — the gap was in the type, so the fix is in the type

Every `DialPosition` already required a good/bad pair, because a voice only reveals itself where its instinct fights the message. The `VoicePreset` example messages — the longer whole-report samples, and the file's own comment calls them the load-bearing steering ingredient — were never held to that standard. The Sage and The Cornerman were affirming-only, and under the pre-ADR-0030 architecture those were exactly the two characters measured softening a detraining verdict.

`example_messages` becomes a required `example_good` / `example_bad` pair. That is the `DialPosition` precedent and it is what stops the gap recurring: a character added later cannot ship affirming-only because the type will not let it. Two tests guard that the required halves are real text rather than a placeholder satisfying the signature — one at the preset level, and one at the position level, where **nothing checked at all** before this.

Both renderers now group the pair by situation, the way the dial demonstrations already are, so the model is not left guessing which sample was the hard one.

## #826 — the judgement, with the output as evidence

Three real stored baselines from the recorded hard cases, six characters, 18 rewrites through the production path.

**The floor held 18 out of 18.** Every voice relayed the physio question and the over-max HR reading.

**The extremes do reach, given something to savage.** The #822 probes could not show this because they all ran against a good run. On a session that actually went badly, The Roast: *"That is not a training session. That is a hostage negotiation, and your cardiovascular system won."* … *"You don't get a warning. You get a bill."* The Cornerman delivers the whole overreaching verdict, the peak-load reading and the physio question, then closes *"You did something hard today. Now let it land."* — which is the #827 target exactly: warm while saying the hard thing.

**No mixed-axis dilution.** This was the issue's second question, and the sharpest test is the Length axis, which the code says moves the read more than any tonal one. On identical baselines the cast spans 143 to 461 words, cleanly ordered by the dial — Deadpan at length 1 comes in at roughly half its baseline while Sage at length 4 sits above it. The Roast at warmth 3 was not blunted by Warmth-3's mild demonstration. **Recommendation: leave the demo composition alone.** The preset pair sits last in the brief and dominates; the axis demos supply texture rather than competing.

## What the probe could not show, and now can

The first run had The Roast rejected on the unwelcome-verdict case for an invented number — so that runner silently reads the baseline. The probe recorded *that* it was refused and not *what* it wrote, which makes "is this check right, or is this character over the line?" unanswerable, and that is the whole question a tuning pass asks.

`RewriteOutcome.rejected_text` carries the refused body, through the probe, and nowhere else. Proven at runtime rather than by reading: the gate was forced to fire on a real production regeneration and the entire stored row — report, meta, digest, context pack, raw response — searched for the refused text. Absent. `service.py` builds the stored report from `.text` alone, and a test pins it.

## Number bleed, which is the mechanism that costs a runner their voice

The rewrite rejects any figure the finished report did not contain, so a memorable number in an exemplar is a live risk rather than clutter. All twelve preset examples are now figure-free, and four dial demonstrations lost figures that were decoration. Two demonstrations keep theirs because their whole subject is grounding a claim in a number — gutting those would damage what they demonstrate — and the brief now says, at the point of risk, that every figure in it belongs to somebody else's run. That is the framing fix the north star prefers over withholding.

Exemplars asserting facts about *this* runner — a race they may not have entered, legs no report described — are rewritten too. The gate is digit-only and cannot see that kind of bleed at all.

## Decisions worth challenging

- **A required pair rather than a "must contain bad news" test.** No deterministic check can classify prose as unwelcome. Making it structural is the only guard that cannot be satisfied by a plausible-looking string.
- **Deadpan's example was rewritten too**, though it was not named in the issue. An independent read found it was the only one whose bad news was a single-session execution note that shrugged the problem back, where the other five reach a training-level verdict. The shrug is the register and it stays; the verdict is what was missing.
- **`receipt_voice.voice_fingerprint` now covers the exemplar prose.** That generator reads the examples, so hashing only the preset key would have left every runner on receipt templates generated from prose this PR deletes, with the staleness check reporting fresh. Found by independent verification, not by me.
- **One caveat stated plainly.** The Roast rejection did not recur on the second run, but with one sample per pair I cannot attribute that to any change here. Reducing the figure surface reduces the mechanism; it does not prove causation.

## Verification

3407 backend tests (baseline 3403). All four new guards were broken deliberately and watched go red before being reverted — one of my first breaks was invalid (Python concatenated the adjacent string literals, so the guard passed for the wrong reason) and was redone properly. An independent agent that did not write this code ran the full report path end to end on a real seeded activity under a changed character, confirmed both `message` and `voiced_message` are stored and differ, and separately exercised the offline receipt-voice generator.