### PR TITLE
fix(coach): stop the turn failing, and record it when it does (#966)

### DIFF
--- a/backend/app/services/coach/chat.py
+++ b/backend/app/services/coach/chat.py
@@ -384,6 +384,20 @@ async def _buffered_tool_loop(
                         yield _heartbeat()
 
             if final_msg is None:
+                # #966: the OTHER way a turn fails, and until now the silent one.
+                # No exception is raised here, so the except below never runs and
+                # nothing was recorded at all -- yet the runner saw the identical
+                # message as an upstream error. From the outside the two were
+                # indistinguishable, which is why the recurring Schedule-screen
+                # failure could not be told apart from an empty stream. Logged as
+                # its own event so it can be.
+                logger.error(
+                    "coach_turn_failed: stream ended with no final message "
+                    "(round %s of %s, tools=%s)",
+                    round_idx + 1,
+                    _MAX_TOOL_ROUNDS,
+                    "on" if tools_arg else "off",
+                )
                 stream_failed = True
                 break
 
@@ -486,7 +500,19 @@ async def _buffered_tool_loop(
         # error — consistent with how the report path degrades on rate limits. Any
         # other transport error keeps the generic message.
         rate_limited = isinstance(e, anthropic.RateLimitError)
-        logger.error("Chat streaming error (rate_limited=%s): %s", rate_limited, e)
+        # #966: type + traceback, matching every neighbouring fail-soft handler.
+        # This one is the only failure the runner can SEE, and it was the only one
+        # logging the message alone -- so when the cause was a bug in our own code
+        # rather than an API error, the recorded line was a bare string with
+        # nothing locating it. The live example: "AsyncMessages.stream() got an
+        # unexpected keyword argument 'temperature'", which named neither the
+        # call site nor the fact that it was a TypeError from our own arguments.
+        logger.exception(
+            "coach_turn_failed: %s from the upstream call (rate_limited=%s): %s",
+            type(e).__name__,
+            rate_limited,
+            e,
+        )
         stream_failed = True
         stream_fail_message = (
             "I'm getting a lot of requests right now, so I couldn't finish that "

--- a/backend/app/services/coach/llm.py
+++ b/backend/app/services/coach/llm.py
@@ -116,7 +116,7 @@ class RetryLadder:
         import anthropic
 
         if not retriable:
-            return False
+            return self._give_up(exc, "mid_stream_cannot_reissue")
         if isinstance(
             exc,
             (
@@ -134,7 +134,7 @@ class RetryLadder:
             return await self._transient(exc)
         if isinstance(exc, anthropic.RateLimitError):
             if self._rate_limit_retries >= _MAX_RATE_LIMIT_RETRIES:
-                return False
+                return self._give_up(exc, "rate_limit_budget_exhausted")
             delay = _rate_limit_backoff_seconds(exc, self._rate_limit_retries)
             self._rate_limit_retries += 1
             logger.warning(
@@ -148,12 +148,33 @@ class RetryLadder:
             # bug and won't get better on retry.
             if exc.status_code >= 500:
                 return await self._transient(exc, event="5xx_retry")
-            return False
+            return self._give_up(exc, "non_retriable_status")
+        return self._give_up(exc, "not_a_retriable_error")
+
+    def _give_up(self, exc: BaseException, reason: str) -> bool:
+        """Record WHY the ladder stopped retrying, then tell the caller to re-raise.
+
+        #966: every one of these exits used to return False silently, so an error
+        the ladder declined to retry reached the caller's fail-soft handler with
+        nothing upstream explaining the decision. The 4xx exit is the one the
+        issue names, but the decision is shared, so the record is made in one
+        place rather than five. Not `logger.exception`: the caller re-raises and
+        logs the traceback, and this line is about the RETRY decision, not the
+        error. `False` is returned so each call site stays a single expression.
+        """
+        detail = {
+            "reason": reason,
+            "kind": type(exc).__name__,
+            "status": getattr(exc, "status_code", None),
+            "transient_retries": self._transient_retries,
+            "rate_limit_retries": self._rate_limit_retries,
+        }
+        logger.warning(f"{self._prefix}_not_retried", extra=detail)
         return False
 
     async def _transient(self, exc: BaseException, event: str = "transient_failure") -> bool:
         if self._transient_retries >= _MAX_TRANSIENT_RETRIES:
-            return False
+            return self._give_up(exc, "transient_budget_exhausted")
         self._transient_retries += 1
         detail = (
             {"attempt": self._transient_retries, "status": getattr(exc, "status_code", None)}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,7 +28,23 @@ dependencies = [
     "rq>=1.16.0",
     "python-multipart>=0.0.9",
     "numpy>=1.24.0",
-    "anthropic>=0.40.0",
+    # BOUNDED DELIBERATELY (#966), the `fastapi` precedent above applied to the
+    # other dependency whose surface we call directly. `anthropic` 1.0.0 (20 Aug
+    # 2026) removed `temperature` / `top_p` / `top_k` from `messages.create()`
+    # and `messages.stream()`; neither takes `**kwargs`, so the three call sites
+    # in `services/coach/llm.py` that pass one raise TypeError. Under the old
+    # unbounded `>=0.40.0` the 24 Aug image build resolved 1.0.0 and every
+    # conversational turn, period report, schedule draft, voice rewrite, memory
+    # update, distillation and receipt-voice pass failed in production while CI
+    # stayed green -- the suite mocks the client, so nothing bound our call
+    # sites to the SDK's real signature. 1.0.0 also moves the HTTP layer to
+    # `httpx2`, whose `RemoteProtocolError` is unrelated to `httpx`'s, which
+    # silently voids the mid-stream retry rung in `RetryLadder` (#302).
+    # The ceiling means 1.x is adopted on purpose, with those two call-site
+    # changes made together; see the issue for the migration surface.
+    # `test_anthropic_pin_966.py` asserts the INSTALLED version satisfies this
+    # line, so a stale venv is a failure rather than a surprise.
+    "anthropic>=0.125.0,<0.126.0",
     "pyjwt[crypto]>=2.8.0"
 ]
 

--- a/backend/tests/_chat_stubs.py
+++ b/backend/tests/_chat_stubs.py
@@ -102,3 +102,20 @@ def chat_tool_loop_stub(rounds, *, capture: Optional[dict] = None):
 
     _stub.state = state
     return _stub
+
+
+def chat_no_final_stub(*, before: str = ""):
+    """A `stream_chat_turn` replacement whose stream ENDS without a final message.
+
+    #966: the second way a turn fails, and the one that raised no exception and
+    wrote no log line, so from the outside it was indistinguishable from an
+    upstream error. The real shape is a stream that yields deltas (or nothing) and
+    then simply stops, leaving `final_msg` None in the tool loop.
+    """
+    from app.services.coach.llm import ChatTurnDelta
+
+    async def _stub(self, *, system, messages, tools=None, max_tokens=1024):
+        if before:
+            yield ChatTurnDelta(text=before)
+
+    return _stub

--- a/backend/tests/test_anthropic_pin_966.py
+++ b/backend/tests/test_anthropic_pin_966.py
@@ -1,0 +1,65 @@
+"""#966: the `anthropic` version constraint is load-bearing, so assert it holds.
+
+The #809 `test_the_installed_fastapi_matches_the_declared_constraint` pattern,
+applied to the other dependency whose surface we call directly.
+
+Why this dependency earned a bound: `anthropic` 1.0.0 removed `temperature` /
+`top_p` / `top_k` from `messages.create()` and `messages.stream()`, and neither
+takes `**kwargs`, so the three call sites in `services/coach/llm.py` that pass one
+raise TypeError. Unbounded at `>=0.40.0`, the 24 Aug 2026 image build resolved
+1.0.0 and every conversational turn, period report, schedule draft, voice rewrite,
+memory update, material distillation and receipt-voice pass failed in production
+while CI stayed green, because the suite mocks the client end to end.
+
+This test does NOT close that blindness -- it cannot, since it reads a declared
+string rather than binding call sites to the SDK's real signature. What it does is
+make the bound honest: a venv, a CI runner and a deploy that resolve different
+majors is a named failure here rather than a divergence nobody notices.
+"""
+
+
+def _declared_specifier(name: str):
+    import tomllib
+    from pathlib import Path
+
+    from packaging.requirements import Requirement
+
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    declared = [
+        Requirement(dep)
+        for dep in tomllib.loads(pyproject.read_text())["project"]["dependencies"]
+    ]
+    (spec,) = [r.specifier for r in declared if r.name == name]
+    return spec
+
+
+def test_the_installed_anthropic_matches_the_declared_constraint():
+    import anthropic
+
+    spec = _declared_specifier("anthropic")
+    assert str(spec), "anthropic must carry an explicit version constraint (#966)"
+    assert anthropic.__version__ in spec, (
+        f"installed anthropic {anthropic.__version__} does not satisfy the declared "
+        f"'{spec}'. Reinstall the backend (pip install -e './backend[test]'); a venv "
+        "on a different SDK major calls a different parameter surface than CI does."
+    )
+
+
+def test_the_constraint_excludes_the_major_that_broke_production():
+    """The bound must have a CEILING, not just a floor.
+
+    A floor alone is what `>=0.40.0` already was, and it is precisely what let
+    1.0.0 in. Stated as a property of the specifier rather than as a literal
+    string, so raising the floor within 0.x does not touch this test, while
+    widening it to admit 1.x does -- which is the change that must be made on
+    purpose, together with the two call-site fixes the upgrade needs.
+    """
+    spec = _declared_specifier("anthropic")
+
+    assert "1.0.0" not in spec, (
+        "the declared constraint admits anthropic 1.0.0, which removed the sampling "
+        "parameters `services/coach/llm.py` passes. Adopting 1.x is a deliberate "
+        "change: move `temperature` into `extra_body` (or drop it) at the three "
+        "call sites, and re-point the `httpx.RemoteProtocolError` catch in "
+        "`RetryLadder` at `httpx2`, whose exception classes are unrelated."
+    )

--- a/backend/tests/test_coach_chat_stream.py
+++ b/backend/tests/test_coach_chat_stream.py
@@ -8,7 +8,7 @@ survive them.
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -25,7 +25,14 @@ def _seed_activity_with_report(db) -> Activity:
     db.add(StravaAccount(user_id=user.id, strava_athlete_id=1, access_token="t", refresh_token="r", expires_at=9999999999, scope="read"))
     activity = Activity(
         user_id=user.id, strava_activity_id=42,
-        start_date=datetime(2026, 5, 27, 10, 0, 0), type="Run", name="Test run",
+        # #966: relative, not the repo's usual absolute `datetime(2026, 5, 27)`.
+        # `test_chat_tool_loop.test_multi_window_fetch_shows_one_record_per_call`
+        # counts this activity inside a `last_90_days` tool window, so an absolute
+        # date is a time bomb: it passed for 90 days and then started failing on
+        # its own with no code change. The subject run has to stay ~55 days old
+        # for that window assertion to mean anything, which is exactly what that
+        # test's own comment already claims it is.
+        start_date=datetime.now() - timedelta(days=55), type="Run", name="Test run",
         distance_m=5000, moving_time_s=1500, elapsed_time_s=1500, elev_gain_m=10.0,
         avg_hr=140, raw_summary={},
     )

--- a/backend/tests/test_coach_turn_failure_record_966.py
+++ b/backend/tests/test_coach_turn_failure_record_966.py
@@ -1,0 +1,204 @@
+"""#966: a failed coach turn must leave a record saying what failed and where.
+
+The runner-visible failure was the LEAST observable path in the chat surface, and
+it was the one that kept firing. Three gaps, all reproduced below:
+
+  1. the exception handler logged the message alone, with no type and no
+     traceback, so a bug in our own code recorded a bare string with nothing
+     locating it (the live example: "AsyncMessages.stream() got an unexpected
+     keyword argument 'temperature'");
+  2. the stream-ended-with-no-final-message branch wrote NO log line at all while
+     producing the identical runner-facing message, so the two were
+     indistinguishable from the outside;
+  3. the retry ladder re-raised without recording that it had declined to retry,
+     so nothing upstream filled the gap either.
+
+The fourth requirement is a negative: nothing added here reaches the runner. The
+two runner-facing strings are pinned byte for byte.
+"""
+
+import logging
+
+import pytest
+
+from app.services.coach.chat import _buffered_tool_loop
+from tests._chat_stubs import chat_no_final_stub, chat_raising_stub
+
+# The exact strings the runner sees. Pinned here so a change to the log lines
+# cannot quietly leak diagnostics into the reply (#966 AC3).
+GENERIC = "Sorry, I encountered an error. Please try again."
+RATE_LIMITED_LEAD = "I'm getting a lot of requests right now"
+
+
+async def _run_loop(db, monkeypatch, stub) -> dict:
+    """Drive the shared generation core directly with a stubbed client.
+
+    The core is what both chat surfaces share, so testing it here covers the
+    activity chat box and the thread turn at once.
+    """
+    from app.services.coach.llm import AnthropicClient
+
+    monkeypatch.setattr(AnthropicClient, "stream_chat_turn", stub, raising=True)
+    client = AnthropicClient(api_key="test-key", model="claude-sonnet-4-6")
+    out: dict = {}
+    async for _event in _buffered_tool_loop(
+        db,
+        client,
+        system_prompt="you are a coach",
+        llm_messages=[{"role": "user", "content": "talk me through the schedule"}],
+        owner_user_id=None,
+        out=out,
+        tools=None,
+    ):
+        pass
+    return out
+
+
+@pytest.mark.asyncio
+async def test_upstream_error_records_type_and_traceback(db, monkeypatch, caplog):
+    """Gap 1. A TypeError from our own arguments must be locatable in the log.
+
+    `chat_raising_stub` raises RuntimeError; the point is not which class it is
+    but that the class name and a traceback are recorded. Before #966 the record
+    was the message alone, which for the production failure was a bare string
+    naming neither the call site nor that it came from our own kwargs.
+    """
+    with caplog.at_level(logging.ERROR, logger="app.services.coach.chat"):
+        out = await _run_loop(db, monkeypatch, chat_raising_stub())
+
+    assert out["stream_failed"] is True
+    records = [r for r in caplog.records if "coach_turn_failed" in r.getMessage()]
+    assert len(records) == 1, "the failure the runner sees must be recorded exactly once"
+    record = records[0]
+    assert "RuntimeError" in record.getMessage(), "the exception TYPE must be named"
+    assert record.exc_info is not None, "a traceback must be attached"
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_is_recorded_and_distinguishable(db, monkeypatch, caplog):
+    """Gap 2. The branch that raised nothing wrote nothing; now it writes its own
+    line, and that line is DIFFERENT from the upstream-error one."""
+    with caplog.at_level(logging.ERROR, logger="app.services.coach.chat"):
+        out = await _run_loop(db, monkeypatch, chat_no_final_stub())
+
+    assert out["stream_failed"] is True
+    records = [r for r in caplog.records if "coach_turn_failed" in r.getMessage()]
+    assert len(records) == 1, "the silent branch must now record"
+    message = records[0].getMessage()
+    assert "no final message" in message
+    # The distinguishing property the issue asks for: an empty stream must not
+    # read like an upstream error. It carries no exception, hence no traceback.
+    assert records[0].exc_info is None
+    assert "RuntimeError" not in message
+
+
+@pytest.mark.asyncio
+async def test_the_two_failures_do_not_look_alike(db, monkeypatch, caplog):
+    """The acceptance criterion stated directly: given only the log, the two
+    failure modes must be tellable apart. They produce the same runner-facing
+    message, which is why the log is the only place they can differ."""
+    with caplog.at_level(logging.ERROR, logger="app.services.coach.chat"):
+        upstream = await _run_loop(db, monkeypatch, chat_raising_stub())
+        upstream_log = [r for r in caplog.records if "coach_turn_failed" in r.getMessage()][-1]
+        caplog.clear()
+        empty = await _run_loop(db, monkeypatch, chat_no_final_stub())
+        empty_log = [r for r in caplog.records if "coach_turn_failed" in r.getMessage()][-1]
+
+    # Same thing shown to the runner ...
+    assert upstream["stream_fail_message"] == empty["stream_fail_message"] == GENERIC
+    # ... different thing written down.
+    assert upstream_log.getMessage() != empty_log.getMessage()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stub_factory", [chat_raising_stub, chat_no_final_stub])
+async def test_runner_message_carries_no_diagnostics(db, monkeypatch, stub_factory):
+    """Gap 4 (the negative). Nothing added for observability reaches the runner:
+    the served text is byte-identical to the string the issue quotes."""
+    out = await _run_loop(db, monkeypatch, stub_factory())
+
+    assert out["stream_fail_message"] == GENERIC
+    for leak in ("Traceback", "RuntimeError", "TypeError", "keyword argument", "final message"):
+        assert leak not in out["stream_fail_message"]
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_message_still_specialises(db, monkeypatch):
+    """The #625 behaviour must survive: an exhausted 429 keeps its own transparent
+    message rather than collapsing into the generic one."""
+    import anthropic
+    import httpx
+
+    from app.services.coach.llm import ChatTurnDelta  # noqa: F401  (stub shape)
+
+    def _rate_limited_stub():
+        async def _stub(self, *, system, messages, tools=None, max_tokens=1024):
+            raise anthropic.RateLimitError(
+                "rate limited",
+                response=httpx.Response(
+                    429, request=httpx.Request("POST", "https://api.anthropic.com")
+                ),
+                body=None,
+            )
+            yield  # pragma: no cover - makes this an async generator
+
+        return _stub
+
+    out = await _run_loop(db, monkeypatch, _rate_limited_stub())
+
+    assert out["stream_failed"] is True
+    assert out["stream_fail_message"].startswith(RATE_LIMITED_LEAD)
+
+
+def test_retry_ladder_records_why_it_gave_up(caplog):
+    """Gap 3. Every exit that declines to retry now says so, including the
+    non-retriable 4xx the issue names. Before this the caller re-raised into the
+    fail-soft handler with nothing upstream explaining the decision."""
+    import asyncio
+
+    import anthropic
+    import httpx
+
+    from app.services.coach.llm import RetryLadder
+
+    # The class production actually raised on 18 Aug: a 400 invalid_request_error
+    # ("Your credit balance is too low"), which the ladder correctly declines to
+    # retry and, before this change, re-raised with nothing written down.
+    credit_exhausted = anthropic.BadRequestError(
+        "Your credit balance is too low to access the Anthropic API.",
+        response=httpx.Response(
+            400, request=httpx.Request("POST", "https://api.anthropic.com")
+        ),
+        body=None,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="app.services.coach.llm"):
+        ladder = RetryLadder("anthropic_chat")
+        assert asyncio.run(ladder.should_retry(credit_exhausted)) is False
+
+    records = [r for r in caplog.records if r.getMessage() == "anthropic_chat_not_retried"]
+    assert len(records) == 1
+    assert records[0].reason == "non_retriable_status"
+    assert records[0].status == 400
+    assert records[0].kind == "BadRequestError"
+
+
+def test_retry_ladder_records_the_mid_stream_refusal(caplog):
+    """The rung that is NOT about the error at all: once a token has streamed the
+    request must not be re-issued, so the ladder declines regardless of class.
+    That decision was the most invisible of the five, and is now recorded."""
+    import asyncio
+
+    from app.services.coach.llm import RetryLadder
+
+    with caplog.at_level(logging.WARNING, logger="app.services.coach.llm"):
+        ladder = RetryLadder("anthropic_chat")
+        decision = asyncio.run(
+            ladder.should_retry(TypeError("unexpected keyword argument"), retriable=False)
+        )
+
+    assert decision is False
+    records = [r for r in caplog.records if r.getMessage() == "anthropic_chat_not_retried"]
+    assert len(records) == 1
+    assert records[0].reason == "mid_stream_cannot_reissue"
+    assert records[0].kind == "TypeError"

--- a/project-context.md
+++ b/project-context.md
@@ -131,7 +131,7 @@ Data flow: Strava API → strava_ingestion → Activity/ActivityStream rows → 
 `httpx`: outbound HTTP client used for Strava and Anthropic calls.
 `redis`, `rq`: job queue for sync and processing background work.
 `numpy`: numerical computation in the processing pipeline (smoothing, metrics, intervals).
-`anthropic`: Claude API client used by the coach service.
+`anthropic`: Claude API client used by the coach service; BOUNDED DELIBERATELY (`>=0.125.0,<0.126.0`, the `fastapi` precedent) because 1.0.0 removed `temperature`/`top_p`/`top_k` from `messages.create()`/`.stream()` and neither takes `**kwargs`, so the three `llm.py` call sites that pass one raise TypeError -- unbounded, the 24 Aug 2026 image build resolved 1.0.0 and every conversational turn, period report, schedule draft, voice rewrite, memory update, distillation and receipt-voice pass failed in production while CI stayed green, since the suite mocks the client end to end; 1.0.0 also moves the HTTP layer to `httpx2`, whose `RemoteProtocolError` is unrelated to `httpx`'s and so silently voids the mid-stream rung of `RetryLadder`. Adopting 1.x means both call-site changes together; `tests/test_anthropic_pin_966.py` asserts the installed version satisfies the declared line and that the line still excludes 1.0.0.
 `python-multipart`: form parsing required by FastAPI for non-JSON request bodies.
 `sentry-sdk[fastapi]` (optional `observability` extra): error tracking, installed only when Sentry capture is enabled.
 `pytest`, `pytest-asyncio` (test extra): test runner and async test support.


### PR DESCRIPTION
Partially addresses #966 (the 1.x upgrade it defers is not in scope here).

## Root cause, from production logs

The issue said prod logs were unreachable from this environment. They are not: Railway's `deploymentLogs` GraphQL query reads them, including from removed deployments.

| when (UTC) | service | recorded |
|---|---|---|
| 24 Aug 21:43 | web | `AsyncMessages.stream() got an unexpected keyword argument 'temperature'` |
| 24 Aug 21:50 | worker | `AsyncMessages.create() got an unexpected keyword argument 'temperature'` |
| 18 Aug 10:20 | web | `400 invalid_request_error: "Your credit balance is too low"` |

**The two dates are different failures.** #966 treats them as one recurring one; 18 Aug (#936) was an exhausted credit balance.

`anthropic` 1.0.0 (20 Aug) removed `temperature`/`top_p`/`top_k` from `messages.create()` and `.stream()`. Neither takes `**kwargs`, so the three call sites in `llm.py` passing one raise `TypeError`. The dependency was unbounded at `>=0.40.0`, so the 24 Aug image build resolved 1.0.0 and took down **every conversational turn, period report, schedule draft, voice rewrite, memory update, distillation and receipt-voice pass**. Only `generate_coach_message` survived, because it already passes no sampling params by design.

CI stayed green throughout: the suite mocks the client end to end, so nothing binds our call sites to the SDK's real signature.

## Changes

- **Pin `anthropic>=0.125.0,<0.126.0`** (the #809 `fastapi` precedent), with a test asserting the installed version satisfies the line *and* that the line still excludes 1.0.0. A floor alone is what let this in.
- **Observability**, the three gaps the issue names: the runner-visible handler now logs exception type + traceback; the stream-ended-with-no-final-message branch (previously silent, identical runner message) has its own line; the retry ladder records why it declined to retry at all five give-up exits.
- Runner-facing text unchanged, pinned byte for byte including the #625 rate-limited variant.
- Unrelated drive-by: `_seed_activity_with_report` hardcoded `2026-05-27` while a tool-window assertion counts it inside `last_90_days`. It started failing today, day 90, with no code change. Made relative in that fixture only.

## Verification

- **Reproduction from the real call sites**: drove `llm.py`'s four methods with a fake transport, captured the kwargs each actually passes, bound them against both SDKs' real `inspect.signature`. Under 1.0.0 three sites fail on `temperature` and `generate_coach_message` passes, matching both log lines exactly; under the pin all four bind.
- **Every new guard falsified and restored.** Most informative: with the pin reverted to `>=0.40.0`, the installed-version test still passes, which is why the ceiling is a separate assertion.
- Ladder behaviour covered by the 27 pre-existing tests in `test_coach_llm_timeout_retry.py`, all passing.
- Suite 3727 passed / 0 failed (baseline 3716 passed, 1 failed). `make diagram-check` in sync.

## Not verified

- **No live API call** (owner's call). This is Configure modality, so that is a named gap: nothing here proves 0.125.0 talks to the live API.
- **Whether the account has credit.** No call has reached the API since the deploy, so the 18 Aug exhaustion may still be live. If so, this restores the code path and the coach still fails, now with a logged 400. Most likely way this looks fixed and is not.
- **The coverage gap that let this ship is still open**: nothing binds call sites to the SDK signature.

## Follow-ups, not done here

1. The 1.x upgrade is small (3 kwargs, 1 exception class, the pin, declare `httpx2`) but deferred. 1.0.0 also moves to `httpx2`, whose `RemoteProtocolError` is unrelated to `httpx`'s, so under 1.x the mid-stream retry rung (#302) silently never matches. `extra_body={"temperature": 0}` preserves the setting on `claude-sonnet-4-6`, so the upgrade need not cost determinism.
2. `period_report.py` still logs message-only, the same pattern criticised in `chat.py`. The ladder change now puts an upstream record behind it.