### PR TITLE
feat(legal): public privacy policy and terms pages (#964)

### DIFF
--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -1,0 +1,260 @@
+import type { Metadata } from 'next';
+import LegalPage from '@/components/legal/LegalPage';
+
+// #964: public privacy policy. Required before the Google OAuth app can leave
+// Testing mode (which blocks the Clerk production cutover, #626), and needed on
+// its own terms — this app processes heart-rate series, injury and pain notes,
+// stated body measurements and free-text health commentary, and forwards
+// several of those to a third-party model provider.
+//
+// The content describes the system AS BUILT. If what the app collects or who it
+// is sent to changes, this page changes in the same PR.
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy · PulseCoach AI',
+  description:
+    'What PulseCoach AI collects, why, who it is shared with, and how to delete it.',
+};
+
+const CONTACT = 'philippe@twohourssleep.com';
+
+export default function PrivacyPage() {
+  return (
+    <LegalPage title="Privacy Policy" updated="24 August 2026">
+      <p>
+        PulseCoach AI (&ldquo;the app&rdquo;) is a running coaching service that connects to your
+        Strava account, analyses your training, and writes coaching feedback. This
+        page explains what it collects, why, who else sees it, and how to get rid
+        of it.
+      </p>
+      <p>
+        It is written to be read, not to be survived. If anything here is unclear
+        or looks wrong, email{' '}
+        <a href={`mailto:${CONTACT}`}>{CONTACT}</a> and ask.
+      </p>
+
+      <h2>Health data, stated plainly</h2>
+      <p>
+        Much of what this app handles is health information about you: heart-rate
+        recordings, perceived exertion, pain reports, sleep quality, injuries, and
+        any weight or height you choose to state. Some of it is sent to a
+        third-party AI provider so the coach can write about it (see{' '}
+        <a href="#sharing">Who else sees your data</a>).
+      </p>
+      <p>
+        If you are not comfortable with that, do not connect the app. You can also
+        use it while leaving the optional fields blank; the coach works with less
+        and will say so rather than guess.
+      </p>
+
+      <h2>What the app collects</h2>
+
+      <h3>Your account</h3>
+      <p>
+        You sign in with a social login handled by <strong>Clerk</strong>. The app
+        receives your verified email address, and whatever name and profile image
+        that provider passes along. The verified email is your identity in the
+        app: sign in again with the same address and you land back on your own
+        data. The app never receives or stores your social account password.
+      </p>
+
+      <h3>From Strava, once you connect it</h3>
+      <ul>
+        <li>Your Strava athlete ID and access tokens for your account.</li>
+        <li>
+          Activity records: type, start time, distance, duration, elevation,
+          average and maximum heart rate, recorded laps, and the rest of the
+          summary Strava provides.
+        </li>
+        <li>
+          Per-sample time-series streams for those activities: heart rate, pace,
+          cadence and power.
+        </li>
+        <li>Your heart-rate zone boundaries as configured in Strava.</li>
+      </ul>
+      <p>
+        The app only ever reads from Strava. It does not post, edit or delete
+        anything in your Strava account.
+      </p>
+
+      <h3>What you tell the app directly</h3>
+      <ul>
+        <li>
+          Profile: your goal, experience level, typical weekly volume, maximum
+          heart rate, upcoming races, injuries, and optionally your weight and
+          height.
+        </li>
+        <li>
+          Post-run check-ins: perceived effort, pain, sleep quality, and free-text
+          notes.
+        </li>
+        <li>Your conversations with the coach, and how you want it to sound.</li>
+        <li>Any coaching material you upload for the coach to read.</li>
+        <li>
+          Your Telegram chat ID, only if you choose to link Telegram for
+          notifications.
+        </li>
+      </ul>
+
+      <h3>What the app derives</h3>
+      <p>
+        From the above it computes training metrics, training load and fitness
+        estimates, rolling baselines, a written memory of what you have told it,
+        and the coaching reports themselves. These are stored alongside your
+        account.
+      </p>
+
+      <h2>Why the app uses it</h2>
+      <ul>
+        <li>To analyse your runs and produce coaching feedback.</li>
+        <li>
+          To compare a session against your own history rather than a population
+          average.
+        </li>
+        <li>To send you notifications you have asked for.</li>
+        <li>To keep the service running, and to diagnose faults.</li>
+      </ul>
+      <p>
+        Your data is not sold. It is not used for advertising. It is not used to
+        train anyone&rsquo;s AI models.
+      </p>
+
+      <h2>Legal basis</h2>
+      <p>
+        Where UK or EU data protection law applies, the app relies on your{' '}
+        <strong>explicit consent</strong> to process health data, given when you
+        connect Strava and when you fill in optional health fields. Account and
+        service operation rely on performance of a contract with you. You can
+        withdraw consent at any time by disconnecting Strava or deleting your
+        account, which is described below.
+      </p>
+
+      <h2 id="sharing">Who else sees your data</h2>
+      <p>
+        The app is run by one person and uses a small number of service providers.
+        Each one only receives what it needs.
+      </p>
+      <ul>
+        <li>
+          <strong>Clerk</strong> — sign-in and session management. Holds your
+          email and social profile.
+        </li>
+        <li>
+          <strong>Strava</strong> — the source of your activity data, under the
+          permissions you granted.
+        </li>
+        <li>
+          <strong>Anthropic</strong> — the AI provider that writes your coaching
+          reports and chat replies. It receives the training context assembled for
+          a given run or conversation, which can include your metrics, your
+          check-in notes, your stated profile, your messages to the coach, and any
+          material you uploaded. It does not receive your email address or your
+          Strava tokens.
+        </li>
+        <li>
+          <strong>Telegram</strong> — only if you link it, and only to deliver
+          your notifications.
+        </li>
+        <li>
+          <strong>Railway</strong> and <strong>Vercel</strong> — hosting for the
+          application, database and website.
+        </li>
+        <li>
+          <strong>Sentry</strong> — error diagnostics, only when enabled. Receives
+          technical error details, not your training data.
+        </li>
+      </ul>
+      <p>
+        Beyond these, your data is disclosed only if the law requires it.
+      </p>
+
+      <h2>Where it is stored</h2>
+      <p>
+        Your data lives in a managed PostgreSQL database and Redis instance hosted
+        by Railway, with the website served by Vercel. The providers listed above
+        operate internationally, so your data may be processed outside the country
+        you live in, including in the United States.
+      </p>
+
+      <h2>How long it is kept</h2>
+      <p>
+        Your data is kept for as long as your account exists. There is no
+        automatic expiry, because the coach&rsquo;s value comes from your history:
+        it compares this week against your own last two years, not against a
+        typical runner.
+      </p>
+      <p>When you delete your account, it goes.</p>
+
+      <h2>Deleting your data</h2>
+      <p>You have two levers, and both work immediately.</p>
+      <ul>
+        <li>
+          <strong>Disconnect Strava</strong> — stops any further activity data
+          reaching the app.
+        </li>
+        <li>
+          <strong>Delete your account</strong>, from your profile page. This
+          removes your sign-in record first, so the account cannot be reopened into
+          an empty shell, and then deletes every row the app holds about you in a
+          single operation: activities, streams, derived metrics, coaching reports,
+          conversations, check-ins, memory, uploaded materials, baselines, your
+          Strava connection and your profile.
+        </li>
+      </ul>
+      <p>
+        This is a real deletion, not a flag. It cannot be undone, and the app
+        cannot recover your history afterwards. Backups held by the hosting
+        providers may retain copies for a short period before rotating out.
+      </p>
+
+      <h2>Your rights</h2>
+      <p>
+        If you are in the UK or the EU, you have the right to access your data,
+        correct it, delete it, receive a portable copy, restrict or object to its
+        processing, and withdraw consent. Deletion is built into the app as
+        described above. For anything else, email{' '}
+        <a href={`mailto:${CONTACT}`}>{CONTACT}</a> and it will be handled within
+        one month.
+      </p>
+      <p>
+        You also have the right to complain to your data protection authority. In
+        the UK that is the Information Commissioner&rsquo;s Office.
+      </p>
+
+      <h2>Cookies and local storage</h2>
+      <p>
+        The app sets a session cookie through Clerk so you stay signed in. It
+        stores your light/dark theme preference in your browser. There are no
+        advertising cookies and no third-party analytics trackers.
+      </p>
+
+      <h2>Children</h2>
+      <p>
+        The app is not intended for anyone under 16, and accounts should not be
+        created for them.
+      </p>
+
+      <h2>Security</h2>
+      <p>
+        Traffic is encrypted in transit. Access to the production database is
+        restricted to the app and its operator. No system is perfectly secure, and
+        this one is operated by an individual rather than a company with a security
+        team, which is worth knowing when you decide what to put in a free-text
+        note.
+      </p>
+
+      <h2>Changes to this policy</h2>
+      <p>
+        If what the app collects or who it shares with changes, this page changes
+        with it and the date at the top moves. Material changes will be flagged in
+        the app.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        Questions, requests, or corrections:{' '}
+        <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+      </p>
+    </LegalPage>
+  );
+}

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -1,0 +1,163 @@
+import type { Metadata } from 'next';
+import LegalPage from '@/components/legal/LegalPage';
+
+// #964: public terms of service. Required before the Google OAuth app can leave
+// Testing mode (which blocks the Clerk production cutover, #626).
+//
+// The "not medical advice" section is not boilerplate: it is the user-facing
+// statement of the same boundary the backend enforces mechanically in
+// services/coach/validator.py, whose medical-scope rule refuses dose advice,
+// diagnosis verbs, medication directives and asserted clinical conditions in
+// every coach output. If that boundary ever moves, this section moves with it.
+
+export const metadata: Metadata = {
+  title: 'Terms of Service · PulseCoach AI',
+  description:
+    'The terms you agree to when using PulseCoach AI, including what the coaching is and is not.',
+};
+
+const CONTACT = 'philippe@twohourssleep.com';
+
+export default function TermsPage() {
+  return (
+    <LegalPage title="Terms of Service" updated="24 August 2026">
+      <p>
+        These terms cover your use of PulseCoach AI (&ldquo;the app&rdquo;). By
+        creating an account you agree to them. If you do not, do not use the app.
+      </p>
+
+      <h2>What the app is</h2>
+      <p>
+        The app connects to your Strava account, analyses your running, and
+        produces written coaching feedback using an AI model. It is a personal
+        project run by an individual, not a company, and it is offered free of
+        charge.
+      </p>
+
+      <h2>This is not medical advice</h2>
+      <p>
+        This is the most important section on the page.
+      </p>
+      <p>
+        The app is a training tool. It is <strong>not</strong> a medical device,
+        and the coaching it produces is <strong>not</strong> medical advice,
+        diagnosis or treatment. The coach is built to stay inside that boundary:
+        it will not prescribe medication or dosages, will not diagnose you, and
+        will not assert that you have a clinical condition. When your data shows a
+        pattern worth a professional&rsquo;s eyes, it will say so and suggest you
+        speak to one.
+      </p>
+      <p>
+        It can still be wrong. It works from imperfect sensor data and from what
+        you tell it, and an AI model can misread either. Use your judgement.
+      </p>
+      <p>
+        <strong>
+          If you are injured, in pain, unwell, or considering a significant change
+          in training, speak to a doctor or a qualified professional. If you think
+          you are having a medical emergency, contact your local emergency
+          services immediately.
+        </strong>{' '}
+        Do not delay seeking medical advice because of something the app said, and
+        do not use it as a substitute for care.
+      </p>
+      <p>
+        You train at your own risk. You are responsible for deciding what to
+        actually do.
+      </p>
+
+      <h2>Your account</h2>
+      <ul>
+        <li>You must be at least 16 years old.</li>
+        <li>
+          Sign in through the social login provided. Keep that account secure;
+          anyone with access to it has access to your training data.
+        </li>
+        <li>The account is yours alone. Do not share it.</li>
+        <li>Provide accurate information. The coaching is only as good as it.</li>
+      </ul>
+
+      <h2>Connecting Strava</h2>
+      <p>
+        Connecting Strava is optional but the app does very little without it. You
+        grant read access to your activity data, which you can revoke at any time
+        from your Strava settings or by disconnecting inside the app. The app never
+        writes to your Strava account. Your use of Strava remains governed by
+        Strava&rsquo;s own terms.
+      </p>
+
+      <h2>Acceptable use</h2>
+      <p>Do not:</p>
+      <ul>
+        <li>Use the app for anyone other than yourself, or upload someone else&rsquo;s data without their consent.</li>
+        <li>Attempt to access another user&rsquo;s account or data.</li>
+        <li>Probe, scrape, overload or reverse-engineer the service.</li>
+        <li>Use it for anything unlawful.</li>
+        <li>
+          Try to steer the coach into producing medical, diagnostic or otherwise
+          harmful output.
+        </li>
+      </ul>
+
+      <h2>What you upload</h2>
+      <p>
+        You keep ownership of everything you put into the app: your notes, your
+        messages, and any coaching material you upload. You grant permission to
+        store and process it for the purpose of running the service and generating
+        your coaching, as set out in the{' '}
+        <a href="/privacy">Privacy Policy</a>.
+      </p>
+      <p>
+        Do not upload material you do not have the right to share. Uploaded
+        material informs how the coach reasons; it does not override your safety or
+        the boundaries described above.
+      </p>
+
+      <h2>Availability</h2>
+      <p>
+        The app is provided as-is and as-available, with no warranty of any kind.
+        It is actively developed and may change, break, or go down without notice.
+        Features may be added or removed. There is no uptime commitment and no
+        support obligation.
+      </p>
+      <p>
+        Keep your own records if your training history matters to you. Strava
+        remains the source of truth for your activities.
+      </p>
+
+      <h2>Limitation of liability</h2>
+      <p>
+        To the fullest extent the law allows, the operator is not liable for any
+        injury, loss, damage, lost data or lost opportunity arising from your use
+        of the app or from decisions you made based on its output.
+      </p>
+      <p>
+        Nothing in these terms limits liability for death or personal injury caused
+        by negligence, for fraud, or for anything else that cannot lawfully be
+        excluded. If you are a consumer, your statutory rights are unaffected.
+      </p>
+
+      <h2>Ending your use</h2>
+      <p>
+        You can delete your account at any time from your profile page, which
+        permanently removes your data as described in the{' '}
+        <a href="/privacy">Privacy Policy</a>. Access may be suspended or removed
+        if these terms are breached, or if the service is discontinued. Reasonable
+        notice will be given before shutting the service down, where possible.
+      </p>
+
+      <h2>Changes to these terms</h2>
+      <p>
+        These terms may change. The date at the top moves when they do, and
+        material changes will be flagged in the app. Continuing to use the app
+        after a change means you accept it.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        Questions about these terms:{' '}
+        <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+      </p>
+    </LegalPage>
+  );
+}

