### PR TITLE
feat(profile): the profile says what the coach knows before it asks you to edit it (#941)

### DIFF
--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { Suspense, useCallback, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { AlertTriangle, CheckCircle2 } from 'lucide-react';
 import ConnectStravaButton from '@/components/ConnectStravaButton';
 import LinkTelegramButton from '@/components/LinkTelegramButton';
 import ImportStravaHistory from '@/components/ImportStravaHistory';
@@ -11,305 +11,239 @@ import VoiceDialsPanel from '@/components/VoiceDialsPanel';
 import StanceDialsPanel from '@/components/StanceDialsPanel';
 import UserMaterialsPanel from '@/components/UserMaterialsPanel';
 import FeatureDisabledGate from '@/components/FeatureDisabledGate';
+import ProfileHub from '@/components/profile/ProfileHub';
+import SectionScreen from '@/components/profile/SectionScreen';
+import {
+  AppSection,
+  BodySection,
+  HealthSection,
+  TrainingSection,
+} from '@/components/profile/EditSections';
+import {
+  coerceField,
+  EMPTY_PROFILE_FORM,
+  ProfileForm,
+  profileFromApi,
+} from '@/components/profile/profileForm';
 import { useCoachFeatureFlags } from '@/lib/useCoachFeatureFlags';
 import { fetchFromAPI } from '@/lib/api';
 
+// #941: the profile is a hub of current values with focused screens behind each
+// row, not one long form. Which screen is showing is a `?s=` query param on this
+// same route, so the component never unmounts -- no refetch when you open a
+// screen, and hardware Back returns you to the hub instead of leaving the page.
+
 export default function ProfilePage() {
+  // The bottom padding clears the coach launcher. The layout's `main` reserves
+  // room for the tab bar only, and the launcher floats ~2.5rem above that, so
+  // without this it lands on top of the last row -- which on the hub is a link,
+  // so it was covering a tap target, not just some text.
+  //
+  // useSearchParams needs a Suspense boundary: /profile is statically
+  // prerendered, and without one the whole route deopts to client rendering.
+  return (
+    <div className="pb-14 md:pb-0">
+      <Suspense fallback={<div className="p-8">Loading profile...</div>}>
+        <ProfileScreens />
+      </Suspense>
+    </div>
+  );
+}
+
+function ProfileScreens() {
   const router = useRouter();
+  const section = useSearchParams().get('s');
   const coachFlags = useCoachFeatureFlags();
+
+  // `profile` is what is stored; `draft` is what the open screen is editing.
+  const [profile, setProfile] = useState<ProfileForm>(EMPTY_PROFILE_FORM);
+  const [draft, setDraft] = useState<ProfileForm>(EMPTY_PROFILE_FORM);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  
-  // Form State
-  const [formData, setFormData] = useState({
-    goal_type: 'general',
-    experience_level: 'intermediate',
-    weekly_days_available: 4,
-    current_weekly_km: 0,
-    injury_notes: '',
-    // upcoming_races handling skipped for simple MVP form, 
-    // but field exists in backend schema
-    upcoming_races: [],
-    max_hr: 0, // New field state
-    resting_hr: 0,
-    // #742: null, not 0. These post straight through to the coach pack, and the
-    // backend rejects a physiologically impossible figure rather than coaching on
-    // it — so the other fields' 0-means-empty sentinel would be a 422 here.
-    weight_kg: null as number | null,
-    height_cm: null as number | null,
-    week_starts_on: 0 // 0=Monday (default), 6=Sunday (#676)
-  });
+  const [error, setError] = useState<string | null>(null);
+  const [justSaved, setJustSaved] = useState(false);
 
   useEffect(() => {
     fetchFromAPI('/api/profile')
-      .then(data => {
-        if (!data) {
-          setLoading(false);
-          return;
-        }
-        setFormData({
-            goal_type: data.goal_type || 'general',
-            experience_level: data.experience_level || 'intermediate',
-            weekly_days_available: data.weekly_days_available || 4,
-            current_weekly_km: data.current_weekly_km || 0,
-            injury_notes: data.injury_notes || '',
-            upcoming_races: data.upcoming_races || [],
-            max_hr: data.max_hr || 0,
-            resting_hr: data.resting_hr || 0,
-            weight_kg: data.weight_kg ?? null,
-            height_cm: data.height_cm ?? null,
-            week_starts_on: data.week_starts_on ?? 0
-        });
+      .then((data) => {
+        const loaded = profileFromApi(data);
+        setProfile(loaded);
+        setDraft(loaded);
         setLoading(false);
       })
-      .catch(err => {
+      .catch((err) => {
         console.error(err);
         setLoading(false);
       });
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  // Opening or leaving a screen starts from what is stored, so edits abandoned
+  // with Back are discarded rather than silently carried into the next save.
+  useEffect(() => {
+    setDraft(profile);
+    setError(null);
+  }, [section, profile]);
+
+  const set = useCallback((name: keyof ProfileForm, value: string) => {
+    setDraft((prev) => ({ ...prev, [name]: coerceField(name, value) }));
+  }, []);
+
+  const handleSave = useCallback(async () => {
     setSaving(true);
+    setError(null);
     try {
-      await fetchFromAPI('/api/profile', {
+      // The whole object, exactly as the flat form posted it: PUT /api/profile
+      // validates against UserProfileCreate, which requires goal_type,
+      // experience_level and weekly_days_available on every request.
+      const updated = await fetchFromAPI('/api/profile', {
         method: 'PUT',
-        body: JSON.stringify(formData),
+        body: JSON.stringify(draft),
       });
-      router.push('/');
+      setProfile(updated ? profileFromApi(updated) : draft);
+      setJustSaved(true);
+      router.replace('/profile', { scroll: false });
     } catch (err) {
       console.error(err);
-      alert('Error updating profile');
+      // Stay on the screen with the edits intact. The flat form raised a
+      // browser alert() and left the runner to work out what had happened.
+      setError('Could not save your profile. Check your connection and try again.');
+    } finally {
       setSaving(false);
     }
-  };
+  }, [draft, router]);
 
-  // #742: clearing a body field must send null ("not stated"), never 0 — the coach
-  // pack drops an unstated build rather than reading it as a real figure.
-  const NULLABLE_NUMERIC = ['weight_kg', 'height_cm'];
-  const NUMERIC = ['weekly_days_available', 'current_weekly_km', 'max_hr', 'resting_hr', 'week_starts_on'];
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
-    setFormData(prev => ({
-        ...prev,
-        [name]: NULLABLE_NUMERIC.includes(name)
-          ? (value === '' ? null : Number(value))
-          : NUMERIC.includes(name) ? Number(value) : value
-    }));
-  };
+  useEffect(() => {
+    if (!justSaved) return;
+    const timer = setTimeout(() => setJustSaved(false), 4000);
+    return () => clearTimeout(timer);
+  }, [justSaved]);
 
   if (loading) return <div className="p-8">Loading profile...</div>;
 
-  return (
-    <div className="max-w-2xl mx-auto p-4 md:p-8">
-      <header className="mb-6 flex flex-wrap justify-between items-center gap-4">
-        <h1 className="text-2xl font-bold whitespace-nowrap">Athlete Profile</h1>
-        <div className="flex items-center gap-4 flex-wrap">
-            <ThemeToggle />
-            <ConnectStravaButton />
-            <LinkTelegramButton />
-            <Link href="/" className="text-blue-600 dark:text-blue-400 hover:underline">Cancel</Link>
-        </div>
-      </header>
+  const saveProps = { onSave: handleSave, saving };
 
-      <div className="mb-6">
-        <ImportStravaHistory />
-      </div>
-
-      <form onSubmit={handleSubmit} className="space-y-6 bg-white dark:bg-gray-800 p-6 border dark:border-gray-700 rounded-xl shadow-sm">
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-                <label htmlFor="goal_type" className="block text-sm font-medium mb-1">Goal Type</label>
-                <select
-                    id="goal_type"
-                    name="goal_type"
-                    value={formData.goal_type}
-                    onChange={handleChange}
-                    className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
-                >
-                    <option value="general">General Fitness</option>
-                    <option value="5k">5k</option>
-                    <option value="10k">10k</option>
-                    <option value="half">Half Marathon</option>
-                    <option value="marathon">Marathon</option>
-                </select>
-            </div>
-
-            <div>
-                <label htmlFor="experience_level" className="block text-sm font-medium mb-1">Experience Level</label>
-                <select
-                    id="experience_level"
-                    name="experience_level"
-                    value={formData.experience_level}
-                    onChange={handleChange}
-                    className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
-                >
-                    <option value="new">Beginner</option>
-                    <option value="intermediate">Intermediate</option>
-                    <option value="advanced">Advanced</option>
-                </select>
-            </div>
-
-            <div>
-                <label htmlFor="weekly_days_available" className="block text-sm font-medium mb-1">Weekly Days Available</label>
-                <input
-                    type="number" min="1" max="7"
-                    id="weekly_days_available"
-                    name="weekly_days_available"
-                    value={formData.weekly_days_available}
-                    onChange={handleChange}
-                    className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
-                />
-            </div>
-
-            <div>
-                <label htmlFor="max_hr" className="block text-sm font-medium mb-1">Max Heart Rate (bpm)</label>
-                <input
-                    type="number" min="100" max="250"
-                    id="max_hr"
-                    name="max_hr"
-                    value={formData.max_hr || ''}
-                    onChange={handleChange}
-                    placeholder="e.g. 190"
-                    aria-describedby="max_hr-hint"
-                    className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
-                />
-                 <p id="max_hr-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                    Used to calculate zones. If unknown, estimate with 220 minus age.
-                </p>
-            </div>
-
-            <div>
-                <label htmlFor="resting_hr" className="block text-sm font-medium mb-1">Resting Heart Rate (bpm)</label>
-                <input
-                    type="number" min="30" max="120"
-                    id="resting_hr"
-                    name="resting_hr"
-                    value={formData.resting_hr || ''}
-                    onChange={handleChange}
-                    placeholder="e.g. 50"
-                    aria-describedby="resting_hr-hint"
-                    className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
-                />
-                 <p id="resting_hr-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                    Your typical morning resting HR. Helps the coach read fatigue trends.
-                </p>
-            </div>
-
-            <div>
-                <label htmlFor="weight_kg" className="block text-sm font-medium mb-1">Weight (kg)</label>
-                <input
-                    type="number" min="20" max="300" step="0.1"
-                    id="weight_kg"
-                    name="weight_kg"
-                    value={formData.weight_kg ?? ''}
-                    onChange={handleChange}
-                    placeholder="e.g. 72.5"
-                    className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
-                />
-            </div>
-
-            <div>
-                <label htmlFor="height_cm" className="block text-sm font-medium mb-1">Height (cm)</label>
-                <input
-                    type="number" min="100" max="250" step="0.5"
-                    id="height_cm"
-                    name="height_cm"
-                    value={formData.height_cm ?? ''}
-                    onChange={handleChange}
-                    placeholder="e.g. 178"
-                    aria-describedby="height_cm-hint"
-                    className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
-                />
-                 <p id="height_cm-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                    Optional. Your coach uses your build to judge how fast to ramp volume
-                    and how much strength work to prescribe &mdash; not to set a target
-                    weight. Leave blank and it simply won&apos;t be considered.
-                </p>
-            </div>
-
-            <div>
-                <label htmlFor="current_weekly_km" className="block text-sm font-medium mb-1">Current Weekly Volume (km)</label>
-                <input
-                    type="number" min="0"
-                    id="current_weekly_km"
-                    name="current_weekly_km"
-                    value={formData.current_weekly_km}
-                    onChange={handleChange}
-                    className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
-                />
-            </div>
-
-            <div>
-                <label htmlFor="week_starts_on" className="block text-sm font-medium mb-1">Week Starts On</label>
-                <select
-                    id="week_starts_on"
-                    name="week_starts_on"
-                    aria-describedby="week_starts_on-hint"
-                    value={formData.week_starts_on}
-                    onChange={handleChange}
-                    className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
-                >
-                    <option value={0}>Monday</option>
-                    <option value={6}>Sunday</option>
-                </select>
-                <p id="week_starts_on-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                    Sets which day your training week begins, for &ldquo;this week&rdquo; on the coach and Trends.
-                </p>
-            </div>
-        </div>
-
-        <div>
-            <label htmlFor="injury_notes" className="block text-sm font-medium mb-1">Injury / Health Notes</label>
-            <textarea
-                id="injury_notes"
-                name="injury_notes"
-                value={formData.injury_notes}
-                onChange={handleChange}
-                rows={3}
-                placeholder="Any nagging pains or past injuries?"
-                className="w-full border dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 rounded p-2"
-            />
-        </div>
-
-        <button 
-            type="submit" 
-            disabled={saving}
-            className="w-full bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700 disabled:opacity-50"
-        >
-            {saving ? 'Saving...' : 'Save Profile'}
-        </button>
-
-      </form>
-
-      <div className="mt-6">
-        <FeatureDisabledGate
-          disabled={!coachFlags.voice}
-          note="Voice is turned off in the coach configuration, so these settings have no effect right now."
-        >
-          <VoiceDialsPanel />
-        </FeatureDisabledGate>
-      </div>
-
-      <div className="mt-6">
-        <FeatureDisabledGate
-          disabled={!coachFlags.stance}
-          note="Stance is turned off in the coach configuration, so these settings have no effect right now."
-        >
-          <StanceDialsPanel />
-        </FeatureDisabledGate>
-      </div>
-
-      <div className="mt-6">
-        <FeatureDisabledGate
-          disabled={!coachFlags.user_materials}
-          note="Coaching materials are turned off in the coach configuration, so uploads have no effect right now."
-        >
-          <UserMaterialsPanel />
-        </FeatureDisabledGate>
-      </div>
+  const errorBanner = error ? (
+    <div
+      role="alert"
+      className="mb-4 flex items-start gap-2 rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-900/30 dark:text-red-200"
+    >
+      <AlertTriangle size={16} aria-hidden="true" className="mt-0.5 shrink-0" />
+      <span>{error}</span>
     </div>
-  );
+  ) : null;
+
+  switch (section) {
+    case 'training':
+      return (
+        <SectionScreen
+          title="Training goal"
+          description="Your goal shapes every session the coach prescribes."
+          {...saveProps}
+        >
+          {errorBanner}
+          <TrainingSection form={draft} onChange={set} />
+        </SectionScreen>
+      );
+
+    case 'body':
+      return (
+        <SectionScreen
+          title="Your body"
+          description="What the coach uses to set your zones and judge how fast to ramp."
+          {...saveProps}
+        >
+          {errorBanner}
+          <BodySection form={draft} onChange={set} />
+        </SectionScreen>
+      );
+
+    case 'health':
+      return (
+        <SectionScreen title="Injuries & health" {...saveProps}>
+          {errorBanner}
+          <HealthSection form={draft} onChange={set} />
+        </SectionScreen>
+      );
+
+    case 'app':
+      return (
+        <SectionScreen title="App preferences" {...saveProps}>
+          {errorBanner}
+          <AppSection form={draft} onChange={set} themeControl={<ThemeToggle />} />
+        </SectionScreen>
+      );
+
+    // The screens below own their own saving, so they get no Save in the
+    // header -- which is the point of splitting them out.
+    case 'connections':
+      return (
+        <SectionScreen
+          title="Connections"
+          description="Where your runs come from, and where your coach reaches you."
+        >
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center gap-4 rounded-xl border bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <ConnectStravaButton />
+            </div>
+            <div className="flex flex-wrap items-center gap-4 rounded-xl border bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <LinkTelegramButton />
+            </div>
+            <ImportStravaHistory />
+          </div>
+        </SectionScreen>
+      );
+
+    case 'voice':
+      return (
+        <SectionScreen title="Coach voice">
+          <FeatureDisabledGate
+            disabled={!coachFlags.voice}
+            note="Voice is turned off in the coach configuration, so these settings have no effect right now."
+          >
+            <VoiceDialsPanel />
+          </FeatureDisabledGate>
+        </SectionScreen>
+      );
+
+    case 'stance':
+      return (
+        <SectionScreen title="Coach stance">
+          <FeatureDisabledGate
+            disabled={!coachFlags.stance}
+            note="Stance is turned off in the coach configuration, so these settings have no effect right now."
+          >
+            <StanceDialsPanel />
+          </FeatureDisabledGate>
+        </SectionScreen>
+      );
+
+    case 'materials':
+      return (
+        <SectionScreen title="Coaching materials">
+          <FeatureDisabledGate
+            disabled={!coachFlags.user_materials}
+            note="Coaching materials are turned off in the coach configuration, so uploads have no effect right now."
+          >
+            <UserMaterialsPanel />
+          </FeatureDisabledGate>
+        </SectionScreen>
+      );
+
+    // No section, or one this build does not know: the hub.
+    default:
+      return (
+        <>
+          {justSaved && (
+            <div
+              role="status"
+              className="mx-auto mb-4 flex max-w-2xl items-center gap-2 rounded-lg border border-green-300 bg-green-50 p-3 text-sm text-green-800 dark:border-green-800 dark:bg-green-900/30 dark:text-green-200"
+            >
+              <CheckCircle2 size={16} aria-hidden="true" className="shrink-0" />
+              Profile saved.
+            </div>
+          )}
+          <ProfileHub form={profile} />
+        </>
+      );
+  }
 }

--- a/frontend/components/profile/EditSections.tsx
+++ b/frontend/components/profile/EditSections.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { ChipGroup, CountPicker, FieldHint, NumberField, SegmentedControl } from './controls';
+import { ProfileForm } from './profileForm';
+
+// The screens that edit profile fields (#941). Each renders a slice of the one
+// ProfileForm the page owns; none of them saves -- the page does, with the
+// whole object, because the backend requires goal_type, experience_level and
+// weekly_days_available on every PUT.
+
+type SectionProps = {
+  form: ProfileForm;
+  onChange: (name: keyof ProfileForm, value: string) => void;
+};
+
+const CARD =
+  'rounded-xl border bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800';
+
+export function TrainingSection({ form, onChange }: SectionProps) {
+  return (
+    <div className={`${CARD} space-y-6`}>
+      <ChipGroup
+        legend="What you're training for"
+        name="goal_type"
+        value={form.goal_type}
+        onChange={(v) => onChange('goal_type', v)}
+        options={[
+          { value: '5k', label: '5k' },
+          { value: '10k', label: '10k' },
+          { value: 'half', label: 'Half marathon' },
+          { value: 'marathon', label: 'Marathon' },
+          { value: 'general', label: 'General fitness' },
+        ]}
+      />
+
+      <SegmentedControl
+        legend="Experience"
+        name="experience_level"
+        value={form.experience_level}
+        onChange={(v) => onChange('experience_level', v)}
+        options={[
+          { value: 'new', label: 'Beginner' },
+          { value: 'intermediate', label: 'Intermediate' },
+          { value: 'advanced', label: 'Advanced' },
+        ]}
+      />
+
+      <CountPicker
+        legend="Days you can run each week"
+        name="weekly_days_available"
+        max={7}
+        value={form.weekly_days_available}
+        onChange={(v) => onChange('weekly_days_available', v)}
+      />
+
+      <div className="space-y-1">
+        <NumberField
+          id="current_weekly_km"
+          label="Current weekly volume (km)"
+          unit="km"
+          min="0"
+          value={form.current_weekly_km || ''}
+          onChange={(v) => onChange('current_weekly_km', v)}
+          hintId="current_weekly_km-hint"
+        />
+        <FieldHint id="current_weekly_km-hint">
+          Roughly what you are running now, so the coach ramps from the right place.
+        </FieldHint>
+      </div>
+    </div>
+  );
+}
+
+export function BodySection({ form, onChange }: SectionProps) {
+  return (
+    <div className={`${CARD} space-y-5`}>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <NumberField
+          id="max_hr"
+          label="Max heart rate (bpm)"
+          unit="bpm"
+          min="100"
+          max="250"
+          placeholder="e.g. 190"
+          value={form.max_hr || ''}
+          onChange={(v) => onChange('max_hr', v)}
+          hintId="body-hint"
+        />
+        <NumberField
+          id="resting_hr"
+          label="Resting heart rate (bpm)"
+          unit="bpm"
+          min="30"
+          max="120"
+          placeholder="e.g. 50"
+          value={form.resting_hr || ''}
+          onChange={(v) => onChange('resting_hr', v)}
+          hintId="body-hint"
+        />
+        <NumberField
+          id="weight_kg"
+          label="Weight (kg)"
+          unit="kg"
+          min="20"
+          max="300"
+          step="0.1"
+          placeholder="e.g. 72.5"
+          value={form.weight_kg ?? ''}
+          onChange={(v) => onChange('weight_kg', v)}
+          hintId="body-hint"
+        />
+        <NumberField
+          id="height_cm"
+          label="Height (cm)"
+          unit="cm"
+          min="100"
+          max="250"
+          step="0.5"
+          placeholder="e.g. 178"
+          value={form.height_cm ?? ''}
+          onChange={(v) => onChange('height_cm', v)}
+          hintId="body-hint"
+        />
+      </div>
+
+      {/* One note for the group. The flat form carried three separate hints
+          under three of the fields and none under the fourth, which is what
+          made its two-column layout ragged. */}
+      <div className="rounded-lg border bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900">
+        <FieldHint id="body-hint">
+          Your heart rates set your training zones — if you do not know your max,
+          estimate it with 220 minus your age. Weight and height only tell the coach
+          how fast to ramp volume and how much strength work to prescribe, never a
+          target weight. Leave them blank and they simply are not considered.
+        </FieldHint>
+      </div>
+    </div>
+  );
+}
+
+export function HealthSection({ form, onChange }: SectionProps) {
+  return (
+    <div className={CARD}>
+      <label htmlFor="injury_notes" className="block text-sm font-medium mb-1">
+        Injury / health notes
+      </label>
+      <textarea
+        id="injury_notes"
+        name="injury_notes"
+        value={form.injury_notes}
+        onChange={(e) => onChange('injury_notes', e.target.value)}
+        rows={6}
+        placeholder="Anything nagging, or an old injury the coach should work around?"
+        aria-describedby="injury_notes-hint"
+        className="w-full rounded-lg border border-gray-300 bg-white p-3 text-base outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+      />
+      <FieldHint id="injury_notes-hint">
+        The coach reads this before it prescribes. It is not medical advice and it
+        does not replace seeing someone about a persistent pain.
+      </FieldHint>
+    </div>
+  );
+}
+
+export function AppSection({
+  form,
+  onChange,
+  themeControl,
+}: SectionProps & { themeControl: ReactNode }) {
+  return (
+    <div className="space-y-4">
+      <div className={`${CARD} space-y-1`}>
+        <SegmentedControl
+          legend="Your week starts on"
+          name="week_starts_on"
+          value={form.week_starts_on}
+          onChange={(v) => onChange('week_starts_on', v)}
+          hintId="week_starts_on-hint"
+          options={[
+            { value: 0, label: 'Monday' },
+            { value: 6, label: 'Sunday' },
+          ]}
+        />
+        <FieldHint id="week_starts_on-hint">
+          Sets which day your training week begins, for “this week” on the coach,
+          Load and Trends.
+        </FieldHint>
+      </div>
+
+      {/* Appearance is a device preference, not profile data: it saves itself
+          the moment you pick it and is not part of the profile's Save. */}
+      <div className={CARD}>
+        <h2 className="text-sm font-medium mb-2">Appearance</h2>
+        {themeControl}
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          Applies to this device straight away.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/profile/ProfileHub.tsx
+++ b/frontend/components/profile/ProfileHub.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useTheme } from 'next-themes';
+import { CheckCircle2, AlertCircle } from 'lucide-react';
+import { SettingGroup, SettingRow } from './SettingRow';
+import { useConnectionStatus } from '@/lib/useConnectionStatus';
+import {
+  EXPERIENCE_LABELS,
+  GOAL_LABELS,
+  ProfileForm,
+} from './profileForm';
+
+// The profile hub (#941): what the coach knows about you, stated as values you
+// can read without touching a control. Every row links to the screen that edits
+// it. Nothing here writes.
+
+function summaryLine(form: ProfileForm): string {
+  const parts = [
+    GOAL_LABELS[form.goal_type] ?? form.goal_type,
+    EXPERIENCE_LABELS[form.experience_level] ?? form.experience_level,
+    `${form.weekly_days_available} days a week`,
+  ];
+  return parts.join(' · ');
+}
+
+function heartRateValue(form: ProfileForm): string {
+  if (!form.max_hr && !form.resting_hr) return 'Not set';
+  return `${form.max_hr || '—'} / ${form.resting_hr || '—'} bpm`;
+}
+
+function buildValue(form: ProfileForm): string {
+  const parts: string[] = [];
+  if (form.weight_kg != null) parts.push(`${form.weight_kg} kg`);
+  if (form.height_cm != null) parts.push(`${form.height_cm} cm`);
+  // #742: not stated is a real state, distinct from a figure of zero.
+  return parts.length ? parts.join(' · ') : 'Not stated';
+}
+
+// One chip per external account, stating linked/not rather than offering the
+// control. The controls live on the connections screen this links to.
+function ConnectionChip({
+  label,
+  state,
+}: {
+  label: string;
+  state: 'on' | 'off' | 'unknown';
+}) {
+  return (
+    <span className="flex flex-1 items-center gap-2 rounded-lg border bg-white px-3 py-2.5 dark:border-gray-700 dark:bg-gray-800">
+      {state === 'on' ? (
+        <CheckCircle2
+          size={16}
+          aria-hidden="true"
+          className="shrink-0 text-green-600 dark:text-green-400"
+        />
+      ) : (
+        <AlertCircle
+          size={16}
+          aria-hidden="true"
+          className="shrink-0 text-gray-400 dark:text-gray-500"
+        />
+      )}
+      <span className="truncate text-sm font-medium">{label}</span>
+      <span className="ml-auto shrink-0 text-xs text-gray-500 dark:text-gray-400">
+        {state === 'on' ? 'Linked' : state === 'off' ? 'Not linked' : '…'}
+      </span>
+    </span>
+  );
+}
+
+const THEME_LABELS: Record<string, string> = {
+  light: 'Light',
+  dark: 'Dark',
+  system: 'System',
+};
+
+export default function ProfileHub({ form }: { form: ProfileForm }) {
+  const { strava, telegram } = useConnectionStatus();
+
+  // next-themes only knows the real theme after hydration, so the row shows a
+  // neutral placeholder until then rather than guessing and flipping.
+  const { theme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  const themeValue = mounted ? (THEME_LABELS[theme ?? 'system'] ?? 'System') : '—';
+
+  const stravaState = strava ? (strava.connected ? 'on' : 'off') : 'unknown';
+  const telegramState = telegram ? (telegram.linked ? 'on' : 'off') : 'unknown';
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold">Athlete Profile</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {summaryLine(form)}
+        </p>
+      </header>
+
+      <Link
+        href="/profile?s=connections"
+        aria-label="Connected accounts"
+        className="flex gap-2 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      >
+        <ConnectionChip label="Strava" state={stravaState} />
+        {/* Bot not configured: the row is meaningless, so it is not shown at
+            all -- the same rule LinkTelegramButton applies to itself. */}
+        {telegram?.configured !== false && (
+          <ConnectionChip label="Telegram" state={telegramState} />
+        )}
+      </Link>
+
+      <SettingGroup title="Training">
+        <SettingRow
+          href="/profile?s=training"
+          name="Goal"
+          value={GOAL_LABELS[form.goal_type] ?? form.goal_type}
+        />
+        <SettingRow
+          href="/profile?s=training"
+          name="Experience"
+          value={EXPERIENCE_LABELS[form.experience_level] ?? form.experience_level}
+        />
+        <SettingRow
+          href="/profile?s=training"
+          name="Days per week"
+          value={String(form.weekly_days_available)}
+          mono
+        />
+        <SettingRow
+          href="/profile?s=training"
+          name="Weekly volume"
+          value={form.current_weekly_km ? `${form.current_weekly_km} km` : 'Not set'}
+          valueTone={form.current_weekly_km ? 'default' : 'attention'}
+          mono={Boolean(form.current_weekly_km)}
+        />
+      </SettingGroup>
+
+      <SettingGroup title="You">
+        <SettingRow
+          href="/profile?s=body"
+          name="Heart rate"
+          value={heartRateValue(form)}
+          mono={Boolean(form.max_hr || form.resting_hr)}
+        />
+        <SettingRow
+          href="/profile?s=body"
+          name="Build"
+          value={buildValue(form)}
+          valueTone={form.weight_kg == null && form.height_cm == null ? 'muted' : 'default'}
+          mono={form.weight_kg != null || form.height_cm != null}
+        />
+        <SettingRow
+          href="/profile?s=health"
+          name="Injuries & health"
+          value={form.injury_notes.trim() ? 'Noted' : 'Nothing noted'}
+          valueTone={form.injury_notes.trim() ? 'default' : 'muted'}
+        />
+      </SettingGroup>
+
+      {/* These three save independently of the profile, which is why they sit
+          in their own group and their own screens rather than under the
+          profile's Save. */}
+      <SettingGroup title="Your coach">
+        <SettingRow
+          href="/profile?s=voice"
+          name="Voice"
+          value="How it sounds"
+          valueTone="muted"
+        />
+        <SettingRow
+          href="/profile?s=stance"
+          name="Stance"
+          value="What it emphasises"
+          valueTone="muted"
+        />
+        <SettingRow
+          href="/profile?s=materials"
+          name="Coaching materials"
+          value="Your uploads"
+          valueTone="muted"
+        />
+      </SettingGroup>
+
+      <SettingGroup title="App">
+        <SettingRow
+          href="/profile?s=app"
+          name="Week starts on"
+          value={form.week_starts_on === 6 ? 'Sunday' : 'Monday'}
+        />
+        <SettingRow href="/profile?s=app" name="Appearance" value={themeValue} />
+      </SettingGroup>
+    </div>
+  );
+}

--- a/frontend/components/profile/SectionScreen.tsx
+++ b/frontend/components/profile/SectionScreen.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronLeft, Loader2 } from 'lucide-react';
+import { ReactNode } from 'react';
+
+// The chrome every profile detail screen shares (#941): back to the hub on the
+// left, the screen's name as the page heading, and -- where the screen edits
+// profile fields -- one Save on the right.
+//
+// Screens that own their own save (the coach dial panels, the connection
+// buttons) pass no onSave and get no button, which is what makes it
+// unambiguous which control writes what. The old page put a "Save Profile"
+// button above three panels that each saved separately.
+
+export default function SectionScreen({
+  title,
+  description,
+  backHref = '/profile',
+  onSave,
+  saving = false,
+  children,
+}: {
+  title: string;
+  description?: string;
+  backHref?: string;
+  onSave?: () => void;
+  saving?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="mb-6 flex items-center gap-2">
+        <Link
+          href={backHref}
+          className="-ml-2 flex min-h-[44px] items-center gap-1 rounded-md px-2 text-blue-600 transition-colors hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-blue-400 dark:hover:bg-blue-900/30"
+        >
+          <ChevronLeft size={20} aria-hidden="true" />
+          <span className="text-sm">Profile</span>
+        </Link>
+
+        <h1 className="flex-1 truncate text-center text-lg font-semibold">{title}</h1>
+
+        {onSave ? (
+          <button
+            type="submit"
+            onClick={onSave}
+            disabled={saving}
+            className="flex min-h-[44px] items-center gap-1.5 rounded-md px-3 text-sm font-semibold text-blue-600 transition-colors hover:bg-blue-50 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-blue-400 dark:hover:bg-blue-900/30"
+          >
+            {saving && <Loader2 size={14} className="animate-spin" aria-hidden="true" />}
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        ) : (
+          // Keeps the heading optically centred against the back link.
+          <span aria-hidden="true" className="w-[72px]" />
+        )}
+      </div>
+
+      {description && (
+        <p className="mb-5 text-sm text-gray-500 dark:text-gray-400">{description}</p>
+      )}
+
+      {children}
+    </div>
+  );
+}

--- a/frontend/components/profile/SettingRow.tsx
+++ b/frontend/components/profile/SettingRow.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronRight } from 'lucide-react';
+import { ReactNode } from 'react';
+
+// The hub's building blocks (#941): a titled group of rows, each stating a
+// setting's CURRENT VALUE and linking to the screen that edits it. Rows are
+// real links so they keep link semantics -- keyboard, focus ring, open in new
+// tab -- and so Next keeps the profile route mounted when only the query
+// changes, which is what makes the hub feel instant.
+
+export function SettingGroup({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  const headingId = `group-${title.toLowerCase().replace(/[^a-z]+/g, '-')}`;
+  return (
+    <section aria-labelledby={headingId}>
+      <h2
+        id={headingId}
+        className="px-1 pb-2 text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+      >
+        {title}
+      </h2>
+      <div className="overflow-hidden rounded-xl border bg-white dark:border-gray-700 dark:bg-gray-800">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export function SettingRow({
+  href,
+  name,
+  value,
+  valueTone = 'default',
+  mono = false,
+}: {
+  href: string;
+  name: string;
+  // The current value, read out after the name so the row announces as
+  // "Goal, Half marathon" rather than leaving the value as decoration.
+  value: string;
+  valueTone?: 'default' | 'muted' | 'attention';
+  mono?: boolean;
+}) {
+  const toneClass =
+    valueTone === 'attention'
+      ? 'text-amber-700 dark:text-amber-400'
+      : valueTone === 'muted'
+        ? 'text-gray-400 dark:text-gray-500'
+        : 'text-gray-500 dark:text-gray-400';
+
+  return (
+    <Link
+      href={href}
+      className="flex min-h-[56px] items-center gap-3 border-b px-4 py-2 transition-colors last:border-b-0 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 dark:border-gray-700 dark:hover:bg-gray-700/40"
+    >
+      <span className="flex-1 text-[15px]">{name}</span>
+      <span className={`text-sm ${toneClass} ${mono ? 'font-mono' : ''}`}>{value}</span>
+      <ChevronRight
+        size={18}
+        aria-hidden="true"
+        className="shrink-0 text-gray-400 dark:text-gray-500"
+      />
+    </Link>
+  );
+}

--- a/frontend/components/profile/controls.tsx
+++ b/frontend/components/profile/controls.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { InputHTMLAttributes, ReactNode } from 'react';
+
+// Form controls for the profile section screens (#941). Every one of these
+// keeps the programmatic association the flat form had (#849, #873, #912): the
+// choice controls are real radio inputs inside a fieldset whose legend names
+// them, so a screen reader announces the group and the option together, and any
+// hint is wired through aria-describedby on the fieldset rather than floating
+// beside it.
+
+export function FieldHint({ id, children }: { id: string; children: ReactNode }) {
+  return (
+    <p id={id} className="text-xs text-gray-500 dark:text-gray-400">
+      {children}
+    </p>
+  );
+}
+
+type Option = { value: string | number; label: string; note?: string };
+
+// Radio group rendered as pill chips. Wraps to as many rows as it needs, so a
+// long option set stays readable at phone width instead of truncating.
+export function ChipGroup({
+  legend,
+  name,
+  options,
+  value,
+  onChange,
+  hintId,
+}: {
+  legend: string;
+  name: string;
+  options: Option[];
+  value: string | number;
+  onChange: (value: string) => void;
+  hintId?: string;
+}) {
+  return (
+    <fieldset aria-describedby={hintId}>
+      <legend className="text-sm font-medium mb-2">{legend}</legend>
+      <div className="flex flex-wrap gap-2">
+        {options.map((option) => (
+          <label key={option.value} className="cursor-pointer">
+            <input
+              type="radio"
+              name={name}
+              value={option.value}
+              checked={value === option.value}
+              onChange={(e) => onChange(e.target.value)}
+              className="sr-only peer"
+            />
+            <span className="flex items-center min-h-[44px] px-4 rounded-full border border-gray-300 text-sm text-gray-700 transition-colors peer-checked:border-blue-600 peer-checked:bg-blue-50 peer-checked:font-semibold peer-checked:text-blue-700 peer-focus-visible:ring-2 peer-focus-visible:ring-blue-500 peer-focus-visible:ring-offset-2 dark:border-gray-600 dark:text-gray-200 dark:peer-checked:border-blue-500 dark:peer-checked:bg-blue-900/40 dark:peer-checked:text-blue-200 dark:peer-focus-visible:ring-offset-gray-800">
+              {option.label}
+            </span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+// Radio group rendered as one joined bar. For 2-3 mutually exclusive options
+// where seeing them side by side IS the explanation (Monday vs Sunday).
+export function SegmentedControl({
+  legend,
+  name,
+  options,
+  value,
+  onChange,
+  hintId,
+}: {
+  legend: string;
+  name: string;
+  options: Option[];
+  value: string | number;
+  onChange: (value: string) => void;
+  hintId?: string;
+}) {
+  return (
+    <fieldset aria-describedby={hintId}>
+      <legend className="text-sm font-medium mb-2">{legend}</legend>
+      <div className="flex rounded-lg border border-gray-300 overflow-hidden dark:border-gray-600">
+        {options.map((option) => (
+          <label
+            key={option.value}
+            className="flex-1 cursor-pointer border-r border-gray-300 last:border-r-0 dark:border-gray-600"
+          >
+            <input
+              type="radio"
+              name={name}
+              value={option.value}
+              checked={value === option.value}
+              onChange={(e) => onChange(e.target.value)}
+              className="sr-only peer"
+            />
+            <span className="flex items-center justify-center min-h-[44px] px-2 text-sm text-gray-700 transition-colors peer-checked:bg-blue-100 peer-checked:font-semibold peer-checked:text-blue-800 peer-focus-visible:ring-2 peer-focus-visible:ring-inset peer-focus-visible:ring-blue-500 dark:text-gray-200 dark:peer-checked:bg-blue-900/50 dark:peer-checked:text-blue-200">
+              {option.label}
+            </span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+// A 1..max radio row for a small integer count.
+export function CountPicker({
+  legend,
+  name,
+  max,
+  value,
+  onChange,
+  hintId,
+}: {
+  legend: string;
+  name: string;
+  max: number;
+  value: number;
+  onChange: (value: string) => void;
+  hintId?: string;
+}) {
+  return (
+    <fieldset aria-describedby={hintId}>
+      <legend className="text-sm font-medium mb-2">{legend}</legend>
+      <div className="grid grid-cols-7 gap-1.5">
+        {Array.from({ length: max }, (_, i) => i + 1).map((n) => (
+          <label key={n} className="cursor-pointer">
+            <input
+              type="radio"
+              name={name}
+              value={n}
+              checked={value === n}
+              onChange={(e) => onChange(e.target.value)}
+              className="sr-only peer"
+            />
+            <span className="flex items-center justify-center min-h-[44px] rounded-lg border border-gray-300 font-mono text-sm text-gray-700 transition-colors peer-checked:border-blue-600 peer-checked:bg-blue-50 peer-checked:font-semibold peer-checked:text-blue-700 peer-focus-visible:ring-2 peer-focus-visible:ring-blue-500 dark:border-gray-600 dark:text-gray-200 dark:peer-checked:border-blue-500 dark:peer-checked:bg-blue-900/40 dark:peer-checked:text-blue-200">
+              {n}
+            </span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+// Numeric input with its unit rendered beside it. The unit is aria-hidden
+// because it is already in the visible label ("Weight (kg)").
+export function NumberField({
+  id,
+  label,
+  unit,
+  value,
+  onChange,
+  hintId,
+  ...inputProps
+}: {
+  id: string;
+  label: string;
+  unit?: string;
+  value: string | number;
+  onChange: (value: string) => void;
+  hintId?: string;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'id' | 'value' | 'onChange'>) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium mb-1">
+        {label}
+      </label>
+      <div className="flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 focus-within:ring-2 focus-within:ring-blue-500 dark:border-gray-600 dark:bg-gray-900">
+        <input
+          {...inputProps}
+          type="number"
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          aria-describedby={hintId}
+          className="min-h-[46px] w-full bg-transparent font-mono text-base text-gray-900 outline-none dark:text-gray-100"
+        />
+        {unit && (
+          <span aria-hidden="true" className="text-sm text-gray-500 dark:text-gray-400">
+            {unit}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/profile/profileForm.ts
+++ b/frontend/components/profile/profileForm.ts
@@ -1,0 +1,87 @@
+// The profile edit payload, unchanged from the single-form page it replaces
+// (#941). Every section screen edits a copy of this shape and saves the WHOLE
+// object, because PUT /api/profile validates against UserProfileCreate, which
+// requires goal_type, experience_level and weekly_days_available on every
+// request -- a per-section partial body would be rejected before
+// `exclude_unset` ever ran.
+
+export type ProfileForm = {
+  goal_type: string;
+  experience_level: string;
+  weekly_days_available: number;
+  current_weekly_km: number;
+  injury_notes: string;
+  upcoming_races: unknown[];
+  max_hr: number;
+  resting_hr: number;
+  // #742: null, not 0. These post straight through to the coach pack, and the
+  // backend rejects a physiologically impossible figure rather than coaching on
+  // it -- so the other fields' 0-means-empty sentinel would be a 422 here.
+  weight_kg: number | null;
+  height_cm: number | null;
+  week_starts_on: number; // 0=Monday (default), 6=Sunday (#676)
+};
+
+export const EMPTY_PROFILE_FORM: ProfileForm = {
+  goal_type: 'general',
+  experience_level: 'intermediate',
+  weekly_days_available: 4,
+  current_weekly_km: 0,
+  injury_notes: '',
+  // upcoming_races is round-tripped, never edited here; the form has no UI for
+  // it and dropping the key would leave the stored races unset on every save.
+  upcoming_races: [],
+  max_hr: 0,
+  resting_hr: 0,
+  weight_kg: null,
+  height_cm: null,
+  week_starts_on: 0,
+};
+
+// #742: clearing a body field must send null ("not stated"), never 0 -- the
+// coach pack drops an unstated build rather than reading it as a real figure.
+const NULLABLE_NUMERIC = ['weight_kg', 'height_cm'];
+const NUMERIC = [
+  'weekly_days_available',
+  'current_weekly_km',
+  'max_hr',
+  'resting_hr',
+  'week_starts_on',
+];
+
+export function coerceField(name: string, value: string): string | number | null {
+  if (NULLABLE_NUMERIC.includes(name)) return value === '' ? null : Number(value);
+  if (NUMERIC.includes(name)) return Number(value);
+  return value;
+}
+
+export function profileFromApi(data: Record<string, unknown> | null): ProfileForm {
+  if (!data) return EMPTY_PROFILE_FORM;
+  return {
+    goal_type: (data.goal_type as string) || 'general',
+    experience_level: (data.experience_level as string) || 'intermediate',
+    weekly_days_available: (data.weekly_days_available as number) || 4,
+    current_weekly_km: (data.current_weekly_km as number) || 0,
+    injury_notes: (data.injury_notes as string) || '',
+    upcoming_races: (data.upcoming_races as unknown[]) || [],
+    max_hr: (data.max_hr as number) || 0,
+    resting_hr: (data.resting_hr as number) || 0,
+    weight_kg: (data.weight_kg as number | null) ?? null,
+    height_cm: (data.height_cm as number | null) ?? null,
+    week_starts_on: (data.week_starts_on as number) ?? 0,
+  };
+}
+
+export const GOAL_LABELS: Record<string, string> = {
+  general: 'General fitness',
+  '5k': '5k',
+  '10k': '10k',
+  half: 'Half marathon',
+  marathon: 'Marathon',
+};
+
+export const EXPERIENCE_LABELS: Record<string, string> = {
+  new: 'Beginner',
+  intermediate: 'Intermediate',
+  advanced: 'Advanced',
+};

--- a/frontend/lib/useConnectionStatus.ts
+++ b/frontend/lib/useConnectionStatus.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { fetchFromAPI } from '@/lib/api';
+
+// #941: the profile hub states Strava and Telegram as VALUES ("Connected",
+// "Not linked") alongside every other setting, so the summary reads as one list
+// rather than a row of live controls. The controls themselves stay in
+// ConnectStravaButton / LinkTelegramButton on the connections screen; this hook
+// only reads, and deliberately duplicates their fetch rather than refactoring
+// two working components to hoist their state.
+//
+// Fails to "unknown", never to "disconnected": telling a runner their Strava is
+// gone because a status call failed is worse than saying nothing.
+
+export type StravaConnection = {
+  connected: boolean;
+  athleteId: number | null;
+};
+
+export type TelegramConnection = {
+  // Bot not configured at all -- the row is meaningless and the hub hides it,
+  // matching LinkTelegramButton's own rule.
+  configured: boolean;
+  linked: boolean;
+};
+
+export type ConnectionStatus = {
+  loading: boolean;
+  strava: StravaConnection | null;
+  telegram: TelegramConnection | null;
+};
+
+export function useConnectionStatus(): ConnectionStatus {
+  const [loading, setLoading] = useState(true);
+  const [strava, setStrava] = useState<StravaConnection | null>(null);
+  const [telegram, setTelegram] = useState<TelegramConnection | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const readStrava = fetchFromAPI('/api/auth/strava/status')
+      .then((data) => {
+        if (cancelled || !data) return;
+        setStrava({
+          connected: Boolean(data.connected),
+          athleteId: data.athlete_id ?? null,
+        });
+      })
+      .catch(() => {
+        /* leave null: unknown, not disconnected */
+      });
+
+    const readTelegram = fetchFromAPI('/api/coach/telegram/link-status')
+      .then((data) => {
+        if (cancelled || !data) return;
+        setTelegram({
+          configured: Boolean(data.configured),
+          linked: Boolean(data.linked),
+        });
+      })
+      .catch(() => {
+        /* leave null */
+      });
+
+    Promise.all([readStrava, readTelegram]).finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { loading, strava, telegram };
+}


### PR DESCRIPTION
Closes #941.

## What changed

The profile opened straight into its whole edit surface: a theme control, Strava status, Telegram status and a Cancel link sharing one `flex-wrap` row, then nine fields in a single undifferentiated card. Nothing stated a current value as a value — you read each one off the control holding it.

It now opens on a hub. Every setting is a row stating what it currently is, grouped into **Training / You / Your coach / App**, with connection state as two chips at the top. Each row opens a focused screen behind a `?s=` query param on the same route, so the page component stays mounted: opening a screen refetches nothing, and Back returns to the hub rather than leaving the page.

Three structural fixes fall out of the split:

- The coach dial panels used to render **below** the profile's Save button while saving separately from it. They now have their own screens, and only screens that edit profile fields carry a Save.
- Back discards an abandoned edit instead of carrying it into the next save.
- A failed save states what happened in place and keeps the edits, rather than raising a browser `alert()` and navigating away.

Two smaller things picked up on the way: the page was applying its own `p-4` inside the layout's `px-4`, so mobile gutters were 32px rather than 16; and the coach launcher was landing on the last row, which on the hub is a link — so it was covering a tap target, not just some text.

## What did not change

The request is identical: one PUT of the whole profile object, the same eleven keys, the same `0`-means-empty and `null`-means-not-stated coercion. Per-section partial bodies are not possible — `UserProfileCreate` requires `goal_type`, `experience_level` and `weekly_days_available` on every request, so validation rejects them before `exclude_unset` ever runs.

The choice controls are real radio inputs in a `fieldset` whose `legend` names them, so the group and the option are announced together (#849, #873, #912). `ConnectStravaButton`, `LinkTelegramButton`, `ImportStravaHistory`, `ThemeToggle` and the three dial panels are reused untouched.

## Verification

- `tsc --noEmit` clean; `next lint` clean apart from the pre-existing `CoachSheet.tsx:485` warning; `next build` clean.
- `make frontend-smoke` passes.
- The built page driven in Chromium against a mock API, 31 checks: the PUT carries exactly the flat form's eleven keys, edited fields reach the server, untouched fields survive, `upcoming_races` round-trips, a cleared weight posts `null` not `0` (#742), Back sends no PUT and discards the edit, coach screens carry no profile Save, and a row tap keeps the component mounted with no refetch.
- All re-run after rebasing onto current `main`.

**Not verified:** there is no real backend in the environment this was built in, so every runtime check ran against a mock matched to the Pydantic schema by reading it. Real 422 handling, Clerk session handling through the proxy, and the live Strava/Telegram status shapes are unconfirmed. The visual judgement is unverified by definition — worth a look on a real phone, in both themes.

## Known limitations

- The three coach rows show descriptors ("Voice — How it sounds") rather than live values, because reading real state means three more requests on a summary screen. It is the one place the hub does not keep its promise.
- All four Training rows open the same screen, so tapping "Experience" lands on a screen titled "Training goal". One screen per row would have meant thirteen screens.

## Follow-ups, not in this PR

- The coach launcher overlaps content app-wide: `main` reserves room for the tab bar but not the FAB. Fixed here on `/profile` only; Load, Trends and Schedule likely have the same bite.
- `useConnectionStatus` duplicates fetches `ConnectStravaButton` and `LinkTelegramButton` already make, rather than refactoring two working components.
- `project-context.md` calls `frontend/app/profile/page.tsx` "the profile editor" and does not know about `frontend/components/profile/`. Refreshing it is its own task (and overlaps #907).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRHAiF3dzGcnbXEJHgdDFG

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRHAiF3dzGcnbXEJHgdDFG)_