### PR TITLE
A truncated memory-writer call is a failure, not an empty profile (#931)

### DIFF
--- a/backend/app/services/coach/llm.py
+++ b/backend/app/services/coach/llm.py
@@ -304,6 +304,18 @@ class AnthropicClient:
         discipline as `generate_json`. Raises ValueError if no matching tool_use block
         is returned (a logic error, not transient — not retried here; the caller
         treats it as a failed distillation).
+
+        A `max_tokens` stop ALSO raises (#931). The SDK cannot assemble a partial
+        tool call, so a truncated response arrives as a tool_use block whose input
+        is `{}` — which, to the caller, is indistinguishable from a model that
+        legitimately answered with nothing. That is only SILENT for a schema whose
+        fields all carry defaults, which is exactly how the runner-memory writer
+        stored an empty profile over a large history and stamped it as a successful
+        pass. Raising makes truncation visible to every structured caller.
+
+        Not retried, for the same reason a missing block is not: the same call at
+        the same cap truncates again. The right fix is a cap that fits the work,
+        and this raise is what makes an undersized one findable instead of silent.
         """
         tool_name = tool["name"]
         ladder = RetryLadder("anthropic_structured")
@@ -320,6 +332,15 @@ class AnthropicClient:
                     timeout=_TIMEOUT_SECONDS,
                 )
                 usage = _usage_from_response(response)
+                stop_reason = (
+                    response.get("stop_reason") if isinstance(response, dict)
+                    else getattr(response, "stop_reason", None)
+                )
+                if stop_reason == "max_tokens":
+                    raise ValueError(
+                        f"{tool_name} tool call truncated at max_tokens={max_tokens}; "
+                        "the tool input is incomplete and must not be read as an answer"
+                    )
                 for block in response.content:
                     btype = (
                         block.get("type") if isinstance(block, dict)

--- a/backend/app/services/coach/memory_update.py
+++ b/backend/app/services/coach/memory_update.py
@@ -78,7 +78,19 @@ _MAX_CHAT_MESSAGES = 120
 # (the ones that matter) stay complete since real threads are short.
 _MAX_COACH_CHAT_MESSAGES = 80
 _MAX_RECENT_DIGESTS = 5
-_MAX_WRITER_TOKENS = 2000
+# The writer's OUTPUT ceiling. Sized from the work, not guessed (#931): the gather
+# caps above bound the source set at ~325 items, and a measured pass over a real
+# 206-source history emitted 43-56 candidates costing ~3.5-4.7k output tokens.
+# Scaling that to the gather ceiling lands under 8k, with headroom for the run-to-run
+# variance a temperature-0 call still has.
+#
+# It was 2000, which truncated that real history mid-tool-call. The truncated call
+# returned `{}`, `candidates` defaulted to `[]`, and an EMPTY profile was stored and
+# stamped as a successful pass — silently, for as long as the runner's history was
+# large. A cap is still a number that could one day be too small, so the durable half
+# of the fix is in `generate_structured_with_usage`, which now RAISES on a max_tokens
+# stop: undersizing this constant is now a visible failure rather than an empty profile.
+_MAX_WRITER_TOKENS = 8000
 
 _SectionKey = Literal[
     "who_you_are",
@@ -435,6 +447,50 @@ def build_writer_messages(sources: MemorySources) -> tuple[str, str]:
 
 
 # --------------------------------------------------------------------------- #
+# Per-candidate coercion (#931).
+# --------------------------------------------------------------------------- #
+def coerce_candidates(raw: object, *, user_id: object = None) -> List[MemoryCandidate]:
+    """Coerce the writer's tool output one candidate at a time, dropping the
+    off-shape ones and keeping the rest.
+
+    Whole-object validation made the pass ALL-OR-NOTHING: a real 206-source history
+    produced 43 candidates of which 2 overran `MAX_LINE_LENGTH`, and the strict
+    `model_validate` discarded all 43. The tool schema does declare `maxLength`, but
+    a JSON-schema bound is guidance to the model rather than a guarantee from the
+    API, so an over-long line is an expected output, not an exceptional one.
+
+    Dropping the offending line is the module's existing idiom rather than a new one:
+    a candidate whose cited sources are all unknown already drops here while the raw
+    source keeps the fact. Truncating the text instead would silently put words in
+    the writer's mouth. A drop is logged, never silent.
+
+    Raises only when the payload itself is not a candidate list — that is off-contract
+    output rather than one bad line, and the caller fails the pass.
+    """
+    if not isinstance(raw, dict):
+        raise ValueError(f"memory writer output is {type(raw).__name__}, not an object")
+    items = raw.get("candidates")
+    if items is None:
+        items = []
+    if not isinstance(items, list):
+        raise ValueError(f"memory writer candidates is {type(items).__name__}, not a list")
+
+    kept: List[MemoryCandidate] = []
+    dropped = 0
+    for item in items:
+        try:
+            kept.append(MemoryCandidate.model_validate(item))
+        except Exception:  # noqa: BLE001 — one bad line never costs the pass
+            dropped += 1
+    if dropped:
+        logger.info(
+            "memory writer: dropped %s off-shape candidate(s) of %s for user %s",
+            dropped, len(items), user_id,
+        )
+    return kept
+
+
+# --------------------------------------------------------------------------- #
 # Deterministic graduate-or-drop (the structural half of the incident fix).
 # --------------------------------------------------------------------------- #
 def _dedupe_keep_order(lines: Iterable[str]) -> List[str]:
@@ -577,13 +633,13 @@ async def update_memory(
     )
 
     try:
-        output = RunnerMemoryWriterOutput.model_validate(raw)
+        candidates = coerce_candidates(raw, user_id=user_id)
     except Exception:  # noqa: BLE001 — off-shape tool output fails the pass, not the worker
         logger.exception("memory writer returned off-shape output for user %s", user_id)
         return None
 
     profile = apply_graduation(
-        output.candidates,
+        candidates,
         sources.source_ids,
         durable_source_ids=sources.durable_source_ids,
         plan_min_sources=settings.COACH_MEMORY_PLAN_GRADUATION_MIN,

--- a/backend/tests/test_memory_writer_truncation_931.py
+++ b/backend/tests/test_memory_writer_truncation_931.py
@@ -1,0 +1,177 @@
+"""#931 — a truncated writer call must never be stored as an empty profile.
+
+The production account with the longest history held a memory profile of five
+empty sections against 206 consumed sources, stamped with fresh provenance as a
+successful pass. Reproduced against that real history: the writer hit
+`max_tokens=2000` mid-tool-call, the SDK returned a `tool_use` block whose input
+was `{}`, `candidates` defaulted to `[]`, and an empty profile was written over
+the runner's whole stated history.
+
+Three defects, pinned here:
+
+1. A `max_tokens` stop is now a raised error rather than a partial dict, so the
+   silence is impossible for EVERY structured caller, not just this one. The
+   memory writer was the only silent victim because it is the only structured
+   schema whose fields all carry defaults.
+2. The pass writes nothing when the call fails, so a stored profile is never
+   worse than the one it replaced.
+3. Coercion is per-candidate. The same real history produced 43 candidates of
+   which 2 overran MAX_LINE_LENGTH; whole-object validation discarded all 43.
+"""
+
+import asyncio
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.schemas.coach_memory import MAX_LINE_LENGTH
+from app.services.coach.llm import AnthropicClient, Usage
+from app.services.coach.memory_store import get_memory
+from app.services.coach.memory_update import (
+    _MAX_WRITER_TOKENS,
+    coerce_candidates,
+    update_memory,
+)
+
+from tests.test_memory_update import _activity, _chat, _user  # reuse the fixtures
+
+
+_TOOL = {"name": "record_runner_memory", "input_schema": {"type": "object"}}
+
+
+def _response(stop_reason, tool_input):
+    return SimpleNamespace(
+        stop_reason=stop_reason,
+        usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+        content=[SimpleNamespace(type="tool_use", name="record_runner_memory", input=tool_input)],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 1. The shared seam: truncation raises instead of returning a partial answer.
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_truncated_tool_call_raises_instead_of_returning_empty():
+    """The exact production shape: stop_reason=max_tokens with an empty input."""
+    client = AnthropicClient(api_key="k", model="m")
+    client.client.messages.create = AsyncMock(return_value=_response("max_tokens", {}))
+
+    with pytest.raises(ValueError, match="truncated"):
+        await client.generate_structured_with_usage(
+            system="s", user="u", tool=_TOOL, max_tokens=2000
+        )
+
+
+@pytest.mark.asyncio
+async def test_truncation_is_not_retried():
+    """The same call at the same cap truncates again; retrying only burns spend."""
+    client = AnthropicClient(api_key="k", model="m")
+    create = AsyncMock(return_value=_response("max_tokens", {}))
+    client.client.messages.create = create
+
+    with pytest.raises(ValueError):
+        await client.generate_structured_with_usage(
+            system="s", user="u", tool=_TOOL, max_tokens=2000
+        )
+    assert create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_complete_call_still_returns_its_input():
+    """The guard must not fire on a normal completion (positive control)."""
+    client = AnthropicClient(api_key="k", model="m")
+    payload = {"candidates": [{"text": "t", "section": "lately", "supporting_source_ids": ["chat0"]}]}
+    client.client.messages.create = AsyncMock(return_value=_response("tool_use", payload))
+
+    result, usage = await client.generate_structured_with_usage(
+        system="s", user="u", tool=_TOOL, max_tokens=2000
+    )
+    assert result == payload
+    assert usage.output_tokens == 20
+
+
+# --------------------------------------------------------------------------- #
+# 2. The pass writes nothing when the writer call fails.
+# --------------------------------------------------------------------------- #
+class _TruncatingClient:
+    """Stands in for the truncated call, which now raises out of the client."""
+
+    model = "claude-haiku-4-5"
+
+    async def generate_structured_with_usage(self, *, system, user, tool, max_tokens):
+        raise ValueError("record_runner_memory tool call truncated at max_tokens=2000")
+
+
+def test_a_truncated_pass_stores_no_profile(db):
+    """The regression: the bug was an EMPTY profile written and stamped as success."""
+    uid = _user(db)
+    activity = _activity(db, uid)
+    _chat(db, activity, "user", "My race is on September 27th.")
+    db.flush()
+
+    result = asyncio.run(update_memory(db, uid, client=_TruncatingClient()))
+
+    assert result is None, "a failed pass must not return a stored row"
+    assert get_memory(db, uid) is None, "a failed pass must not write a profile"
+
+
+def test_the_production_shape_end_to_end_writes_no_profile(db, monkeypatch):
+    """The whole path, exactly as production hit it: a real AnthropicClient whose
+    underlying call truncates. Before the fix this stored five empty sections and
+    stamped fresh provenance; the failure was invisible at every layer."""
+    uid = _user(db)
+    activity = _activity(db, uid)
+    _chat(db, activity, "user", "My race is on September 27th.")
+    db.flush()
+
+    client = AnthropicClient(api_key="k", model="claude-haiku-4-5")
+    # stop_reason=max_tokens with an empty tool input — what the SDK returns when
+    # it cannot assemble a partial tool call.
+    client.client.messages.create = AsyncMock(return_value=_response("max_tokens", {}))
+
+    result = asyncio.run(update_memory(db, uid, client=client))
+
+    assert result is None
+    assert get_memory(db, uid) is None
+
+
+# --------------------------------------------------------------------------- #
+# 3. Per-candidate coercion: one bad line does not cost the pass.
+# --------------------------------------------------------------------------- #
+def test_an_over_long_line_drops_and_the_rest_survive():
+    """Measured on the real history: 2 of 43 candidates overran MAX_LINE_LENGTH."""
+    good = {"text": "Races a half marathon on 27 Sep", "section": "goals_and_plans",
+            "supporting_source_ids": ["chat0", "chat1"]}
+    over_long = {"text": "x" * (MAX_LINE_LENGTH + 1), "section": "lately",
+                 "supporting_source_ids": ["chat2"]}
+    other_good = {"text": "Uses a metronome at 170 spm", "section": "what_works_for_you",
+                  "supporting_source_ids": ["chat3", "chat4"]}
+
+    kept = coerce_candidates({"candidates": [good, over_long, other_good]})
+
+    assert [c.text for c in kept] == [good["text"], other_good["text"]]
+
+
+def test_a_missing_candidates_key_is_an_empty_list_not_a_crash():
+    assert coerce_candidates({}) == []
+
+
+def test_an_off_contract_payload_raises_so_the_caller_fails_the_pass():
+    """A non-list `candidates` is off-contract output, not one bad line."""
+    with pytest.raises(ValueError):
+        coerce_candidates({"candidates": "not a list"})
+    with pytest.raises(ValueError):
+        coerce_candidates(["not", "an", "object"])
+
+
+# --------------------------------------------------------------------------- #
+# 4. The cap is sized for the work the gather bounds allow.
+# --------------------------------------------------------------------------- #
+def test_the_writer_cap_covers_the_measured_need():
+    """A real 206-source history cost ~3.5-4.7k output tokens. The gather caps
+    admit ~325 sources, so the cap must clear that scaled need with headroom.
+    This is a floor, not a target: raising the cap is safe, lowering it below
+    the measurement is the bug."""
+    assert _MAX_WRITER_TOKENS >= 7500


### PR DESCRIPTION
Closes #931.

## What was wrong

The production account with the longest history held a memory profile of five empty sections against 206 consumed sources, stamped with fresh provenance as a successful pass. The coach had been re-asking facts the runner had already stated: the race date three times across seven weeks, a settled decision about the peak long run re-opened a week after it was agreed.

Three defects in one chain. Only the first was visible before running it.

1. **The writer's output cap was 2000 tokens.** That history needs 3.5k to 4.7k, so the call stopped at `max_tokens` mid-tool-call and the SDK returned a `tool_use` block whose input was `{}`.
2. **Truncation was silent.** `generate_structured_with_usage` never inspected `stop_reason`, so `{}` reached the caller as an answer. That is only silent for a schema whose fields all carry defaults, which is why the memory writer was the only one of four structured callers to lose data quietly: `candidates` defaulted to `[]` and an empty profile was written over the runner's whole stated history.
3. **One over-long line discarded the whole pass.** Only reachable once 1 and 2 were fixed. Whole-object validation is all-or-nothing, and that same history produced 43 candidates of which 2 overran `MAX_LINE_LENGTH`, throwing away the other 41. Fixing 1 and 2 alone would have turned a silent failure into a visible one that still produced nothing.

## The fix

`generate_structured_with_usage` now raises on a `max_tokens` stop, so truncation is visible to every structured caller rather than arriving as a partial answer. It is deliberately not retried: the same call at the same cap truncates again.

`_MAX_WRITER_TOKENS` goes to 8000, sized from the measurement rather than guessed. The gather caps bound the source set at roughly 325 items, and a real 206-source pass cost 3.5k to 4.7k output tokens. A cap is still a number that could one day be too small, which is what the raise is for.

Candidate coercion is per-candidate, dropping an off-shape line and logging it. This is the module's existing idiom, not a new one: a candidate whose cited sources are all unknown already drops here while the raw source keeps the fact. Truncating the text instead would put words in the writer's mouth.

## Verification

Reproduced against the real history first, which is the only input that shows it. The control is the other live account: 11 sources graduates four lines, 206 graduates none.

End to end on the seeded real history, before and after:

```
BEFORE:  who_you_are 0 · limits 0 · goals_and_plans 0 · what_works 0 · lately 0
AFTER:   who_you_are 1 · limits 2 · goals_and_plans 6 · what_works 3 · lately 6
```

The stored profile now holds the 27 Sep race and the 1:39:59 goal, the 20km peak commitment with its stated risk acceptance, the right-foot injury history, and the metronome cadence. The once-mentioned left-knee niggle appears hedged as "mentioned once", so the safety-hold rule is working.

Nine new tests, **each proven to fail with its fix reverted and pass when restored**, including the end-to-end one, which writes the empty `RunnerMemory` row without the `llm.py` guard. Full suite 3500 passed, 0 failed (baseline 3491). `make diagram-check` green, so the coach pack shape is unchanged.

**The coverage gap that let this ship:** no test used a large source set. The stub client always returns a well-formed dict, and the real-LLM replay corpus uses small synthetic histories, so nothing in the suite could produce a greater-than-2000-token output.

## Not checked

- The other three structured callers (material distiller, receipt-voice, schedule draft) were not exercised with a truncating response. I read their error handling and each degrades visibly, but that is reasoned rather than observed. A truncated call that previously returned `{}` and failed coercion will now raise instead, which routes the schedule draft into its transport-retry path.
- Cost of the raised cap is measured only from two probe runs. On a large history the pass now spends up to about 2.3x the output tokens it used to.
- Verified against a copy of production, not in production.

## Follow-up, not acted on

`RunnerMemoryWriterOutput` is now unused. Removing it needs a call, and it may be worth keeping as the documented shape of the tool contract.