--- a/frontend/components/legal/LegalPage.tsx
+++ b/frontend/components/legal/LegalPage.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+
+// #964: the shell both legal pages share, so /privacy and /terms cannot drift
+// apart in framing or typography. Deliberately a server component with no
+// client state: these pages must render for a signed-out visitor (and for
+// Google's OAuth review, which fetches them unauthenticated), so nothing here
+// may depend on a session. See middleware.ts, where both paths are declared
+// public.
+
+export default function LegalPage({
+  title,
+  updated,
+  children,
+}: {
+  title: string;
+  updated: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10 sm:px-6 sm:py-14">
+      <Link
+        href="/"
+        className="inline-flex items-center gap-1.5 text-sm text-gray-500 transition-colors hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to the app
+      </Link>
+
+      <header className="mt-6">
+        <h1 className="font-serif text-3xl text-gray-900 sm:text-4xl dark:text-gray-50">
+          {title}
+        </h1>
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          Last updated {updated}
+        </p>
+      </header>
+
+      <article className="prose prose-gray mt-8 max-w-none dark:prose-invert prose-headings:font-serif prose-h2:mt-10 prose-h2:mb-3 prose-h2:text-xl prose-p:leading-relaxed prose-li:my-1">
+        {children}
+      </article>
+
+      <footer className="mt-14 border-t border-gray-200 pt-6 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+        <nav className="flex gap-5">
+          <Link href="/privacy" className="hover:text-gray-800 dark:hover:text-gray-200">
+            Privacy Policy
+          </Link>
+          <Link href="/terms" className="hover:text-gray-800 dark:hover:text-gray-200">
+            Terms of Service
+          </Link>
+        </nav>
+      </footer>
+    </main>
+  );
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -7,12 +7,29 @@ import { clerkEnabled } from '@/lib/authMode';
 // `make verify-local` -- the middleware is a pass-through, so routes load
 // without a sign-in. See lib/authMode.ts for the single source of truth.
 
-// Public routes never require a session: the auth pages themselves, and /api/*
-// (the proxy forwards the Clerk token and the FastAPI backend is the real
-// enforcer -- redirecting an XHR to an HTML sign-in page would just break it).
+// Public routes never require a session: the auth pages themselves, the legal
+// pages, and /api/* (the proxy forwards the Clerk token and the FastAPI backend
+// is the real enforcer -- redirecting an XHR to an HTML sign-in page would just
+// break it).
+//
+// /privacy and /terms MUST be here (#964). Neither path contains a dot, so both
+// fall inside the matcher below, and without this they would be handed to
+// `auth().protect()` and bounced to /sign-in. That breaks them for the two
+// audiences who need them most: Google, which fetches both URLs unauthenticated
+// when reviewing the OAuth consent screen and will not publish the app if they
+// do not resolve, and a prospective user deciding whether to sign up at all --
+// a privacy policy you must first create an account to read is not a privacy
+// policy. This is the /apple-icon failure from #228 in a different costume: a
+// dotless path silently swallowed by the gate, with a green build either way.
+//
+// They are marked public rather than excluded from the matcher (as apple-icon
+// is) because they are real pages that should render normally; they simply must
+// not require a session.
 const isPublicRoute = createRouteMatcher([
   '/sign-in(.*)',
   '/sign-up(.*)',
+  '/privacy',
+  '/terms',
   '/api/(.*)',
 ]);
 

--- a/frontend/scripts/smoke.mjs
+++ b/frontend/scripts/smoke.mjs
@@ -851,6 +851,15 @@ const routesToCheck = [
   // above the tabs in both views. Its races arrive client-side; the heading is
   // what proves the surface is there at all.
   { path: "/schedule", expectedText: "Goal race" },
+  // #964: the legal pages. These prove the routes BOOT and render their content.
+  // They do NOT prove the pages are publicly reachable, which is the property
+  // that actually matters for them: the smoke harness runs with no Clerk
+  // publishable key, so `clerkEnabled` is false and middleware.ts is a
+  // pass-through here. Whether `isPublicRoute` still covers them can only be
+  // shown with Clerk ON -- see the #964 PR for that check, and re-run it by hand
+  // if the matcher or the public-route list is ever touched.
+  { path: "/privacy", expectedText: "Health data, stated plainly" },
+  { path: "/terms", expectedText: "This is not medical advice" },
 ];
 
 function createMockApiServer() {


### PR DESCRIPTION
Partially addresses #964. Unblocks #626.

## Why

Google will not let the OAuth app leave **Testing** mode without a privacy policy and terms of service URL. While it sits in Testing, only explicitly-listed test users can sign in (cap 100 for the app's lifetime), so cutting Clerk over without publishing would break new signups *worse* than the current dev instance, which borrows Google's already-published credentials.

Independently of Google: this app processes heart-rate series, injury and pain notes, sleep quality, stated weight/height and free-text health commentary, and forwards several of those to a third-party model provider, with beta users in the EU/UK. Having no privacy policy was a gap on its own terms.

## What's here

| File | |
|---|---|
| `frontend/app/privacy/page.tsx` | new |
| `frontend/app/terms/page.tsx` | new |
| `frontend/components/legal/LegalPage.tsx` | new, shared shell so the two cannot drift |
| `frontend/middleware.ts` | `/privacy` + `/terms` added to `isPublicRoute` |
| `frontend/scripts/smoke.mjs` | +2 route checks |

Content describes the system **as built**, not a template: Clerk for identity, Strava read-only, Anthropic receiving the assembled context and chat turns, Telegram when linked, Railway and Vercel for hosting, Sentry only when configured. The erasure section points at the real FK-ordered cascade in `services/account_deletion.py` (which already removes the Clerk user first) rather than at an email address.

The terms carry a prominent **"not medical advice"** section. That is the user-facing statement of the same boundary `validator.py` already enforces mechanically, refusing dose advice, diagnosis verbs, medication directives and asserted clinical conditions in every coach output. If that boundary moves, the section moves with it.

## The routing change is the part that matters

Neither path contains a dot, so both fall **inside** the middleware matcher `'/((?!_next|apple-icon|.*\\..*).*)'`. Without being declared public they are handed to `auth().protect()` and answered with a 404 — for Google, which fetches both URLs unauthenticated during OAuth review and will not publish the app if they do not resolve, and for anyone deciding whether to sign up at all. A privacy policy you must first create an account to read is not a privacy policy.

This is the `/apple-icon` failure from #228 in a different costume: a dotless path silently swallowed by the gate, **with a green build either way**.

They are marked public rather than excluded from the matcher (as `apple-icon` is) because they are real pages that should render normally; they simply must not require a session.

## Verification

A green build proves nothing here, so this was checked at runtime against a production build with a real Clerk key:

| | `/privacy` | `/terms` | `/` | `/profile` | `/trends` |
|---|---|---|---|---|---|
| **with the fix** | 200 | 200 | 404 | 404 | 404 |
| **without the fix** | 404 | 404 | 404 | 404 | 404 |

Two things this establishes that a one-sided check would not:

- **The control is load-bearing.** Had Clerk been inert, `/` would have returned 200 and the whole test would have proved nothing. It returns 404, so the gate is genuinely enforcing.
- **The fix is what does it.** Reverting only the middleware change and rebuilding drops both pages to 404; restoring it returns them to 200.

The smoke additions were confirmed the same way — pointed at text that does not exist, `make frontend-smoke` failed with `Error 1` — rather than trusted on a single green run.

`make frontend-smoke`, `npm run test` (lint + build) and the repo validation gate (3717 backend tests) all pass.

### Not checked

- **Light theme and narrow viewports.** Only dark on desktop was viewed. The pages reuse the same prose and `dark:` conventions as `CoachReportPanel`, so this is low risk, but it was not looked at.
- **The deployed environment.** Verified against a local production build with the *dev* Clerk key. Same code and mechanism, but Vercel's edge runtime with the prod key is not literally what ran. **Confirm both URLs return 200 on pulsecoachai.com after deploy, before handing them to Google.**
- **Backend tests** were run by the gate but are not meaningful here; zero backend files changed.
- **Whether the content is legally adequate.** It accurately describes the system. That is not the same thing, and is not something this PR can establish.

## Blocking before merge

- [ ] Owner has read both pages in full
- [ ] **Governing law / jurisdiction clause** added to the terms — deliberately omitted rather than guessed, since inventing a jurisdiction would put a false statement into a legal document
- [ ] **Legal entity** named, or confirmed that "operated by an individual" is the accurate framing
- [ ] Contact address `philippe@twohourssleep.com` confirmed (already public on the Google consent screen)

## Follow-up, not in this PR

Nothing in the app links to `/privacy` or `/terms`. Reachable by URL, which satisfies Google, but a person using the app cannot find them. A footer or sign-in-page link would fix it.

## After merge

Vercel deploys → confirm both URLs are 200 on the live domain → paste them into the Google Branding page → **Publish app** → Vercel + Railway env swap → fresh-signup acceptance test (#626).