### PR TITLE
feat(load): open the Weekly Load Trend on 4 weeks and mark the selected one

### DIFF
--- a/frontend/components/load/LoadTrendChart.tsx
+++ b/frontend/components/load/LoadTrendChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import type { ReactNode } from "react";
 import {
   ComposedChart,
   Area,
@@ -23,7 +24,10 @@ interface Props {
 type TrendView = "all" | "4w";
 
 export default function LoadTrendChart({ weeks, selectedWeekStart }: Props) {
-  const [view, setView] = useState<TrendView>("all");
+  // The 4-week view is the one that answers what this card exists to ask —
+  // is this week's load inside the range built from the 4 weeks before it —
+  // so it opens there; "All" (52 weeks) is history, a tap away.
+  const [view, setView] = useState<TrendView>("4w");
 
   // Per-week optimal range; null for early weeks that lack a trailing baseline.
   const rawBands = weeks.map((w) =>
@@ -60,10 +64,20 @@ export default function LoadTrendChart({ weeks, selectedWeekStart }: Props) {
   // 0.8-1.3x the mean of the 4 weeks before each week). Slice after the band
   // fill so the carried-forward optimal range stays correct.
   const WEEKS_IN_4W_VIEW = 5; // 4 trailing + selected
+  // Both views slice `chartData` starting at `sliceStart` ("All" starts at 0,
+  // i.e. no slicing) — computed once and reused below for the dot highlight,
+  // so the two can never disagree about which rendered point is the selected
+  // week.
+  const sliceStart =
+    view === "4w" ? Math.max(0, effectiveIndex + 1 - WEEKS_IN_4W_VIEW) : 0;
   const visibleData =
-    view === "4w"
-      ? chartData.slice(Math.max(0, effectiveIndex + 1 - WEEKS_IN_4W_VIEW), effectiveIndex + 1)
-      : chartData;
+    view === "4w" ? chartData.slice(sliceStart, effectiveIndex + 1) : chartData;
+  // `visibleData` is a SLICE of `chartData`, so the selected week's position
+  // in the rendered series is not `effectiveIndex` itself but its offset from
+  // where the slice starts. In "All" view sliceStart is 0, so this reduces to
+  // effectiveIndex unchanged; in "4w" view it is effectiveIndex's distance
+  // from the trailing edge of the 5-week window.
+  const selectedVisibleIndex = effectiveIndex - sliceStart;
 
   // Derivation of the selected week's optimal range, for the 4-week view
   // visual: the trailing 4-week average (the chronic baseline) and the band
@@ -87,6 +101,72 @@ export default function LoadTrendChart({ weeks, selectedWeekStart }: Props) {
           status: currentWeek.status,
         }
       : null;
+
+  // The selected week's own status, for the trend-line marker below — the
+  // same directional read DerivationStrip renders as its "current week" dot,
+  // just expressed as SVG-usable hex rather than a Tailwind bg-* class.
+  const selectedStatusHex = STATUS_HEX[currentWeek?.status ?? ""] ?? STATUS_HEX.default;
+  const isCurrentReal = effectiveIndex === weeks.length - 1;
+
+  // Custom dot for the `score` Line, called once per rendered point. Every
+  // week keeps today's plain marker (r=2, white fill / blue ring — recharts'
+  // own default for `dot={{ r: 2 }}` on this Line); only the SELECTED week
+  // (by its index within the rendered/visible series, not its index in the
+  // full history) gets the larger status-coloured marker plus a naming label,
+  // in BOTH views — 52 undifferentiated points in "All" is exactly where
+  // knowing which one is "now" matters most.
+  //
+  // The x-axis's own tick labels are not used for the naming cue: recharts
+  // thins ticks (`interval="preserveEnd"`) once there isn't room for all of
+  // them, and the selected week's tick can be one of the ones dropped — a
+  // label added there could silently stop rendering. Anchoring the label to
+  // the dot instead (rendered for every point, never thinned) keeps it
+  // reliable at any history length.
+  function renderScoreDot(props: {
+    cx?: number;
+    cy?: number;
+    index?: number;
+  }): ReactNode {
+    const { cx, cy, index } = props;
+    if (cx == null || cy == null) {
+      return null;
+    }
+    if (index !== selectedVisibleIndex) {
+      return <circle cx={cx} cy={cy} r={2} fill="#fff" stroke="#3b82f6" strokeWidth={2} />;
+    }
+    const label = isCurrentReal ? "This week" : "Selected week";
+    // The selected week is very often the RIGHTMOST point (it's the current
+    // week whenever the runner hasn't stepped back) — a middle-anchored label
+    // there runs off the chart's right edge and gets clipped. Anchor from
+    // whichever side has room: the first point anchors left, the last point
+    // anchors right, everything in between stays centred.
+    const isFirstPoint = selectedVisibleIndex === 0;
+    const isLastPoint = selectedVisibleIndex === visibleData.length - 1;
+    const textAnchor = isLastPoint ? "end" : isFirstPoint ? "start" : "middle";
+    const textX = isLastPoint ? cx + 4 : isFirstPoint ? cx - 4 : cx;
+    return (
+      <g>
+        <text
+          x={textX}
+          y={cy - 12}
+          textAnchor={textAnchor}
+          fontSize={10}
+          fontWeight={600}
+          className="fill-gray-600 dark:fill-gray-300"
+        >
+          {label}
+        </text>
+        <circle
+          cx={cx}
+          cy={cy}
+          r={5}
+          fill={selectedStatusHex}
+          strokeWidth={2}
+          className="stroke-white dark:stroke-gray-800"
+        />
+      </g>
+    );
+  }
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 shadow-sm p-5">
@@ -128,7 +208,11 @@ export default function LoadTrendChart({ weeks, selectedWeekStart }: Props) {
         </p>
       ) : (
         <ResponsiveContainer width="100%" height={260}>
-          <ComposedChart data={visibleData}>
+          {/* Extra top margin reserves headroom for the selected week's
+              "This week"/"Selected week" label, which sits above its marker
+              and would otherwise be able to clip against the chart's edge
+              when that week's score is near the top of the visible range. */}
+          <ComposedChart data={visibleData} margin={{ top: 18, right: 4, left: 4, bottom: 4 }}>
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
             <XAxis dataKey="label" tick={{ fontSize: 12 }} tickLine={false} axisLine={false} />
             <YAxis tick={{ fontSize: 12 }} tickLine={false} axisLine={false} width={40} />
@@ -156,7 +240,7 @@ export default function LoadTrendChart({ weeks, selectedWeekStart }: Props) {
               dataKey="score"
               stroke="#3b82f6"
               strokeWidth={2}
-              dot={{ r: 2 }}
+              dot={renderScoreDot}
               isAnimationActive={false}
             />
           </ComposedChart>
@@ -177,6 +261,17 @@ const STATUS_FILL: Record<string, string> = {
   optimal: "bg-emerald-500",
   high: "bg-amber-500",
   below: "bg-sky-500",
+};
+
+// The same palette as STATUS_FILL (Tailwind's emerald-500/amber-500/sky-500/
+// gray-500), as literal hex — recharts renders the trend-line marker as raw
+// SVG, whose `fill` attribute cannot take a Tailwind class. Keep in sync with
+// STATUS_FILL above if that mapping ever changes.
+const STATUS_HEX: Record<string, string> = {
+  optimal: "#10b981",
+  high: "#f59e0b",
+  below: "#0ea5e9",
+  default: "#6b7280",
 };
 
 function DerivationStrip({


### PR DESCRIPTION
Two changes to the Weekly Load Trend card, both asked for by the runner after looking at the live screen. **Stacked on #955** (`feat/948-window-navigation`) → #952 → #950, because that PR already touches this file.

## 1. The card opens on "4 weeks"

It opened on "All". The 4-week view is the one that answers the question the card exists to ask — *is this week's load inside the range built from the four weeks before it*. "All" is 52 weeks of history in which that judgement is invisible. Opening on the read the runner wants, with history one tap away, is the right default.

`DerivationStrip` is gated on `view === "4w"`, so "how this week's range is set" now renders on first paint rather than only after a tap. Checked: no layout shift, and it does not throw when `derivation` is null.

## 2. The selected week is marked

Every point rendered identically at `r=2`, so the week the entire card is describing looked exactly like the four weeks of context around it.

The marked week is the **selected** one — the week the #955 arrows move and that `DerivationStrip` already follows. When nothing has been stepped to, that is the current week, so the common case is what the runner expects. The label says so: "This week" when it is the real current week, "Selected week" when it is not.

**Marked in both views, not just 4-week.** In "All" you are looking at up to 52 undifferentiated points, which is exactly where knowing which one is *now* matters most.

### The index arithmetic, which is where this would have gone wrong

`visibleData` is a **slice** of `chartData`, so the selected week's index within the rendered series is not `effectiveIndex`, and the offset differs per view. Both now derive from one `sliceStart`:

```
sliceStart = view === "4w" ? max(0, effectiveIndex + 1 - 5) : 0
visibleData = chartData.slice(sliceStart, effectiveIndex + 1)
selectedVisibleIndex = effectiveIndex - sliceStart
```

In "All" `sliceStart` is always 0, so the two indices coincide; in "4w" it is the offset from the trailing edge. Getting this off by one would silently mark the *wrong week* while looking entirely correct, so it was verified in-browser by stepping the arrows and reading the highlighted point off the axis labels — not by eyeballing which dot is bigger.

### Colour and placement

Non-selected points keep their exact prior visual (recharts' own default for `dot={{r:2}}`, reproduced by hand). The selected point gets `r=5`, the week's own status colour from the existing `STATUS_HEX` (no new palette), and a ring mirroring `DerivationStrip`'s existing current-week dot.

The label is anchored to the **dot**, not the x-axis tick, because recharts' default `interval="preserveEnd"` thins ticks when space runs short — at the 52-week ceiling in "All", the selected week's tick can silently be one of the dropped ones.

## A real bug found during browser verification

The first version centre-anchored the label, which clipped it off the right edge of the chart whenever the selected week was the rightmost point — **i.e. every time in the default, unstepped state**, the most common case there is. Fixed with edge-aware text anchoring (`start`/`middle`/`end` by position) and documented in the code.

## Verification

Browser-driven in Chrome, **both themes**, against mock data and then confirmed against the real seeded production snapshot:

- Opens on "4 weeks" with the derivation strip visible.
- The selected week is unmistakably marked, no clipping.
- In "All", the highlighted point was confirmed correct by **counting weeks against the axis labels**, not by eyeballing.
- Stepping the arrows back three weeks moved the highlight to the matching point in both views, and the label correctly switched to "Selected week".

`npm run test` (lint + build) green, backend baseline unaffected (3526 passed — frontend-only change), validation gate passed with no overrides.

## Related: #960

This surfaced a **pre-existing** inconsistency rather than causing one. The Load screen states one verdict in two colour languages: `below` is amber in the page badge and sky in the chart; `high` is red in the badge and amber in the chart. Previously the chart's language appeared only in a small strip, so the two rarely sat together — a large status-coloured dot under the badge makes it obvious.

Deliberately **not** fixed here: which language wins is a product judgement, not a refactor, and #960 carries the decision with a recommendation.

## Not verified

No narrow mobile viewport check — this is a phone-first app and the label anchoring is the part most likely to behave differently in a narrow chart, so it is worth a look on a real device.
