### PR TITLE
chore(workflow): vendor ai-coding-workflow 3.27.0 (#975)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,9 +48,11 @@ frontend/tsconfig.tsbuildinfo
 .idea/
 
 # AI workflow and skills (tooling config, not product code)
-# The installer only ignores the last-installed tool's paths in its managed
-# block below, and strips those paths from anywhere else in this file; after
-# every `scripts/update.sh` run, re-add the other tools' paths here.
+# These overlap the installer's managed block below and are kept deliberately.
+# They are broader than what the installer manages (.agents/ rather than only
+# .agents/skills/, and .github/* with a workflows exception), and since
+# workflow 3.25.1 the installer builds its block as a union and leaves a
+# matching line outside it alone, so these survive an update untouched.
 .agents/
 .gemini/
 .github/*
@@ -77,4 +79,12 @@ ai-workflow.md
 .githooks/
 CLAUDE.md
 .claude/
+AGENTS.md
+.codex/
+.agents/skills/
+GEMINI.md
+.gemini/
+.github/copilot-instructions.md
+.github/hooks/
+.vscode/
 # <<< ai-workflow <<<


### PR DESCRIPTION
Closes #975. Brings the skill fix into this repository, plus everything between the vendored 3.18.0 and upstream 3.27.0.

## The fix this was for

Upstream philippe-ths/ai-coding-workflow#237 (PR #238). `aiw-project-context-management` now fires **before any edit** to `project-context.md`, including recording a fact from work just completed, rather than only on a refresh the human asks for. One sentence per line carries the clause that a new fact gets its own line rather than extending one that exists, and the 300-line cap is restated as a full file where adding means choosing what leaves.

That closes the loop on #907. This repository's file grew 15,969 characters against 7 lines in the week after its first trim, because the cap was counted in a unit that could not see a line getting longer.

## Why the diff is one file

Every vendored file is gitignored, so `.gitignore` is the only tracked change.

The eight added lines make the installer-managed block a **union of all four installed tools' paths** rather than only the last-installed tool's. That is upstream 3.25.1, which fixed the footgun this repository had been working around by hand: each run used to rebuild the block from one tool's paths and strip those paths from elsewhere in the file, so running the four tools in sequence left only the last one ignored, one `git add -A` away from committing vendored tooling.

## The stale instruction

The comment above the hand-maintained section described that old behaviour and told the reader to re-add the other tools' paths after every update. That instruction is now wrong, and a stale instruction is worse than none, so it now records why those entries are kept: they are broader than what the installer manages (`.agents/` rather than only `.agents/skills/`, and `.github/*` with a workflows exception), and the installer leaves a matching line outside its block alone. The entries themselves stay as defence in depth.

## Verification

What could have broken: the vendored tooling could stop being ignored and get committed; the update could overwrite the two files authored in-target; the new policy hooks could be inert; the product could regress.

Evidence:

- **The `.gitignore` union behaviour was verified rather than assumed**, since the working note recorded it as unfixable. Across four sequential `update.sh` runs (codex, gemini, copilot, claude), all seven previously hand-restored paths stayed ignored, and the diff is insertions only, with no deletion anywhere else in the file.
- `project-context.md` and `project-checks.md` are authored in-target and untouched: 299 lines, 46,842 characters, `git diff` empty against HEAD.
- `test_context_budget_907.py` still passes on it.
- `make backend-test`: 3730 passed, matching the pre-update baseline.
- The vendored `aiw-project-context-management/SKILL.md` is byte-identical to upstream, which was the closing condition recorded on #975.
- The new hooks are demonstrably live: `check-pr-verification.sh`, which arrived in this update, blocked the first attempt to open this pull request because a heredoc body cannot be read by the shell route. This body is passed with `--body-file` for that reason.

## What was not checked

**The nine minor versions of unrelated workflow change are not individually verified.** 3.18.0 to 3.27.0 spans ten releases, and this pull request exercises exactly two of them: the skill fix from 3.27.0 and the `.gitignore` union from 3.25.1. The rest change agent instructions rather than product code, so no test in the suite would notice a regression in them. They surface through use, and the risk is that a workflow rule now behaves differently in a way nobody has read.

**The ship-time trigger is still unproven in a live session.** Upstream #238 records the same gap: the probes there handed the skill body to the agent directly, which bypasses description-based skill selection entirely. Whether the new description actually causes the skill to load when an agent finishes a feature is the specific claim the change makes, and it can only be observed in normal use.

**Frontend was not run locally.** The update touches no frontend file, and CI's `frontend-test` job covers it.
