### PR TITLE
feat(navigation): Trends, All Activities and Load step back a period at a time (#948)

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -225,6 +225,21 @@ def read_activities(
     # already-normalized instances directly to keep normalization at exactly one pass.
     return JSONResponse(content=jsonable_encoder(responses))
 
+
+@router.get("/activities/earliest-date")
+def read_earliest_activity_date(db: DbSession, user: CurrentUser):
+    """The local calendar day of the runner's oldest non-deleted activity, or
+    null with no history (#948).
+
+    The window-navigation floor for the Activities and Trends screens: fetched
+    once per screen load so a Previous-arrow tap can clamp against it without a
+    round trip per step. Registered ahead of ``/activities/{activity_id}`` so
+    "earliest-date" is never captured as an activity id.
+    """
+    earliest = activity_queries.get_earliest_activity_local_date(db, user_id=user.id)
+    return {"earliest_activity_date": earliest.isoformat() if earliest else None}
+
+
 @router.get("/activities/{activity_id}", response_model=ActivityDetailRead)
 def read_activity(
     activity: OwnedActivityDetail,

--- a/backend/app/api/trends.py
+++ b/backend/app/api/trends.py
@@ -2,6 +2,7 @@
 API router for /api/trends — aggregated activity data for trend charts.
 """
 
+from datetime import date
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
@@ -41,10 +42,16 @@ def get_trends(
     range: str = Query("30D", description="Time range: 7D, 30D, 3M, 6M, 1Y, ALL"),
     types: Optional[List[str]] = Query(None, description="Activity types to include (multi-select)"),
     mode: str = Query("rolling", description="Window framing: rolling | calendar (#400)"),
+    as_of: Optional[date] = Query(
+        None,
+        description="Judge the (range, mode) window as of this date instead of "
+        "today (#948), so window-navigation arrows can step the whole report "
+        "back and forward. Defaults to today.",
+    ),
     db: Session = Depends(get_db),
     user: User = Depends(require_current_user),
 ):
-    return get_trends_report(db, range, types, user_id=user.id, mode=mode)
+    return get_trends_report(db, range, types, user_id=user.id, mode=mode, as_of=as_of)
 
 
 @router.get("/trends/load", response_model=LoadResponse)
@@ -60,15 +67,21 @@ def get_training_load(
 def get_volume(
     range: str = Query("7D", description="7D | 30D | 3M | 6M | 1Y"),
     types: Optional[List[str]] = Query(None, description="Activity types to include (multi-select)"),
+    as_of: Optional[date] = Query(
+        None,
+        description="Judge the report as of this date instead of today (#948), "
+        "so window-navigation arrows can step the vs-norm read back and forward "
+        "in step with the Trends charts. Defaults to today.",
+    ),
     db: Session = Depends(get_db),
     user: User = Depends(require_current_user),
 ):
-    """Frequency-/volume-vs-norm report for the selected range, as of today:
-    per-metric current vs the runner's norm, in rolling and calendar-period
-    framings scaled to the range (#400). ``types`` scopes both the window and the
-    norm baseline so the comparison stays like-for-like with the filtered Trends
-    charts (#413)."""
-    return get_volume_report(db, user.id, range, types=types)
+    """Frequency-/volume-vs-norm report for the selected range, as of `as_of`
+    (defaults to today): per-metric current vs the runner's norm, in rolling and
+    calendar-period framings scaled to the range (#400). ``types`` scopes both
+    the window and the norm baseline so the comparison stays like-for-like with
+    the filtered Trends charts (#413)."""
+    return get_volume_report(db, user.id, range, as_of=as_of, types=types)
 
 
 @router.get("/stats/weekly", response_model=WeeklyStatsResponse)

--- a/backend/app/services/activity_queries.py
+++ b/backend/app/services/activity_queries.py
@@ -69,6 +69,31 @@ def get_activities(
     )
 
 
+def get_earliest_activity_local_date(db: Session, *, user_id: uuid.UUID) -> date | None:
+    """The local calendar day of the runner's oldest non-deleted activity, or
+    None with no history (#948).
+
+    Window-navigation arrows (Activities, Trends) must stop stepping backward
+    once the target window would fall entirely before the runner's history
+    rather than paging into an empty one; this is the floor they clamp against.
+    Fetched once per screen load and reused across steps rather than re-queried
+    per step. Uses the same ``coalesce(start_date_local, start_date)``
+    local-day precedence as ``get_activities``'s own filtering.
+    """
+    local_start = func.coalesce(Activity.start_date_local, Activity.start_date)
+    earliest = (
+        db.query(local_start)
+        .filter(Activity.is_deleted == False)  # noqa: E712
+        .filter(Activity.user_id == user_id)
+        .order_by(local_start.asc())
+        .limit(1)
+        .scalar()
+    )
+    if earliest is None:
+        return None
+    return earliest.date() if isinstance(earliest, datetime) else earliest
+
+
 def get_activity(
     db: Session,
     activity_id: str | uuid.UUID,

--- a/backend/app/services/trends.py
+++ b/backend/app/services/trends.py
@@ -525,6 +525,7 @@ def get_trends_report(
     *,
     user_id=None,
     mode: str = "rolling",
+    as_of: Optional[date] = None,
 ) -> TrendsResponse:
     """
     Main entry point for generating the complete trends report.
@@ -533,17 +534,22 @@ def get_trends_report(
     global window framing: ``rolling`` (trailing N days, the default) or
     ``calendar`` (the current calendar period — week/month/quarter/half/year — for
     the range), which shifts the window start and the previous-period comparison
-    for the whole report (summary, deltas, and every chart).
+    for the whole report (summary, deltas, and every chart). ``as_of`` (#948) is
+    the date the window is judged as of, defaulting to today; passing an earlier
+    date shows the same (range, mode) window as it stood on that date instead of
+    the one ending today, so window-navigation arrows can step the whole report
+    back and forward a period at a time.
     """
     range_upper = range_key.upper()
     if range_upper not in ALLOWED_RANGES:
         range_upper = "30D"
     if mode not in ("rolling", "calendar"):
         mode = "rolling"
+    resolved_as_of = as_of or date.today()
 
     # The (range, mode) window: `since` starts the current window; the previous
     # comparison spans [prev_start, prev_end). Calendar mode shifts both.
-    since, prev_start, prev_end = resolve_window(range_upper, mode)
+    since, prev_start, prev_end = resolve_window(range_upper, mode, today=resolved_as_of)
 
     # The runner's chosen week start (0=Monday default, 6=Sunday), which the
     # calendar-mode weekly/biweekly bars align to (#676). Rolling mode buckets by
@@ -554,17 +560,19 @@ def get_trends_report(
         else None
     )
 
-    # Rolling mode buckets the bars in fixed-width blocks rolling back from today
-    # rather than snapping to the calendar grid (#630). None keeps the calendar
-    # keying (ISO-Monday weeks / calendar months / the fortnight grid).
-    rolling_anchor: Optional[date] = date.today() if mode == "rolling" else None
+    # Rolling mode buckets the bars in fixed-width blocks rolling back from
+    # `as_of` rather than snapping to the calendar grid (#630). None keeps the
+    # calendar keying (ISO-Monday weeks / calendar months / the fortnight grid).
+    rolling_anchor: Optional[date] = resolved_as_of if mode == "rolling" else None
 
-    # Chart x-axis frame end (#413): rolling stops at today (until=None); calendar
-    # spans the whole current period (e.g. Mon–Sun for 7D), so the period's last
-    # day frames the chart and days after today render as empty bars.
-    until: Optional[date] = None
+    # Chart x-axis frame end (#413): rolling stops at `as_of` (today by default);
+    # calendar spans the whole current period (e.g. Mon–Sun for 7D), so the
+    # period's last day frames the chart and days after `as_of` render as empty
+    # bars. Set explicitly (rather than left None) so a stepped-back `as_of`
+    # cannot fall through to a builder's own real-today default (#948).
+    until: Optional[date] = resolved_as_of
     if mode == "calendar" and range_upper in RANGE_DAYS and RANGE_DAYS[range_upper]:
-        _, until, _, _ = calendar_period(range_upper, date.today(), week_starts_on)
+        _, until, _, _ = calendar_period(range_upper, resolved_as_of, week_starts_on)
 
     # 1. Activity-level facts (filtered by types if provided)
     activity_facts = build_activity_facts(

--- a/backend/tests/test_window_navigation_948.py
+++ b/backend/tests/test_window_navigation_948.py
@@ -1,0 +1,231 @@
+"""Window-navigation arrows on Trends/Activities/Load step by exactly one
+selected period and never silently re-anchor to real "today" (#948).
+
+`get_trends_report`/`get_volume_report` already resolved most of the window
+from an explicit `as_of`/`today` date; the bug this closes is narrower but would
+have made every rolling-mode step a no-op: the chart x-axis end (`until`) fell
+through to a builder's own `date.today()` default whenever the caller passed an
+`as_of` that was not literally today, so a stepped-back rolling window still
+rendered bars up to the real current date. These tests pin the fix at the
+function level (deterministic, independent of the real wall-clock date) and at
+the API level (the new `as_of` query params + the earliest-activity-date
+floor endpoint).
+"""
+
+import uuid
+from datetime import date, datetime, time, timedelta
+
+from app.api.profile import get_current_user_profile
+from app.models import Activity, DerivedMetric, User
+from app.services.activity_facts import resolve_window
+from app.services.activity_queries import get_earliest_activity_local_date
+from app.services.trends import get_trends_report
+
+
+def _user(db) -> uuid.UUID:
+    user = User(email=f"{uuid.uuid4()}@example.com")
+    db.add(user)
+    db.flush()
+    return user.id
+
+
+def _activity_on(db, user_id, on: date, *, distance_m: int = 5000) -> Activity:
+    activity = Activity(
+        user_id=user_id,
+        strava_activity_id=int(uuid.uuid4().int % 1_000_000_000),
+        start_date=datetime.combine(on, time(12, 0)),
+        type="Run",
+        name="Run",
+        distance_m=distance_m,
+        moving_time_s=1500,
+        elapsed_time_s=1500,
+        elev_gain_m=0.0,
+        raw_summary={},
+    )
+    db.add(activity)
+    db.flush()
+    db.add(
+        DerivedMetric(
+            id=uuid.uuid4(),
+            activity_id=activity.id,
+            effort_score=1.0,
+            confidence="high",
+            flags=[],
+            confidence_reasons=[],
+        )
+    )
+    db.flush()
+    return activity
+
+
+# A fixed anchor divorced from the real wall-clock date, so these tests are
+# deterministic regardless of when they run and cannot pass by accident just
+# because `as_of` happens to equal the real `date.today()`.
+_ANCHOR = date(2021, 3, 17)  # a Wednesday
+
+
+# ---------------------------------------------------------------------------
+# resolve_window: the (range, mode) -> (since, prev_start, prev_end) primitive
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_window_rolling_honours_an_explicit_today():
+    since, prev_start, prev_end = resolve_window("7D", "rolling", today=_ANCHOR)
+    assert since == _ANCHOR - timedelta(days=6)
+    assert prev_end == since
+    assert prev_start == since - timedelta(days=7)
+
+
+def test_resolve_window_calendar_honours_an_explicit_today():
+    since, prev_start, prev_end = resolve_window("30D", "calendar", today=_ANCHOR)
+    assert since == _ANCHOR.replace(day=1)
+    assert prev_end == since
+
+
+def test_resolve_window_all_range_ignores_today():
+    assert resolve_window("ALL", "rolling", today=_ANCHOR) == (None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# get_trends_report: the regression this issue is actually about — the whole
+# report (including the chart x-axis end) must follow `as_of`, not real today.
+# ---------------------------------------------------------------------------
+
+
+def test_rolling_report_window_ends_on_as_of_not_real_today(db):
+    uid = _user(db)
+    _activity_on(db, uid, _ANCHOR)
+    _activity_on(db, uid, _ANCHOR - timedelta(days=6))
+
+    report = get_trends_report(db, "7D", user_id=uid, mode="rolling", as_of=_ANCHOR)
+
+    # Exactly 7 continuous days, the last one being as_of itself. Before the fix
+    # `until` fell through to a builder's own `date.today()` default, so this
+    # would fail (wrong length and/or wrong last date) on any day that isn't
+    # literally `_ANCHOR`.
+    assert len(report.daily_distance) == 7
+    assert report.daily_distance[0].date == _ANCHOR - timedelta(days=6)
+    assert report.daily_distance[-1].date == _ANCHOR
+    assert report.summary.activity_count == 2
+
+
+def test_rolling_report_stepping_back_one_period_is_gap_and_overlap_free(db):
+    uid = _user(db)
+    report_now = get_trends_report(db, "7D", user_id=uid, mode="rolling", as_of=_ANCHOR)
+    stepped_back = get_trends_report(
+        db, "7D", user_id=uid, mode="rolling", as_of=_ANCHOR - timedelta(days=7)
+    )
+    # The frontend steps "previous" by moving as_of to (current window start - 1
+    # day); the resulting window must abut the current one exactly.
+    assert stepped_back.daily_distance[-1].date == report_now.daily_distance[0].date - timedelta(days=1)
+    assert len(stepped_back.daily_distance) == len(report_now.daily_distance) == 7
+
+
+def test_calendar_report_as_of_shows_the_previous_month(db):
+    uid = _user(db)
+    report = get_trends_report(db, "30D", user_id=uid, mode="calendar", as_of=_ANCHOR)
+    assert report.daily_distance[0].date == _ANCHOR.replace(day=1)
+    # March 2021 has 31 days; calendar mode frames the whole month.
+    assert report.daily_distance[-1].date == date(2021, 3, 31)
+
+    prev_month_anchor = _ANCHOR.replace(day=1) - timedelta(days=1)  # Feb 28, 2021
+    prev = get_trends_report(db, "30D", user_id=uid, mode="calendar", as_of=prev_month_anchor)
+    assert prev.daily_distance[0].date == date(2021, 2, 1)
+    assert prev.daily_distance[-1].date == date(2021, 2, 28)
+
+
+def test_empty_history_as_of_a_past_date_abstains_cleanly(db):
+    uid = _user(db)
+    report = get_trends_report(db, "7D", user_id=uid, mode="rolling", as_of=_ANCHOR)
+    assert report.summary.activity_count == 0
+    assert len(report.daily_distance) == 7
+    assert all(p.total_distance_m == 0 for p in report.daily_distance)
+
+
+def test_as_of_absent_defaults_to_today_byte_identical(db):
+    """The compatibility requirement: omitting `as_of` must be unchanged."""
+    uid = _user(db)
+    _activity_on(db, uid, date.today())
+
+    with_default = get_trends_report(db, "30D", user_id=uid, mode="rolling")
+    with_explicit_today = get_trends_report(
+        db, "30D", user_id=uid, mode="rolling", as_of=date.today()
+    )
+    assert with_default.model_dump() == with_explicit_today.model_dump()
+
+    with_default_cal = get_trends_report(db, "30D", user_id=uid, mode="calendar")
+    with_explicit_today_cal = get_trends_report(
+        db, "30D", user_id=uid, mode="calendar", as_of=date.today()
+    )
+    assert with_default_cal.model_dump() == with_explicit_today_cal.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# API level: the as_of query params + the earliest-activity-date floor endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_trends_endpoint_honours_as_of(client, db):
+    uid = get_current_user_profile(db).user_id
+    _activity_on(db, uid, _ANCHOR)
+
+    resp = client.get(f"/api/trends?range=7D&mode=rolling&as_of={_ANCHOR.isoformat()}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["daily_distance"][-1]["date"] == _ANCHOR.isoformat()
+    assert body["summary"]["activity_count"] == 1
+
+
+def test_trends_endpoint_as_of_absent_is_unchanged(client, db):
+    resp_default = client.get("/api/trends?range=7D&mode=rolling")
+    resp_explicit = client.get(f"/api/trends?range=7D&mode=rolling&as_of={date.today().isoformat()}")
+    assert resp_default.status_code == resp_explicit.status_code == 200
+    assert resp_default.json() == resp_explicit.json()
+
+
+def test_volume_endpoint_honours_as_of(client, db):
+    uid = get_current_user_profile(db).user_id
+    _activity_on(db, uid, _ANCHOR)
+
+    resp = client.get(f"/api/trends/volume?range=7D&as_of={_ANCHOR.isoformat()}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["rolling"]["period_end"] == _ANCHOR.isoformat()
+    assert body["rolling"]["period_start"] == (_ANCHOR - timedelta(days=6)).isoformat()
+
+
+def test_volume_endpoint_as_of_absent_is_unchanged(client, db):
+    resp_default = client.get("/api/trends/volume?range=7D")
+    resp_explicit = client.get(f"/api/trends/volume?range=7D&as_of={date.today().isoformat()}")
+    assert resp_default.status_code == resp_explicit.status_code == 200
+    assert resp_default.json() == resp_explicit.json()
+
+
+def test_earliest_activity_date_endpoint_no_history(client):
+    resp = client.get("/api/activities/earliest-date")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"earliest_activity_date": None}
+
+
+def test_earliest_activity_date_endpoint_with_history(client, db):
+    uid = get_current_user_profile(db).user_id
+    _activity_on(db, uid, date(2020, 5, 1))
+    _activity_on(db, uid, date(2020, 6, 1))
+    _activity_on(db, uid, date(2020, 4, 15))
+
+    resp = client.get("/api/activities/earliest-date")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"earliest_activity_date": "2020-04-15"}
+
+
+def test_get_earliest_activity_local_date_scopes_to_owner_and_excludes_deleted(db):
+    uid = _user(db)
+    other_uid = _user(db)
+    _activity_on(db, other_uid, date(2019, 1, 1))
+    a = _activity_on(db, uid, date(2022, 1, 1))
+    deleted = _activity_on(db, uid, date(2018, 1, 1))
+    deleted.is_deleted = True
+    db.flush()
+
+    assert get_earliest_activity_local_date(db, user_id=uid) == date(2022, 1, 1)
+    assert get_earliest_activity_local_date(db, user_id=other_uid) == date(2019, 1, 1)

--- a/frontend/app/activities/page.tsx
+++ b/frontend/app/activities/page.tsx
@@ -54,12 +54,23 @@ export default function AllActivitiesPage() {
   const [hasMore, setHasMore] = useState(true);
   const [availableTypes, setAvailableTypes] = useState<string[]>([]);
   const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  // The floor the date-range stepper (#948) clamps "previous" against, fetched
+  // once rather than per step; null until loaded or with no history.
+  const [earliestActivityDate, setEarliestActivityDate] = useState<string | null>(null);
 
   // The distinct activity types present in the history, for the type filter.
   // Reuses the Trends endpoint (#404), which returns non-deleted types sorted.
   useEffect(() => {
     fetchFromAPI('/api/trends/types')
       .then((types: string[] | null) => setAvailableTypes(types ?? []))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    fetchFromAPI('/api/activities/earliest-date')
+      .then((r: { earliest_activity_date: string | null } | null) =>
+        setEarliestActivityDate(r?.earliest_activity_date ?? null),
+      )
       .catch(() => {});
   }, []);
 
@@ -110,6 +121,7 @@ export default function AllActivitiesPage() {
           onChange={(r: DateRange) =>
             setFilters((f) => ({ ...f, startDate: r.startDate, endDate: r.endDate }))
           }
+          earliestActivityDate={earliestActivityDate}
         />
         {isFiltered && (
           <button

--- a/frontend/app/load/page.tsx
+++ b/frontend/app/load/page.tsx
@@ -166,7 +166,7 @@ export default function LoadPage() {
       </div>
 
       {/* Long-term trend */}
-      <LoadTrendChart weeks={data.weeks} />
+      <LoadTrendChart weeks={data.weeks} selectedWeekStart={week.week_start} />
 
       {/* Per-activity contributions */}
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-sm p-5">

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -6,6 +6,7 @@ import { TrendsData, TrendsRange, TrendsGranularity } from "@/lib/types";
 import { formatDistanceKm, formatDuration } from "@/lib/format";
 import { fetchFromAPI } from "@/lib/api";
 import RangeSelector from "@/components/trends/RangeSelector";
+import WindowStepper from "@/components/trends/WindowStepper";
 import GranularitySelector from "@/components/trends/GranularitySelector";
 import { resolveGranularity, DAYS_PER_BUCKET, ROLLING_BIN_DAYS } from "@/components/trends/granularity";
 import ActivityTypeFilter from "@/components/trends/ActivityTypeFilter";
@@ -23,6 +24,18 @@ import type {
 } from "@/lib/types/volume";
 
 type WindowMode = "rolling" | "calendar";
+
+// Parse "YYYY-MM-DD" as a local date (avoids the UTC-midnight shift `new
+// Date(iso)` would introduce), add `days` (may be negative), and format back.
+function addDaysISO(iso: string, days: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(y, m - 1, d);
+  dt.setDate(dt.getDate() + days);
+  const yy = dt.getFullYear();
+  const mm = String(dt.getMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
 
 // #746: the efficiency headline compares CLEAN-conditions activities (not hilly,
 // stop-heavy or hot) when both windows hold enough of them, because an
@@ -103,8 +116,18 @@ export default function TrendsPage() {
   const [availableTypes, setAvailableTypes] = useState<string[]>([]);
   const [data, setData] = useState<TrendsData | null>(null);
   const [volume, setVolume] = useState<VolumeReport | null>(null);
+  const [volumeLoading, setVolumeLoading] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Window navigation (#948): `asOf` judges the (range, mode) window as of this
+  // date instead of today; undefined means "today" (the live window). Stepping
+  // "previous" pushes the window we're leaving onto `asOfHistory` so "next" can
+  // simply pop back to it — a browser-history idiom that sidesteps re-deriving
+  // calendar-period math (month/quarter/year lengths vary) on the client.
+  const [asOf, setAsOf] = useState<string | undefined>(undefined);
+  const [asOfHistory, setAsOfHistory] = useState<(string | undefined)[]>([]);
+  const [earliestActivityDate, setEarliestActivityDate] = useState<string | null>(null);
 
   // The user-chosen bar granularity (#432), clamped to what the range offers.
   // Keeping the raw choice means it's remembered when the runner returns to a
@@ -145,8 +168,25 @@ export default function TrendsPage() {
       .catch(() => {});
   }, []);
 
+  // The window-navigation floor (#948): fetched once, not per step.
+  useEffect(() => {
+    fetchFromAPI("/api/activities/earliest-date")
+      .then((r: { earliest_activity_date: string | null } | null) =>
+        setEarliestActivityDate(r?.earliest_activity_date ?? null),
+      )
+      .catch(() => {});
+  }, []);
+
   // Calendar mode has no meaning for the unbounded "All" range.
   const effectiveMode: WindowMode = range === "ALL" ? "rolling" : mode;
+
+  // A window carries no meaning across a range or framing change (a "previous
+  // month" step means nothing once the range becomes 7D), so reset to "today"
+  // whenever either changes.
+  useEffect(() => {
+    setAsOf(undefined);
+    setAsOfHistory([]);
+  }, [range, effectiveMode]);
 
   // #767: publish this page's view selections for the coach sheet's screen
   // pointer + ribbon (selections only — the server recomputes the numbers).
@@ -156,7 +196,7 @@ export default function TrendsPage() {
   });
 
   const fetchTrends = useCallback(
-    async (r: TrendsRange, types: string[], m: WindowMode) => {
+    async (r: TrendsRange, types: string[], m: WindowMode, asOfParam?: string) => {
       setLoading(true);
       setError(null);
       try {
@@ -165,6 +205,7 @@ export default function TrendsPage() {
         if (types.length > 0) {
           types.forEach((t) => params.append("types", t));
         }
+        if (asOfParam) params.set("as_of", asOfParam);
         const json: TrendsData = await fetchFromAPI(`/api/trends?${params}`);
         setData(json);
       } catch (e: any) {
@@ -177,33 +218,67 @@ export default function TrendsPage() {
   );
 
   useEffect(() => {
-    fetchTrends(range, selectedTypes, effectiveMode);
-  }, [range, selectedTypes, effectiveMode, fetchTrends]);
+    fetchTrends(range, selectedTypes, effectiveMode, asOf);
+  }, [range, selectedTypes, effectiveMode, asOf, fetchTrends]);
 
   // The vs-norm comparison shown on the quick-view cards (no norm for "All").
   // Pass the same activity-type filter as the charts (#413) so "typical" is
   // scoped to the selected types and never compares a filtered window against an
-  // all-activity norm.
+  // all-activity norm. Also the source of the window-navigation bounds (#948):
+  // both framings' `period_start`/`period_end` ride this same response, so the
+  // stepper needs no extra fetch of its own.
   useEffect(() => {
     if (range === "ALL") {
       setVolume(null);
       return;
     }
     let active = true;
+    setVolumeLoading(true);
     const params = new URLSearchParams({ range });
     selectedTypes.forEach((t) => params.append("types", t));
+    if (asOf) params.set("as_of", asOf);
     fetchFromAPI(`/api/trends/volume?${params}`)
       .then((v: VolumeReport) => active && setVolume(v))
-      .catch(() => active && setVolume(null));
+      .catch(() => active && setVolume(null))
+      .finally(() => active && setVolumeLoading(false));
     return () => {
       active = false;
     };
-  }, [range, selectedTypes]);
+  }, [range, selectedTypes, asOf]);
 
   // Map each metric to its vs-norm comparison for the framing in view.
   const normByMetric: Partial<Record<string, VolumeMetricVsNorm>> = {};
   if (volume && volume.has_baseline) {
     for (const m of volume[effectiveMode].metrics) normByMetric[m.metric] = m;
+  }
+
+  // Window navigation (#948): the currently-shown window's bounds, off the same
+  // volume fetch every framing already carries `period_start`/`period_end` on
+  // regardless of whether a baseline was found.
+  const currentFraming = volume ? volume[effectiveMode] : null;
+  // Gated on !volumeLoading too: `stepWindowBack`/`stepWindowForward` below
+  // close over `currentFraming` from the render at click time, so a second tap
+  // landing before the in-flight fetch resolves would otherwise recompute the
+  // same target window off the same stale bounds instead of advancing further.
+  const canStepBack =
+    !volumeLoading &&
+    !!currentFraming &&
+    !!earliestActivityDate &&
+    earliestActivityDate < currentFraming.period_start;
+  const canStepForward = !volumeLoading && asOfHistory.length > 0;
+
+  function stepWindowBack() {
+    if (!currentFraming) return;
+    const newAsOf = addDaysISO(currentFraming.period_start, -1);
+    setAsOfHistory((h) => [...h, asOf]);
+    setAsOf(newAsOf);
+  }
+
+  function stepWindowForward() {
+    if (asOfHistory.length === 0) return;
+    const prev = asOfHistory[asOfHistory.length - 1];
+    setAsOfHistory((h) => h.slice(0, -1));
+    setAsOf(prev);
   }
 
   // "vs prev" labeling (#413): calendar mode names the period it compares to
@@ -299,6 +374,16 @@ export default function TrendsPage() {
                 </button>
               ))}
             </div>
+          )}
+          {range !== "ALL" && currentFraming && (
+            <WindowStepper
+              periodStart={currentFraming.period_start}
+              periodEnd={currentFraming.period_end}
+              canStepBack={canStepBack}
+              canStepForward={canStepForward}
+              onStepBack={stepWindowBack}
+              onStepForward={stepWindowForward}
+            />
           )}
         </div>
       </header>

--- a/frontend/components/activities/DateRangeFilter.tsx
+++ b/frontend/components/activities/DateRangeFilter.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { formatDateLabel } from "@/lib/format";
+
 export interface DateRange {
   startDate: string | null; // YYYY-MM-DD, inclusive
   endDate: string | null; // YYYY-MM-DD, inclusive
@@ -9,6 +12,10 @@ interface Props {
   startDate: string | null;
   endDate: string | null;
   onChange: (range: DateRange) => void;
+  // The local calendar day of the runner's oldest activity, or null when
+  // unknown/no history (#948). Stepping back stops here rather than paging
+  // into an empty window.
+  earliestActivityDate?: string | null;
 }
 
 // Preset windows expressed as days back from today; null = all time.
@@ -34,7 +41,33 @@ function daysAgoISO(days: number): string {
   return toISO(d);
 }
 
-export default function DateRangeFilter({ startDate, endDate, onChange }: Props) {
+function todayISO(): string {
+  return toISO(new Date());
+}
+
+// Parse "YYYY-MM-DD" as a local date (avoids the UTC-midnight shift `new
+// Date(iso)` would introduce), add `days` (may be negative), and format back.
+function addDaysISO(iso: string, days: number): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(y, m - 1, d);
+  dt.setDate(dt.getDate() + days);
+  return toISO(dt);
+}
+
+function daysBetweenInclusiveISO(startIso: string, endIso: string): number {
+  const [sy, sm, sd] = startIso.split("-").map(Number);
+  const [ey, em, ed] = endIso.split("-").map(Number);
+  const start = Date.UTC(sy, sm - 1, sd);
+  const end = Date.UTC(ey, em - 1, ed);
+  return Math.round((end - start) / 86_400_000) + 1;
+}
+
+export default function DateRangeFilter({
+  startDate,
+  endDate,
+  onChange,
+  earliestActivityDate,
+}: Props) {
   // A preset is "active" when the current range matches the window it would set:
   // a start `days` back and an open end. Editing a date input therefore clears the
   // highlight automatically, since the range no longer matches any preset.
@@ -47,6 +80,46 @@ export default function DateRangeFilter({ startDate, endDate, onChange }: Props)
     if (days === null) return !startDate && !endDate;
     return startDate === daysAgoISO(days) && !endDate;
   }
+
+  // Stepping (#948): the selected window's own length, moved back/forward by
+  // exactly that many days so the arrows always move by "the period already
+  // selected" — a preset's window or a manually-picked custom range alike. No
+  // meaning for "All" (open on both ends), so the arrows are not offered then.
+  const today = todayISO();
+  const effectiveEnd = endDate ?? today;
+  const windowDays = startDate ? daysBetweenInclusiveISO(startDate, effectiveEnd) : null;
+
+  const canStepBack =
+    !!startDate &&
+    !!earliestActivityDate &&
+    earliestActivityDate < startDate;
+  const canStepForward = endDate !== null; // open end already means "through today"
+
+  function stepBack() {
+    if (!startDate || windowDays === null) return;
+    const newEnd = addDaysISO(startDate, -1);
+    const newStart = addDaysISO(newEnd, -(windowDays - 1));
+    onChange({ startDate: newStart, endDate: newEnd });
+  }
+
+  function stepForward() {
+    if (!startDate || windowDays === null) return;
+    const newStart = addDaysISO(effectiveEnd, 1);
+    const newEnd = addDaysISO(newStart, windowDays - 1);
+    // Landing back on (or past) today re-opens the end, matching the preset's
+    // own "through today" shape rather than freezing on a stale explicit date.
+    if (newEnd >= today) {
+      onChange({ startDate: addDaysISO(today, -(windowDays - 1)), endDate: null });
+    } else {
+      onChange({ startDate: newStart, endDate: newEnd });
+    }
+  }
+
+  const showStepper = startDate !== null;
+  const windowLabel =
+    showStepper && startDate
+      ? `${formatDateLabel(startDate)} – ${formatDateLabel(effectiveEnd)}`
+      : null;
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -65,6 +138,33 @@ export default function DateRangeFilter({ startDate, endDate, onChange }: Props)
           </button>
         ))}
       </div>
+
+      {showStepper && (
+        <div className="inline-flex items-center gap-1">
+          <button
+            type="button"
+            aria-label="Previous period"
+            onClick={stepBack}
+            disabled={!canStepBack}
+            className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-30"
+          >
+            <ChevronLeft size={18} />
+          </button>
+          <span className="text-sm font-medium text-gray-600 dark:text-gray-400 min-w-[9.5rem] text-center">
+            {windowLabel}
+          </span>
+          <button
+            type="button"
+            aria-label="Next period"
+            onClick={stepForward}
+            disabled={!canStepForward}
+            className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-30"
+          >
+            <ChevronRight size={18} />
+          </button>
+        </div>
+      )}
+
       <div className="inline-flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400">
         <input
           type="date"

--- a/frontend/components/load/LoadTrendChart.tsx
+++ b/frontend/components/load/LoadTrendChart.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 type TrendView = "all" | "4w";
 
-export default function LoadTrendChart({ weeks }: Props) {
+export default function LoadTrendChart({ weeks, selectedWeekStart }: Props) {
   const [view, setView] = useState<TrendView>("all");
 
   // Per-week optimal range; null for early weeks that lack a trailing baseline.
@@ -46,19 +46,30 @@ export default function LoadTrendChart({ weeks }: Props) {
     band: filledBands[i],
   }));
 
-  // The 4-week view shows the 4 weeks PRECEDING the current week plus the
-  // current week itself (#565) — i.e. the trailing window the current week's
+  // #948: everything below follows the SELECTED week (the week-navigation
+  // arrows on the page above), not always the last entry — a runner stepping
+  // back through history must see that week's own range/status, not today's.
+  const selectedIndex = selectedWeekStart
+    ? weeks.findIndex((w) => w.week_start === selectedWeekStart)
+    : -1;
+  const effectiveIndex = selectedIndex >= 0 ? selectedIndex : weeks.length - 1;
+
+  // The 4-week view shows the 4 weeks PRECEDING the selected week plus the
+  // selected week itself (#565) — i.e. the trailing window the selected week's
   // optimal range is computed from (backend training_load.py: the band is
   // 0.8-1.3x the mean of the 4 weeks before each week). Slice after the band
   // fill so the carried-forward optimal range stays correct.
-  const WEEKS_IN_4W_VIEW = 5; // 4 trailing + current
-  const visibleData = view === "4w" ? chartData.slice(-WEEKS_IN_4W_VIEW) : chartData;
+  const WEEKS_IN_4W_VIEW = 5; // 4 trailing + selected
+  const visibleData =
+    view === "4w"
+      ? chartData.slice(Math.max(0, effectiveIndex + 1 - WEEKS_IN_4W_VIEW), effectiveIndex + 1)
+      : chartData;
 
-  // Derivation of the current week's optimal range, for the 4-week view visual:
-  // the trailing 4-week average (the chronic baseline) and the band around it
-  // that the current week is judged against. The current week is the last entry.
-  const currentWeek = weeks[weeks.length - 1];
-  const trailingWeeks = weeks.slice(Math.max(0, weeks.length - 1 - 4), weeks.length - 1);
+  // Derivation of the selected week's optimal range, for the 4-week view
+  // visual: the trailing 4-week average (the chronic baseline) and the band
+  // around it that the selected week is judged against.
+  const currentWeek = weeks[effectiveIndex];
+  const trailingWeeks = weeks.slice(Math.max(0, effectiveIndex - 4), effectiveIndex);
   const trailingAvg =
     trailingWeeks.length > 0
       ? trailingWeeks.reduce((sum, w) => sum + w.score, 0) / trailingWeeks.length

--- a/frontend/components/trends/WindowStepper.tsx
+++ b/frontend/components/trends/WindowStepper.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { formatDateLabel } from "@/lib/format";
+
+interface Props {
+  // The window currently on screen (ISO dates), so the label always states
+  // what is actually shown rather than assuming "today" (#948).
+  periodStart: string;
+  periodEnd: string;
+  canStepBack: boolean;
+  canStepForward: boolean;
+  onStepBack: () => void;
+  onStepForward: () => void;
+}
+
+/** Previous/next arrows + a "what window is this" label, matching the Load
+ * page's week-stepper treatment (chevron buttons either side of a centered
+ * label) so the three window-navigation surfaces read as one product. */
+export default function WindowStepper({
+  periodStart,
+  periodEnd,
+  canStepBack,
+  canStepForward,
+  onStepBack,
+  onStepForward,
+}: Props) {
+  return (
+    <div className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        aria-label="Previous period"
+        onClick={onStepBack}
+        disabled={!canStepBack}
+        className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-30"
+      >
+        <ChevronLeft size={18} />
+      </button>
+      <span className="text-sm font-medium text-gray-600 dark:text-gray-400 min-w-[9.5rem] text-center">
+        {formatDateLabel(periodStart)} – {formatDateLabel(periodEnd)}
+      </span>
+      <button
+        type="button"
+        aria-label="Next period"
+        onClick={onStepForward}
+        disabled={!canStepForward}
+        className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-30"
+      >
+        <ChevronRight size={18} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/scripts/smoke.mjs
+++ b/frontend/scripts/smoke.mjs
@@ -143,29 +143,186 @@ const mockProfile = {
   max_hr: 190,
 };
 
-const mockTrends = {
-  summary: {
-    total_distance_m: 25000,
-    total_moving_time_s: 7200,
-    activity_count: 3,
-    total_suffer_score: 120,
-  },
-  previous_summary: {
-    total_distance_m: 22000,
-    total_moving_time_s: 6900,
-    activity_count: 3,
-    total_suffer_score: 105,
-  },
-  daily_distance: [],
-  weekly_distance: [],
-  daily_time: [],
-  weekly_time: [],
-  daily_suffer_score: [],
-  weekly_suffer_score: [],
-  efficiency_trend: [],
-  daily_zone_load: [],
-  weekly_zone_load: [],
-};
+// #948: window-navigation support. A synthetic activity every other day over
+// ~400 days back from today, so every range/mode/as_of combination the
+// stepper can request has real (and DIFFERENT) content to show — the point
+// being to prove the arrows actually move the window, not just render it once.
+const RANGE_WINDOW_DAYS = { "7D": 7, "30D": 30, "3M": 90, "6M": 180, "1Y": 365 };
+
+function isoDate(d) {
+  return d.toISOString().slice(0, 10);
+}
+function addDaysISO(iso, days) {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return isoDate(d);
+}
+function todayISO() {
+  return isoDate(new Date());
+}
+function mondayOfISO(iso) {
+  const d = new Date(`${iso}T00:00:00Z`);
+  const day = d.getUTCDay(); // 0=Sun..6=Sat
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setUTCDate(d.getUTCDate() + diff);
+  return isoDate(d);
+}
+function calendarPeriodStart(rangeKey, asOf) {
+  const [y, m] = asOf.split("-").map(Number);
+  if (rangeKey === "7D") return mondayOfISO(asOf);
+  if (rangeKey === "30D") return `${y}-${String(m).padStart(2, "0")}-01`;
+  if (rangeKey === "3M") {
+    const qm = Math.floor((m - 1) / 3) * 3 + 1;
+    return `${y}-${String(qm).padStart(2, "0")}-01`;
+  }
+  if (rangeKey === "6M") return m <= 6 ? `${y}-01-01` : `${y}-07-01`;
+  return `${y}-01-01`; // 1Y
+}
+function computeFraming(rangeKey, mode, asOf) {
+  const n = RANGE_WINDOW_DAYS[rangeKey] ?? 7;
+  if (mode === "calendar") {
+    return { period_start: calendarPeriodStart(rangeKey, asOf), period_end: asOf };
+  }
+  return { period_start: addDaysISO(asOf, -(n - 1)), period_end: asOf };
+}
+
+function synthActivities() {
+  const today = todayISO();
+  const acts = [];
+  for (let i = 0; i < 400; i += 2) {
+    acts.push({
+      date: addDaysISO(today, -i),
+      distance_m: 5000 + (i % 5) * 1000,
+      moving_time_s: 1800 + (i % 5) * 300,
+      effort_score: 40 + (i % 5) * 10,
+    });
+  }
+  return acts; // newest first
+}
+const SYNTH_ACTIVITIES = synthActivities();
+const EARLIEST_ACTIVITY_DATE = SYNTH_ACTIVITIES[SYNTH_ACTIVITIES.length - 1].date;
+
+function activitiesInRange(start, end) {
+  return SYNTH_ACTIVITIES.filter((a) => (!start || a.date >= start) && a.date <= end);
+}
+
+function buildTrendsResponse(rangeKey, mode, asOf) {
+  const { period_start, period_end } = computeFraming(rangeKey, mode, asOf);
+  const inWindow = activitiesInRange(period_start, period_end);
+  const daily = [];
+  for (let d = period_start; d <= period_end; d = addDaysISO(d, 1)) {
+    const dayActs = inWindow.filter((a) => a.date === d);
+    daily.push({
+      date: d,
+      total_distance_m: dayActs.reduce((s, a) => s + a.distance_m, 0),
+      activity_count: dayActs.length,
+    });
+  }
+  return {
+    range: rangeKey,
+    summary: {
+      total_distance_m: inWindow.reduce((s, a) => s + a.distance_m, 0),
+      total_moving_time_s: inWindow.reduce((s, a) => s + a.moving_time_s, 0),
+      activity_count: inWindow.length,
+      total_suffer_score: inWindow.reduce((s, a) => s + a.effort_score, 0),
+    },
+    previous_summary: null,
+    daily_distance: daily,
+    weekly_distance: [],
+    daily_time: daily.map((p) => ({
+      date: p.date,
+      total_moving_time_s: p.activity_count * 1800,
+      activity_count: p.activity_count,
+    })),
+    weekly_time: [],
+    daily_suffer_score: daily.map((p) => ({ date: p.date, effort_score: p.activity_count * 40 })),
+    weekly_suffer_score: [],
+    efficiency_trend: [],
+    daily_zone_load: [],
+    weekly_zone_load: [],
+    biweekly_distance: [],
+    monthly_distance: [],
+    biweekly_time: [],
+    monthly_time: [],
+    biweekly_suffer_score: [],
+    monthly_suffer_score: [],
+    biweekly_zone_load: [],
+    monthly_zone_load: [],
+  };
+}
+
+function buildVolumeResponse(rangeKey, asOf) {
+  const days = RANGE_WINDOW_DAYS[rangeKey] ?? 7;
+  function framing(mode) {
+    const { period_start, period_end } = computeFraming(rangeKey, mode, asOf);
+    const inWindow = activitiesInRange(period_start, period_end);
+    const distance = inWindow.reduce((s, a) => s + a.distance_m, 0);
+    return {
+      framing: mode,
+      label: mode === "rolling" ? `${days}-day rolling` : "This period",
+      window_days: days,
+      days_elapsed: days,
+      complete: true,
+      period_start,
+      period_end,
+      baseline_start: addDaysISO(period_start, -84),
+      baseline_end: addDaysISO(period_start, -1),
+      metrics: [
+        {
+          metric: "sessions", current_all: inWindow.length, current_runs: inWindow.length,
+          norm: Math.round(days / 3), norm_recent: Math.round(days / 3), pct_vs_norm: 0,
+          direction: "in_line", direction_recent: "in_line",
+        },
+        {
+          metric: "distance_m", current_all: distance, current_runs: distance,
+          norm: Math.round(days * 800), norm_recent: Math.round(days * 800), pct_vs_norm: 0,
+          direction: "in_line", direction_recent: "in_line",
+        },
+        {
+          metric: "moving_time_s", current_all: 0, current_runs: 0,
+          norm: null, norm_recent: null, pct_vs_norm: null,
+          direction: "no_norm", direction_recent: "no_norm",
+        },
+        {
+          metric: "effort_score", current_all: 0, current_runs: 0,
+          norm: null, norm_recent: null, pct_vs_norm: null,
+          direction: "no_norm", direction_recent: "no_norm",
+        },
+      ],
+    };
+  }
+  return {
+    range: rangeKey,
+    rolling: framing("rolling"),
+    calendar: framing("calendar"),
+    has_baseline: true,
+    baseline_label: "the last 12 weeks",
+  };
+}
+
+function buildLoadResponse() {
+  const monday = mondayOfISO(todayISO());
+  const weeks = [];
+  for (let i = 9; i >= 0; i--) {
+    const week_start = addDaysISO(monday, -i * 7);
+    const score = 150 + ((9 - i) % 4) * 40;
+    const hasBaseline = i < 6; // the oldest few weeks abstain (no trailing 4wk yet)
+    const status = !hasBaseline ? "no_baseline" : i % 3 === 0 ? "high" : i % 3 === 1 ? "below" : "optimal";
+    weeks.push({
+      week_start,
+      score,
+      daily: [20, 30, 0, 40, 0, score - 90, 0].map((v) => Math.max(0, v)),
+      target_min: hasBaseline ? Math.round(score * 0.8) : null,
+      target_max: hasBaseline ? Math.round(score * 1.3) : null,
+      status,
+      activities:
+        i === 0
+          ? [{ id: "42", name: "Morning Tempo", date: week_start, effort_score: 48, headline: "Tempo run" }]
+          : [],
+    });
+  }
+  return { weeks, week_starts_on: 0 };
+}
 
 // #830: the schedule week. A planned week (so free mode is not the only shape
 // exercised) carrying a pinned done session, a floating one whose window has
@@ -679,6 +836,10 @@ const routesToCheck = [
   { path: "/", expectedText: "Weekly Summary" },
   { path: "/activities", expectedText: "All Activities" },
   { path: "/trends", expectedText: "Track your progress over time." },
+  // Client-fetched (loading gate), so the server-rendered shell shows the
+  // loading state rather than the fetched heading — this still proves the
+  // route boots and the mock's /api/trends/load shape is reachable.
+  { path: "/load", expectedText: "Loading…" },
   { path: "/profile", expectedText: "Loading profile..." },
   { path: "/activity/42", expectedText: "Morning Tempo" },
   { path: "/schedule", expectedText: "The week ahead" },
@@ -752,16 +913,37 @@ function createMockApiServer() {
       return;
     }
 
+    // #948: the window-navigation floor, fetched once by the Activities and
+    // Trends pages.
+    if (pathname === "/api/activities/earliest-date") {
+      return sendJson(res, 200, { earliest_activity_date: EARLIEST_ACTIVITY_DATE });
+    }
+
     if (pathname === "/api/profile") {
       return sendJson(res, 200, mockProfile);
     }
 
+    // #948: as_of (defaulting to today) drives the whole window, so the
+    // stepper's back/forward taps show materially different content.
     if (pathname === "/api/trends") {
-      return sendJson(res, 200, mockTrends);
+      const rangeKey = searchParams.get("range") ?? "30D";
+      const mode = searchParams.get("mode") ?? "rolling";
+      const asOf = searchParams.get("as_of") ?? todayISO();
+      return sendJson(res, 200, buildTrendsResponse(rangeKey, mode, asOf));
     }
 
     if (pathname === "/api/trends/types") {
       return sendJson(res, 200, ["Run"]);
+    }
+
+    if (pathname === "/api/trends/volume") {
+      const rangeKey = searchParams.get("range") ?? "7D";
+      const asOf = searchParams.get("as_of") ?? todayISO();
+      return sendJson(res, 200, buildVolumeResponse(rangeKey, asOf));
+    }
+
+    if (pathname === "/api/trends/load") {
+      return sendJson(res, 200, buildLoadResponse());
     }
 
     if (pathname === "/api/schedule/week") {


### PR DESCRIPTION
Closes #948. **Stacked on #952** (`feat/947-activity-list-by-day`) → #950, because both touch `frontend/app/activities/page.tsx`.

## What changed

Trends, All Activities and Load now step **back and forward by the period already selected**. 30D selected steps by 30 days; 3M by three months; on Load the period is the week. Every screen states which window it is showing.

These screens were anchored to today. You could change how *much* you saw, never *where you looked* — so "how did March compare" was answerable only by hand-typing dates on All Activities, and not at all on the other two.

## A real bug found on the way

`get_trends_report`'s `until` (the chart's x-axis end) fell through to a builder's own `date.today()` default whenever `as_of` was not literally today. So a stepped-back rolling window would still have drawn its bars out to the **real current date** — the window would move while the axis did not.

It was caught by writing the test first: pinning `daily_distance[-1].date == as_of` against a fixed historical anchor, independent of wall-clock date. Worth noting because it is invisible on the only case anyone ever exercises by hand — the window ending today, where the fallthrough gives the right answer for the wrong reason.

## Three screens, three different sizes of change

**Trends — the large one.** No route accepted an as-of. `get_trends_report` now takes `as_of` (defaulting to `date.today()`), and `GET /trends` and `GET /trends/volume` expose it — the volume route was not exposing `get_volume_report`'s *existing* `as_of` parameter at all. The arrows read window bounds off the `/trends/volume` response (`period_start`/`period_end`, already present in both framings), so stepping costs no extra fetch.

**All Activities — small.** The backend already accepted `start_date`/`end_date`. Arrows step by the *currently selected* window's own length, which means they work for a manually-picked custom range as well as a preset.

**Load — small, and it was already half-built.** The arrows existed. The bug was that the 4-week derivation strip and the trailing-average slice always read `weeks[weeks.length-1]` — today — instead of the selected week. So the "how this week's range is set" panel described the current week no matter where the arrows were. Now threaded through a `selectedWeekStart` prop.

## Rolling vs calendar

These give "the previous window" two genuinely different meanings, so they are not fudged into one. Rolling steps by exactly the range's day count (`new as_of = period_start - 1 day`). Calendar steps to the previous calendar period, reusing the existing `calendar_period` primitive **server-side** — the frontend never computes month/quarter/year lengths itself. #630, #413 and #179 are what window-boundary assumptions have already cost here.

## History floor

New `GET /activities/earliest-date`, fetched **once per screen** and reused across steps rather than re-queried per click. Back-stepping stops there instead of paging into empty windows; forward stops at today; "All" offers no arrows at all, because stepping an unbounded window has no meaning.

## Verification

- Backend **3526 passed, 0 failed** (rebased onto #952). 15 new tests in `test_window_navigation_948.py`: rolling and calendar window math, gap/overlap-free stepping between adjacent windows, empty-history abstention, the earliest-date endpoint (no history, with history, owner-scoped, soft-delete excluded).
- **Compatibility proven, not assumed:** `as_of`-absent is byte-identical to today's behaviour, tested at both function and API level. That was the hard requirement — this touches the busiest read path in the app.
- Frontend lint + build clean (one pre-existing warning at `CoachSheet.tsx:485`).
- **Browser-verified in Chrome, both themes**, against extended mocks carrying ~400 days of synthetic history so every window holds different real content: stepping on all three screens, forward disabled at today, back disabled at the history floor (traced to the boundary month against the mock's `2025-07-21` earliest date), and no arrows under "All".
- **Coexistence with #947 checked after rebase** — the day-grouping and the stepper both live on `activities/page.tsx` and were confirmed working together, not merely merged without conflict.

A second real bug was found during the browser pass and fixed: rapid double-clicking the Trends stepper before the in-flight fetch resolved could waste a click through a stale closure. The stepper is now disabled while loading.

## Not verified / follow-up

- **The coach's screen pointer does not carry `asOf`.** `usePublishScreenSelections` publishes the Trends range and type filter but not the stepped window, so the coach sheet's "LOOKING AT" ribbon will describe the window ending today even when the runner is looking at March. Out of scope for #948 and worth its own issue — it is exactly the class of thing ADR 0028 exists to keep honest.
- Temporary smoke scaffolding (CORS headers, a keep-alive flag) used for interactive browser driving was reverted before committing; the final `smoke.mjs` diff is only new mock endpoints and data.
- No real backend was exercised — mocks throughout.
